### PR TITLE
Fix libsignal temp dir leak from signal-cli subprocess churn

### DIFF
--- a/internal/signallive/client.go
+++ b/internal/signallive/client.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -54,21 +55,58 @@ var (
 	runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
 		commandArgs := append([]string{"--config", configDir}, args...)
 		cmd := exec.CommandContext(ctx, signalCLIExecutable(), commandArgs...)
+		tmpDir, cleanupTmp, tmpErr := newSignalRunTmpDir(configDir)
+		if tmpErr == nil {
+			cmd.Env = signalCLIEnv(os.Environ(), tmpDir)
+			defer cleanupTmp()
+		}
+		configureSignalCancel(cmd)
 		return cmd.CombinedOutput()
 	}
 
 	startSignalLink = func(ctx context.Context, configDir string) (io.ReadCloser, func() error, error) {
 		cmd := exec.CommandContext(ctx, "script", "-q", "/dev/null", signalCLIExecutable(), "--config", configDir, "link", "-n", "OpenMessage")
+		tmpDir, cleanupTmp, tmpErr := newSignalRunTmpDir(configDir)
+		if tmpErr == nil {
+			cmd.Env = signalCLIEnv(os.Environ(), tmpDir)
+		}
+		configureSignalCancel(cmd)
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
+			if tmpErr == nil {
+				cleanupTmp()
+			}
 			return nil, nil, err
 		}
 		if err := cmd.Start(); err != nil {
+			if tmpErr == nil {
+				cleanupTmp()
+			}
 			return nil, nil, err
 		}
-		return stdout, cmd.Wait, nil
+		wait := func() error {
+			err := cmd.Wait()
+			if tmpErr == nil {
+				cleanupTmp()
+			}
+			return err
+		}
+		return stdout, wait, nil
 	}
 )
+
+// configureSignalCancel asks for a graceful stop before the hard kill so
+// the JVM gets a chance to run its shutdown hooks (which include libsignal
+// temp cleanup) and flush output when a context deadline fires.
+func configureSignalCancel(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			return cmd.Process.Kill()
+		}
+		return nil
+	}
+	cmd.WaitDelay = 3 * time.Second
+}
 
 type Callbacks struct {
 	OnConversationsChange func()
@@ -165,6 +203,7 @@ type Bridge struct {
 		importedMessages      int
 	}
 	lastReceiveRecoveryAt int64
+	lastTmpSweep          time.Time
 }
 
 type signalReceiveRecoveryRecord struct {
@@ -326,6 +365,14 @@ func New(configDir string, store *db.Store, logger zerolog.Logger, callbacks Cal
 		contactByACI: map[string]string{},
 	}
 	bridge.account = bridge.firstStoredAccount()
+	bridge.lastTmpSweep = now()
+	go sweepSignalTmpRoot(logger, configDir, signalRunTmpMaxAge)
+	if bridge.account != "" {
+		// Only a paired install can have produced libsignal litter, so the
+		// legacy system-temp sweep stays scoped to installs that ran the
+		// bridge before per-run temp dirs existed.
+		go sweepLegacyLibsignalTemp(logger)
+	}
 	return bridge, nil
 }
 
@@ -839,6 +886,8 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 		default:
 		}
 
+		b.maybeSweepTmp()
+
 		callCtx, callCancel := context.WithTimeout(ctx, time.Duration(receiveTimeoutSeconds+3)*time.Second)
 		b.commandMu.Lock()
 		output, err := runSignalCLI(callCtx, b.configDir, "-a", probedAccount, "--output", "json", "receive", "--timeout", strconv.Itoa(receiveTimeoutSeconds), "--max-messages", strconv.Itoa(receiveMaxMessages))
@@ -898,6 +947,25 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 		if err := b.handleReceiveOutput(probedAccount, output); err != nil {
 			b.logger.Debug().Err(err).Msg("Failed to process Signal receive payload")
 		}
