### PR TITLE
Make checks green: vet lock-copies + flaky binary test

### DIFF
--- a/cmd/binary_test.go
+++ b/cmd/binary_test.go
@@ -48,23 +48,29 @@ func TestBuiltBinaryAcceptsPairCommand(t *testing.T) {
 		t.Fatalf("failed to start binary: %v", err)
 	}
 
-	// Wait briefly then kill — we just want to confirm it doesn't crash immediately
-	timer := time.AfterFunc(3*time.Second, func() {
-		cmd.Process.Kill()
-	})
-	defer timer.Stop()
+	// We only want to confirm the binary doesn't crash on startup. Surviving
+	// the grace period is a pass in itself: pairing may legitimately produce
+	// no output for a while (it contacts Google before printing the QR), so
+	// a kill-then-inspect approach can't tell a quiet healthy process from a
+	// crashed one.
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
 
-	err := cmd.Wait()
-	output := out.String()
-
-	// The process should either still be running (killed by our timer) or
-	// have produced some output before failing. A zero-length output + immediate
-	// exit means the binary crashed.
-	if err != nil && len(output) == 0 {
-		t.Errorf("binary exited immediately with no output: %v", err)
+	select {
+	case err := <-done:
+		// Exited on its own — fine if it said something first (e.g. a
+		// pairing error without a phone), a crash if it was silent.
+		if err != nil && len(out.String()) == 0 {
+			t.Errorf("binary exited immediately with no output: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		// Still running after the grace period: startup succeeded.
+		_ = cmd.Process.Kill()
+		<-done
 	}
 
-	// Should not contain panic traces
+	// Should not contain panic traces in either outcome.
+	output := out.String()
 	if strings.Contains(output, "panic:") || strings.Contains(output, "runtime error") {
 		t.Errorf("binary panicked:\n%s", output)
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -33,9 +33,9 @@ const (
 
 const maxErrorDetails = 100
 
-// BackfillProgress tracks the current state of a deep backfill operation.
-type BackfillProgress struct {
-	mu                 sync.Mutex
+// BackfillSnapshot is a point-in-time copy of backfill progress, safe to
+// pass and marshal by value.
+type BackfillSnapshot struct {
 	Running            bool          `json:"running"`
 	Phase              BackfillPhase `json:"phase"`
 	FoldersScanned     int           `json:"folders_scanned"`
@@ -44,6 +44,12 @@ type BackfillProgress struct {
 	ContactsChecked    int           `json:"contacts_checked"`
 	Errors             int           `json:"errors"`
 	ErrorDetails       []string      `json:"error_details,omitempty"`
+}
+
+// BackfillProgress tracks the current state of a deep backfill operation.
+type BackfillProgress struct {
+	mu sync.Mutex
+	BackfillSnapshot
 }
 
 // reset clears all fields for a fresh backfill run.
@@ -95,10 +101,10 @@ func (p *BackfillProgress) add(conversations, messages, contacts, folders int) {
 	p.FoldersScanned += folders
 }
 
-func (p *BackfillProgress) snapshot() BackfillProgress {
+func (p *BackfillProgress) snapshot() BackfillSnapshot {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	cp := *p
+	cp := p.BackfillSnapshot
 	if len(p.ErrorDetails) > 0 {
 		cp.ErrorDetails = append([]string(nil), p.ErrorDetails...)
 	}
@@ -569,7 +575,7 @@ func (a *App) IsDeepBackfillRunning() bool {
 }
 
 // GetBackfillProgress returns a snapshot of the current backfill progress.
-func (a *App) GetBackfillProgress() BackfillProgress {
+func (a *App) GetBackfillProgress() BackfillSnapshot {
 	snap := a.BackfillProgress.snapshot()
 	// A shallow Backfill (startup catch-up) holds the same mutual-exclusion
 	// guard (backfillRunning) without populating the deep-backfill progress


### PR DESCRIPTION
## Summary

Two small fixes that make `go vet ./...` and `go test ./...` fully green:

- **vet:** `BackfillProgress.snapshot()` / `GetBackfillProgress()` copied the struct including its `sync.Mutex`. The data fields now live in a mutex-free `BackfillSnapshot` embedded in `BackfillProgress`; snapshot paths return that. No consumer changes needed (`cmd/serve.go` marshals it as `any`; `backfill.go` reads fields).
- **flaky test:** `TestBuiltBinaryAcceptsPairCommand` killed the process after 3s and then read "non-zero exit + empty output" as a crash — the kill itself produces that signature when `pair` is quiet (it contacts Google before printing the QR). The test now treats surviving the grace period as the pass it is.

## Verification

- `go vet ./...` clean
- `go test ./cmd ./internal/app ./internal/web` green (binary tests 3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)