### PR TITLE
Add Playwright web UI tests and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  go-test:
+    name: Go Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run Go test suite
+        run: go test ./...
+
+  e2e:
+    name: Web E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright suite
+        run: npm run test:e2e
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          if-no-files-found: ignore
+          path: |
+            playwright-report/
+            test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ macos/OpenMessages/.build/
 .vercel
 .env*.local
 .build/
+node_modules/
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ The web UI runs at `http://localhost:7007` when the server is started. It provid
 ```bash
 go test ./...        # Run all tests
 go build .           # Build binary
+npm install          # Install Playwright test runner
+npx playwright install chromium
+npm run test:e2e     # Run browser-level web UI tests
 ./openmessage pair  # Pair with phone
 ./openmessage serve # Start server
 ```

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/web"
+)
+
+const (
+	defaultPort        = 7010
+	pagedConversation  = "conv-paged"
+	pagedConversationN = 150
+)
+
+func main() {
+	logger := zerolog.Nop()
+	store, err := db.New(":memory:")
+	if err != nil {
+		panic(err)
+	}
+	defer store.Close()
+
+	if err := seedFixture(store); err != nil {
+		panic(err)
+	}
+
+	events := web.NewEventBroker()
+	base := web.APIHandlerWithOptions(store, nil, logger, nil, web.APIOptions{
+		Events:      events,
+		IsConnected: func() bool { return true },
+	})
+
+	var nextID atomic.Int64
+	nextID.Store(time.Now().UnixNano())
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	mux.HandleFunc("/_e2e/messages", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Body           string `json:"body"`
+			ConversationID string `json:"conversation_id"`
+			IsFromMe       bool   `json:"is_from_me"`
+			SenderName     string `json:"sender_name"`
+			SenderNumber   string `json:"sender_number"`
+			TimestampMS    int64  `json:"timestamp_ms"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.ConversationID == "" || req.Body == "" {
+			http.Error(w, "conversation_id and body are required", http.StatusBadRequest)
+			return
+		}
+		if req.TimestampMS == 0 {
+			req.TimestampMS = time.Now().UnixMilli()
+		}
+		msg, err := upsertSyntheticMessage(store, req.ConversationID, req.Body, req.TimestampMS, req.IsFromMe, req.SenderName, req.SenderNumber, nextID.Add(1))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		events.PublishMessages(req.ConversationID)
+		events.PublishConversations()
+		writeJSON(w, map[string]any{
+			"message_id": msg.MessageID,
+			"success":    true,
+		})
+	})
+
+	mux.HandleFunc("/_e2e/drafts", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Body           string `json:"body"`
+			ConversationID string `json:"conversation_id"`
+			DraftID        string `json:"draft_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.ConversationID == "" || req.Body == "" {
+			http.Error(w, "conversation_id and body are required", http.StatusBadRequest)
+			return
+		}
+		if req.DraftID == "" {
+			req.DraftID = fmt.Sprintf("draft-%d", nextID.Add(1))
+		}
+		if err := store.UpsertDraft(&db.Draft{
+			DraftID:        req.DraftID,
+			ConversationID: req.ConversationID,
+			Body:           req.Body,
+			CreatedAt:      time.Now().UnixMilli(),
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		events.PublishDrafts(req.ConversationID)
+		writeJSON(w, map[string]any{
+			"draft_id": req.DraftID,
+			"success":  true,
+		})
+	})
+
+	mux.HandleFunc("/api/send", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			base.ServeHTTP(w, r)
+			return
+		}
+		var req struct {
+			ConversationID string `json:"conversation_id"`
+			Message        string `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.ConversationID == "" || req.Message == "" {
+			http.Error(w, "conversation_id and message are required", http.StatusBadRequest)
+			return
+		}
+		msg, err := upsertSyntheticMessage(store, req.ConversationID, req.Message, time.Now().UnixMilli(), true, "Me", "+15551234567", nextID.Add(1))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		events.PublishMessages(req.ConversationID)
+		events.PublishConversations()
+		writeJSON(w, map[string]any{
+			"message_id": msg.MessageID,
+			"status":     "SUCCESS",
+			"success":    true,
+		})
+	})
+
+	mux.HandleFunc("/api/drafts/send", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			base.ServeHTTP(w, r)
+			return
+		}
+		var req struct {
+			Body    string `json:"body"`
+			DraftID string `json:"draft_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.DraftID == "" || req.Body == "" {
+			http.Error(w, "draft_id and body are required", http.StatusBadRequest)
+			return
+		}
+		draft, err := store.GetDraft(req.DraftID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if draft == nil {
+			http.Error(w, "draft not found", http.StatusNotFound)
+			return
+		}
+		msg, err := upsertSyntheticMessage(store, draft.ConversationID, req.Body, time.Now().UnixMilli(), true, "Me", "+15551234567", nextID.Add(1))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if err := store.DeleteDraft(req.DraftID); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		events.PublishMessages(draft.ConversationID)
+		events.PublishDrafts(draft.ConversationID)
+		events.PublishConversations()
+		writeJSON(w, map[string]any{
+			"message_id": msg.MessageID,
+			"status":     "SUCCESS",
+			"success":    true,
+		})
+	})
+
+	mux.Handle("/", base)
+
+	addr := "127.0.0.1:" + strconv.Itoa(serverPort())
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		panic(err)
+	}
+}
+
+func seedFixture(store *db.Store) error {
+	if err := store.SeedDemo(); err != nil {
+		return err
+	}
+	if err := store.UpsertConversation(&db.Conversation{
+		ConversationID: pagedConversation,
+		Name:           "Paged Thread",
+		Participants:   `[{"name":"Pat Page","number":"+15550001111"}]`,
+		LastMessageTS:  pagedMessageTimestamp(pagedConversationN),
+		SourcePlatform: "sms",
+	}); err != nil {
+		return err
+	}
+	for i := 1; i <= pagedConversationN; i++ {
+		if err := store.UpsertMessage(&db.Message{
+			MessageID:      fmt.Sprintf("paged-%03d", i),
+			ConversationID: pagedConversation,
+			SenderName:     pagedSenderName(i),
+			SenderNumber:   pagedSenderNumber(i),
+			Body:           fmt.Sprintf("Paged message %03d", i),
+			TimestampMS:    pagedMessageTimestamp(i),
+			Status:         "delivered",
+			IsFromMe:       i%2 == 0,
+			SourcePlatform: "sms",
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upsertSyntheticMessage(store *db.Store, conversationID, body string, timestampMS int64, isFromMe bool, senderName, senderNumber string, id int64) (*db.Message, error) {
+	msg := &db.Message{
+		MessageID:      fmt.Sprintf("e2e-%d", id),
+		ConversationID: conversationID,
+		SenderName:     senderName,
+		SenderNumber:   senderNumber,
+		Body:           body,
+		TimestampMS:    timestampMS,
+		Status:         syntheticStatus(isFromMe),
+		IsFromMe:       isFromMe,
+		SourcePlatform: "sms",
+	}
+	if err := store.UpsertMessage(msg); err != nil {
+		return nil, err
+	}
+
+	conv, err := store.GetConversation(conversationID)
+	if err != nil {
+		conv = &db.Conversation{
+			ConversationID: conversationID,
+			Name:           senderName,
+			Participants:   "[]",
+			SourcePlatform: "sms",
+		}
+	}
+	conv.LastMessageTS = timestampMS
+	if !isFromMe {
+		conv.UnreadCount++
+	}
+	if err := store.UpsertConversation(conv); err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+
+func pagedMessageTimestamp(i int) int64 {
+	base := time.Date(2026, time.March, 1, 9, 0, 0, 0, time.UTC).UnixMilli()
+	return base + int64(i*60_000)
+}
+
+func pagedSenderName(i int) string {
+	if i%2 == 0 {
+		return "Me"
+	}
+	return "Pat Page"
+}
+
+func pagedSenderNumber(i int) string {
+	if i%2 == 0 {
+		return "+15551234567"
+	}
+	return "+15550001111"
+}
+
+func serverPort() int {
+	if raw := os.Getenv("OPENMESSAGES_E2E_PORT"); raw != "" {
+		if port, err := strconv.Atoi(raw); err == nil && port > 0 {
+			return port
+		}
+	}
+	return defaultPort
+}
+
+func syntheticStatus(isFromMe bool) string {
+	if isFromMe {
+		return "OUTGOING_COMPLETE"
+	}
+	return "delivered"
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -1,0 +1,86 @@
+const { test, expect } = require('@playwright/test');
+
+const hikingDraft = 'Count me in for Saturday! Lands End trail looks clear — 62°F and sunny. Want me to bring snacks?';
+
+async function openConversation(page, name) {
+  await page.getByText(name, { exact: true }).click();
+  await expect(page.locator('#chat-header-name')).toHaveText(name);
+}
+
+test.beforeEach(async ({ page, request }) => {
+  await request.post('/_e2e/drafts', {
+    data: {
+      body: hikingDraft,
+      conversation_id: 'conv3',
+      draft_id: 'draft1',
+    },
+  });
+  await page.goto('/');
+});
+
+test('loads the seeded conversation list and thread view', async ({ page }) => {
+  await expect(page.locator('#connection-banner.disconnected')).toHaveCount(0);
+  await expect(page.locator('#conversation-list .convo-item')).toHaveCount(9);
+  await openConversation(page, 'Sarah Chen');
+  await expect(page.locator('#messages-area')).toContainText('Hey! Are you free for dinner tonight?');
+  await expect(page.locator('#compose-input')).toBeVisible();
+});
+
+test('sends a message through the compose box', async ({ page }) => {
+  const outbound = `Playwright outbound ${Date.now()}`;
+
+  await openConversation(page, 'Sarah Chen');
+  await page.locator('#compose-input').fill(outbound);
+  await page.locator('#send-btn').click();
+
+  await expect(page.locator('#messages-area')).toContainText(outbound);
+});
+
+test('refreshes the active thread from SSE invalidations', async ({ page, request }) => {
+  const inbound = `SSE inbound ${Date.now()}`;
+
+  await openConversation(page, 'Sarah Chen');
+  await request.post('/_e2e/messages', {
+    data: {
+      body: inbound,
+      conversation_id: 'conv1',
+      sender_name: 'Sarah Chen',
+      sender_number: '+14155551234',
+    },
+  });
+
+  await expect(page.locator('#messages-area')).toContainText(inbound);
+});
+
+test('loads older pages when scrolling up in a long thread', async ({ page }) => {
+  await openConversation(page, 'Paged Thread');
+  await expect(page.locator('#messages-area .msg')).toHaveCount(100);
+  await expect(page.locator('#messages-area')).not.toContainText('Paged message 001');
+
+  await page.locator('#messages-area').evaluate((el) => {
+    el.scrollTop = 0;
+    el.dispatchEvent(new Event('scroll'));
+  });
+
+  await expect(page.locator('#messages-area')).toContainText('Paged message 001');
+  await expect(page.locator('#messages-area .msg')).toHaveCount(150);
+});
+
+test('sends an AI draft from the thread banner', async ({ page }) => {
+  const draftReply = `Draft sent ${Date.now()}`;
+
+  await openConversation(page, 'Weekend Hiking Group');
+  await expect(page.locator('.draft-banner')).toHaveCount(1);
+  await page.locator('.draft-text').fill(draftReply);
+  await page.locator('.draft-send-btn').click();
+
+  await expect(page.locator('.draft-banner')).toHaveCount(0);
+  await expect(page.locator('#messages-area')).toContainText(draftReply);
+});
+
+test('discards an AI draft from the thread banner', async ({ page }) => {
+  await openConversation(page, 'Weekend Hiking Group');
+  await expect(page.locator('.draft-banner')).toHaveCount(1);
+  await page.locator('.draft-discard-btn').click();
+  await expect(page.locator('.draft-banner')).toHaveCount(0);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "openmessage",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openmessage",
+      "devDependencies": {
+        "@playwright/test": "^1.58.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "openmessage",
+  "private": true,
+  "scripts": {
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.0"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,28 @@
+const { defineConfig } = require('@playwright/test');
+
+const port = process.env.OPENMESSAGES_E2E_PORT || '7010';
+const baseURL = `http://127.0.0.1:${port}`;
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  timeout: 30_000,
+  use: {
+    baseURL,
+    headless: true,
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'go run ./cmd/e2e-server',
+    cwd: __dirname,
+    env: {
+      ...process.env,
+      OPENMESSAGES_E2E_PORT: port,
+    },
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    url: `${baseURL}/healthz`,
+  },
+  workers: 1,
+});


### PR DESCRIPTION
## Summary
- add a Playwright harness for the web UI with a deterministic e2e fixture server
- cover initial load, compose/send, SSE refresh, pagination, and draft flows in browser tests
- run both Go tests and Playwright in GitHub Actions on PRs and main

## Testing
- go test ./...
- npm ci
- npm run test:e2e