### PR TITLE
Add relationship visualization infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ Local-first universal message database with built-in MCP server. Ingests message
 │   ├── db/           SQLite store (conversations, messages, contacts, unified_contacts, drafts)
 │   ├── importer/     Multi-platform import adapters (gchat, imessage, whatsapp)
 │   ├── story/        Stats computation + narrative story generation
-│   ├── tools/        MCP tools (13 tools)
+│   ├── tools/        MCP tools (16 tools)
+│   ├── viz/          Relationship visualization renderer (self-contained HTML)
 │   └── web/          HTTP API + embedded React UI
 ├── macos/            Swift macOS app wrapper
 │   ├── OpenMessage/  Swift package (BackendManager, PairingView, etc.)
@@ -32,13 +33,16 @@ openmessage import whatsapp /path/to/chat.txt --name "Your Name"
 
 ### MCP tools
 
-13 tools registered:
+16 tools registered:
 - `get_messages`, `get_conversation`, `search_messages` — cross-platform by default
 - `list_conversations` — optional `source_platform` filter (sms, gchat, imessage, whatsapp)
 - `get_person_messages` — all messages with a person across all platforms
 - `import_messages` — import from any supported source
-- `conversation_stats` — volume, heatmap, phrases, response times, gaps
-- `generate_story` — narrative chapters with optional Claude API enhancement
+- `conversation_stats` — volume, heatmap, phrases, response times, gaps (single conversation)
+- `generate_story` — narrative chapters with optional Claude API enhancement (single conversation)
+- `person_stats` — cross-platform stats for all 1:1 messages with a person (merges + deduplicates)
+- `generate_person_story` — cross-platform narrative story for a person (merges + deduplicates)
+- `generate_viz` — self-contained HTML visualization combining data dashboards + narrative (see below)
 - `send_message`, `draft_message`, `download_media`, `list_contacts`, `get_status`
 
 ### HTTP API