+	}
+}
+
+// maybeSweepTmp runs the crash-backstop sweeps at most once per
+// signalTmpSweepInterval. Normal runs clean up after themselves, so the
+// app-tmp sweep usually finds nothing; the legacy sweep keeps reaping
+// system-temp dirs leaked by older builds as they age past the gate.
+func (b *Bridge) maybeSweepTmp() {
+	b.mu.Lock()
+	due := now().Sub(b.lastTmpSweep) >= signalTmpSweepInterval
+	if due {
+		b.lastTmpSweep = now()
+	}
+	b.mu.Unlock()
+	if due {
+		go func() {
+			sweepSignalTmpRoot(b.logger, b.configDir, signalRunTmpMaxAge)
+			sweepLegacyLibsignalTemp(b.logger)
+		}()
 	}
 }
 

--- a/internal/signallive/tmpdir.go
+++ b/internal/signallive/tmpdir.go
@@ -1,0 +1,180 @@
+package signallive
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// signal-cli runs on the JVM; libsignal-client extracts ~21MB of native
+// libraries into a fresh java.io.tmpdir subdirectory (libsignal*) on every
+// invocation and does not reliably remove it on exit. Because the bridge
+// invokes signal-cli repeatedly (receive polling, sends, metadata refresh),
+// leaked directories can fill the disk (issue #27). Three defenses:
+//
+//  1. Every invocation runs with TMPDIR/java.io.tmpdir pointed at a private
+//     per-run directory under <configDir>/tmp, removed as soon as the
+//     process exits — no accumulation by construction.
+//  2. <configDir>/tmp is swept at startup and periodically for entries old
+//     enough that no live invocation can still own them (crash backstop).
+//  3. A one-time sweep of the system temp dir removes libsignal* dirs
+//     abandoned by earlier versions, so existing installs recover their
+//     disk space without manual cleanup.
+
+const (
+	// signalRunTmpMaxAge must exceed the longest legitimate signal-cli run.
+	// Receive polls finish in seconds and sends within sendTimeout, but a
+	// `link` session can stay open while the user fetches their phone, so
+	// keep a generous margin.
+	signalRunTmpMaxAge = 30 * time.Minute
+
+	signalTmpSweepInterval = 10 * time.Minute
+
+	// legacyLibsignalMaxAge gates the one-time system temp dir sweep. A day
+	// is far older than any live signal-cli process while young enough to
+	// recover a runaway leak quickly.
+	legacyLibsignalMaxAge = 24 * time.Hour
+
+	signalTmpSweepEnvVar = "OPENMESSAGES_SIGNAL_TMP_SWEEP"
+)
+
+func signalTmpRoot(configDir string) string {
+	return filepath.Join(configDir, "tmp")
+}
+
+// newSignalRunTmpDir creates a private temp dir for one signal-cli
+// invocation. The returned cleanup removes it; callers must invoke cleanup
+// only after the subprocess has exited.
+func newSignalRunTmpDir(configDir string) (string, func(), error) {
+	root := signalTmpRoot(configDir)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return "", nil, err
+	}
+	dir, err := os.MkdirTemp(root, "run-")
+	if err != nil {
+		return "", nil, err
+	}
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+// signalCLIEnv rebases the subprocess's temp space onto dir. TMPDIR covers
+// signal-cli itself plus anything it spawns; java.io.tmpdir (appended last
+// to SIGNAL_CLI_OPTS so it wins) covers JVMs that derive their temp dir from
+// the platform default instead of TMPDIR.
+func signalCLIEnv(base []string, dir string) []string {
+	javaOpt := "-Djava.io.tmpdir=" + dir
+	opts := javaOpt
+	env := make([]string, 0, len(base)+2)
+	for _, kv := range base {
+		switch {
+		case strings.HasPrefix(kv, "TMPDIR="):
+			continue
+		case strings.HasPrefix(kv, "SIGNAL_CLI_OPTS="):
+			if existing := strings.TrimSpace(strings.TrimPrefix(kv, "SIGNAL_CLI_OPTS=")); existing != "" {
+				opts = existing + " " + javaOpt
+			}
+			continue
+		}
+		env = append(env, kv)
+	}
+	return append(env, "TMPDIR="+dir, "SIGNAL_CLI_OPTS="+opts)
+}
+
+func signalTmpSweepDisabled() bool {
+	return strings.TrimSpace(os.Getenv(signalTmpSweepEnvVar)) == "0"
+}
+
+// sweepSignalTmpRoot removes entries under <configDir>/tmp older than
+// maxAge. The bridge owns this directory outright, so every stale entry is
+// a leftover from a crashed run regardless of its name.
+func sweepSignalTmpRoot(logger zerolog.Logger, configDir string, maxAge time.Duration) {
+	if signalTmpSweepDisabled() {
+		return
+	}
+	removed, bytes := sweepDirEntries(signalTmpRoot(configDir), maxAge, func(string) bool { return true })
+	if removed > 0 {
+		logger.Info().
+			Int("dirs", removed).
+			Str("reclaimed", humanBytes(bytes)).
+			Msg("Swept stale signal-cli temp dirs left by interrupted runs")
+	}
+}
+
+// sweepLegacyLibsignalTemp clears libsignal* dirs that earlier OpenMessage
+// versions leaked into the system temp dir (issue #27). Only dirs beyond
+// legacyLibsignalMaxAge are touched: anything that old cannot belong to a
+// live signal-cli run, and libsignal re-extracts on demand if another app
+// somehow still references one.
+func sweepLegacyLibsignalTemp(logger zerolog.Logger) {
+	if signalTmpSweepDisabled() {
+		return
+	}
+	removed, bytes := sweepDirEntries(os.TempDir(), legacyLibsignalMaxAge, func(name string) bool {
+		return strings.HasPrefix(name, "libsignal")
+	})
+	if removed > 0 {
+		logger.Warn().
+			Int("dirs", removed).
+			Str("reclaimed", humanBytes(bytes)).
+			Msg("Removed libsignal temp dirs leaked by earlier versions (see issue #27)")
+	}
+}
+
+func sweepDirEntries(root string, maxAge time.Duration, match func(name string) bool) (int, int64) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return 0, 0
+	}
+	cutoff := now().Add(-maxAge)
+	removed := 0
+	var reclaimed int64
+	for _, entry := range entries {
+		if !entry.IsDir() || !match(entry.Name()) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		size := dirSize(path)
+		if err := os.RemoveAll(path); err != nil {
+			continue
+		}
+		removed++
+		reclaimed += size
+	}
+	return removed, reclaimed
+}
+
+func dirSize(root string) int64 {
+	var total int64
+	_ = filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if info, err := d.Info(); err == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return strconv.FormatInt(n, 10) + " B"
+	}
+	div, exp := int64(unit), 0
+	for m := n / unit; m >= unit; m /= unit {
+		div *= unit
+		exp++
+	}
+	return strconv.FormatFloat(float64(n)/float64(div), 'f', 1, 64) + " " + string("KMGTPE"[exp]) + "iB"
+}

