### PR TITLE
Fix races: relocate signal-cli tmp root, join bridge goroutines on Close

### DIFF
--- a/internal/signallive/client.go
+++ b/internal/signallive/client.go
@@ -55,7 +55,7 @@ var (
 	runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
 		commandArgs := append([]string{"--config", configDir}, args...)
 		cmd := exec.CommandContext(ctx, signalCLIExecutable(), commandArgs...)
-		tmpDir, cleanupTmp, tmpErr := newSignalRunTmpDir(configDir)
+		tmpDir, cleanupTmp, tmpErr := newSignalRunTmpDir()
 		if tmpErr == nil {
 			cmd.Env = signalCLIEnv(os.Environ(), tmpDir)
 			defer cleanupTmp()
@@ -66,7 +66,7 @@ var (
 
 	startSignalLink = func(ctx context.Context, configDir string) (io.ReadCloser, func() error, error) {
 		cmd := exec.CommandContext(ctx, "script", "-q", "/dev/null", signalCLIExecutable(), "--config", configDir, "link", "-n", "OpenMessage")
-		tmpDir, cleanupTmp, tmpErr := newSignalRunTmpDir(configDir)
+		tmpDir, cleanupTmp, tmpErr := newSignalRunTmpDir()
 		if tmpErr == nil {
 			cmd.Env = signalCLIEnv(os.Environ(), tmpDir)
 		}
@@ -204,6 +204,22 @@ type Bridge struct {
 	}
 	lastReceiveRecoveryAt int64
 	lastTmpSweep          time.Time
+
+	// wg tracks background goroutines (link, receive loop, metadata refresh,
+	// sweeps, sync requests) so Close can wait for them to finish. Without
+	// the join, reuse of package state after Close — tests swapping the
+	// runSignalCLI stub, serve restarting a bridge — races with loops that
+	// are still draining.
+	wg sync.WaitGroup
+}
+
+// goTracked runs fn on a goroutine that Close waits for.
+func (b *Bridge) goTracked(fn func()) {
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		fn()
+	}()
 }
 
 type signalReceiveRecoveryRecord struct {
@@ -366,7 +382,7 @@ func New(configDir string, store *db.Store, logger zerolog.Logger, callbacks Cal
 	}
 	bridge.account = bridge.firstStoredAccount()
 	bridge.lastTmpSweep = now()
-	go sweepSignalTmpRoot(logger, configDir, signalRunTmpMaxAge)
+	go sweepSignalTmpRoot(logger, signalRunTmpMaxAge)
 	if bridge.account != "" {
 		// Only a paired install can have produced libsignal litter, so the
 		// legacy system-temp sweep stays scoped to installs that ran the
@@ -413,7 +429,7 @@ func (b *Bridge) ConnectIfPaired() error {
 	account := b.account
 	b.mu.Unlock()
 	b.emitStatusChange()
-	go b.startReceiveLoop(account, false)
+	b.goTracked(func() { b.startReceiveLoop(account, false) })
 	return nil
 }
 
@@ -433,7 +449,7 @@ func (b *Bridge) Connect() error {
 		account := b.account
 		b.mu.Unlock()
 		b.emitStatusChange()
-		go b.startReceiveLoop(account, false)
+		b.goTracked(func() { b.startReceiveLoop(account, false) })
 		return nil
 	}
 	if b.pairing || b.connecting {
@@ -449,12 +465,16 @@ func (b *Bridge) Connect() error {
 	b.qr = QRSnapshot{}
 	b.mu.Unlock()
 	b.emitStatusChange()
-	go b.runLink(ctx)
+	b.goTracked(func() { b.runLink(ctx) })
 	return nil
 }
 
 func (b *Bridge) Unpair() error {
 	b.cancelBackgroundWork(true)
+	// Wait for in-flight loops before removing the config dir: a draining
+	// receive poll may still be writing WAL/recovery files inside it, and
+	// RemoveAll on a directory that's being written to fails part-way.
+	b.wg.Wait()
 	if err := os.RemoveAll(b.configDir); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove Signal config dir: %w", err)
 	}
@@ -737,6 +757,7 @@ func (b *Bridge) SendReaction(conversationID, targetMessageID, emoji, action str
 
 func (b *Bridge) Close() error {
 	b.cancelBackgroundWork(false)
+	b.wg.Wait()
 	return nil
 }
 
@@ -860,7 +881,7 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 	b.lastError = ""
 	b.mu.Unlock()
 	b.emitStatusChange()
-	go b.refreshMetadataAndReplay(probedAccount)
+	b.goTracked(func() { b.refreshMetadataAndReplay(probedAccount) })
 	if requestSync {
 		b.beginHistorySync()
 		b.emitStatusChange()
@@ -962,10 +983,10 @@ func (b *Bridge) maybeSweepTmp() {
 	}
 	b.mu.Unlock()
 	if due {
-		go func() {
-			sweepSignalTmpRoot(b.logger, b.configDir, signalRunTmpMaxAge)
+		b.goTracked(func() {
+			sweepSignalTmpRoot(b.logger, signalRunTmpMaxAge)
 			sweepLegacyLibsignalTemp(b.logger)
-		}()
+		})
 	}
 }
 
@@ -1192,11 +1213,11 @@ func (b *Bridge) recordReceiveRecoveryIssue(account string, rawLine []byte, reas
 	}
 	b.beginHistorySync()
 	b.emitStatusChange()
-	go func() {
+	b.goTracked(func() {
 		if syncErr := b.requestSync(account); syncErr != nil {
 			b.logger.Debug().Err(syncErr).Str("reason", reason).Msg("Failed to request Signal recovery sync")
 		}
-	}()
+	})
 }
 
 func (b *Bridge) appendReceiveRecoveryRecord(account string, rawLine []byte, reason string, cause error) error {

--- a/internal/signallive/tmpdir.go
+++ b/internal/signallive/tmpdir.go
@@ -1,6 +1,7 @@
 package signallive
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -18,9 +19,9 @@ import (
 // leaked directories can fill the disk (issue #27). Three defenses:
 //
 //  1. Every invocation runs with TMPDIR/java.io.tmpdir pointed at a private
-//     per-run directory under <configDir>/tmp, removed as soon as the
+//     per-run directory under signalTmpRoot(), removed as soon as the
 //     process exits — no accumulation by construction.
-//  2. <configDir>/tmp is swept at startup and periodically for entries old
+//  2. signalTmpRoot() is swept at startup and periodically for entries old
 //     enough that no live invocation can still own them (crash backstop).
 //  3. A one-time sweep of the system temp dir removes libsignal* dirs
 //     abandoned by earlier versions, so existing installs recover their
@@ -43,15 +44,20 @@ const (
 	signalTmpSweepEnvVar = "OPENMESSAGES_SIGNAL_TMP_SWEEP"
 )
 
-func signalTmpRoot(configDir string) string {
-	return filepath.Join(configDir, "tmp")
+// signalTmpRoot lives under the system temp dir rather than the Signal
+// config dir: Unpair removes the config dir wholesale (and tests remove
+// their temp config dirs on cleanup), which would race with a lingering
+// invocation still creating its run dir inside. The uid suffix keeps the
+// root private per user on systems with a shared /tmp.
+func signalTmpRoot() string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("openmessage-signal-cli-%d", os.Getuid()))
 }
 
 // newSignalRunTmpDir creates a private temp dir for one signal-cli
 // invocation. The returned cleanup removes it; callers must invoke cleanup
 // only after the subprocess has exited.
-func newSignalRunTmpDir(configDir string) (string, func(), error) {
-	root := signalTmpRoot(configDir)
+func newSignalRunTmpDir() (string, func(), error) {
+	root := signalTmpRoot()
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		return "", nil, err
 	}
@@ -89,14 +95,14 @@ func signalTmpSweepDisabled() bool {
 	return strings.TrimSpace(os.Getenv(signalTmpSweepEnvVar)) == "0"
 }
 
-// sweepSignalTmpRoot removes entries under <configDir>/tmp older than
-// maxAge. The bridge owns this directory outright, so every stale entry is
-// a leftover from a crashed run regardless of its name.
-func sweepSignalTmpRoot(logger zerolog.Logger, configDir string, maxAge time.Duration) {
+// sweepSignalTmpRoot removes entries under the app-owned tmp root older
+// than maxAge. The bridge owns this directory outright, so every stale
+// entry is a leftover from a crashed run regardless of its name.
+func sweepSignalTmpRoot(logger zerolog.Logger, maxAge time.Duration) {
 	if signalTmpSweepDisabled() {
 		return
 	}
-	removed, bytes := sweepDirEntries(signalTmpRoot(configDir), maxAge, func(string) bool { return true })
+	removed, bytes := sweepDirEntries(signalTmpRoot(), maxAge, func(string) bool { return true })
 	if removed > 0 {
 		logger.Info().
 			Int("dirs", removed).

--- a/internal/signallive/tmpdir_test.go
+++ b/internal/signallive/tmpdir_test.go
@@ -58,13 +58,13 @@ func TestSignalCLIEnvAppendsToExistingOptsSoOursWins(t *testing.T) {
 }
 
 func TestNewSignalRunTmpDirCreatesAndCleansUp(t *testing.T) {
-	configDir := t.TempDir()
-	dir, cleanup, err := newSignalRunTmpDir(configDir)
+	t.Setenv("TMPDIR", t.TempDir())
+	dir, cleanup, err := newSignalRunTmpDir()
 	if err != nil {
 		t.Fatalf("newSignalRunTmpDir: %v", err)
 	}
-	if !strings.HasPrefix(dir, signalTmpRoot(configDir)) {
-		t.Fatalf("run dir %q not under tmp root %q", dir, signalTmpRoot(configDir))
+	if !strings.HasPrefix(dir, signalTmpRoot()) {
+		t.Fatalf("run dir %q not under tmp root %q", dir, signalTmpRoot())
 	}
 	if err := os.WriteFile(filepath.Join(dir, "libsignal.so"), []byte("x"), 0o600); err != nil {
 		t.Fatalf("write fixture: %v", err)
@@ -76,8 +76,8 @@ func TestNewSignalRunTmpDirCreatesAndCleansUp(t *testing.T) {
 }
 
 func TestSweepSignalTmpRootRemovesOnlyStaleEntries(t *testing.T) {
-	configDir := t.TempDir()
-	root := signalTmpRoot(configDir)
+	t.Setenv("TMPDIR", t.TempDir())
+	root := signalTmpRoot()
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func TestSweepSignalTmpRootRemovesOnlyStaleEntries(t *testing.T) {
 		}
 	}
 
-	sweepSignalTmpRoot(zerolog.Nop(), configDir, signalRunTmpMaxAge)
+	sweepSignalTmpRoot(zerolog.Nop(), signalRunTmpMaxAge)
 
 	if _, err := os.Stat(stale); !os.IsNotExist(err) {
 		t.Fatalf("stale run dir should be removed, stat err = %v", err)
@@ -163,7 +163,7 @@ func TestSweepRespectsOptOut(t *testing.T) {
 	}
 
 	sweepLegacyLibsignalTemp(zerolog.Nop())
-	sweepSignalTmpRoot(zerolog.Nop(), tempRoot, signalRunTmpMaxAge)
+	sweepSignalTmpRoot(zerolog.Nop(), signalRunTmpMaxAge)
 
 	if _, err := os.Stat(leak); err != nil {
 		t.Fatalf("opt-out must disable all sweeping: %v", err)
@@ -174,6 +174,7 @@ func TestSweepRespectsOptOut(t *testing.T) {
 // against a stub executable to prove the subprocess sees the confined
 // TMPDIR/SIGNAL_CLI_OPTS and that the per-run dir is removed afterwards.
 func TestRunSignalCLIConfinesTempAndCleansUp(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
 	configDir := t.TempDir()
 	stub := filepath.Join(t.TempDir(), "signal-cli-stub")
 	script := "#!/bin/sh\nprintf '%s|%s' \"$TMPDIR\" \"$SIGNAL_CLI_OPTS\"\nmkdir -p \"$TMPDIR/libsignal-test\"\n"
@@ -191,8 +192,8 @@ func TestRunSignalCLIConfinesTempAndCleansUp(t *testing.T) {
 		t.Fatalf("unexpected stub output: %q", out)
 	}
 	tmpdir, opts := parts[0], parts[1]
-	if !strings.HasPrefix(tmpdir, signalTmpRoot(configDir)) {
-		t.Fatalf("subprocess TMPDIR %q not confined under %q", tmpdir, signalTmpRoot(configDir))
+	if !strings.HasPrefix(tmpdir, signalTmpRoot()) {
+		t.Fatalf("subprocess TMPDIR %q not confined under %q", tmpdir, signalTmpRoot())
 	}
 	if !strings.Contains(opts, "-Djava.io.tmpdir="+tmpdir) {
 		t.Fatalf("subprocess SIGNAL_CLI_OPTS %q missing java.io.tmpdir", opts)
@@ -200,7 +201,7 @@ func TestRunSignalCLIConfinesTempAndCleansUp(t *testing.T) {
 	if _, err := os.Stat(tmpdir); !os.IsNotExist(err) {
 		t.Fatalf("per-run tmp dir %q should be removed after the run, stat err = %v", tmpdir, err)
 	}
-	entries, err := os.ReadDir(signalTmpRoot(configDir))
+	entries, err := os.ReadDir(signalTmpRoot())
 	if err != nil {
 		t.Fatalf("tmp root should still exist: %v", err)
 	}


### PR DESCRIPTION
## Summary

The Go Race CI job on main failed after #28 (`TestConnectEmitsSignalQRCodeAndStoresPairedAccount`: "TempDir RemoveAll cleanup: directory not empty"). Investigating reproduced two distinct races:

1. **Run-tmp location** — #28 put per-invocation temp dirs under the Signal config dir. Any teardown that removes that dir wholesale (production `Unpair` → `os.RemoveAll(configDir)`, `t.TempDir()` cleanup) races with a lingering invocation's `MkdirTemp`. The root now lives at `os.TempDir()/openmessage-signal-cli-<uid>` — app-owned, per-user, outside every wholesale-removal path. All #28 guarantees hold (per-run dir removed on process exit, startup + periodic sweeps, legacy `libsignal*` reaping, `OPENMESSAGES_SIGNAL_TMP_SWEEP=0` opt-out).
2. **Close without join** — `Bridge.Close` cancelled contexts but never waited for the link/receive/refresh/sweep/sync goroutines, so reusing package state after Close (tests swapping the `runSignalCLI` stub between `-count` runs; serve restarting a bridge) raced with loops still draining. Goroutines are now tracked in a WaitGroup; `Close` joins, and `Unpair` joins **before** `RemoveAll(configDir)` — a draining poll can still be writing WAL/recovery files inside it.

## Verification

- `go test ./internal/signallive -race -run TestConnectEmitsSignalQRCode -count=30`: all pass (previously ~1/20 failure)
- `go test ./internal/signallive -race -count=3`, `go vet ./...`, full `go test ./...`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)