### PR TITLE
Add SSE push updates for the web UI

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -28,6 +28,11 @@ func RunServe(logger zerolog.Logger) error {
 	}
 	defer a.Close()
 
+	events := web.NewEventBroker()
+	a.OnConversationsChange = events.PublishConversations
+	a.OnMessagesChange = events.PublishMessages
+	a.OnStatusChange = events.PublishStatus
+
 	// Connect to Google Messages (skip in demo mode)
 	if os.Getenv("OPENMESSAGES_DEMO") == "" {
 		if err := a.LoadAndConnect(); err != nil {
@@ -72,6 +77,7 @@ func RunServe(logger zerolog.Logger) error {
 	identityName := app.LocalIdentityName()
 	lastImportErr := map[string]string{}
 	syncLocalPlatforms := func() {
+		changed := false
 		syncPlatform := func(platform, successMsg string, importFromDB func(*db.Store) (*importer.ImportResult, error)) {
 			result, err := importFromDB(a.Store)
 			if err != nil {
@@ -83,6 +89,7 @@ func RunServe(logger zerolog.Logger) error {
 			}
 
 			lastImportErr[platform] = ""
+			changed = true
 			logger.Info().
 				Int("messages", result.MessagesImported).
 				Int("conversations", result.ConversationsCreated).
@@ -95,6 +102,10 @@ func RunServe(logger zerolog.Logger) error {
 		syncPlatform("imessage", "iMessage sync complete", func(store *db.Store) (*importer.ImportResult, error) {
 			return (&importer.IMessage{MyName: identityName}).ImportFromDB(store)
 		})
+		if changed {
+			events.PublishConversations()
+			events.PublishMessages("")
+		}
 	}
 
 	// Run once immediately, then every 30 seconds
@@ -135,6 +146,7 @@ func RunServe(logger zerolog.Logger) error {
 
 	httpHandler := web.APIHandlerWithOptions(a.Store, nil, logger, sseSrv, web.APIOptions{
 		Client:            a.GetClient,
+		Events:            events,
 		IsConnected:       func() bool { return a.Connected.Load() },
 		Unpair:            a.Unpair,
 		StartDeepBackfill: a.StartDeepBackfill,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -100,14 +100,17 @@ func (p *BackfillProgress) snapshot() BackfillProgress {
 }
 
 type App struct {
-	clientMu     sync.RWMutex
-	Client       *client.Client
-	Store        *db.Store
-	EventHandler *client.EventHandler
-	Logger       zerolog.Logger
-	DataDir      string
-	SessionPath  string
-	Connected    atomic.Bool
+	clientMu              sync.RWMutex
+	Client                *client.Client
+	Store                 *db.Store
+	EventHandler          *client.EventHandler
+	Logger                zerolog.Logger
+	DataDir               string
+	SessionPath           string
+	Connected             atomic.Bool
+	OnConversationsChange func()
+	OnMessagesChange      func(string)
+	OnStatusChange        func(bool)
 
 	// gmClient is used by backfill methods. If nil, it's derived from Client.GM.
 	// Set this field directly in tests to inject a mock.
@@ -209,9 +212,16 @@ func (a *App) LoadAndConnect() error {
 		Logger:      a.Logger,
 		SessionPath: a.SessionPath,
 		Client:      cli,
+		OnConversationsChange: func() {
+			a.emitConversationsChange()
+		},
+		OnMessagesChange: func(conversationID string) {
+			a.emitMessagesChange(conversationID)
+		},
 		OnDisconnect: func() {
 			a.Connected.Store(false)
 			a.setClient(nil)
+			a.emitStatusChange(false)
 			a.Logger.Warn().Msg("Disconnected from Google Messages")
 		},
 	}
@@ -221,6 +231,7 @@ func (a *App) LoadAndConnect() error {
 		return fmt.Errorf("connect: %w", err)
 	}
 	a.Connected.Store(true)
+	a.emitStatusChange(true)
 	a.Logger.Info().Msg("Connected to Google Messages")
 	return nil
 }
@@ -228,6 +239,7 @@ func (a *App) LoadAndConnect() error {
 // Unpair deletes the session file so the app can re-pair.
 func (a *App) Unpair() error {
 	a.Connected.Store(false)
+	a.emitStatusChange(false)
 	if cli := a.GetClient(); cli != nil {
 		cli.GM.Disconnect()
 		a.setClient(nil)
@@ -257,6 +269,24 @@ func (a *App) StartDeepBackfill() bool {
 	}
 	go a.deepBackfill()
 	return true
+}
+
+func (a *App) emitConversationsChange() {
+	if a.OnConversationsChange != nil {
+		a.OnConversationsChange()
+	}
+}
+
+func (a *App) emitMessagesChange(conversationID string) {
+	if a.OnMessagesChange != nil {
+		a.OnMessagesChange(conversationID)
+	}
+}
+
+func (a *App) emitStatusChange(connected bool) {
+	if a.OnStatusChange != nil {
+		a.OnStatusChange(connected)
+	}
 }
 
 func (a *App) IsDeepBackfillRunning() bool {

--- a/internal/app/backfill.go
+++ b/internal/app/backfill.go
@@ -47,6 +47,8 @@ func (a *App) Backfill() error {
 	}
 
 	a.Logger.Info().Int("conversations", len(convos)).Msg("Backfill complete")
+	a.emitConversationsChange()
+	a.emitMessagesChange("")
 	return nil
 }
 
@@ -111,6 +113,8 @@ func (a *App) deepBackfill() {
 		Int("contacts_checked", progress.ContactsChecked).
 		Int("errors", progress.Errors).
 		Msg("Deep backfill complete")
+	a.emitConversationsChange()
+	a.emitMessagesChange("")
 }
 
 // paginateFolder fetches all conversations in a folder using cursor pagination.
@@ -312,6 +316,8 @@ func (a *App) BackfillConversationByPhone(phone string) error {
 		Str("conv_id", conv.GetConversationID()).
 		Int("messages", n).
 		Msg("Phone backfill complete")
+	a.emitConversationsChange()
+	a.emitMessagesChange(conv.GetConversationID())
 
 	return nil
 }

--- a/internal/app/backfill_test.go
+++ b/internal/app/backfill_test.go
@@ -26,10 +26,10 @@ type mockGMClient struct {
 	getOrCreateResults map[string]*gmproto.Conversation
 
 	// Error injection
-	listConvErrors   map[gmproto.ListConversationsRequest_Folder]error // folder -> error
-	fetchMsgErrors   map[string]error                                  // convID -> error
-	listContactsErr  error
-	getOrCreateErrs  map[string]error // phone -> error
+	listConvErrors  map[gmproto.ListConversationsRequest_Folder]error // folder -> error
+	fetchMsgErrors  map[string]error                                  // convID -> error
+	listContactsErr error
+	getOrCreateErrs map[string]error // phone -> error
 }
 
 func (m *mockGMClient) ListConversationsWithCursor(count int, folder gmproto.ListConversationsRequest_Folder, cursor *gmproto.Cursor) (*gmproto.ListConversationsResponse, error) {
@@ -132,7 +132,7 @@ func makeConv(id, name string) *gmproto.Conversation {
 	return &gmproto.Conversation{
 		ConversationID:       id,
 		Name:                 name,
-		LastMessageTimestamp:  1000000, // 1000ms
+		LastMessageTimestamp: 1000000, // 1000ms
 	}
 }
 
@@ -205,7 +205,7 @@ func TestDeepBackfillMultiPageSingleFolder(t *testing.T) {
 	mock := &mockGMClient{
 		conversations: map[gmproto.ListConversationsRequest_Folder][][]*gmproto.Conversation{
 			gmproto.ListConversationsRequest_INBOX: {
-				{makeConv("c1", "Alice"), makeConv("c2", "Bob")},    // page 0
+				{makeConv("c1", "Alice"), makeConv("c2", "Bob")},     // page 0
 				{makeConv("c3", "Charlie"), makeConv("c4", "Diana")}, // page 1
 			},
 		},
@@ -332,8 +332,8 @@ func TestDeepBackfillContactDiscovery(t *testing.T) {
 			},
 		},
 		messages: map[string][][]*gmproto.Message{
-			"c1":      {{makeMsg("m1", "c1", "hi", 100)}},
-			"c-mary":  {{makeMsg("m2", "c-mary", "old msg", 50)}},
+			"c1":     {{makeMsg("m1", "c1", "hi", 100)}},
+			"c-mary": {{makeMsg("m2", "c-mary", "old msg", 50)}},
 		},
 		contacts: []*gmproto.Contact{
 			{
@@ -555,6 +555,42 @@ func TestDeepBackfillEmptyFolders(t *testing.T) {
 	}
 }
 
+func TestDeepBackfillPublishesChangeNotifications(t *testing.T) {
+	mock := &mockGMClient{
+		conversations: map[gmproto.ListConversationsRequest_Folder][][]*gmproto.Conversation{
+			gmproto.ListConversationsRequest_INBOX: {
+				{makeConv("c1", "Alice")},
+			},
+		},
+		messages: map[string][][]*gmproto.Message{
+			"c1": {
+				{makeMsg("m1", "c1", "hello", 100)},
+			},
+		},
+	}
+
+	a := newTestApp(t, mock)
+	var (
+		conversationChanges int
+		messagesChangedFor  string
+	)
+	a.OnConversationsChange = func() {
+		conversationChanges++
+	}
+	a.OnMessagesChange = func(conversationID string) {
+		messagesChangedFor = conversationID
+	}
+
+	a.DeepBackfill()
+
+	if conversationChanges != 1 {
+		t.Fatalf("conversation change callback count = %d, want 1", conversationChanges)
+	}
+	if messagesChangedFor != "" {
+		t.Fatalf("messages change callback conversation = %q, want global refresh", messagesChangedFor)
+	}
+}
+
 func TestDeepBackfillTargetedPhoneBackfill(t *testing.T) {
 	mock := &mockGMClient{
 		getOrCreateResults: map[string]*gmproto.Conversation{
@@ -569,6 +605,16 @@ func TestDeepBackfillTargetedPhoneBackfill(t *testing.T) {
 	}
 
 	a := newTestApp(t, mock)
+	var (
+		conversationChanges int
+		messagesChangedFor  string
+	)
+	a.OnConversationsChange = func() {
+		conversationChanges++
+	}
+	a.OnMessagesChange = func(conversationID string) {
+		messagesChangedFor = conversationID
+	}
 	err := a.BackfillConversationByPhone("+14157934268")
 	if err != nil {
 		t.Fatalf("BackfillConversationByPhone: %v", err)
@@ -585,6 +631,12 @@ func TestDeepBackfillTargetedPhoneBackfill(t *testing.T) {
 	msgs, _ := a.Store.GetMessagesByConversation("c-mary", 100)
 	if len(msgs) != 3 {
 		t.Fatalf("got %d messages, want 3 (2 pages)", len(msgs))
+	}
+	if conversationChanges != 1 {
+		t.Fatalf("conversation change callback count = %d, want 1", conversationChanges)
+	}
+	if messagesChangedFor != "c-mary" {
+		t.Fatalf("messages change callback conversation = %q, want c-mary", messagesChangedFor)
 	}
 }
 

--- a/internal/client/events.go
+++ b/internal/client/events.go
@@ -16,11 +16,13 @@ import (
 type OnDisconnect func()
 
 type EventHandler struct {
-	Store        *db.Store
-	Logger       zerolog.Logger
-	SessionPath  string
-	Client       *Client
-	OnDisconnect OnDisconnect
+	Store                 *db.Store
+	Logger                zerolog.Logger
+	SessionPath           string
+	Client                *Client
+	OnConversationsChange func()
+	OnDisconnect          OnDisconnect
+	OnMessagesChange      func(string)
 }
 
 func (h *EventHandler) Handle(rawEvt any) {
@@ -60,7 +62,10 @@ func (h *EventHandler) handleClientReady(evt *events.ClientReady) {
 		Msg("Client ready")
 
 	for _, conv := range evt.Conversations {
-		h.handleConversation(conv)
+		h.storeConversation(conv)
+	}
+	if len(evt.Conversations) > 0 && h.OnConversationsChange != nil {
+		h.OnConversationsChange()
 	}
 }
 
@@ -118,9 +123,25 @@ func (h *EventHandler) handleMessage(evt *libgm.WrappedMessage) {
 		Str("from", senderName).
 		Bool("is_old", evt.IsOld).
 		Msg("Stored message")
+
+	if h.OnMessagesChange != nil {
+		h.OnMessagesChange(dbMsg.ConversationID)
+	}
+	if h.OnConversationsChange != nil {
+		h.OnConversationsChange()
+	}
 }
 
 func (h *EventHandler) handleConversation(conv *gmproto.Conversation) {
+	if !h.storeConversation(conv) {
+		return
+	}
+	if h.OnConversationsChange != nil {
+		h.OnConversationsChange()
+	}
+}
+
+func (h *EventHandler) storeConversation(conv *gmproto.Conversation) bool {
 	participantsJSON := "[]"
 	if ps := conv.GetParticipants(); len(ps) > 0 {
 		type pInfo struct {
@@ -163,9 +184,10 @@ func (h *EventHandler) handleConversation(conv *gmproto.Conversation) {
 
 	if err := h.Store.UpsertConversation(dbConv); err != nil {
 		h.Logger.Error().Err(err).Str("conv_id", dbConv.ConversationID).Msg("Failed to store conversation")
-		return
+		return false
 	}
 	h.Logger.Debug().Str("conv_id", dbConv.ConversationID).Str("name", dbConv.Name).Msg("Stored conversation")
+	return true
 }
 
 func (h *EventHandler) handleAuthRefresh() {

--- a/internal/client/events_test.go
+++ b/internal/client/events_test.go
@@ -36,9 +36,19 @@ func TestHandleMessage_RemovesOnlyMatchingTmpPlaceholder(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var (
+		conversationChanges int
+		messagesChangedFor  string
+	)
 	handler := &EventHandler{
 		Store:  store,
 		Logger: zerolog.Nop(),
+		OnConversationsChange: func() {
+			conversationChanges++
+		},
+		OnMessagesChange: func(conversationID string) {
+			messagesChangedFor = conversationID
+		},
 	}
 
 	handler.handleMessage(&libgm.WrappedMessage{
@@ -76,5 +86,11 @@ func TestHandleMessage_RemovesOnlyMatchingTmpPlaceholder(t *testing.T) {
 		t.Fatalf("lookup real message: %v", err)
 	} else if got == nil {
 		t.Fatal("real echoed message should be stored")
+	}
+	if messagesChangedFor != "c1" {
+		t.Fatalf("messages change callback conversation = %q, want c1", messagesChangedFor)
+	}
+	if conversationChanges != 1 {
+		t.Fatalf("conversation change callback count = %d, want 1", conversationChanges)
 	}
 }

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -36,6 +36,7 @@ type UnpairFunc func() error
 // APIOptions holds optional callbacks for the API handler.
 type APIOptions struct {
 	Client            func() *client.Client
+	Events            *EventBroker
 	IsConnected       StatusChecker
 	Unpair            UnpairFunc
 	StartDeepBackfill func() bool
@@ -65,6 +66,78 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		}
 		return cli
 	}
+	publishConversations := func() {
+		if opts.Events != nil {
+			opts.Events.PublishConversations()
+		}
+	}
+	publishDrafts := func(conversationID string) {
+		if opts.Events != nil {
+			opts.Events.PublishDrafts(conversationID)
+		}
+	}
+	publishMessages := func(conversationID string) {
+		if opts.Events != nil {
+			opts.Events.PublishMessages(conversationID)
+		}
+	}
+	publishStatus := func(connected bool) {
+		if opts.Events != nil {
+			opts.Events.PublishStatus(connected)
+		}
+	}
+
+	mux.HandleFunc("/api/events", func(w http.ResponseWriter, r *http.Request) {
+		if opts.Events == nil {
+			httpError(w, "event stream not available", 404)
+			return
+		}
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			httpError(w, "streaming not supported", 500)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+
+		connected := getClient() != nil
+		if opts.IsConnected != nil {
+			connected = opts.IsConnected()
+		}
+		if err := writeSSEEvent(w, StreamEvent{
+			Type:      EventTypeStatus,
+			Connected: &connected,
+		}); err != nil {
+			return
+		}
+		flusher.Flush()
+
+		subID, ch := opts.Events.Subscribe()
+		defer opts.Events.Unsubscribe(subID)
+
+		keepalive := time.NewTicker(25 * time.Second)
+		defer keepalive.Stop()
+
+		for {
+			select {
+			case evt := <-ch:
+				if err := writeSSEEvent(w, evt); err != nil {
+					return
+				}
+				flusher.Flush()
+			case <-keepalive.C:
+				if _, err := io.WriteString(w, ": keepalive\n\n"); err != nil {
+					return
+				}
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+		}
+	})
 
 	mux.HandleFunc("/api/conversations", func(w http.ResponseWriter, r *http.Request) {
 		limit := queryInt(r, "limit", 50)
@@ -189,6 +262,8 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			})
 			// Bump conversation to top of list
 			store.UpdateConversationTimestamp(req.ConversationID, now)
+			publishMessages(req.ConversationID)
+			publishConversations()
 		}
 		writeJSON(w, map[string]any{
 			"status":  resp.GetStatus().String(),
@@ -282,6 +357,8 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 				DecryptionKey:  hex.EncodeToString(media.DecryptionKey),
 			})
 			store.UpdateConversationTimestamp(convID, now)
+			publishMessages(convID)
+			publishConversations()
 		}
 		writeJSON(w, map[string]any{
 			"status":  resp.GetStatus().String(),
@@ -424,6 +501,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			Name:           name,
 			LastMessageTS:  time.Now().UnixMilli(),
 		})
+		publishConversations()
 
 		writeJSON(w, map[string]any{
 			"conversation_id": convoID,
@@ -451,6 +529,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "mark read: "+err.Error(), 500)
 			return
 		}
+		publishConversations()
 		writeJSON(w, map[string]string{"status": "ok"})
 	})
 
@@ -539,6 +618,9 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			})
 			store.UpdateConversationTimestamp(draft.ConversationID, now)
 			store.DeleteDraft(req.DraftID)
+			publishMessages(draft.ConversationID)
+			publishDrafts(draft.ConversationID)
+			publishConversations()
 		}
 		writeJSON(w, map[string]any{
 			"status":  resp.GetStatus().String(),
@@ -556,9 +638,18 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "draft_id required", 400)
 			return
 		}
+		draft, err := store.GetDraft(draftID)
+		if err != nil {
+			httpError(w, "get draft: "+err.Error(), 500)
+			return
+		}
 		if err := store.DeleteDraft(draftID); err != nil {
 			httpError(w, "delete draft: "+err.Error(), 500)
 			return
+		}
+		if draft != nil {
+			publishDrafts(draft.ConversationID)
+			publishMessages(draft.ConversationID)
 		}
 		writeJSON(w, map[string]string{"status": "ok"})
 	})
@@ -662,6 +753,8 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "backfill phone: "+err.Error(), 502)
 			return
 		}
+		publishConversations()
+		publishMessages("")
 		writeJSON(w, map[string]string{"status": "ok"})
 	})
 
@@ -686,6 +779,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 				return
 			}
 		}
+		publishStatus(false)
 		writeJSON(w, map[string]string{"status": "ok"})
 	})
 
@@ -734,6 +828,24 @@ func BuildReactionPayload(messageID, emoji, action string, sim *gmproto.SIMPaylo
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(v)
+}
+
+func writeSSEEvent(w http.ResponseWriter, evt StreamEvent) error {
+	data, err := json.Marshal(evt)
+	if err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, "event: "+evt.Type+"\n"); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, "data: "); err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, "\n\n")
+	return err
 }
 
 func httpError(w http.ResponseWriter, msg string, code int) {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -1,11 +1,13 @@
 package web
 
 import (
+	"bufio"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
@@ -21,6 +23,10 @@ type testServer struct {
 }
 
 func newTestServer(t *testing.T) *testServer {
+	return newTestServerWithOptions(t, APIOptions{})
+}
+
+func newTestServerWithOptions(t *testing.T, opts APIOptions) *testServer {
 	t.Helper()
 	store, err := db.New(":memory:")
 	if err != nil {
@@ -28,7 +34,7 @@ func newTestServer(t *testing.T) *testServer {
 	}
 
 	logger := zerolog.Nop()
-	h := APIHandler(store, nil, logger, nil)
+	h := APIHandlerWithOptions(store, nil, logger, nil, opts)
 	srv := httptest.NewServer(h)
 
 	t.Cleanup(func() {
@@ -37,6 +43,56 @@ func newTestServer(t *testing.T) *testServer {
 	})
 
 	return &testServer{store: store, server: srv}
+}
+
+type sseEvent struct {
+	Data  string
+	Event string
+}
+
+func readSSEEvent(t *testing.T, reader *bufio.Reader) sseEvent {
+	t.Helper()
+
+	type result struct {
+		err error
+		evt sseEvent
+	}
+	ch := make(chan result, 1)
+	go func() {
+		var evt sseEvent
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				ch <- result{err: err}
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			if line == "" {
+				ch <- result{evt: evt}
+				return
+			}
+			if strings.HasPrefix(line, ":") {
+				continue
+			}
+			if strings.HasPrefix(line, "event: ") {
+				evt.Event = strings.TrimPrefix(line, "event: ")
+			}
+			if strings.HasPrefix(line, "data: ") {
+				evt.Data = strings.TrimPrefix(line, "data: ")
+			}
+		}
+	}()
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			t.Fatal(res.err)
+		}
+		return res.evt
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for SSE event")
+		return sseEvent{}
+	}
 }
 
 func TestListConversations(t *testing.T) {
@@ -967,5 +1023,92 @@ func TestStatusUsesLiveClientGetter(t *testing.T) {
 	}
 	if status2["connected"] != false {
 		t.Fatalf("expected connected=false after client getter returns nil, got %v", status2["connected"])
+	}
+}
+
+func TestEventsStreamPublishesStatusAndMessages(t *testing.T) {
+	events := NewEventBroker()
+	ts := newTestServerWithOptions(t, APIOptions{
+		Events:      events,
+		IsConnected: func() bool { return true },
+	})
+
+	resp, err := http.Get(ts.server.URL + "/api/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("content-type = %q, want text/event-stream", got)
+	}
+
+	reader := bufio.NewReader(resp.Body)
+	statusEvt := readSSEEvent(t, reader)
+	if statusEvt.Event != EventTypeStatus {
+		t.Fatalf("first SSE event = %q, want %q", statusEvt.Event, EventTypeStatus)
+	}
+
+	var status StreamEvent
+	if err := json.Unmarshal([]byte(statusEvt.Data), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.Connected == nil || !*status.Connected {
+		t.Fatalf("initial status event = %+v, want connected=true", status)
+	}
+
+	events.PublishMessages("c1")
+
+	msgEvt := readSSEEvent(t, reader)
+	if msgEvt.Event != EventTypeMessages {
+		t.Fatalf("stream event = %q, want %q", msgEvt.Event, EventTypeMessages)
+	}
+
+	var msg StreamEvent
+	if err := json.Unmarshal([]byte(msgEvt.Data), &msg); err != nil {
+		t.Fatal(err)
+	}
+	if msg.ConversationID != "c1" {
+		t.Fatalf("messages event conversation_id = %q, want c1", msg.ConversationID)
+	}
+}
+
+func TestMarkReadPublishesConversationInvalidation(t *testing.T) {
+	events := NewEventBroker()
+	ts := newTestServerWithOptions(t, APIOptions{
+		Events: events,
+	})
+
+	if err := ts.store.UpsertConversation(&db.Conversation{
+		ConversationID: "c1",
+		Name:           "Alice",
+		UnreadCount:    1,
+		LastMessageTS:  100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(ts.server.URL + "/api/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	reader := bufio.NewReader(resp.Body)
+	_ = readSSEEvent(t, reader) // initial status event
+
+	reqBody := strings.NewReader(`{"conversation_id":"c1"}`)
+	markReadResp, err := http.Post(ts.server.URL+"/api/mark-read", "application/json", reqBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer markReadResp.Body.Close()
+
+	if markReadResp.StatusCode != 200 {
+		t.Fatalf("mark-read status = %d, want 200", markReadResp.StatusCode)
+	}
+
+	evt := readSSEEvent(t, reader)
+	if evt.Event != EventTypeConversations {
+		t.Fatalf("stream event = %q, want %q", evt.Event, EventTypeConversations)
 	}
 }

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -1,0 +1,108 @@
+package web
+
+import "sync"
+
+const (
+	EventTypeConversations = "conversations"
+	EventTypeDrafts        = "drafts"
+	EventTypeMessages      = "messages"
+	EventTypeStatus        = "status"
+)
+
+// StreamEvent is a small invalidation payload pushed to connected browsers.
+type StreamEvent struct {
+	Type           string `json:"type"`
+	ConversationID string `json:"conversation_id,omitempty"`
+	Connected      *bool  `json:"connected,omitempty"`
+}
+
+// EventBroker fans out lightweight invalidation events to SSE subscribers.
+type EventBroker struct {
+	mu          sync.RWMutex
+	nextID      int
+	subscribers map[int]chan StreamEvent
+}
+
+func NewEventBroker() *EventBroker {
+	return &EventBroker{
+		subscribers: make(map[int]chan StreamEvent),
+	}
+}
+
+func (b *EventBroker) Subscribe() (int, <-chan StreamEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	id := b.nextID
+	b.nextID++
+	ch := make(chan StreamEvent, 32)
+	b.subscribers[id] = ch
+	return id, ch
+}
+
+func (b *EventBroker) Unsubscribe(id int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.subscribers, id)
+}
+
+func (b *EventBroker) Publish(evt StreamEvent) {
+	b.mu.RLock()
+	subs := make([]chan StreamEvent, 0, len(b.subscribers))
+	for _, ch := range b.subscribers {
+		subs = append(subs, ch)
+	}
+	b.mu.RUnlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- evt:
+		default:
+			select {
+			case <-ch:
+			default:
+			}
+			select {
+			case ch <- evt:
+			default:
+			}
+		}
+	}
+}
+
+func (b *EventBroker) PublishConversations() {
+	if b == nil {
+		return
+	}
+	b.Publish(StreamEvent{Type: EventTypeConversations})
+}
+
+func (b *EventBroker) PublishDrafts(conversationID string) {
+	if b == nil {
+		return
+	}
+	b.Publish(StreamEvent{
+		Type:           EventTypeDrafts,
+		ConversationID: conversationID,
+	})
+}
+
+func (b *EventBroker) PublishMessages(conversationID string) {
+	if b == nil {
+		return
+	}
+	b.Publish(StreamEvent{
+		Type:           EventTypeMessages,
+		ConversationID: conversationID,
+	})
+}
+
+func (b *EventBroker) PublishStatus(connected bool) {
+	if b == nil {
+		return
+	}
+	b.Publish(StreamEvent{
+		Type:      EventTypeStatus,
+		Connected: &connected,
+	})
+}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -1396,7 +1396,13 @@ html, body {
   const API = '';
   let activeConvoId = null;
   let conversations = [];
-  let pollTimer = null;
+  let conversationsRefreshTimer = null;
+  let eventSource = null;
+  let fallbackConversationsTimer = null;
+  let fallbackStatusTimer = null;
+  let fallbackThreadTimer = null;
+  let streamReconnectTimer = null;
+  let threadRefreshTimer = null;
 
   // ─── DOM refs ───
   const $convoList = document.getElementById('conversation-list');
@@ -1665,10 +1671,6 @@ html, body {
     }
     resetLoadedThreadState();
     await loadMessages(convo.ConversationID, {reset: true});
-
-    // Start polling for new messages
-    clearInterval(pollTimer);
-    pollTimer = setInterval(() => loadMessages(activeConvoId, {poll: true}), 3000);
   }
 
   // ─── Load Messages ───
@@ -2176,17 +2178,118 @@ html, body {
   });
 
   // ─── Status Check ───
+  function setConnectionState(connected) {
+    $connectionBanner.className = connected ? 'connection-banner' : 'connection-banner disconnected';
+  }
+
   async function checkStatus() {
     try {
       const status = await fetchJSON('/api/status');
-      if (status.connected) {
-        $connectionBanner.className = 'connection-banner';
-      } else {
-        $connectionBanner.className = 'connection-banner disconnected';
-      }
+      setConnectionState(!!status.connected);
     } catch {
-      $connectionBanner.className = 'connection-banner disconnected';
+      setConnectionState(false);
     }
+  }
+
+  function scheduleConversationsRefresh(delay = 120) {
+    if ($searchInput.value.trim()) return;
+    clearTimeout(conversationsRefreshTimer);
+    conversationsRefreshTimer = setTimeout(() => {
+      conversationsRefreshTimer = null;
+      loadConversations();
+    }, delay);
+  }
+
+  function scheduleThreadRefresh(conversationId, delay = 100) {
+    if (!activeConvoId) return;
+    if (conversationId && conversationId !== activeConvoId) return;
+    clearTimeout(threadRefreshTimer);
+    threadRefreshTimer = setTimeout(() => {
+      threadRefreshTimer = null;
+      if (activeConvoId) loadMessages(activeConvoId, {poll: true});
+    }, delay);
+  }
+
+  function stopFallbackPolling() {
+    clearInterval(fallbackStatusTimer);
+    clearInterval(fallbackConversationsTimer);
+    clearInterval(fallbackThreadTimer);
+    fallbackStatusTimer = null;
+    fallbackConversationsTimer = null;
+    fallbackThreadTimer = null;
+  }
+
+  function startFallbackPolling() {
+    if (fallbackStatusTimer || fallbackConversationsTimer || fallbackThreadTimer) return;
+    fallbackStatusTimer = setInterval(checkStatus, 10000);
+    fallbackConversationsTimer = setInterval(() => {
+      if (!$searchInput.value.trim()) loadConversations();
+    }, 5000);
+    fallbackThreadTimer = setInterval(() => {
+      if (activeConvoId) loadMessages(activeConvoId, {poll: true});
+    }, 3000);
+  }
+
+  function parseStreamEvent(raw) {
+    try {
+      return raw ? JSON.parse(raw) : {};
+    } catch (err) {
+      console.error('Failed to parse stream event:', err);
+      return {};
+    }
+  }
+
+  function startEventStream() {
+    if (!window.EventSource) {
+      startFallbackPolling();
+      return;
+    }
+    if (eventSource) return;
+
+    const source = new EventSource('/api/events');
+    eventSource = source;
+
+    const markHealthy = () => {
+      stopFallbackPolling();
+      if (streamReconnectTimer) {
+        clearTimeout(streamReconnectTimer);
+        streamReconnectTimer = null;
+      }
+    };
+
+    source.onopen = markHealthy;
+    source.addEventListener('status', (evt) => {
+      markHealthy();
+      const payload = parseStreamEvent(evt.data);
+      setConnectionState(!!payload.connected);
+    });
+    source.addEventListener('conversations', () => {
+      markHealthy();
+      scheduleConversationsRefresh();
+    });
+    source.addEventListener('messages', (evt) => {
+      markHealthy();
+      const payload = parseStreamEvent(evt.data);
+      scheduleConversationsRefresh();
+      scheduleThreadRefresh(payload.conversation_id || '');
+    });
+    source.addEventListener('drafts', (evt) => {
+      markHealthy();
+      const payload = parseStreamEvent(evt.data);
+      scheduleThreadRefresh(payload.conversation_id || '');
+    });
+    source.onerror = () => {
+      startFallbackPolling();
+      if (source.readyState === EventSource.CLOSED && !streamReconnectTimer) {
+        streamReconnectTimer = setTimeout(() => {
+          streamReconnectTimer = null;
+          if (eventSource === source) {
+            eventSource = null;
+            startEventStream();
+          }
+        }, 3000);
+      }
+    };
   }
 
   // ─── Load Conversations ───
@@ -2364,7 +2467,8 @@ html, body {
   function deselectConversation() {
     activeConvoId = null;
     activeConvoIsGroup = false;
-    clearInterval(pollTimer);
+    clearTimeout(threadRefreshTimer);
+    threadRefreshTimer = null;
     document.querySelectorAll('.convo-item').forEach(el => el.classList.remove('active'));
     $emptyState.style.display = '';
     $chatHeader.style.display = 'none';
@@ -2529,12 +2633,9 @@ html, body {
   });
 
   // ─── Init ───
+  startEventStream();
   loadConversations();
   checkStatus();
-  setInterval(checkStatus, 10000);
-  setInterval(() => {
-    if (!$searchInput.value.trim()) loadConversations();
-  }, 5000);
 
   // Screenshot mode: hide banner
   if (isScreenshotMode) {


### PR DESCRIPTION
## Summary
- add a lightweight SSE broker and /api/events endpoint for UI invalidation
- publish conversation, message, draft, and status changes from app, client, import, and API flows
- replace steady browser polling with EventSource-driven refreshes plus fallback polling when streams are unavailable

## Testing
- go test ./...
- node -e "const fs=require("fs"); const html=fs.readFileSync("/Users/maxghenis/openmessage/internal/web/static/index.html","utf8"); const m=html.match(/<script>([\s\S]*)<\/script>/); if(!m) throw new Error("script tag not found"); new Function(m[1]); console.log("web-ui-js-ok");"