--- a/internal/signallive/tmpdir_test.go
+++ b/internal/signallive/tmpdir_test.go
@@ -1,0 +1,210 @@
+package signallive
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func TestSignalCLIEnvReplacesTmpDirAndSetsJavaOpt(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "TMPDIR=/var/folders/xx/T", "HOME=/Users/u"}
+	env := signalCLIEnv(base, "/data/signal-cli/tmp/run-1")
+
+	var tmpdir, opts string
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "TMPDIR=") {
+			if tmpdir != "" {
+				t.Fatalf("duplicate TMPDIR entries in env: %v", env)
+			}
+			tmpdir = strings.TrimPrefix(kv, "TMPDIR=")
+		}
+		if strings.HasPrefix(kv, "SIGNAL_CLI_OPTS=") {
+			opts = strings.TrimPrefix(kv, "SIGNAL_CLI_OPTS=")
+		}
+	}
+	if tmpdir != "/data/signal-cli/tmp/run-1" {
+		t.Fatalf("TMPDIR = %q, want confined dir", tmpdir)
+	}
+	if opts != "-Djava.io.tmpdir=/data/signal-cli/tmp/run-1" {
+		t.Fatalf("SIGNAL_CLI_OPTS = %q, want java.io.tmpdir flag", opts)
+	}
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, "PATH=/usr/bin") || !strings.Contains(joined, "HOME=/Users/u") {
+		t.Fatalf("unrelated env vars must pass through: %v", env)
+	}
+}
+
+func TestSignalCLIEnvAppendsToExistingOptsSoOursWins(t *testing.T) {
+	base := []string{"SIGNAL_CLI_OPTS=-Xmx512m -Djava.io.tmpdir=/users/choice"}
+	env := signalCLIEnv(base, "/confined")
+
+	var opts string
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "SIGNAL_CLI_OPTS=") {
+			opts = strings.TrimPrefix(kv, "SIGNAL_CLI_OPTS=")
+		}
+	}
+	if !strings.HasPrefix(opts, "-Xmx512m") {
+		t.Fatalf("user opts not preserved: %q", opts)
+	}
+	if !strings.HasSuffix(opts, "-Djava.io.tmpdir=/confined") {
+		t.Fatalf("confined tmpdir flag must come last so it wins: %q", opts)
+	}
+}
+
+func TestNewSignalRunTmpDirCreatesAndCleansUp(t *testing.T) {
+	configDir := t.TempDir()
+	dir, cleanup, err := newSignalRunTmpDir(configDir)
+	if err != nil {
+		t.Fatalf("newSignalRunTmpDir: %v", err)
+	}
+	if !strings.HasPrefix(dir, signalTmpRoot(configDir)) {
+		t.Fatalf("run dir %q not under tmp root %q", dir, signalTmpRoot(configDir))
+	}
+	if err := os.WriteFile(filepath.Join(dir, "libsignal.so"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	cleanup()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("run dir still exists after cleanup: %v", err)
+	}
+}
+
+func TestSweepSignalTmpRootRemovesOnlyStaleEntries(t *testing.T) {
+	configDir := t.TempDir()
+	root := signalTmpRoot(configDir)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := filepath.Join(root, "run-stale")
+	fresh := filepath.Join(root, "run-fresh")
+	for _, dir := range []string{stale, fresh} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "payload"), make([]byte, 128), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	staleFile := filepath.Join(root, "stray-file")
+	if err := os.WriteFile(staleFile, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * signalRunTmpMaxAge)
+	for _, p := range []string{stale, staleFile} {
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sweepSignalTmpRoot(zerolog.Nop(), configDir, signalRunTmpMaxAge)
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale run dir should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("fresh run dir should survive: %v", err)
+	}
+	if _, err := os.Stat(staleFile); err != nil {
+		t.Fatalf("plain files should never be swept: %v", err)
+	}
+}
+
+func TestSweepLegacyLibsignalTempFiltersByNameAndAge(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+
+	oldLeak := filepath.Join(tempRoot, "libsignal12345")
+	freshLeak := filepath.Join(tempRoot, "libsignal67890")
+	unrelated := filepath.Join(tempRoot, "com.apple.thing")
+	for _, dir := range []string{oldLeak, freshLeak, unrelated} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-2 * legacyLibsignalMaxAge)
+	for _, p := range []string{oldLeak, unrelated} {
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sweepLegacyLibsignalTemp(zerolog.Nop())
+
+	if _, err := os.Stat(oldLeak); !os.IsNotExist(err) {
+		t.Fatalf("old libsignal dir should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(freshLeak); err != nil {
+		t.Fatalf("fresh libsignal dir should survive (could be live): %v", err)
+	}
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Fatalf("non-libsignal dir must never be touched: %v", err)
+	}
+}
+
+func TestSweepRespectsOptOut(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	t.Setenv(signalTmpSweepEnvVar, "0")
+
+	leak := filepath.Join(tempRoot, "libsignal-optout")
+	if err := os.MkdirAll(leak, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * legacyLibsignalMaxAge)
+	if err := os.Chtimes(leak, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	sweepLegacyLibsignalTemp(zerolog.Nop())
+	sweepSignalTmpRoot(zerolog.Nop(), tempRoot, signalRunTmpMaxAge)
+
+	if _, err := os.Stat(leak); err != nil {
+		t.Fatalf("opt-out must disable all sweeping: %v", err)
+	}
+}
+
+// TestRunSignalCLIConfinesTempAndCleansUp exercises the real runSignalCLI
+// against a stub executable to prove the subprocess sees the confined
+// TMPDIR/SIGNAL_CLI_OPTS and that the per-run dir is removed afterwards.
+func TestRunSignalCLIConfinesTempAndCleansUp(t *testing.T) {
+	configDir := t.TempDir()
+	stub := filepath.Join(t.TempDir(), "signal-cli-stub")
+	script := "#!/bin/sh\nprintf '%s|%s' \"$TMPDIR\" \"$SIGNAL_CLI_OPTS\"\nmkdir -p \"$TMPDIR/libsignal-test\"\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OPENMESSAGES_SIGNAL_CLI", stub)
+
+	out, err := runSignalCLI(context.Background(), configDir, "receive")
+	if err != nil {
+		t.Fatalf("runSignalCLI: %v (out=%s)", err, out)
+	}
+	parts := strings.SplitN(string(out), "|", 2)
+	if len(parts) != 2 {
+		t.Fatalf("unexpected stub output: %q", out)
+	}
+	tmpdir, opts := parts[0], parts[1]
+	if !strings.HasPrefix(tmpdir, signalTmpRoot(configDir)) {
+		t.Fatalf("subprocess TMPDIR %q not confined under %q", tmpdir, signalTmpRoot(configDir))
+	}
+	if !strings.Contains(opts, "-Djava.io.tmpdir="+tmpdir) {
+		t.Fatalf("subprocess SIGNAL_CLI_OPTS %q missing java.io.tmpdir", opts)
+	}
+	if _, err := os.Stat(tmpdir); !os.IsNotExist(err) {
+		t.Fatalf("per-run tmp dir %q should be removed after the run, stat err = %v", tmpdir, err)
+	}
+	entries, err := os.ReadDir(signalTmpRoot(configDir))
+	if err != nil {
+		t.Fatalf("tmp root should still exist: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("tmp root should be empty after run, has %d entries", len(entries))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #27 — the Signal receive loop leaked a ~21MB `libsignal*` temp dir per signal-cli invocation until the disk filled (87GB / 4,455 dirs observed).

**Root cause:** every poll spawns a fresh JVM that extracts libsignal's native libraries under `java.io.tmpdir`. Runs that overran their context deadline were SIGKILLed by `exec.CommandContext`'s default cancel, so the JVM's cleanup shutdown hooks never ran. (Verified against signal-cli 0.14.1: a SIGTERM'd run removes its extraction dir; a SIGKILLed one strands it.)

## Defenses (layered)

1. **Confine + deterministic cleanup** — each invocation runs with `TMPDIR` and `-Djava.io.tmpdir` (appended last to `SIGNAL_CLI_OPTS`, so it wins over user opts) pointed at a private per-run dir under `<configDir>/tmp`, removed as soon as the process exits. Leaks are structurally impossible even on SIGKILL.
2. **Graceful cancel** — context cancellation now sends SIGTERM with a 3s `WaitDelay` before the hard kill, letting JVM shutdown hooks run and output flush.
3. **Sweeps** — the app-owned tmp root is swept at startup and every 10 min for entries older than any live run could own (crash backstop); `libsignal*` dirs older than 24h that earlier builds leaked into the **system** temp dir are reaped on the same cadence, so existing installs recover disk automatically. Opt out: `OPENMESSAGES_SIGNAL_TMP_SWEEP=0`.

## Verification

- 7 new tests: env construction (user `SIGNAL_CLI_OPTS` preserved, ours wins), per-run dir lifecycle, backstop sweep age/name filters, legacy sweep gates, opt-out, and an end-to-end subprocess test proving the child sees the confined `TMPDIR` and the run dir is gone afterwards.
- Live check against real signal-cli 0.14.1: native lib extracts into the confined dir while running; cleaned on SIGTERM.
- Homebrew's launcher (gradle start script) confirmed to splice `SIGNAL_CLI_OPTS` into the java command line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