@@ -97,12 +101,32 @@ go test ./cmd/ -v      # Unit + integration tests
 go test ./... -v       # All tests
 ```
 
+## Relationship visualization (`generate_viz`)
+
+Generates a self-contained HTML file combining data dashboards with narrative chapters. Output is deployable to Vercel or viewable locally.
+
+**Sections**: password gate, hero, timeline nav, narrative chapters (early/middle/late), monthly volume chart (Chart.js), sender split donut, response times, hour-of-week heatmap, phrase cloud (colored by sender ratio), longest gap callout, photo gallery, interludes, closing.
+
+**Key parameters**: `name` (person to search), `output_path`, `timezone` (default ET), `password`, `api_key` (for Claude-generated narrative), colors (`primary_color`, `secondary_color`, etc.).
+
+**Architecture**:
+- `internal/viz/config.go` — `VizConfig` struct, section ordering, color theming
+- `internal/viz/render.go` — `RenderHTML()` orchestrator, Chart.js data building
+- `internal/viz/template.go` — Go html/template with all CSS/JS inline (except CDN fonts + Chart.js)
+- `internal/viz/photos.go` — `FindMediaMessages()` for photo gallery
+- `internal/tools/viz.go` — MCP tool handler
+
+**Stats engine extensions** (`internal/story/stats.go`):
+- `PhraseCount.BySender` — per-sender phrase counts for colored word cloud
+- `ComputeStats(messages, tz)` — timezone parameter for TZ-shifted heatmap
+
 ## Key files
 
 - `internal/app/app.go` — data dir resolution (`OPENMESSAGES_DATA_DIR` env var, defaults to `~/.local/share/openmessage`)
 - `internal/db/db.go` — schema, structs, migration
 - `internal/importer/` — gchat.go, imessage.go, whatsapp.go
-- `internal/story/stats.go` — conversation statistics computation
+- `internal/story/stats.go` — conversation statistics computation (with timezone + per-sender phrases)
 - `internal/story/generate.go` — narrative story generation (local or Claude API)
+- `internal/viz/` — relationship visualization renderer (config, template, render, photos)
 - `internal/client/events.go` — handles Google Messages protocol events
 - `macos/OpenMessage/Sources/BackendManager.swift` — launches Go backend, manages app state

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -122,6 +122,34 @@ func (s *Store) GetMessageByID(messageID string) (*Message, error) {
 	return m, nil
 }
 
+// GetMessagesByConversations returns messages from multiple conversations,
+// ordered by timestamp ascending. Useful for cross-platform person queries.
+func (s *Store) GetMessagesByConversations(conversationIDs []string, limit int) ([]*Message, error) {
+	if len(conversationIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(conversationIDs))
+	args := make([]any, len(conversationIDs))
+	for i, id := range conversationIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	args = append(args, limit)
+
+	rows, err := s.db.Query(`
+		SELECT `+messageColumns+`
+		FROM messages
+		WHERE conversation_id IN (`+strings.Join(placeholders, ",")+`)
+		ORDER BY timestamp_ms ASC
+		LIMIT ?
+	`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanMessages(rows)
+}
+
 // DeleteTmpMessages removes locally-created tmp_ messages for a conversation.
 // Called when the server echo arrives with a real message ID.
 func (s *Store) DeleteTmpMessages(conversationID string) (int64, error) {

--- a/internal/story/generate.go
+++ b/internal/story/generate.go
@@ -60,7 +60,7 @@ func Generate(messages []*db.Message, config GenerateConfig) (*Story, error) {
 		return sorted[i].TimestampMS < sorted[j].TimestampMS
 	})
 
-	stats := ComputeStats(sorted)
+	stats := ComputeStats(sorted, nil)
 	sampled := sampleMessages(sorted, config.MaxSampleMessages)
 
 	story := &Story{

--- a/internal/story/stats.go
+++ b/internal/story/stats.go
@@ -42,8 +42,9 @@ type HourCount struct {
 }
 
 type PhraseCount struct {
-	Phrase string `json:"phrase"`
-	Count  int    `json:"count"`
+	Phrase   string         `json:"phrase"`
+	Count    int            `json:"count"`
+	BySender map[string]int `json:"by_sender"`
 }
 
 type Gap struct {
@@ -54,7 +55,11 @@ type Gap struct {
 
 // ComputeStats calculates conversation statistics from a list of messages.
 // Messages should be sorted by timestamp ascending for correct gap/response calculations.
-func ComputeStats(messages []*db.Message) *Stats {
+func ComputeStats(messages []*db.Message, tz *time.Location) *Stats {
+	if tz == nil {
+		tz = time.UTC
+	}
+
 	if len(messages) == 0 {
 		return &Stats{
 			SenderSplit:      map[string]int{},
@@ -77,14 +82,15 @@ func ComputeStats(messages []*db.Message) *Stats {
 
 	// Date range
 	stats.DateRange = DateRange{
-		Start: time.UnixMilli(sorted[0].TimestampMS).UTC().Format("2006-01-02"),
-		End:   time.UnixMilli(sorted[len(sorted)-1].TimestampMS).UTC().Format("2006-01-02"),
+		Start: time.UnixMilli(sorted[0].TimestampMS).In(tz).Format("2006-01-02"),
+		End:   time.UnixMilli(sorted[len(sorted)-1].TimestampMS).In(tz).Format("2006-01-02"),
 	}
 
 	// Group by year
 	yearMap := map[string]*YearStats{}
 	hourMap := map[[2]int]int{} // [hour, dayOfWeek] -> count
 	phraseMap := map[string]int{}
+	phraseBySender := map[string]map[string]int{} // phrase -> sender -> count
 
 	// Response time tracking
 	responseTotal := map[string]float64{}
@@ -98,7 +104,7 @@ func ComputeStats(messages []*db.Message) *Stats {
 	var prevTS int64
 
 	for _, m := range sorted {
-		t := time.UnixMilli(m.TimestampMS).UTC()
+		t := time.UnixMilli(m.TimestampMS).In(tz)
 		year := t.Format("2006")
 		month := int(t.Month()) - 1
 		hour := t.Hour()
@@ -120,8 +126,8 @@ func ComputeStats(messages []*db.Message) *Stats {
 		// Hour heatmap
 		hourMap[[2]int{hour, dow}]++
 
-		// Phrase counting
-		countPhrases(m.Body, phraseMap)
+		// Phrase counting (with per-sender tracking)
+		countPhrases(m.Body, phraseMap, phraseBySender, sender)
 
 		// Response times and gaps
 		if prevTS > 0 {
@@ -168,7 +174,7 @@ func ComputeStats(messages []*db.Message) *Stats {
 	}
 
 	// Top phrases (filter stop words)
-	stats.TopPhrases = topPhrases(phraseMap, 100)
+	stats.TopPhrases = topPhrases(phraseMap, phraseBySender, 100)
 
 	// Average response times
 	for sender, total := range responseTotal {
@@ -180,8 +186,8 @@ func ComputeStats(messages []*db.Message) *Stats {
 	// Longest gap
 	if longestGap.days > 0 {
 		stats.LongestGap = Gap{
-			Start: time.UnixMilli(longestGap.start).UTC().Format("2006-01-02"),
-			End:   time.UnixMilli(longestGap.end).UTC().Format("2006-01-02"),
+			Start: time.UnixMilli(longestGap.start).In(tz).Format("2006-01-02"),
+			End:   time.UnixMilli(longestGap.end).In(tz).Format("2006-01-02"),
 			Days:  int(math.Round(longestGap.days)),
 		}
 	}
@@ -204,7 +210,7 @@ func senderKey(m *db.Message) string {
 
 var wordRe = regexp.MustCompile(`[^\w\s]`)
 
-func countPhrases(text string, phraseMap map[string]int) {
+func countPhrases(text string, phraseMap map[string]int, phraseBySender map[string]map[string]int, sender string) {
 	cleaned := wordRe.ReplaceAllString(strings.ToLower(text), "")
 	words := strings.Fields(cleaned)
 	// Filter short words
@@ -214,20 +220,29 @@ func countPhrases(text string, phraseMap map[string]int) {
 			filtered = append(filtered, w)
 		}
 	}
+
+	addPhrase := func(phrase string) {
+		phraseMap[phrase]++
+		if phraseBySender[phrase] == nil {
+			phraseBySender[phrase] = map[string]int{}
+		}
+		phraseBySender[phrase][sender]++
+	}
+
 	// Bigrams
 	for i := 0; i < len(filtered)-1; i++ {
 		phrase := filtered[i] + " " + filtered[i+1]
-		phraseMap[phrase]++
+		addPhrase(phrase)
 	}
 	// Single words > 3 chars
 	for _, w := range filtered {
 		if len([]rune(w)) > 3 && !isStopWord(w) {
-			phraseMap[w]++
+			addPhrase(w)
 		}
 	}
 }
 
-func topPhrases(phraseMap map[string]int, n int) []PhraseCount {
+func topPhrases(phraseMap map[string]int, phraseBySender map[string]map[string]int, n int) []PhraseCount {
 	type kv struct {
 		phrase string
 		count  int
@@ -266,7 +281,11 @@ func topPhrases(phraseMap map[string]int, n int) []PhraseCount {
 	}
 	result := make([]PhraseCount, len(items))
 	for i, kv := range items {
-		result[i] = PhraseCount{Phrase: kv.phrase, Count: kv.count}
+		bySender := phraseBySender[kv.phrase]
+		if bySender == nil {
+			bySender = map[string]int{}
+		}
+		result[i] = PhraseCount{Phrase: kv.phrase, Count: kv.count, BySender: bySender}
 	}
 	return result
 }

--- a/internal/story/stats_test.go
+++ b/internal/story/stats_test.go
@@ -2,12 +2,13 @@ package story
 
 import (
 	"testing"
+	"time"
 
 	"github.com/maxghenis/openmessage/internal/db"
 )
 
 func TestComputeStatsEmpty(t *testing.T) {
-	stats := ComputeStats(nil)
+	stats := ComputeStats(nil, nil)
 	if stats.TotalMessages != 0 {
 		t.Errorf("total = %d, want 0", stats.TotalMessages)
 	}
@@ -22,7 +23,7 @@ func TestComputeStats(t *testing.T) {
 		{MessageID: "5", SenderName: "Alice", Body: "Want to grab coffee?", TimestampMS: 1700000240000, IsFromMe: false},
 	}
 
-	stats := ComputeStats(messages)
+	stats := ComputeStats(messages, nil)
 
 	if stats.TotalMessages != 5 {
 		t.Errorf("total = %d, want 5", stats.TotalMessages)
@@ -61,7 +62,7 @@ func TestComputeStatsResponseTimes(t *testing.T) {
 		{MessageID: "3", SenderName: "Alice", Body: "What's up", TimestampMS: 1700000600000, IsFromMe: false}, // 5 min later
 	}
 
-	stats := ComputeStats(messages)
+	stats := ComputeStats(messages, nil)
 
 	// "me" responded to Alice in 5 minutes
 	if rt, ok := stats.AvgResponseTimes["me"]; !ok || rt != 5 {
@@ -80,10 +81,121 @@ func TestComputeStatsLongestGap(t *testing.T) {
 		{MessageID: "2", Body: "Hi again", TimestampMS: 1700864000000, IsFromMe: true},
 	}
 
-	stats := ComputeStats(messages)
+	stats := ComputeStats(messages, nil)
 
 	if stats.LongestGap.Days != 10 {
 		t.Errorf("longest gap = %d days, want 10", stats.LongestGap.Days)
+	}
+}
+
+func TestPhraseCountBySender(t *testing.T) {
+	// Alice says "really great" twice, "me" says "really great" once
+	// "really" alone (>3 chars, not stop word) should also appear per-sender
+	messages := []*db.Message{
+		{MessageID: "1", SenderName: "Alice", Body: "This is really great stuff", TimestampMS: 1700000000000, IsFromMe: false},
+		{MessageID: "2", Body: "I think really great work here", TimestampMS: 1700000060000, IsFromMe: true},
+		{MessageID: "3", SenderName: "Alice", Body: "Yes really great results overall", TimestampMS: 1700000120000, IsFromMe: false},
+	}
+
+	stats := ComputeStats(messages, nil)
+
+	// Find "really great" in top phrases
+	var found *PhraseCount
+	for i := range stats.TopPhrases {
+		if stats.TopPhrases[i].Phrase == "really great" {
+			found = &stats.TopPhrases[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected 'really great' in top phrases")
+	}
+	if found.Count != 3 {
+		t.Errorf("'really great' total count = %d, want 3", found.Count)
+	}
+	if found.BySender == nil {
+		t.Fatal("BySender should not be nil")
+	}
+	if found.BySender["Alice"] != 2 {
+		t.Errorf("'really great' Alice count = %d, want 2", found.BySender["Alice"])
+	}
+	if found.BySender["me"] != 1 {
+		t.Errorf("'really great' me count = %d, want 1", found.BySender["me"])
+	}
+}
+
+func TestComputeStatsTimezone(t *testing.T) {
+	// Create a message at a known UTC time: 2023-11-14 03:00:00 UTC
+	// That's 2023-11-13 22:00:00 EST (UTC-5, November is standard time)
+	// TimestampMS for 2023-11-14 03:00 UTC = 1699930800000
+	utcTime := time.Date(2023, 11, 14, 3, 0, 0, 0, time.UTC)
+	tsMS := utcTime.UnixMilli()
+
+	messages := []*db.Message{
+		{MessageID: "1", SenderName: "Alice", Body: "Late night message", TimestampMS: tsMS, IsFromMe: false},
+	}
+
+	nyTZ, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("failed to load timezone: %v", err)
+	}
+
+	stats := ComputeStats(messages, nyTZ)
+
+	// In UTC: hour=3, day=Tuesday (2023-11-14 is a Tuesday)
+	// In EST: hour=22, day=Monday (2023-11-13 is a Monday)
+	// dayOfWeek: Monday=1
+
+	// Verify heatmap has the count in the EST bucket
+	var utcBucket, estBucket HourCount
+	for _, hc := range stats.HourHeatmap {
+		if hc.Hour == 3 && hc.Day == 2 { // UTC: hour 3, Tuesday
+			utcBucket = hc
+		}
+		if hc.Hour == 22 && hc.Day == 1 { // EST: hour 22, Monday
+			estBucket = hc
+		}
+	}
+	if estBucket.Count != 1 {
+		t.Errorf("EST bucket (hour=22, day=Monday) count = %d, want 1", estBucket.Count)
+	}
+	if utcBucket.Count != 0 {
+		t.Errorf("UTC bucket (hour=3, day=Tuesday) count = %d, want 0 (should be shifted to EST)", utcBucket.Count)
+	}
+
+	// Verify date range is formatted in EST
+	// 2023-11-14 03:00 UTC = 2023-11-13 in EST
+	if stats.DateRange.Start != "2023-11-13" {
+		t.Errorf("DateRange.Start = %s, want 2023-11-13 (EST date)", stats.DateRange.Start)
+	}
+}
+
+func TestComputeStatsTimezoneNil(t *testing.T) {
+	// Same message as above: 2023-11-14 03:00:00 UTC
+	utcTime := time.Date(2023, 11, 14, 3, 0, 0, 0, time.UTC)
+	tsMS := utcTime.UnixMilli()
+
+	messages := []*db.Message{
+		{MessageID: "1", SenderName: "Alice", Body: "A test message", TimestampMS: tsMS, IsFromMe: false},
+	}
+
+	stats := ComputeStats(messages, nil)
+
+	// With nil timezone, should use UTC
+	// UTC: hour=3, day=Tuesday (dayOfWeek=2)
+	var utcBucket HourCount
+	for _, hc := range stats.HourHeatmap {
+		if hc.Hour == 3 && hc.Day == 2 { // UTC: hour 3, Tuesday
+			utcBucket = hc
+		}
+	}
+	if utcBucket.Count != 1 {
+		t.Errorf("UTC bucket (hour=3, day=Tuesday) count = %d, want 1", utcBucket.Count)
+	}
+
+	// Date should be in UTC: 2023-11-14
+	if stats.DateRange.Start != "2023-11-14" {
+		t.Errorf("DateRange.Start = %s, want 2023-11-14 (UTC date)", stats.DateRange.Start)
 	}
 }
 

--- a/internal/tools/story.go
+++ b/internal/tools/story.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/db"
 	"github.com/maxghenis/openmessage/internal/story"
 )
 
@@ -40,7 +42,7 @@ func conversationStatsHandler(a *app.App) server.ToolHandlerFunc {
 			return textResult("No messages found in this conversation."), nil
 		}
 
-		stats := story.ComputeStats(msgs)
+		stats := story.ComputeStats(msgs, nil)
 		statsJSON, _ := json.MarshalIndent(stats, "", "  ")
 
 		var sb strings.Builder
@@ -162,4 +164,235 @@ func generateStoryHandler(a *app.App) server.ToolHandlerFunc {
 
 		return textResult(sb.String()), nil
 	}
+}
+
+// --- Person-level tools (cross-platform) ---
+
+func personStatsTool() mcp.Tool {
+	return mcp.NewTool("person_stats",
+		mcp.WithDescription("Compute statistics for all messages with a person across all platforms (SMS, iMessage, WhatsApp, etc). Merges and deduplicates cross-platform messages."),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Person's name to search for (case-insensitive partial match)")),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+	)
+}
+
+func personStatsHandler(a *app.App) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		name := strArg(args, "name")
+		if name == "" {
+			return errorResult("name is required"), nil
+		}
+
+		msgs, convNames, err := collectPersonMessages(a, name)
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+		if len(msgs) == 0 {
+			return textResult(fmt.Sprintf("No messages found with '%s'.", name)), nil
+		}
+
+		stats := story.ComputeStats(msgs, nil)
+		statsJSON, _ := json.MarshalIndent(stats, "", "  ")
+
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "Stats for messages with '%s' across %d conversation(s):\n", name, len(convNames))
+		for _, cn := range convNames {
+			fmt.Fprintf(&sb, "  - %s\n", cn)
+		}
+		sb.WriteString("\n")
+
+		fmt.Fprintf(&sb, "Total messages: %d (after dedup)\n", stats.TotalMessages)
+		fmt.Fprintf(&sb, "Date range: %s to %s\n", stats.DateRange.Start, stats.DateRange.End)
+		fmt.Fprintf(&sb, "Sender split: ")
+		for sender, count := range stats.SenderSplit {
+			fmt.Fprintf(&sb, "%s=%d ", sender, count)
+		}
+		sb.WriteString("\n")
+
+		if stats.LongestGap.Days > 0 {
+			fmt.Fprintf(&sb, "Longest gap: %d days (%s to %s)\n", stats.LongestGap.Days, stats.LongestGap.Start, stats.LongestGap.End)
+		}
+
+		for sender, rt := range stats.AvgResponseTimes {
+			fmt.Fprintf(&sb, "Avg response time (%s): %d min\n", sender, rt)
+		}
+
+		if len(stats.Yearly) > 0 {
+			sb.WriteString("\nYearly breakdown:\n")
+			for _, ys := range stats.Yearly {
+				fmt.Fprintf(&sb, "  %s: %d messages\n", ys.Year, ys.Total)
+			}
+		}
+
+		if len(stats.TopPhrases) > 0 {
+			sb.WriteString("\nTop phrases:\n")
+			limit := 20
+			if len(stats.TopPhrases) < limit {
+				limit = len(stats.TopPhrases)
+			}
+			for _, p := range stats.TopPhrases[:limit] {
+				fmt.Fprintf(&sb, "  %q (%d)\n", p.Phrase, p.Count)
+			}
+		}
+
+		sb.WriteString("\nFull stats JSON:\n")
+		sb.Write(statsJSON)
+
+		return textResult(sb.String()), nil
+	}
+}
+
+func generatePersonStoryTool() mcp.Tool {
+	return mcp.NewTool("generate_person_story",
+		mcp.WithDescription("Generate a narrative story about your relationship with a person, across all platforms (SMS, iMessage, WhatsApp, etc). Merges and deduplicates cross-platform messages."),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Person's name to search for (case-insensitive partial match)")),
+		mcp.WithString("style", mcp.Description("Story style: intimate, professional, friendship (default: auto-detect)")),
+		mcp.WithString("api_key", mcp.Description("Anthropic API key for AI-generated narrative (without it, generates stats + sampled quotes)")),
+		mcp.WithDestructiveHintAnnotation(false),
+	)
+}
+
+func generatePersonStoryHandler(a *app.App) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		name := strArg(args, "name")
+		if name == "" {
+			return errorResult("name is required"), nil
+		}
+		style := strArg(args, "style")
+		apiKey := strArg(args, "api_key")
+
+		msgs, convNames, err := collectPersonMessages(a, name)
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+		if len(msgs) == 0 {
+			return textResult(fmt.Sprintf("No messages found with '%s'.", name)), nil
+		}
+
+		s, err := story.Generate(msgs, story.GenerateConfig{
+			Style:             style,
+			APIKey:            apiKey,
+			MaxSampleMessages: 200,
+		})
+		if err != nil {
+			return errorResult(fmt.Sprintf("generate story: %v", err)), nil
+		}
+
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "# %s\n\n", s.Title)
+		fmt.Fprintf(&sb, "*Based on %d messages across %d conversation(s): %s*\n\n",
+			s.Stats.TotalMessages, len(convNames), strings.Join(convNames, ", "))
+		fmt.Fprintf(&sb, "%s\n\n", s.Summary)
+		fmt.Fprintf(&sb, "---\n\n")
+
+		for _, ch := range s.Chapters {
+			fmt.Fprintf(&sb, "## %s", ch.Title)
+			if ch.Period != "" {
+				fmt.Fprintf(&sb, " (%s)", ch.Period)
+			}
+			sb.WriteString("\n\n")
+
+			if ch.Content != "" {
+				fmt.Fprintf(&sb, "%s\n\n", ch.Content)
+			}
+
+			for _, q := range ch.Quotes {
+				ts := q.Timestamp
+				if t, err := time.Parse(time.RFC3339, ts); err == nil {
+					ts = t.Format("Jan 2, 2006")
+				}
+				fmt.Fprintf(&sb, "> **%s** (%s): \"%s\"\n\n", q.Sender, ts, q.Text)
+			}
+		}
+
+		fmt.Fprintf(&sb, "---\n\n**Stats:** %d messages, %s to %s\n",
+			s.Stats.TotalMessages, s.Stats.DateRange.Start, s.Stats.DateRange.End)
+
+		return textResult(sb.String()), nil
+	}
+}
+
+// collectPersonMessages finds all 1:1 conversations matching the name, loads
+// all messages, deduplicates cross-platform duplicates, and returns them sorted
+// chronologically. Also returns conversation display names for context.
+func collectPersonMessages(a *app.App, name string) ([]*db.Message, []string, error) {
+	allConvs, err := a.Store.ListConversations(1000)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list conversations: %v", err)
+	}
+
+	nameLower := strings.ToLower(name)
+	var matchingConvIDs []string
+	var convNames []string
+	for _, c := range allConvs {
+		// Skip group chats — we want 1:1 conversations with this person
+		if c.IsGroup {
+			continue
+		}
+		if strings.Contains(strings.ToLower(c.Name), nameLower) ||
+			strings.Contains(strings.ToLower(c.Participants), nameLower) {
+			matchingConvIDs = append(matchingConvIDs, c.ConversationID)
+			platform := c.SourcePlatform
+			if platform == "" {
+				platform = "sms"
+			}
+			convNames = append(convNames, fmt.Sprintf("%s [%s]", c.Name, platform))
+		}
+	}
+
+	if len(matchingConvIDs) == 0 {
+		return nil, nil, nil
+	}
+
+	msgs, err := a.Store.GetMessagesByConversations(matchingConvIDs, 500000)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get messages: %v", err)
+	}
+
+	// Deduplicate: messages with identical body + timestamp within 2 seconds
+	// are likely the same message on different platforms (SMS + iMessage).
+	deduped := deduplicateMessages(msgs)
+
+	return deduped, convNames, nil
+}
+
+// deduplicateMessages removes near-duplicate messages (same body and timestamp
+// within 2 seconds). Keeps the first occurrence (by platform order).
+func deduplicateMessages(msgs []*db.Message) []*db.Message {
+	if len(msgs) <= 1 {
+		return msgs
+	}
+
+	// Sort by timestamp
+	sort.Slice(msgs, func(i, j int) bool {
+		return msgs[i].TimestampMS < msgs[j].TimestampMS
+	})
+
+	var result []*db.Message
+	for _, m := range msgs {
+		isDup := false
+		// Check against recent messages (look back up to 20 for efficiency)
+		start := len(result) - 20
+		if start < 0 {
+			start = 0
+		}
+		for i := len(result) - 1; i >= start; i-- {
+			prev := result[i]
+			tsDiff := m.TimestampMS - prev.TimestampMS
+			if tsDiff > 2000 {
+				break // Too far apart in time
+			}
+			if tsDiff >= 0 && tsDiff <= 2000 && m.Body == prev.Body && m.IsFromMe == prev.IsFromMe {
+				isDup = true
+				break
+			}
+		}
+		if !isDup {
+			result = append(result, m)
+		}
+	}
+	return result
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -24,6 +24,9 @@ func Register(s *server.MCPServer, a *app.App) {
 	s.AddTool(getPersonMessagesTool(), getPersonMessagesHandler(a))
 	s.AddTool(conversationStatsTool(), conversationStatsHandler(a))
 	s.AddTool(generateStoryTool(), generateStoryHandler(a))
+	s.AddTool(personStatsTool(), personStatsHandler(a))
+	s.AddTool(generatePersonStoryTool(), generatePersonStoryHandler(a))
+	s.AddTool(generateVizTool(), generateVizHandler(a))
 }
 
 func strArg(args map[string]any, key string) string {

--- a/internal/tools/viz.go
+++ b/internal/tools/viz.go
@@ -1,0 +1,176 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/story"
+	"github.com/maxghenis/openmessage/internal/viz"
+)
+
+func generateVizTool() mcp.Tool {
+	return mcp.NewTool("generate_viz",
+		mcp.WithDescription("Generate a self-contained HTML visualization of a relationship. Combines data dashboards (charts, heatmap, phrase cloud) with narrative chapters. Output is a single HTML file deployable to Vercel or viewable locally."),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Person's name to search for (case-insensitive partial match)")),
+		mcp.WithString("output_path", mcp.Required(), mcp.Description("File path to write the HTML output (e.g. /tmp/viz.html)")),
+		mcp.WithString("person1", mcp.Description("First person's display name (default: 'Max')")),
+		mcp.WithString("person2", mcp.Description("Second person's display name (default: matched name)")),
+		mcp.WithString("timezone", mcp.Description("Timezone for heatmap and dates (default: America/New_York)")),
+		mcp.WithString("password", mcp.Description("Password to protect the viz (will be SHA-256 hashed client-side). Empty = no gate.")),
+		mcp.WithString("primary_color", mcp.Description("Primary CSS color for person2 (e.g. '#be123c')")),
+		mcp.WithString("secondary_color", mcp.Description("Secondary CSS color for person1 (e.g. '#d97706')")),
+		mcp.WithString("accent_color", mcp.Description("Accent CSS color (e.g. '#fbbf24')")),
+		mcp.WithString("background_color", mcp.Description("Background CSS color (e.g. '#0c0a09')")),
+		mcp.WithString("style", mcp.Description("Story style: intimate, professional, friendship (default: auto-detect)")),
+		mcp.WithString("api_key", mcp.Description("Anthropic API key for AI-generated narrative (without it, generates stats + sampled quotes)")),
+		mcp.WithDestructiveHintAnnotation(false),
+	)
+}
+
+func generateVizHandler(a *app.App) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		name := strArg(args, "name")
+		if name == "" {
+			return errorResult("name is required"), nil
+		}
+		outputPath := strArg(args, "output_path")
+		if outputPath == "" {
+			return errorResult("output_path is required"), nil
+		}
+
+		// Collect messages across all platforms
+		msgs, convNames, err := collectPersonMessages(a, name)
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+		if len(msgs) == 0 {
+			return textResult(fmt.Sprintf("No messages found with '%s'.", name)), nil
+		}
+
+		// Parse timezone
+		tzName := strArg(args, "timezone")
+		if tzName == "" {
+			tzName = "America/New_York"
+		}
+		tz, err := time.LoadLocation(tzName)
+		if err != nil {
+			return errorResult(fmt.Sprintf("invalid timezone %q: %v", tzName, err)), nil
+		}
+
+		// Compute stats with timezone
+		stats := story.ComputeStats(msgs, tz)
+
+		// Generate narrative
+		style := strArg(args, "style")
+		apiKey := strArg(args, "api_key")
+		st, err := story.Generate(msgs, story.GenerateConfig{
+			Style:             style,
+			APIKey:            apiKey,
+			MaxSampleMessages: 200,
+		})
+		if err != nil {
+			return errorResult(fmt.Sprintf("generate story: %v", err)), nil
+		}
+		// Use the stats we computed with timezone
+		st.Stats = stats
+
+		// Find media messages
+		mediaMessages := viz.FindMediaMessages(msgs)
+
+		// Build config
+		person1 := strArg(args, "person1")
+		if person1 == "" {
+			person1 = "Max"
+		}
+		person2 := strArg(args, "person2")
+		if person2 == "" {
+			// Use the matched name from conversations
+			for sender := range stats.SenderSplit {
+				if sender != "me" {
+					person2 = sender
+					break
+				}
+			}
+			if person2 == "" {
+				person2 = name
+			}
+		}
+
+		config := viz.VizConfig{
+			Person1:         person1,
+			Person2:         person2,
+			PrimaryColor:    strArg(args, "primary_color"),
+			SecondaryColor:  strArg(args, "secondary_color"),
+			AccentColor:     strArg(args, "accent_color"),
+			BackgroundColor: strArg(args, "background_color"),
+			Timezone:        tzName,
+			PasswordHash:    strArg(args, "password"), // raw password — template does SHA-256 client-side
+		}
+
+		// Render HTML
+		html, err := viz.RenderHTML(stats, st, config)
+		if err != nil {
+			return errorResult(fmt.Sprintf("render HTML: %v", err)), nil
+		}
+
+		// Ensure output directory exists
+		if dir := filepath.Dir(outputPath); dir != "" {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return errorResult(fmt.Sprintf("create output dir: %v", err)), nil
+			}
+		}
+
+		// Write the file
+		if err := os.WriteFile(outputPath, html, 0o644); err != nil {
+			return errorResult(fmt.Sprintf("write file: %v", err)), nil
+		}
+
+		// Build summary
+		fileInfo, _ := os.Stat(outputPath)
+		sizeKB := 0
+		if fileInfo != nil {
+			sizeKB = int(fileInfo.Size() / 1024)
+		}
+
+		summary := fmt.Sprintf("Visualization generated!\n\n"+
+			"Output: %s (%d KB)\n"+
+			"Person: %s & %s\n"+
+			"Messages: %d across %d conversation(s)\n"+
+			"Conversations: %s\n"+
+			"Date range: %s to %s\n"+
+			"Timezone: %s\n"+
+			"Media messages found: %d\n"+
+			"Chapters: %d\n",
+			outputPath, sizeKB,
+			person1, person2,
+			stats.TotalMessages, len(convNames),
+			joinNames(convNames),
+			stats.DateRange.Start, stats.DateRange.End,
+			tzName,
+			len(mediaMessages),
+			len(st.Chapters),
+		)
+
+		if config.PasswordHash != "" {
+			summary += "Password gate: enabled\n"
+		}
+
+		return textResult(summary), nil
+	}
+}
+
+func joinNames(names []string) string {
+	if len(names) > 3 {
+		return fmt.Sprintf("%s, %s, %s, +%d more", names[0], names[1], names[2], len(names)-3)
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/tools/viz_test.go
+++ b/internal/tools/viz_test.go
@@ -1,0 +1,21 @@
+package tools
+
+import "testing"
+
+func TestJoinNames(t *testing.T) {
+	tests := []struct {
+		names []string
+		want  string
+	}{
+		{nil, ""},
+		{[]string{"A [sms]"}, "A [sms]"},
+		{[]string{"A [sms]", "B [imessage]"}, "A [sms], B [imessage]"},
+		{[]string{"A", "B", "C", "D", "E"}, "A, B, C, +2 more"},
+	}
+	for _, tt := range tests {
+		got := joinNames(tt.names)
+		if got != tt.want {
+			t.Errorf("joinNames(%v) = %q, want %q", tt.names, got, tt.want)
+		}
+	}
+}

--- a/internal/viz/config.go
+++ b/internal/viz/config.go
@@ -1,0 +1,54 @@
+package viz
+
+// VizConfig holds all configuration for rendering a relationship visualization.
+type VizConfig struct {
+	// People
+	Person1 string // e.g. "Alice"
+	Person2 string // e.g. "Bob"
+
+	// Colors (CSS variable values)
+	PrimaryColor    string // e.g. "#be123c" (rose)
+	SecondaryColor  string // e.g. "#d97706" (amber)
+	AccentColor     string // e.g. "#fbbf24"
+	BackgroundColor string // e.g. "#0c0a09"
+
+	// Timezone for heatmap display
+	Timezone string // e.g. "America/New_York"
+
+	// Password (SHA-256 hash for client-side gate, empty = no gate)
+	PasswordHash string
+
+	// Section ordering (default order used if empty)
+	Sections []string
+
+	// Custom narrative content
+	Interludes []Interlude // poetic breaks between sections
+
+	// Photo gallery
+	PhotoPaths []string // local file paths to included photos
+}
+
+// Interlude is a poetic break between data sections.
+type Interlude struct {
+	Text     string // prose/poetry text
+	Position string // section name this interlude appears AFTER
+}
+
+// DefaultSections returns the default section ordering.
+func DefaultSections() []string {
+	return []string{
+		"password-gate",
+		"hero",
+		"timeline-nav",
+		"chapter-early",
+		"volume-chart",
+		"chapter-middle",
+		"sender-split",
+		"heatmap",
+		"chapter-late",
+		"phrases",
+		"silence",
+		"photos",
+		"closing",
+	}
+}

--- a/internal/viz/config_test.go
+++ b/internal/viz/config_test.go
@@ -1,0 +1,59 @@
+package viz
+
+import "testing"
+
+func TestDefaultSections(t *testing.T) {
+	sections := DefaultSections()
+
+	if len(sections) == 0 {
+		t.Fatal("DefaultSections() returned empty slice")
+	}
+
+	if sections[0] != "password-gate" {
+		t.Errorf("first section = %q, want %q", sections[0], "password-gate")
+	}
+
+	if sections[len(sections)-1] != "closing" {
+		t.Errorf("last section = %q, want %q", sections[len(sections)-1], "closing")
+	}
+
+	// Verify all expected sections are present.
+	expected := []string{
+		"password-gate", "hero", "timeline-nav",
+		"chapter-early", "volume-chart", "chapter-middle",
+		"sender-split", "heatmap", "chapter-late",
+		"phrases", "silence", "photos", "closing",
+	}
+	if len(sections) != len(expected) {
+		t.Fatalf("got %d sections, want %d", len(sections), len(expected))
+	}
+	for i, s := range expected {
+		if sections[i] != s {
+			t.Errorf("sections[%d] = %q, want %q", i, sections[i], s)
+		}
+	}
+}
+
+func TestVizConfigDefaults(t *testing.T) {
+	// A zero-value VizConfig should be usable without panics.
+	var cfg VizConfig
+
+	if cfg.Person1 != "" {
+		t.Errorf("zero-value Person1 = %q, want empty", cfg.Person1)
+	}
+	if cfg.Person2 != "" {
+		t.Errorf("zero-value Person2 = %q, want empty", cfg.Person2)
+	}
+	if cfg.PasswordHash != "" {
+		t.Errorf("zero-value PasswordHash = %q, want empty", cfg.PasswordHash)
+	}
+	if cfg.Sections != nil {
+		t.Errorf("zero-value Sections = %v, want nil", cfg.Sections)
+	}
+	if cfg.Interludes != nil {
+		t.Errorf("zero-value Interludes = %v, want nil", cfg.Interludes)
+	}
+	if cfg.PhotoPaths != nil {
+		t.Errorf("zero-value PhotoPaths = %v, want nil", cfg.PhotoPaths)
+	}
+}

--- a/internal/viz/photos.go
+++ b/internal/viz/photos.go
@@ -1,0 +1,23 @@
+package viz
+
+import (
+	"strings"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+// FindMediaMessages returns messages that have media attachments (images/videos).
+func FindMediaMessages(messages []*db.Message) []*db.Message {
+	var media []*db.Message
+	for _, m := range messages {
+		if m.MediaID != "" && isVisualMedia(m.MimeType) {
+			media = append(media, m)
+		}
+	}
+	return media
+}
+
+// isVisualMedia checks if a MIME type is an image or video.
+func isVisualMedia(mime string) bool {
+	return strings.HasPrefix(mime, "image/") || strings.HasPrefix(mime, "video/")
+}

--- a/internal/viz/photos_test.go
+++ b/internal/viz/photos_test.go
@@ -1,0 +1,82 @@
+package viz
+
+import (
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+func TestFindMediaMessages(t *testing.T) {
+	messages := []*db.Message{
+		{MessageID: "1", MediaID: "media-1", MimeType: "image/jpeg", Body: "photo"},
+		{MessageID: "2", MediaID: "", MimeType: "", Body: "just text"},
+		{MessageID: "3", MediaID: "media-3", MimeType: "video/mp4", Body: "video"},
+		{MessageID: "4", MediaID: "media-4", MimeType: "audio/ogg", Body: "voice note"},
+		{MessageID: "5", MediaID: "media-5", MimeType: "image/png", Body: "screenshot"},
+		{MessageID: "6", MediaID: "media-6", MimeType: "application/pdf", Body: "document"},
+		{MessageID: "7", MediaID: "", MimeType: "image/gif", Body: "no media id"},
+	}
+
+	result := FindMediaMessages(messages)
+
+	if len(result) != 3 {
+		t.Fatalf("got %d media messages, want 3", len(result))
+	}
+
+	wantIDs := []string{"1", "3", "5"}
+	for i, want := range wantIDs {
+		if result[i].MessageID != want {
+			t.Errorf("result[%d].MessageID = %q, want %q", i, result[i].MessageID, want)
+		}
+	}
+}
+
+func TestFindMediaMessagesEmpty(t *testing.T) {
+	// nil input
+	if got := FindMediaMessages(nil); got != nil {
+		t.Errorf("FindMediaMessages(nil) = %v, want nil", got)
+	}
+
+	// empty input
+	if got := FindMediaMessages([]*db.Message{}); got != nil {
+		t.Errorf("FindMediaMessages([]) = %v, want nil", got)
+	}
+
+	// no media messages
+	noMedia := []*db.Message{
+		{MessageID: "1", Body: "hello"},
+		{MessageID: "2", Body: "world"},
+	}
+	if got := FindMediaMessages(noMedia); got != nil {
+		t.Errorf("FindMediaMessages(text-only) = %v, want nil", got)
+	}
+}
+
+func TestIsVisualMedia(t *testing.T) {
+	tests := []struct {
+		mime string
+		want bool
+	}{
+		{"image/jpeg", true},
+		{"image/png", true},
+		{"image/gif", true},
+		{"image/webp", true},
+		{"image/heic", true},
+		{"video/mp4", true},
+		{"video/quicktime", true},
+		{"video/webm", true},
+		{"audio/ogg", false},
+		{"audio/mpeg", false},
+		{"application/pdf", false},
+		{"text/plain", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mime, func(t *testing.T) {
+			if got := isVisualMedia(tt.mime); got != tt.want {
+				t.Errorf("isVisualMedia(%q) = %v, want %v", tt.mime, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/viz/render.go
+++ b/internal/viz/render.go
@@ -1,0 +1,242 @@
+package viz
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/story"
+)
+
+// templateData holds all data passed to the HTML template.
+type templateData struct {
+	Config         VizConfig
+	Stats          *story.Stats
+	Story          *story.Story
+	Sections       []section
+	MessagesPerDay float64
+	DaysSpan       int
+	// Pre-serialized JSON for Chart.js
+	MonthlyLabelsJSON  string
+	MonthlySeries1JSON string
+	MonthlySeries2JSON string
+	SenderLabelsJSON   string
+	SenderValuesJSON   string
+	HeatmapJSON        string
+}
+
+// section represents a renderable section of the visualization.
+type section struct {
+	Type string // "hero", "chapter", "volume-chart", "sender-split", "heatmap", "phrases", "silence", "photos", "closing", "interlude", "timeline-nav"
+	Data any    // chapter data, interlude text, etc.
+}
+
+// heatmapCell is a pre-computed cell for the heatmap grid.
+type heatmapCell struct {
+	Hour    int
+	Day     int
+	Count   int
+	Opacity float64
+}
+
+// RenderHTML generates a self-contained HTML file from stats, story, and config.
+func RenderHTML(stats *story.Stats, st *story.Story, config VizConfig) ([]byte, error) {
+	data := buildTemplateData(stats, st, config)
+
+	var buf bytes.Buffer
+	tmpl, err := buildTemplate()
+	if err != nil {
+		return nil, fmt.Errorf("build template: %w", err)
+	}
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("execute template: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// buildTemplateData assembles the templateData struct from stats, story, and config.
+func buildTemplateData(stats *story.Stats, st *story.Story, config VizConfig) templateData {
+	// Apply defaults
+	if config.PrimaryColor == "" {
+		config.PrimaryColor = "#be123c"
+	}
+	if config.SecondaryColor == "" {
+		config.SecondaryColor = "#d97706"
+	}
+	if config.AccentColor == "" {
+		config.AccentColor = "#fbbf24"
+	}
+	if config.BackgroundColor == "" {
+		config.BackgroundColor = "#0c0a09"
+	}
+
+	// Compute days span and messages per day
+	daysSpan := 1
+	msgsPerDay := float64(stats.TotalMessages)
+	if stats.DateRange.Start != "" && stats.DateRange.End != "" {
+		startT, err1 := time.Parse("2006-01-02", stats.DateRange.Start)
+		endT, err2 := time.Parse("2006-01-02", stats.DateRange.End)
+		if err1 == nil && err2 == nil {
+			d := int(endT.Sub(startT).Hours()/24) + 1
+			if d > 0 {
+				daysSpan = d
+				msgsPerDay = float64(stats.TotalMessages) / float64(d)
+			}
+		}
+	}
+
+	// Build sections list
+	sectionOrder := config.Sections
+	if len(sectionOrder) == 0 {
+		sectionOrder = DefaultSections()
+	}
+
+	chapterIdx := 0
+
+	knownSections := map[string]bool{
+		"hero": true, "timeline-nav": true, "volume-chart": true,
+		"sender-split": true, "heatmap": true, "phrases": true,
+		"silence": true, "photos": true, "closing": true,
+	}
+	chapterSlotSet := map[string]bool{
+		"chapter-early": true, "chapter-middle": true, "chapter-late": true,
+	}
+
+	var sections []section
+	for _, name := range sectionOrder {
+		switch {
+		case name == "password-gate":
+			// Handled separately in template
+			continue
+		case knownSections[name]:
+			sections = append(sections, section{Type: name, Data: nil})
+		case chapterSlotSet[name]:
+			if st != nil && chapterIdx < len(st.Chapters) {
+				sections = append(sections, section{Type: "chapter", Data: st.Chapters[chapterIdx]})
+				chapterIdx++
+			}
+		}
+
+		// Append interludes that go after this section
+		for _, interlude := range config.Interludes {
+			if interlude.Position == name {
+				sections = append(sections, section{Type: "interlude", Data: interlude.Text})
+			}
+		}
+	}
+
+	// If there are remaining chapters, append them
+	if st != nil {
+		for chapterIdx < len(st.Chapters) {
+			sections = append(sections, section{Type: "chapter", Data: st.Chapters[chapterIdx]})
+			chapterIdx++
+		}
+	}
+
+	// Pre-serialize chart data as JSON for Chart.js
+	monthlyLabels, series1, series2 := buildMonthlyChartData(stats, config)
+	monthlyLabelsJSON, _ := json.Marshal(monthlyLabels)
+	series1JSON, _ := json.Marshal(series1)
+	series2JSON, _ := json.Marshal(series2)
+
+	senderLabels, senderValues := buildSenderSplitData(stats)
+	senderLabelsJSON, _ := json.Marshal(senderLabels)
+	senderValuesJSON, _ := json.Marshal(senderValues)
+
+	heatmapData := buildHeatmapData(stats)
+	heatmapJSON, _ := json.Marshal(heatmapData)
+
+	return templateData{
+		Config:             config,
+		Stats:              stats,
+		Story:              st,
+		Sections:           sections,
+		MessagesPerDay:     math.Round(msgsPerDay*10) / 10,
+		DaysSpan:           daysSpan,
+		MonthlyLabelsJSON:  string(monthlyLabelsJSON),
+		MonthlySeries1JSON: string(series1JSON),
+		MonthlySeries2JSON: string(series2JSON),
+		SenderLabelsJSON:   string(senderLabelsJSON),
+		SenderValuesJSON:   string(senderValuesJSON),
+		HeatmapJSON:        string(heatmapJSON),
+	}
+}
+
+// buildMonthlyChartData creates month labels and per-sender series for the stacked bar chart.
+func buildMonthlyChartData(stats *story.Stats, config VizConfig) (labels []string, series1 []int, series2 []int) {
+	monthNames := []string{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
+
+	for _, ys := range stats.Yearly {
+		for m := 0; m < 12; m++ {
+			labels = append(labels, fmt.Sprintf("%s %s", monthNames[m], ys.Year))
+
+			p1Count, p2Count := splitBySender(ys.BySender, config.Person1)
+			series1 = append(series1, p1Count)
+			series2 = append(series2, p2Count)
+		}
+	}
+	return
+}
+
+// splitBySender splits a sender count map into person1 vs everyone else.
+// If person1's name does not match any key, falls back to "me" as person1.
+func splitBySender(bySender map[string]int, person1 string) (p1Count, p2Count int) {
+	if bySender == nil {
+		return 0, 0
+	}
+
+	p1Count = bySender[person1]
+	for sender, count := range bySender {
+		if sender != person1 {
+			p2Count += count
+		}
+	}
+
+	// Fall back to "me" mapping if person1's name didn't match any key
+	if p1Count == 0 && p2Count == 0 {
+		for sender, count := range bySender {
+			if sender == "me" {
+				p1Count += count
+			} else {
+				p2Count += count
+			}
+		}
+	}
+	return
+}
+
+// buildSenderSplitData creates labels and values for the donut chart.
+func buildSenderSplitData(stats *story.Stats) (labels []string, values []int) {
+	for sender, count := range stats.SenderSplit {
+		labels = append(labels, sender)
+		values = append(values, count)
+	}
+	return
+}
+
+// buildHeatmapData converts the heatmap into a grid with pre-computed opacities.
+func buildHeatmapData(stats *story.Stats) []heatmapCell {
+	maxCount := 0
+	for _, hc := range stats.HourHeatmap {
+		if hc.Count > maxCount {
+			maxCount = hc.Count
+		}
+	}
+
+	cells := make([]heatmapCell, len(stats.HourHeatmap))
+	for i, hc := range stats.HourHeatmap {
+		opacity := 0.0
+		if maxCount > 0 && hc.Count > 0 {
+			opacity = 0.1 + 0.9*float64(hc.Count)/float64(maxCount)
+		}
+		cells[i] = heatmapCell{
+			Hour:    hc.Hour,
+			Day:     hc.Day,
+			Count:   hc.Count,
+			Opacity: math.Round(opacity*100) / 100,
+		}
+	}
+	return cells
+}

--- a/internal/viz/render_test.go
+++ b/internal/viz/render_test.go
@@ -1,0 +1,431 @@
+package viz
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/story"
+)
+
+// minimalStats returns a small but valid Stats for testing.
+func minimalStats() *story.Stats {
+	return &story.Stats{
+		TotalMessages: 142,
+		DateRange: story.DateRange{
+			Start: "2020-03-15",
+			End:   "2025-12-01",
+		},
+		Yearly: []story.YearStats{
+			{Year: "2020", Total: 40, BySender: map[string]int{"Max": 20, "Mary": 20}},
+			{Year: "2021", Total: 50, BySender: map[string]int{"Max": 30, "Mary": 20}},
+			{Year: "2022", Total: 52, BySender: map[string]int{"Max": 22, "Mary": 30}},
+		},
+		HourHeatmap: makeHeatmap(),
+		TopPhrases: []story.PhraseCount{
+			{Phrase: "love you", Count: 50, BySender: map[string]int{"Max": 30, "Mary": 20}},
+			{Phrase: "good morning", Count: 35, BySender: map[string]int{"Max": 10, "Mary": 25}},
+			{Phrase: "miss you", Count: 20, BySender: map[string]int{"Max": 12, "Mary": 8}},
+		},
+		SenderSplit: map[string]int{
+			"Max":  72,
+			"Mary": 70,
+		},
+		AvgResponseTimes: map[string]int{
+			"Max":  8,
+			"Mary": 12,
+		},
+		LongestGap: story.Gap{
+			Start: "2021-06-15",
+			End:   "2021-07-20",
+			Days:  35,
+		},
+	}
+}
+
+// makeHeatmap builds a 24x7 heatmap with a few nonzero entries.
+func makeHeatmap() []story.HourCount {
+	hm := make([]story.HourCount, 0, 168)
+	for h := 0; h < 24; h++ {
+		for d := 0; d < 7; d++ {
+			count := 0
+			if h >= 9 && h <= 22 && d >= 1 && d <= 5 {
+				count = h + d // make weekday daytime nonzero
+			}
+			hm = append(hm, story.HourCount{Hour: h, Day: d, Count: count})
+		}
+	}
+	return hm
+}
+
+// minimalStory returns a small but valid Story for testing.
+func minimalStory() *story.Story {
+	return &story.Story{
+		Title:   "Our story",
+		Summary: "A love story told through texts.",
+		Chapters: []story.Chapter{
+			{
+				Title:   "The beginning",
+				Content: "They met in spring 2020.",
+				Quotes: []story.Quote{
+					{Sender: "Max", Text: "Hey, nice to meet you!", Timestamp: "2020-03-15T10:00:00Z"},
+					{Sender: "Mary", Text: "You too! Let's chat more.", Timestamp: "2020-03-15T10:05:00Z"},
+				},
+				Period: "2020",
+			},
+			{
+				Title:   "Growing closer",
+				Content: "Through 2021 the conversation deepened.",
+				Quotes: []story.Quote{
+					{Sender: "Mary", Text: "I've been thinking about you.", Timestamp: "2021-05-10T20:00:00Z"},
+				},
+				Period: "2021",
+			},
+		},
+	}
+}
+
+// minimalConfig returns a VizConfig with all fields populated.
+func minimalConfig() VizConfig {
+	return VizConfig{
+		Person1:         "Max",
+		Person2:         "Mary",
+		PrimaryColor:    "#be123c",
+		SecondaryColor:  "#d97706",
+		AccentColor:     "#fbbf24",
+		BackgroundColor: "#0c0a09",
+		Timezone:        "America/New_York",
+		PasswordHash:    "",
+		Sections:        nil, // use default
+	}
+}
+
+func TestRenderHTMLBasic(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+	if len(html) == 0 {
+		t.Fatal("RenderHTML returned empty bytes")
+	}
+
+	s := string(html)
+
+	// Must be valid HTML document
+	if !strings.Contains(s, "<!DOCTYPE html>") {
+		t.Error("missing <!DOCTYPE html>")
+	}
+	if !strings.Contains(s, "</html>") {
+		t.Error("missing </html>")
+	}
+
+	// Must contain person names
+	if !strings.Contains(s, "Max") {
+		t.Error("missing person name Max")
+	}
+	if !strings.Contains(s, "Mary") {
+		t.Error("missing person name Mary")
+	}
+
+	// Must contain Chart.js CDN
+	if !strings.Contains(s, "cdn.jsdelivr.net/npm/chart.js") {
+		t.Error("missing Chart.js CDN link")
+	}
+
+	// Must contain CSS variable definitions
+	if !strings.Contains(s, "--primary") {
+		t.Error("missing CSS variable --primary")
+	}
+	if !strings.Contains(s, "--secondary") {
+		t.Error("missing CSS variable --secondary")
+	}
+	if !strings.Contains(s, "--accent") {
+		t.Error("missing CSS variable --accent")
+	}
+	if !strings.Contains(s, "--bg") {
+		t.Error("missing CSS variable --bg")
+	}
+	if !strings.Contains(s, "#be123c") {
+		t.Error("missing primary color value")
+	}
+
+	// Must contain Google Fonts
+	if !strings.Contains(s, "Cormorant Garamond") {
+		t.Error("missing Cormorant Garamond font reference")
+	}
+	if !strings.Contains(s, "DM Sans") {
+		t.Error("missing DM Sans font reference")
+	}
+
+	// Must contain the story title
+	if !strings.Contains(s, "Our story") {
+		t.Error("missing story title")
+	}
+
+	// Must contain message count
+	if !strings.Contains(s, "142") {
+		t.Error("missing total message count")
+	}
+}
+
+func TestRenderHTMLPasswordGate(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+	cfg.PasswordHash = "abc123def456"
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	// Must contain password gate elements
+	if !strings.Contains(s, "password-gate") {
+		t.Error("missing password-gate element")
+	}
+	if !strings.Contains(s, "abc123def456") {
+		t.Error("missing password hash in JS")
+	}
+	// Must have SubtleCrypto / SHA-256 reference
+	if !strings.Contains(s, "SHA-256") {
+		t.Error("missing SHA-256 reference for password hashing")
+	}
+}
+
+func TestRenderHTMLNoPassword(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+	cfg.PasswordHash = ""
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	// Should NOT contain password gate overlay
+	if strings.Contains(s, "password-overlay") {
+		t.Error("password overlay should not be present when PasswordHash is empty")
+	}
+}
+
+func TestRenderHTMLSections(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	// All default sections should appear
+	expectedSections := []string{
+		"section-hero",
+		"section-volume-chart",
+		"section-sender-split",
+		"section-heatmap",
+		"section-phrases",
+		"section-silence",
+	}
+	for _, sec := range expectedSections {
+		if !strings.Contains(s, sec) {
+			t.Errorf("missing section %q", sec)
+		}
+	}
+
+	// Chapter content should appear
+	if !strings.Contains(s, "The beginning") {
+		t.Error("missing chapter title 'The beginning'")
+	}
+	if !strings.Contains(s, "Growing closer") {
+		t.Error("missing chapter title 'Growing closer'")
+	}
+
+	// Chat bubble quotes should appear
+	if !strings.Contains(s, "Hey, nice to meet you!") {
+		t.Error("missing quote text")
+	}
+}
+
+func TestRenderHTMLPhraseCloud(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	// Phrases should appear in the HTML
+	if !strings.Contains(s, "love you") {
+		t.Error("missing phrase 'love you'")
+	}
+	if !strings.Contains(s, "good morning") {
+		t.Error("missing phrase 'good morning'")
+	}
+	if !strings.Contains(s, "miss you") {
+		t.Error("missing phrase 'miss you'")
+	}
+}
+
+func TestRenderHTMLHeatmap(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	// Heatmap grid should be present
+	if !strings.Contains(s, "heatmap") {
+		t.Error("missing heatmap section")
+	}
+
+	// Should contain day labels
+	dayLabels := []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
+	for _, d := range dayLabels {
+		if !strings.Contains(s, d) {
+			t.Errorf("missing day label %q", d)
+		}
+	}
+}
+
+func TestRenderHTMLResponseTimes(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	// Response time values should appear
+	if !strings.Contains(s, "8") && !strings.Contains(s, "8 min") {
+		t.Error("missing Max's response time")
+	}
+	if !strings.Contains(s, "12") && !strings.Contains(s, "12 min") {
+		t.Error("missing Mary's response time")
+	}
+}
+
+func TestRenderHTMLLongestGap(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	// Longest gap section
+	if !strings.Contains(s, "35") {
+		t.Error("missing longest gap days count (35)")
+	}
+	if !strings.Contains(s, "silence") || !strings.Contains(s, "gap") {
+		t.Error("missing silence/gap reference")
+	}
+}
+
+func TestRenderHTMLInterludes(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+	cfg.Interludes = []Interlude{
+		{Text: "Between the lines, love grew quietly.", Position: "hero"},
+	}
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	if !strings.Contains(s, "Between the lines, love grew quietly.") {
+		t.Error("missing interlude text")
+	}
+	if !strings.Contains(s, "interlude") {
+		t.Error("missing interlude class/section")
+	}
+}
+
+func TestRenderHTMLCustomSections(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+	cfg.Sections = []string{"hero", "phrases", "closing"}
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	// Should have hero and phrases
+	if !strings.Contains(s, "section-hero") {
+		t.Error("missing hero section")
+	}
+	if !strings.Contains(s, "section-phrases") {
+		t.Error("missing phrases section")
+	}
+}
+
+func TestRenderHTMLGrainOverlay(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	// Should have grain overlay CSS
+	if !strings.Contains(s, "grain") {
+		t.Error("missing grain overlay")
+	}
+}
+
+func TestRenderHTMLScrollReveal(t *testing.T) {
+	stats := minimalStats()
+	st := minimalStory()
+	cfg := minimalConfig()
+
+	html, err := RenderHTML(stats, st, cfg)
+	if err != nil {
+		t.Fatalf("RenderHTML failed: %v", err)
+	}
+
+	s := string(html)
+
+	// Should have IntersectionObserver-based scroll reveal
+	if !strings.Contains(s, "IntersectionObserver") {
+		t.Error("missing IntersectionObserver for scroll reveal")
+	}
+}

--- a/internal/viz/template.go
+++ b/internal/viz/template.go
@@ -1,0 +1,1129 @@
+package viz
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+
+	"github.com/maxghenis/openmessage/internal/story"
+)
+
+// buildTemplate creates the parsed HTML template.
+func buildTemplate() (*template.Template, error) {
+	funcMap := template.FuncMap{
+		"isChapter":   func(s section) bool { return s.Type == "chapter" },
+		"asChapter":   func(d any) story.Chapter { return d.(story.Chapter) },
+		"asString":    func(d any) string { return d.(string) },
+		"formatHour":  formatHour,
+		"dayName":     dayName,
+		"phraseSize":  phraseSize,
+		"phraseColor": phraseColor,
+		"noescape":    func(s string) template.HTML { return template.HTML(s) },
+		"noescapeJS":  func(s string) template.JS { return template.JS(s) },
+		"noescapeCSS": func(s string) template.CSS { return template.CSS(s) },
+		"seq24":       func() []int { return makeSeq(24) },
+		"seq7":        func() []int { return makeSeq(7) },
+		"mul":         func(a, b int) int { return a * b },
+		"add":         func(a, b int) int { return a + b },
+		"sub":         func(a, b int) int { return a - b },
+		"div":         func(a, b float64) float64 { if b == 0 { return 0 }; return a / b },
+	}
+
+	return template.New("viz").Funcs(funcMap).Parse(htmlTemplate)
+}
+
+func makeSeq(n int) []int {
+	s := make([]int, n)
+	for i := range s {
+		s[i] = i
+	}
+	return s
+}
+
+func formatHour(h int) string {
+	if h == 0 {
+		return "12a"
+	}
+	if h < 12 {
+		return fmt.Sprintf("%da", h)
+	}
+	if h == 12 {
+		return "12p"
+	}
+	return fmt.Sprintf("%dp", h-12)
+}
+
+func dayName(d int) string {
+	names := []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
+	if d >= 0 && d < 7 {
+		return names[d]
+	}
+	return ""
+}
+
+// phraseSize returns a CSS font-size for a phrase based on its count relative to max.
+func phraseSize(count, maxCount int) string {
+	if maxCount == 0 {
+		return "1rem"
+	}
+	// Scale from 0.8rem to 3rem
+	ratio := float64(count) / float64(maxCount)
+	size := 0.8 + ratio*2.2
+	return fmt.Sprintf("%.1frem", size)
+}
+
+// phraseColor returns a CSS color interpolated between primary and secondary based on BySender.
+// Primary represents "me" (person1), secondary represents others (person2).
+// The color blends based on the ratio of non-"me" usage.
+func phraseColor(bySender map[string]int, primary, secondary string) string {
+	if len(bySender) == 0 {
+		return primary
+	}
+	total := 0
+	for _, c := range bySender {
+		total += c
+	}
+	if total == 0 {
+		return primary
+	}
+
+	// Count messages from non-"me" senders to determine blend ratio
+	meCount := bySender["me"]
+	otherCount := total - meCount
+
+	ratio := float64(otherCount) / float64(total)
+
+	// Parse hex colors and interpolate
+	r1, g1, b1 := parseHex(primary)
+	r2, g2, b2 := parseHex(secondary)
+
+	r := int(float64(r1)*(1-ratio) + float64(r2)*ratio)
+	g := int(float64(g1)*(1-ratio) + float64(g2)*ratio)
+	b := int(float64(b1)*(1-ratio) + float64(b2)*ratio)
+
+	return fmt.Sprintf("rgb(%d, %d, %d)", r, g, b)
+}
+
+func parseHex(hex string) (r, g, b int) {
+	hex = strings.TrimPrefix(hex, "#")
+	if len(hex) == 3 {
+		hex = string([]byte{hex[0], hex[0], hex[1], hex[1], hex[2], hex[2]})
+	}
+	if len(hex) != 6 {
+		return 200, 200, 200
+	}
+	fmt.Sscanf(hex, "%02x%02x%02x", &r, &g, &b)
+	return
+}
+
+const htmlTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{.Story.Title}} — {{.Config.Person1}} & {{.Config.Person2}}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=DM+Sans:wght@300;400;500;700&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<style>
+/* ============ Design System ============ */
+:root {
+    --primary: {{.Config.PrimaryColor}};
+    --secondary: {{.Config.SecondaryColor}};
+    --accent: {{.Config.AccentColor}};
+    --bg: {{.Config.BackgroundColor}};
+    --text: #fafaf9;
+    --text-muted: #a8a29e;
+    --font-serif: 'Cormorant Garamond', Georgia, serif;
+    --font-sans: 'DM Sans', -apple-system, sans-serif;
+    --gutter: clamp(1rem, 4vw, 3rem);
+}
+
+*,
+*::before,
+*::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html {
+    font-size: 16px;
+    scroll-behavior: smooth;
+    -webkit-font-smoothing: antialiased;
+}
+
+body {
+    font-family: var(--font-sans);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    overflow-x: hidden;
+    min-height: 100vh;
+}
+
+/* Grain overlay */
+body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 9999;
+    opacity: 0.035;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='grain'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23grain)'/%3E%3C/svg%3E");
+    background-repeat: repeat;
+    background-size: 256px 256px;
+}
+
+/* ============ Typography ============ */
+h1, h2, h3 {
+    font-family: var(--font-serif);
+    font-weight: 300;
+    letter-spacing: -0.02em;
+}
+
+h1 { font-size: clamp(2.5rem, 6vw, 5rem); line-height: 1.1; }
+h2 { font-size: clamp(1.8rem, 4vw, 3rem); line-height: 1.2; }
+h3 { font-size: clamp(1.3rem, 2.5vw, 1.8rem); line-height: 1.3; }
+
+/* ============ Layout ============ */
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 var(--gutter);
+}
+
+.section {
+    padding: 6rem 0;
+    position: relative;
+}
+
+.section + .section {
+    border-top: 1px solid rgba(255,255,255,0.04);
+}
+
+/* ============ Scroll Reveal ============ */
+.reveal {
+    opacity: 0;
+    transform: translateY(40px);
+    transition: opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+                transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* ============ Password Gate ============ */
+{{if .Config.PasswordHash}}
+.password-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    background: var(--bg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 1.5rem;
+    transition: opacity 0.6s ease, visibility 0.6s ease;
+}
+
+.password-overlay.hidden {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.password-overlay h2 {
+    color: var(--text-muted);
+    font-weight: 300;
+}
+
+.password-overlay input {
+    background: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 8px;
+    padding: 0.8rem 1.2rem;
+    font-size: 1.1rem;
+    color: var(--text);
+    font-family: var(--font-sans);
+    width: 280px;
+    text-align: center;
+    outline: none;
+    transition: border-color 0.3s;
+}
+
+.password-overlay input:focus {
+    border-color: var(--primary);
+}
+
+.password-overlay .error {
+    color: var(--primary);
+    font-size: 0.85rem;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+.password-overlay .error.show {
+    opacity: 1;
+}
+
+.password-overlay button {
+    background: var(--primary);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 0.7rem 2rem;
+    font-size: 1rem;
+    font-family: var(--font-sans);
+    cursor: pointer;
+    transition: transform 0.2s, opacity 0.2s;
+}
+
+.password-overlay button:hover {
+    transform: scale(1.03);
+}
+{{end}}
+
+/* ============ Hero ============ */
+.hero {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 4rem var(--gutter);
+    position: relative;
+}
+
+.hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 600px;
+    height: 600px;
+    border-radius: 50%;
+    background: radial-gradient(circle, var(--primary) 0%, transparent 70%);
+    opacity: 0.06;
+    pointer-events: none;
+}
+
+.hero-names {
+    font-family: var(--font-serif);
+    font-size: clamp(3rem, 8vw, 6.5rem);
+    font-weight: 300;
+    line-height: 1.05;
+    margin-bottom: 1.5rem;
+}
+
+.hero-names .ampersand {
+    display: block;
+    font-size: 0.5em;
+    color: var(--accent);
+    font-style: italic;
+    line-height: 1.6;
+}
+
+.hero-subtitle {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-size: clamp(1.1rem, 2.5vw, 1.5rem);
+    color: var(--text-muted);
+    margin-bottom: 3rem;
+    max-width: 500px;
+}
+
+.hero-stats {
+    display: flex;
+    gap: 3rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.hero-stat {
+    text-align: center;
+}
+
+.hero-stat .number {
+    font-family: var(--font-serif);
+    font-size: clamp(2rem, 4vw, 3rem);
+    font-weight: 600;
+    color: var(--accent);
+    display: block;
+}
+
+.hero-stat .label {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+}
+
+/* ============ Chapters ============ */
+.chapter {
+    padding: 5rem 0;
+}
+
+.chapter-period {
+    font-size: 0.75rem;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    margin-bottom: 0.5rem;
+}
+
+.chapter h2 {
+    margin-bottom: 1.5rem;
+    color: var(--text);
+}
+
+.chapter-content {
+    font-size: 1.05rem;
+    line-height: 1.8;
+    color: var(--text-muted);
+    margin-bottom: 2rem;
+}
+
+/* Chat bubbles */
+.chat-bubbles {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+    max-width: 600px;
+    margin: 2rem auto;
+}
+
+.bubble {
+    max-width: 80%;
+    padding: 0.75rem 1rem;
+    border-radius: 18px;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    position: relative;
+    animation: bubbleFade 0.6s ease both;
+}
+
+.bubble-left {
+    align-self: flex-start;
+    background: rgba(255,255,255,0.08);
+    border-bottom-left-radius: 4px;
+    color: var(--text);
+}
+
+.bubble-right {
+    align-self: flex-end;
+    background: var(--primary);
+    border-bottom-right-radius: 4px;
+    color: white;
+}
+
+.bubble-sender {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    opacity: 0.6;
+    margin-bottom: 0.2rem;
+}
+
+.bubble-time {
+    font-size: 0.65rem;
+    opacity: 0.5;
+    margin-top: 0.3rem;
+    text-align: right;
+}
+
+@keyframes bubbleFade {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* ============ Volume Chart ============ */
+.chart-wrapper {
+    position: relative;
+    width: 100%;
+    max-height: 400px;
+}
+
+.chart-wrapper canvas {
+    width: 100% !important;
+}
+
+/* ============ Sender Split ============ */
+.donut-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 3rem;
+    flex-wrap: wrap;
+}
+
+.donut-chart {
+    width: 220px;
+    height: 220px;
+}
+
+.donut-legend {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+}
+
+.legend-swatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+}
+
+.legend-label {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.legend-value {
+    font-family: var(--font-serif);
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--text);
+}
+
+/* ============ Response Times ============ */
+.response-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    margin-top: 2rem;
+}
+
+.response-bar {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.response-bar .name {
+    width: 80px;
+    text-align: right;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.response-bar .bar-track {
+    flex: 1;
+    height: 8px;
+    background: rgba(255,255,255,0.06);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.response-bar .bar-fill {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 1s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.response-bar .time {
+    width: 80px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+/* ============ Heatmap ============ */
+.heatmap-grid {
+    display: grid;
+    grid-template-columns: 50px repeat(7, 1fr);
+    grid-template-rows: auto repeat(24, 1fr);
+    gap: 2px;
+    max-width: 600px;
+    margin: 2rem auto;
+}
+
+.heatmap-header {
+    text-align: center;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.3rem;
+}
+
+.heatmap-hour {
+    text-align: right;
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    padding: 0.2rem 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.heatmap-cell {
+    aspect-ratio: 1;
+    border-radius: 3px;
+    min-height: 16px;
+    transition: transform 0.2s;
+    cursor: default;
+    position: relative;
+}
+
+.heatmap-cell:hover {
+    transform: scale(1.3);
+    z-index: 1;
+}
+
+.heatmap-cell[title]:hover::after {
+    content: attr(title);
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0,0,0,0.85);
+    color: var(--text);
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.65rem;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
+/* ============ Phrase Cloud ============ */
+.phrase-cloud {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: baseline;
+    gap: 0.6rem 1.2rem;
+    padding: 2rem 0;
+}
+
+.phrase {
+    font-family: var(--font-serif);
+    font-weight: 400;
+    cursor: default;
+    transition: transform 0.2s, opacity 0.2s;
+    position: relative;
+    line-height: 1.3;
+}
+
+.phrase:hover {
+    transform: scale(1.1);
+}
+
+.phrase .tooltip {
+    display: none;
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0,0,0,0.9);
+    color: var(--text);
+    padding: 0.4rem 0.8rem;
+    border-radius: 6px;
+    font-family: var(--font-sans);
+    font-size: 0.75rem;
+    white-space: nowrap;
+    z-index: 10;
+}
+
+.phrase:hover .tooltip {
+    display: block;
+}
+
+/* ============ Longest Gap / Silence ============ */
+.silence-card {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 16px;
+    padding: 3rem;
+    text-align: center;
+    max-width: 500px;
+    margin: 0 auto;
+}
+
+.silence-card .days {
+    font-family: var(--font-serif);
+    font-size: clamp(3rem, 6vw, 5rem);
+    font-weight: 300;
+    color: var(--accent);
+    line-height: 1;
+}
+
+.silence-card .days-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--text-muted);
+    margin-top: 0.3rem;
+}
+
+.silence-card .gap-dates {
+    margin-top: 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+/* ============ Interludes ============ */
+.interlude {
+    text-align: center;
+    padding: 4rem var(--gutter);
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.interlude-text {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+    color: var(--text-muted);
+    line-height: 1.8;
+}
+
+/* ============ Photos ============ */
+.photo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 0.5rem;
+}
+
+.photo-grid img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-radius: 8px;
+    transition: transform 0.3s;
+}
+
+.photo-grid img:hover {
+    transform: scale(1.05);
+}
+
+/* ============ Closing ============ */
+.closing {
+    text-align: center;
+    padding: 8rem var(--gutter);
+}
+
+.closing h2 {
+    font-size: clamp(1.5rem, 3vw, 2.5rem);
+    color: var(--text-muted);
+    font-weight: 300;
+}
+
+.closing .still-writing {
+    margin-top: 1rem;
+    font-size: 0.85rem;
+    color: var(--accent);
+    font-style: italic;
+}
+
+/* ============ Responsive ============ */
+@media (max-width: 640px) {
+    .hero-stats {
+        gap: 1.5rem;
+    }
+    .donut-wrapper {
+        flex-direction: column;
+    }
+    .heatmap-grid {
+        grid-template-columns: 40px repeat(7, 1fr);
+    }
+}
+</style>
+</head>
+<body>
+
+{{if .Config.PasswordHash}}
+<!-- Password Gate -->
+<div class="password-overlay" id="password-gate">
+    <h2>Enter the password</h2>
+    <input type="password" id="pw-input" placeholder="Password" autocomplete="off" autofocus>
+    <div class="error" id="pw-error">Incorrect password</div>
+    <button onclick="checkPassword()">Unlock</button>
+</div>
+<script>
+(function() {
+    var expectedHash = '{{.Config.PasswordHash}}';
+
+    window.checkPassword = async function() {
+        var input = document.getElementById('pw-input').value;
+        var encoder = new TextEncoder();
+        var data = encoder.encode(input);
+        var hashBuf = await crypto.subtle.digest('SHA-256', data);
+        var hashArr = Array.from(new Uint8Array(hashBuf));
+        var hashHex = hashArr.map(function(b) { return b.toString(16).padStart(2, '0'); }).join('');
+
+        if (hashHex === expectedHash) {
+            document.getElementById('password-gate').classList.add('hidden');
+        } else {
+            document.getElementById('pw-error').classList.add('show');
+            document.getElementById('pw-input').value = '';
+            setTimeout(function() {
+                document.getElementById('pw-error').classList.remove('show');
+            }, 2000);
+        }
+    };
+
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' && document.getElementById('password-gate') &&
+            !document.getElementById('password-gate').classList.contains('hidden')) {
+            checkPassword();
+        }
+    });
+})();
+</script>
+{{end}}
+
+<!-- Main Content -->
+<main id="main-content">
+{{range $i, $sec := .Sections}}
+{{if eq $sec.Type "hero"}}
+<!-- ==================== HERO ==================== -->
+<section class="hero section reveal" id="section-hero">
+    <div class="hero-names">
+        {{$.Config.Person1}}<span class="ampersand">&amp;</span>{{$.Config.Person2}}
+    </div>
+    {{if $.Story}}
+    <div class="hero-subtitle">{{$.Story.Summary}}</div>
+    {{end}}
+    <div class="hero-stats">
+        <div class="hero-stat">
+            <span class="number">{{$.Stats.TotalMessages}}</span>
+            <span class="label">Messages</span>
+        </div>
+        <div class="hero-stat">
+            <span class="number">{{$.DaysSpan}}</span>
+            <span class="label">Days</span>
+        </div>
+        <div class="hero-stat">
+            <span class="number">{{$.MessagesPerDay}}</span>
+            <span class="label">Per day</span>
+        </div>
+    </div>
+</section>
+
+{{else if eq $sec.Type "chapter"}}
+<!-- ==================== CHAPTER ==================== -->
+{{$ch := asChapter $sec.Data}}
+<section class="chapter section reveal" id="section-chapter-{{$i}}">
+    <div class="container">
+        <div class="chapter-period">{{$ch.Period}}</div>
+        <h2>{{$ch.Title}}</h2>
+        <div class="chapter-content">{{$ch.Content}}</div>
+        {{if $ch.Quotes}}
+        <div class="chat-bubbles">
+            {{range $ch.Quotes}}
+            <div class="bubble {{if eq .Sender $.Config.Person1}}bubble-right{{else}}bubble-left{{end}}">
+                <div class="bubble-sender">{{.Sender}}</div>
+                <div>{{.Text}}</div>
+                {{if .Timestamp}}<div class="bubble-time">{{.Timestamp}}</div>{{end}}
+            </div>
+            {{end}}
+        </div>
+        {{end}}
+    </div>
+</section>
+
+{{else if eq $sec.Type "volume-chart"}}
+<!-- ==================== VOLUME CHART ==================== -->
+<section class="section reveal" id="section-volume-chart">
+    <div class="container">
+        <h2>Messages over time</h2>
+        <div class="chart-wrapper" style="margin-top: 2rem;">
+            <canvas id="volumeChart"></canvas>
+        </div>
+    </div>
+</section>
+
+{{else if eq $sec.Type "sender-split"}}
+<!-- ==================== SENDER SPLIT ==================== -->
+<section class="section reveal" id="section-sender-split">
+    <div class="container">
+        <h2>Who texts more?</h2>
+        <div class="donut-wrapper" style="margin-top: 2rem;">
+            <div class="donut-chart">
+                <canvas id="donutChart"></canvas>
+            </div>
+            <div class="donut-legend">
+                {{range $sender, $count := $.Stats.SenderSplit}}
+                <div class="legend-item">
+                    <div class="legend-swatch" style="background: {{if eq $sender $.Config.Person1}}{{$.Config.PrimaryColor}}{{else}}{{$.Config.SecondaryColor}}{{end}};"></div>
+                    <div>
+                        <div class="legend-label">{{$sender}}</div>
+                        <div class="legend-value">{{$count}}</div>
+                    </div>
+                </div>
+                {{end}}
+            </div>
+        </div>
+        {{if $.Stats.AvgResponseTimes}}
+        <h3 style="margin-top: 3rem;">Average response time</h3>
+        <div class="response-bars">
+            {{range $sender, $minutes := $.Stats.AvgResponseTimes}}
+            <div class="response-bar">
+                <span class="name">{{$sender}}</span>
+                <div class="bar-track">
+                    <div class="bar-fill" style="width: 0%; background: {{if eq $sender $.Config.Person1}}{{$.Config.PrimaryColor}}{{else}}{{$.Config.SecondaryColor}}{{end}};" data-width="{{$minutes}}"></div>
+                </div>
+                <span class="time">{{$minutes}} min</span>
+            </div>
+            {{end}}
+        </div>
+        {{end}}
+    </div>
+</section>
+
+{{else if eq $sec.Type "heatmap"}}
+<!-- ==================== HEATMAP ==================== -->
+<section class="section reveal" id="section-heatmap">
+    <div class="container">
+        <h2>When do you talk?</h2>
+        <div class="heatmap-grid" style="margin-top: 2rem;">
+            <!-- Header row -->
+            <div class="heatmap-header"></div>
+            {{range seq7}}
+            <div class="heatmap-header">{{dayName .}}</div>
+            {{end}}
+            <!-- Data rows (24 hours) -->
+            {{range $h := seq24}}
+            <div class="heatmap-hour">{{formatHour $h}}</div>
+            {{range $d := seq7}}
+            <div class="heatmap-cell" id="hm-{{$h}}-{{$d}}"></div>
+            {{end}}
+            {{end}}
+        </div>
+    </div>
+</section>
+
+{{else if eq $sec.Type "phrases"}}
+<!-- ==================== PHRASE CLOUD ==================== -->
+<section class="section reveal" id="section-phrases">
+    <div class="container">
+        <h2>Your words</h2>
+        <div class="phrase-cloud">
+            {{$maxCount := 0}}
+            {{range $.Stats.TopPhrases}}{{if gt .Count $maxCount}}{{$maxCount = .Count}}{{end}}{{end}}
+            {{range $.Stats.TopPhrases}}
+            <span class="phrase"
+                style="font-size: {{phraseSize .Count $maxCount}}; color: {{phraseColor .BySender $.Config.PrimaryColor $.Config.SecondaryColor}};">
+                {{.Phrase}}
+                <span class="tooltip">
+                    {{.Phrase}}: {{.Count}} times
+                    {{range $sender, $count := .BySender}}
+                    <br>{{$sender}}: {{$count}}
+                    {{end}}
+                </span>
+            </span>
+            {{end}}
+        </div>
+    </div>
+</section>
+
+{{else if eq $sec.Type "silence"}}
+<!-- ==================== LONGEST GAP ==================== -->
+{{if gt $.Stats.LongestGap.Days 0}}
+<section class="section reveal" id="section-silence">
+    <div class="container">
+        <h2>The longest silence</h2>
+        <div class="silence-card" style="margin-top: 2rem;">
+            <div class="days">{{$.Stats.LongestGap.Days}}</div>
+            <div class="days-label">days of silence</div>
+            <div class="gap-dates">{{$.Stats.LongestGap.Start}} &mdash; {{$.Stats.LongestGap.End}}</div>
+        </div>
+    </div>
+</section>
+{{end}}
+
+{{else if eq $sec.Type "photos"}}
+<!-- ==================== PHOTOS ==================== -->
+{{if $.Config.PhotoPaths}}
+<section class="section reveal" id="section-photos">
+    <div class="container">
+        <h2>Moments</h2>
+        <div class="photo-grid" style="margin-top: 2rem;">
+            {{range $.Config.PhotoPaths}}
+            <img src="{{.}}" alt="Photo" loading="lazy">
+            {{end}}
+        </div>
+    </div>
+</section>
+{{end}}
+
+{{else if eq $sec.Type "closing"}}
+<!-- ==================== CLOSING ==================== -->
+<section class="closing section reveal" id="section-closing">
+    <h2>{{$.Stats.DateRange.Start}} &mdash; {{$.Stats.DateRange.End}}</h2>
+    <div class="still-writing">still writing...</div>
+</section>
+
+{{else if eq $sec.Type "interlude"}}
+<!-- ==================== INTERLUDE ==================== -->
+<div class="interlude reveal">
+    <div class="interlude-text">{{asString $sec.Data}}</div>
+</div>
+
+{{else if eq $sec.Type "timeline-nav"}}
+<!-- ==================== TIMELINE NAV ==================== -->
+{{if $.Story}}
+<nav class="section" id="section-timeline-nav" style="text-align: center;">
+    <div class="container">
+        {{range $ci, $ch := $.Story.Chapters}}
+        <a href="#" style="color: var(--text-muted); text-decoration: none; margin: 0 1rem; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.1em;">{{$ch.Period}}</a>
+        {{end}}
+    </div>
+</nav>
+{{end}}
+
+{{end}}
+{{end}}
+</main>
+
+<!-- ==================== SCRIPTS ==================== -->
+<script>
+(function() {
+    'use strict';
+
+    // ---- Scroll Reveal via IntersectionObserver ----
+    var observer = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('visible');
+            }
+        });
+    }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+
+    document.querySelectorAll('.reveal').forEach(function(el) {
+        observer.observe(el);
+    });
+
+    // ---- Chart.js Global Config ----
+    Chart.defaults.color = '#a8a29e';
+    Chart.defaults.font.family = "'DM Sans', sans-serif";
+    Chart.defaults.plugins.legend.display = false;
+
+    // ---- Volume Chart (Stacked Bar) ----
+    var volumeEl = document.getElementById('volumeChart');
+    if (volumeEl) {
+        var vCtx = volumeEl.getContext('2d');
+        new Chart(vCtx, {
+            type: 'bar',
+            data: {
+                labels: {{noescapeJS .MonthlyLabelsJSON}},
+                datasets: [
+                    {
+                        label: '{{.Config.Person1}}',
+                        data: {{noescapeJS .MonthlySeries1JSON}},
+                        backgroundColor: '{{.Config.PrimaryColor}}',
+                        borderRadius: 2,
+                    },
+                    {
+                        label: '{{.Config.Person2}}',
+                        data: {{noescapeJS .MonthlySeries2JSON}},
+                        backgroundColor: '{{.Config.SecondaryColor}}',
+                        borderRadius: 2,
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: {
+                        stacked: true,
+                        grid: { display: false },
+                        ticks: {
+                            maxRotation: 45,
+                            autoSkip: true,
+                            maxTicksLimit: 24,
+                            font: { size: 10 }
+                        }
+                    },
+                    y: {
+                        stacked: true,
+                        grid: { color: 'rgba(255,255,255,0.04)' },
+                        ticks: { font: { size: 10 } }
+                    }
+                },
+                plugins: {
+                    legend: { display: true, position: 'top', labels: { boxWidth: 12, padding: 20 } },
+                    tooltip: {
+                        backgroundColor: 'rgba(0,0,0,0.8)',
+                        titleFont: { size: 12 },
+                        bodyFont: { size: 11 },
+                    }
+                }
+            }
+        });
+    }
+
+    // ---- Donut Chart ----
+    var donutEl = document.getElementById('donutChart');
+    if (donutEl) {
+        var dCtx = donutEl.getContext('2d');
+        new Chart(dCtx, {
+            type: 'doughnut',
+            data: {
+                labels: {{noescapeJS .SenderLabelsJSON}},
+                datasets: [{
+                    data: {{noescapeJS .SenderValuesJSON}},
+                    backgroundColor: ['{{.Config.PrimaryColor}}', '{{.Config.SecondaryColor}}'],
+                    borderWidth: 0,
+                    borderRadius: 4,
+                    spacing: 4,
+                }]
+            },
+            options: {
+                responsive: true,
+                cutout: '70%',
+                plugins: {
+                    legend: { display: false }
+                }
+            }
+        });
+    }
+
+    // ---- Heatmap Coloring ----
+    var heatmapData = {{noescapeJS .HeatmapJSON}};
+    var primaryColor = '{{.Config.PrimaryColor}}';
+    heatmapData.forEach(function(cell) {
+        var el = document.getElementById('hm-' + cell.Hour + '-' + cell.Day);
+        if (el) {
+            if (cell.Count > 0) {
+                el.style.backgroundColor = primaryColor;
+                el.style.opacity = cell.Opacity;
+            } else {
+                el.style.backgroundColor = 'rgba(255,255,255,0.03)';
+            }
+            el.title = cell.Count + ' messages';
+        }
+    });
+
+    // ---- Response Bar Animation ----
+    document.querySelectorAll('.response-bar .bar-fill').forEach(function(bar) {
+        var width = parseInt(bar.dataset.width, 10);
+        // Scale to max 100%: find max among siblings
+        var maxWidth = 0;
+        document.querySelectorAll('.response-bar .bar-fill').forEach(function(b) {
+            var w = parseInt(b.dataset.width, 10);
+            if (w > maxWidth) maxWidth = w;
+        });
+        var pct = maxWidth > 0 ? Math.round((width / maxWidth) * 100) : 0;
+        setTimeout(function() {
+            bar.style.width = pct + '%';
+        }, 500);
+    });
+})();
+</script>
+</body>
+</html>`

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -596,7 +596,7 @@ func APIHandlerFull(store *db.Store, cli *client.Client, logger zerolog.Logger, 
 			httpError(w, "no messages found", 404)
 			return
 		}
