### PR TITLE
Add group text support via CLI and MCP tool

### DIFF
--- a/cmd/binary_test.go
+++ b/cmd/binary_test.go
@@ -60,3 +60,36 @@ func TestBuiltBinaryAcceptsPairCommand(t *testing.T) {
 		t.Errorf("binary panicked:\n%s", output)
 	}
 }
+
+// TestBuiltBinaryRejectsSendGroupNoArgs verifies that running "send-group"
+// with no additional arguments exits non-zero and prints usage information.
+func TestBuiltBinaryRejectsSendGroupNoArgs(t *testing.T) {
+	// Build the binary
+	tmpDir := t.TempDir()
+	binary := filepath.Join(tmpDir, "openmessage")
+	build := exec.Command("go", "build", "-o", binary, "..")
+	build.Dir = filepath.Join(".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build failed: %v\n%s", err, out)
+	}
+
+	// Run with "send-group" and no args — use a temp data dir so it doesn't touch real data
+	dataDir := filepath.Join(tmpDir, "data")
+	os.MkdirAll(dataDir, 0700)
+
+	cmd := exec.Command(binary, "send-group")
+	cmd.Env = append(os.Environ(), "OPENMESSAGES_DATA_DIR="+dataDir)
+
+	out, err := cmd.CombinedOutput()
+	output := string(out)
+
+	// Should exit with non-zero status
+	if err == nil {
+		t.Fatal("expected non-zero exit code, but command succeeded")
+	}
+
+	// Should contain usage information
+	if !strings.Contains(output, "Usage") && !strings.Contains(output, "send-group") {
+		t.Errorf("expected output to contain 'Usage' or 'send-group', got:\n%s", output)
+	}
+}

