### PR TITLE
Preserve session.json on transient ListenFatalError

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -330,15 +330,26 @@ func (a *App) LoadAndConnect() error {
 		OnRealtimeGapRecovered: func(reason string) {
 			a.StartRecentReconcile(reason)
 		},
-		OnDisconnect: func() {
+		OnDisconnect: func(disconnectErr error) {
 			a.Connected.Store(false)
 			a.setClient(nil)
-			if err := os.Remove(a.SessionPath); err != nil && !os.IsNotExist(err) {
-				a.Logger.Warn().Err(err).Msg("Failed to remove invalidated Google Messages session")
+			// Distinguish a true session invalidation (e.g. user unpaired
+			// from their phone, cookies revoked) from a transient fatal
+			// error (network blip, server-side RPC failure). Issue #1
+			// specifies session.json should only be removed when the
+			// session itself is invalid; deleting on every fatal forces a
+			// full re-pair after every transient disconnect, which on
+			// long-running deployments effectively makes pairing fragile.
+			if isSessionInvalidated(disconnectErr) {
+				if err := os.Remove(a.SessionPath); err != nil && !os.IsNotExist(err) {
+					a.Logger.Warn().Err(err).Msg("Failed to remove invalidated Google Messages session")
+				}
+				a.setGoogleLastError("Google Messages session invalidated; pair again")
+			} else {
+				a.setGoogleLastError("Disconnected from Google Messages; will retry with existing session")
 			}
-			a.setGoogleLastError("Google Messages session invalidated; pair again")
 			a.emitStatusChange(false)
-			a.Logger.Warn().Msg("Disconnected from Google Messages")
+			a.Logger.Warn().Err(disconnectErr).Msg("Disconnected from Google Messages")
 		},
 	}
 	cli.GM.SetEventHandler(a.EventHandler.Handle)
@@ -352,6 +363,25 @@ func (a *App) LoadAndConnect() error {
 	a.emitStatusChange(true)
 	a.Logger.Info().Msg("Connected to Google Messages")
 	return nil
+}
+
+// isSessionInvalidated reports whether a disconnect error indicates the
+// Google Messages session itself is no longer valid (the user unpaired from
+// their phone, or the auth cookies were revoked) versus a transient fatal
+// error from libgm (network failure, RPC error). Only the former should
+// trigger session.json removal -- the latter should preserve the session so
+// reconnection can succeed without a full re-pair.
+//
+// libgm surfaces auth invalidation as an HTTP 401 with the
+// SESSION_COOKIE_INVALID error code in the response body. Both signals are
+// matched here for resilience against minor wording changes.
+func isSessionInvalidated(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "401") ||
+		strings.Contains(msg, "SESSION_COOKIE_INVALID")
 }
 
 // Unpair deletes the session file so the app can re-pair.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,6 +55,34 @@ func TestNewDemoUsesIsolatedTempDataDir(t *testing.T) {
 
 	if _, err := os.Stat(demoDir); !os.IsNotExist(err) {
 		t.Fatalf("expected demo dir cleanup, stat err = %v", err)
+	}
+}
+
+func TestIsSessionInvalidated(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"401 status code", errors.New("http 401 while polling"), true},
+		{"SESSION_COOKIE_INVALID code", errors.New("RPC failed: SESSION_COOKIE_INVALID"), true},
+		{"401 in wrapped libgm error",
+			fmt.Errorf("listen: %w", errors.New("server returned status 401")), true},
+		{"transient network failure",
+			errors.New("dial tcp: i/o timeout"), false},
+		{"unrelated 500 error",
+			errors.New("http 500 internal server error"), false},
+		{"transient RPC error",
+			errors.New("context deadline exceeded"), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSessionInvalidated(tc.err); got != tc.want {
+				t.Fatalf("isSessionInvalidated(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/client/events.go
+++ b/internal/client/events.go
@@ -13,8 +13,11 @@ import (
 	"github.com/maxghenis/openmessage/internal/db"
 )
 
-// OnDisconnect is called when the client fatally disconnects (e.g. unpaired).
-type OnDisconnect func()
+// OnDisconnect is called when the client fatally disconnects.
+// The error describes the underlying cause, which the handler can inspect to
+// decide whether the session itself is invalid (caller should re-pair) or the
+// disconnect was transient (caller should reconnect with the existing session).
+type OnDisconnect func(err error)
 
 type EventHandler struct {
 	Store                  *db.Store
@@ -45,7 +48,7 @@ func (h *EventHandler) Handle(rawEvt any) {
 	case *events.ListenFatalError:
 		h.Logger.Error().Err(evt.Error).Msg("Listen fatal error")
 		if h.OnDisconnect != nil {
-			h.OnDisconnect()
+			h.OnDisconnect(evt.Error)
 		}
 	case *events.ListenTemporaryError:
 		h.Logger.Warn().Err(evt.Error).Msg("Listen temporary error")


### PR DESCRIPTION
## Summary

`OnDisconnect` was firing for every libgm `ListenFatalError` and unconditionally calling `os.Remove(SessionPath)`. That includes transient fatals (network blip, RPC failure, server-side hiccup), so any such event silently invalidated the saved session and required a full re-pair on the next start.

[Issue #1](https://github.com/MaxGhenis/openmessage/issues/1)'s intent — per the closing comment — was for `session.json` to be removed only when the session itself is invalid (user unpaired from phone, cookies revoked). This change forwards the underlying error to the `OnDisconnect` callback and gates removal on a 401 / `SESSION_COOKIE_INVALID` classification. The macOS wrapper's `needs_pairing` flow continues to work for true invalidation; transient disconnects now leave `session.json` in place so reconnection can proceed without re-pairing.

## Background

Observed on a long-running headless deployment: the bridge was paired and healthy, then went quiet for a few hours. After the next process restart, startup logged ``Google Messages unavailable error="load session ... session.json: no such file or directory"``. No user-initiated unpair, no obvious 401 in the surviving journal — the session file had been removed by an earlier transient `ListenFatalError`.

## Implementation

- `internal/client/events.go` — `OnDisconnect` is now `func(err error)`. The `ListenFatalError` handler forwards `evt.Error`.
- `internal/app/app.go` — classifies the disconnect cause via a new `isSessionInvalidated(err)` helper. Only when the helper returns true does the handler call `os.Remove(SessionPath)` and surface ``"session invalidated; pair again"``. Other errors set ``"will retry with existing session"``.
- `internal/app/app_test.go` — `TestIsSessionInvalidated` covers nil, `401`, `SESSION_COOKIE_INVALID`, a `fmt.Errorf %w`-wrapped 401, and several transient-error strings.

The classifier matches on error message substrings (`"401"`, `"SESSION_COOKIE_INVALID"`) since libgm surfaces the cause through the error chain rather than a typed sentinel.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/app/ ./internal/client/` — passes (existing + 7 new sub-tests)
- [ ] Spot-check that the macOS app still transitions to the pairing view when the user unpairs from their phone (path of `isSessionInvalidated == true` is unchanged from current behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)