-		stats := story.ComputeStats(msgs)
+		stats := story.ComputeStats(msgs, nil)
 		writeJSON(w, stats)
 	})
 


### PR DESCRIPTION
## Summary

- New `internal/viz/` package that renders self-contained HTML relationship visualizations
- Stats engine extended with per-sender phrase tracking (`BySender`) and configurable timezone for heatmap bucketing
- New `generate_viz` MCP tool orchestrating the full pipeline: collect messages → compute stats → generate narrative → render HTML

## What's in the viz

Data dashboards:
- Monthly volume stacked bar chart (Chart.js)
- Sender split donut chart
- Response time comparison bars
- Hour-of-week heatmap (timezone-aware)
- Phrase cloud colored by sender ratio with per-person hover counts
- Longest gap/silence callout

Narrative elements:
- Chronological chapters with prose and verbatim chat exchanges
- Interlude sections (poetic breaks between data)
- Photo gallery support

Infrastructure:
- Password gate (client-side SHA-256)
- Composable section ordering via `VizConfig.Sections`
- CSS variable theming (any color palette)
- Scroll-reveal animations, grain overlay, Cormorant Garamond + DM Sans typography
- Self-contained HTML (inline CSS/JS, only CDN for fonts + Chart.js)

## New files

| File | Purpose |
|------|---------|
| `internal/viz/config.go` | `VizConfig` struct, `DefaultSections()` |
| `internal/viz/render.go` | `RenderHTML()` orchestrator, Chart.js data builders |
| `internal/viz/template.go` | Full HTML template with all sections |
| `internal/viz/photos.go` | `FindMediaMessages()` media filter |
| `internal/tools/viz.go` | `generate_viz` MCP tool handler |

## Test plan

- [x] `go test ./internal/story/ -v` — per-sender phrase counts, timezone heatmap shifting
- [x] `go test ./internal/viz/ -v` — template rendering (password gate, sections, phrases, heatmap, interludes, scroll-reveal)
- [x] `go test ./... -v` — full suite (10 packages, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)