--- a/cmd/send_group.go
+++ b/cmd/send_group.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+
+	"github.com/maxghenis/openmessage/internal/app"
+)
+
+func RunSendGroup(logger zerolog.Logger, phones []string, message string) error {
+	a, err := app.New(logger)
+	if err != nil {
+		return fmt.Errorf("init app: %w", err)
+	}
+	defer a.Close()
+
+	if err := a.LoadAndConnect(); err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+
+	numbers := make([]*gmproto.ContactNumber, len(phones))
+	for i, phone := range phones {
+		numbers[i] = &gmproto.ContactNumber{
+			MysteriousInt: 7,
+			Number:        phone,
+			Number2:       phone,
+		}
+	}
+
+	convResp, err := a.Client.GM.GetOrCreateConversation(&gmproto.GetOrCreateConversationRequest{
+		Numbers: numbers,
+	})
+	if err != nil {
+		return fmt.Errorf("get/create group conversation: %w", err)
+	}
+
+	conv := convResp.GetConversation()
+	if conv == nil {
+		return fmt.Errorf("no conversation returned")
+	}
+
+	tmpID := uuid.NewString()
+	_, err = a.Client.GM.SendMessage(&gmproto.SendMessageRequest{
+		ConversationID: conv.GetConversationID(),
+		TmpID:          tmpID,
+		MessagePayload: &gmproto.MessagePayload{
+			TmpID:          tmpID,
+			TmpID2:         tmpID,
+			ConversationID: conv.GetConversationID(),
+			ParticipantID:  conv.GetDefaultOutgoingID(),
+			MessageInfo: []*gmproto.MessageInfo{
+				{
+					Data: &gmproto.MessageInfo_MessageContent{
+						MessageContent: &gmproto.MessageContent{
+							Content: message,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("send: %w", err)
+	}
+
+	logger.Info().
+		Str("conversation", conv.GetConversationID()).
+		Str("recipients", strings.Join(phones, ", ")).
+		Msg("Group message sent")
+	return nil
+}

--- a/internal/tools/send_group_message.go
+++ b/internal/tools/send_group_message.go
@@ -1,0 +1,99 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+
+	"github.com/maxghenis/openmessage/internal/app"
+)
+
+func sendGroupMessageTool() mcp.Tool {
+	return mcp.NewTool("send_group_message",
+		mcp.WithDescription("Send a text message to a group conversation (MMS group). Creates the group if it doesn't exist."),
+		mcp.WithString("phone_numbers", mcp.Required(), mcp.Description(`JSON array of phone numbers with country code, e.g. ["+15551234567", "+15559876543"]`)),
+		mcp.WithString("message", mcp.Required(), mcp.Description("Message text to send")),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+	)
+}
+
+func sendGroupMessageHandler(a *app.App) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		phonesRaw := strArg(args, "phone_numbers")
+		message := strArg(args, "message")
+
+		if phonesRaw == "" {
+			return errorResult("phone_numbers is required"), nil
+		}
+		if message == "" {
+			return errorResult("message is required"), nil
+		}
+
+		var phones []string
+		if err := json.Unmarshal([]byte(phonesRaw), &phones); err != nil {
+			return errorResult(fmt.Sprintf("phone_numbers must be a JSON array of strings: %v", err)), nil
+		}
+		if len(phones) < 2 {
+			return errorResult("phone_numbers must contain at least 2 numbers for a group message"), nil
+		}
+
+		if a.Client == nil {
+			return errorResult("not connected to Google Messages"), nil
+		}
+
+		numbers := make([]*gmproto.ContactNumber, len(phones))
+		for i, phone := range phones {
+			numbers[i] = &gmproto.ContactNumber{
+				MysteriousInt: 7,
+				Number:        phone,
+				Number2:       phone,
+			}
+		}
+
+		convResp, err := a.Client.GM.GetOrCreateConversation(&gmproto.GetOrCreateConversationRequest{
+			Numbers: numbers,
+		})
+		if err != nil {
+			return errorResult(fmt.Sprintf("failed to get/create group conversation: %v", err)), nil
+		}
+
+		conv := convResp.GetConversation()
+		if conv == nil {
+			return errorResult("no conversation returned"), nil
+		}
+
+		tmpID := uuid.NewString()
+		_, err = a.Client.GM.SendMessage(&gmproto.SendMessageRequest{
+			ConversationID: conv.GetConversationID(),
+			TmpID:          tmpID,
+			MessagePayload: &gmproto.MessagePayload{
+				TmpID:          tmpID,
+				TmpID2:         tmpID,
+				ConversationID: conv.GetConversationID(),
+				ParticipantID:  conv.GetDefaultOutgoingID(),
+				MessageInfo: []*gmproto.MessageInfo{
+					{
+						Data: &gmproto.MessageInfo_MessageContent{
+							MessageContent: &gmproto.MessageContent{
+								Content: message,
+							},
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			return errorResult(fmt.Sprintf("failed to send group message: %v", err)), nil
+		}
+
+		return textResult(fmt.Sprintf("Group message sent to %s: %s", strings.Join(phones, ", "), message)), nil
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -29,6 +29,7 @@ func Register(s *server.MCPServer, a *app.App) {
 	s.AddTool(generateVizTool(), generateVizHandler(a))
 	s.AddTool(getPersonMessagesRangeTool(), getPersonMessagesRangeHandler(a))
 	s.AddTool(renderStoryTool(), renderStoryHandler(a))
+	s.AddTool(sendGroupMessageTool(), sendGroupMessageHandler(a))
 }
 
 func strArg(args map[string]any, key string) string {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -444,6 +444,111 @@ func TestDownloadMediaMissingID(t *testing.T) {
 	}
 }
 
+func TestSendGroupMessageNotConnected(t *testing.T) {
+	a := testApp(t)
+
+	handler := sendGroupMessageHandler(a)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"phone_numbers": `["+15551234567", "+15559876543"]`,
+		"message":       "Hello group",
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error when not connected")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !contains(text, "not connected") {
+		t.Errorf("expected 'not connected' error, got: %s", text)
+	}
+}
+
+func TestSendGroupMessageMissingPhones(t *testing.T) {
+	a := testApp(t)
+
+	handler := sendGroupMessageHandler(a)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"message": "Hello group",
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for missing phone_numbers")
+	}
+}
+
+func TestSendGroupMessageMissingMessage(t *testing.T) {
+	a := testApp(t)
+
+	handler := sendGroupMessageHandler(a)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"phone_numbers": `["+15551234567", "+15559876543"]`,
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for missing message")
+	}
+}
+
+func TestSendGroupMessageInvalidJSON(t *testing.T) {
+	a := testApp(t)
+
+	handler := sendGroupMessageHandler(a)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"phone_numbers": "not json",
+		"message":       "Hello group",
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for invalid JSON")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !contains(text, "JSON array") {
+		t.Errorf("expected JSON array error, got: %s", text)
+	}
+}
+
+func TestSendGroupMessageTooFewNumbers(t *testing.T) {
+	a := testApp(t)
+
+	handler := sendGroupMessageHandler(a)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"phone_numbers": `["+15551234567"]`,
+		"message":       "Hello group",
+	}
+
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for too few numbers")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !contains(text, "at least 2") {
+		t.Errorf("expected 'at least 2' error, got: %s", text)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rs/zerolog"
 
@@ -19,6 +20,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "  pair                                      - Pair with your phone via QR code")
 		fmt.Fprintln(os.Stderr, "  serve                                     - Start MCP server (stdio)")
 		fmt.Fprintln(os.Stderr, "  send <conversation_id> <msg>              - Send message to a conversation")
+		fmt.Fprintln(os.Stderr, "  send-group <phone1,phone2,...> <msg>       - Send group message (MMS)")
 		fmt.Fprintln(os.Stderr, "  import gchat <groups-dir> [--email you@]  - Import Google Chat Takeout")
 		fmt.Fprintln(os.Stderr, "  import gchat-conversation <messages.json> - Import single GChat conversation")
 		fmt.Fprintln(os.Stderr, "  import imessage [db-path]                 - Import iMessage (needs Full Disk Access)")
@@ -38,6 +40,13 @@ func main() {
 			os.Exit(1)
 		}
 		err = cmd.RunSend(logger, os.Args[2], os.Args[3])
+	case "send-group":
+		if len(os.Args) < 4 {
+			fmt.Fprintln(os.Stderr, "Usage: openmessage send-group <phone1,phone2,...> <message>")
+			os.Exit(1)
+		}
+		phones := strings.Split(os.Args[2], ",")
+		err = cmd.RunSendGroup(logger, phones, os.Args[3])
 	case "import":
 		if len(os.Args) < 3 {
 			fmt.Fprintln(os.Stderr, "Usage: openmessage import <gchat|gchat-conversation|imessage|whatsapp> [args...]")


### PR DESCRIPTION
## Summary
- New `send_group_message` MCP tool: accepts JSON array of phone numbers + message, creates/finds group conversation via GM protocol
- New `send-group` CLI command: `openmessage send-group "+15551234567,+15559876543" "message"`
- Input validation (JSON parsing, min 2 numbers) runs before connection check for better UX
- Usage string updated to include `send-group`
- 5 unit tests for MCP tool (not connected, missing phones, missing message, invalid JSON, too few numbers)
- Binary test for CLI command (rejects missing args)

## Test plan
- [x] `go test ./...` — all pass
- [x] Binary builds and `send-group` appears in usage
- [ ] Re-pair GM connection (`openmessage pair`)
- [ ] Test `openmessage send <existing_conv_id> "test"` for basic send
- [ ] Test `openmessage send-group "+1xxx,+1yyy" "test"` end-to-end
- [ ] Verify MCP tool via Claude Code session

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)