### PR TITLE
Harden HTTP API; fix stale-snapshot unread clobber; contacts query pushdown

### DIFF
--- a/internal/app/backfill.go
+++ b/internal/app/backfill.go
@@ -639,7 +639,7 @@ func (a *App) storeConversation(conv *gmproto.Conversation) error {
 		unread = 1
 	}
 
-	return a.Store.UpsertConversation(&db.Conversation{
+	return a.Store.ApplyConversationSnapshot(&db.Conversation{
 		ConversationID: conv.GetConversationID(),
 		Name:           conv.GetName(),
 		IsGroup:        conv.GetIsGroupChat(),

--- a/internal/client/events.go
+++ b/internal/client/events.go
@@ -242,7 +242,7 @@ func (h *EventHandler) storeConversation(conv *gmproto.Conversation) bool {
 		UnreadCount:    unread,
 	}
 
-	if err := h.Store.UpsertConversation(dbConv); err != nil {
+	if err := h.Store.ApplyConversationSnapshot(dbConv); err != nil {
 		h.Logger.Error().Err(err).Str("conv_id", dbConv.ConversationID).Msg("Failed to store conversation")
 		return false
 	}

--- a/internal/db/contacts.go
+++ b/internal/db/contacts.go
@@ -59,11 +59,21 @@ func (s *Store) ListContacts(query string, limit int) ([]*Contact, error) {
 
 // ListContactsFromConversations extracts contacts from conversation participants
 // as a fallback when the contacts table is empty.
+//
+// The SQL prefilter is a strict superset of the per-participant matching
+// below (the participants JSON contains every name and number verbatim), so
+// it never hides a match — it just keeps a filtered autocomplete keystroke
+// from JSON-decoding every conversation in the store. The row LIMIT bounds
+// worst-case work; it is generous because one row can fan out to many
+// participants and duplicates are dropped.
 func (s *Store) ListContactsFromConversations(query string, limit int) ([]*Contact, error) {
+	queryFilter := strings.ToLower(query)
 	rows, err := s.db.Query(`
 		SELECT conversation_id, name, participants FROM conversations
+		WHERE ? = '' OR instr(lower(name), ?) > 0 OR instr(lower(participants), ?) > 0
 		ORDER BY last_message_ts DESC
-	`)
+		LIMIT ?
+	`, queryFilter, queryFilter, queryFilter, limit*20)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/contacts_test.go
+++ b/internal/db/contacts_test.go
@@ -246,3 +246,57 @@ func TestListContacts_QueryMatchesBothNameAndNumber(t *testing.T) {
 		t.Errorf("count: got %d, want 2 (matches both name and number)", len(got))
 	}
 }
+
+func TestListContactsFromConversationsPrefilter(t *testing.T) {
+	store := newTestStore(t)
+	convos := []*Conversation{
+		{ConversationID: "c1", Name: "Alice Smith", Participants: `[{"name":"Alice Smith","number":"+15551112222"}]`, LastMessageTS: 300},
+		{ConversationID: "c2", Name: "Bob Jones", Participants: `[{"name":"Bob Jones","number":"+15553334444"}]`, LastMessageTS: 200},
+		{ConversationID: "c3", Name: "carol ALICEson", Participants: `[{"name":"carol ALICEson","number":"+15555556666"}]`, LastMessageTS: 100},
+	}
+	for _, c := range convos {
+		if err := store.UpsertConversation(c); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("case-insensitive name match", func(t *testing.T) {
+		got, err := store.ListContactsFromConversations("alice", 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d contacts, want 2 (Alice Smith + carol ALICEson): %+v", len(got), got)
+		}
+	})
+
+	t.Run("number match", func(t *testing.T) {
+		got, err := store.ListContactsFromConversations("5553334444", 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got[0].Name != "Bob Jones" {
+			t.Fatalf("number search wrong: %+v", got)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		got, err := store.ListContactsFromConversations("zzzz", 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("got %d contacts, want 0", len(got))
+		}
+	})
+
+	t.Run("empty query returns all up to limit", func(t *testing.T) {
+		got, err := store.ListContactsFromConversations("", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d contacts, want limit 2", len(got))
+		}
+	})
+}

--- a/internal/db/conversations.go
+++ b/internal/db/conversations.go
@@ -379,3 +379,31 @@ func maybeNotificationModeArg(hasMode bool, mode string) string {
 	}
 	return mode
 }
+
+// ApplyConversationSnapshot upserts a conversation from a platform-state
+// snapshot (a Google Messages conversation event or a backfill page) while
+// guarding local state against stale snapshots:
+//
+//   - last_message_ts never moves backward, matching the recency rule used
+//     for messages (AdvanceConversationRecency).
+//   - A snapshot may set the unread flag only when it carries something
+//     newer than what's stored. The phone re-sends conversation state on
+//     unrelated events, and a snapshot that is no newer than local state
+//     must not resurrect unread on a conversation already read locally.
+//     Clearing unread (the user read it on the phone) is always honored.
+//
+// Live-transport handlers that compute unread deltas themselves (WhatsApp,
+// Signal) should keep using UpsertConversation directly.
+func (s *Store) ApplyConversationSnapshot(c *Conversation) error {
+	existing, err := s.GetConversation(c.ConversationID)
+	if err == nil && existing != nil {
+		snapshotTS := c.LastMessageTS
+		if snapshotTS < existing.LastMessageTS {
+			c.LastMessageTS = existing.LastMessageTS
+		}
+		if c.UnreadCount > 0 && existing.UnreadCount == 0 && snapshotTS <= existing.LastMessageTS {
+			c.UnreadCount = 0
+		}
+	}
+	return s.UpsertConversation(c)
+}

--- a/internal/db/conversations_test.go
+++ b/internal/db/conversations_test.go
@@ -518,3 +518,105 @@ func TestSearchConversationsByMetadata(t *testing.T) {
 		t.Fatalf("got conversation %q, want c1", got[0].ConversationID)
 	}
 }
+
+func TestApplyConversationSnapshotGuardsStaleState(t *testing.T) {
+	store := newTestStore(t)
+
+	seed := &Conversation{
+		ConversationID: "conv-snap",
+		Name:           "Alice",
+		Participants:   `[{"name":"Alice","number":"+15551234567"}]`,
+		LastMessageTS:  5000,
+		UnreadCount:    1,
+	}
+	if err := store.UpsertConversation(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := store.MarkConversationRead("conv-snap"); err != nil {
+		t.Fatalf("mark read: %v", err)
+	}
+
+	t.Run("stale snapshot cannot resurrect unread or regress recency", func(t *testing.T) {
+		stale := &Conversation{
+			ConversationID: "conv-snap",
+			Name:           "Alice",
+			Participants:   seed.Participants,
+			LastMessageTS:  4000, // older than stored 5000
+			UnreadCount:    1,
+		}
+		if err := store.ApplyConversationSnapshot(stale); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		got, _ := store.GetConversation("conv-snap")
+		if got.UnreadCount != 0 {
+			t.Errorf("unread resurrected by stale snapshot: got %d, want 0", got.UnreadCount)
+		}
+		if got.LastMessageTS != 5000 {
+			t.Errorf("recency regressed: got %d, want 5000", got.LastMessageTS)
+		}
+	})
+
+	t.Run("equal-timestamp snapshot cannot resurrect unread", func(t *testing.T) {
+		same := &Conversation{
+			ConversationID: "conv-snap",
+			Participants:   seed.Participants,
+			LastMessageTS:  5000,
+			UnreadCount:    1,
+		}
+		if err := store.ApplyConversationSnapshot(same); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		got, _ := store.GetConversation("conv-snap")
+		if got.UnreadCount != 0 {
+			t.Errorf("unread resurrected by same-age snapshot: got %d, want 0", got.UnreadCount)
+		}
+	})
+
+	t.Run("newer snapshot sets unread and advances recency", func(t *testing.T) {
+		newer := &Conversation{
+			ConversationID: "conv-snap",
+			Participants:   seed.Participants,
+			LastMessageTS:  6000,
+			UnreadCount:    1,
+		}
+		if err := store.ApplyConversationSnapshot(newer); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		got, _ := store.GetConversation("conv-snap")
+		if got.UnreadCount != 1 || got.LastMessageTS != 6000 {
+			t.Errorf("newer snapshot not applied: unread=%d ts=%d, want 1/6000", got.UnreadCount, got.LastMessageTS)
+		}
+	})
+
+	t.Run("phone-side read always clears unread", func(t *testing.T) {
+		read := &Conversation{
+			ConversationID: "conv-snap",
+			Participants:   seed.Participants,
+			LastMessageTS:  6000,
+			UnreadCount:    0,
+		}
+		if err := store.ApplyConversationSnapshot(read); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		got, _ := store.GetConversation("conv-snap")
+		if got.UnreadCount != 0 {
+			t.Errorf("phone read not honored: got %d, want 0", got.UnreadCount)
+		}
+	})
+
+	t.Run("new conversation inserts as-is", func(t *testing.T) {
+		fresh := &Conversation{
+			ConversationID: "conv-new",
+			Name:           "Bob",
+			LastMessageTS:  100,
+			UnreadCount:    1,
+		}
+		if err := store.ApplyConversationSnapshot(fresh); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		got, _ := store.GetConversation("conv-new")
+		if got == nil || got.UnreadCount != 1 {
+			t.Fatalf("fresh insert wrong: %+v", got)
+		}
+	})
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -32,6 +32,11 @@ import (
 //go:embed static/*
 var staticFS embed.FS
 
+// maxUploadBytes bounds /api/send-media request bodies. 128MB sits above
+// every platform's attachment cap (Signal ~100MB, WhatsApp ~64MB, MMS ~1MB)
+// while keeping a runaway POST from exhausting memory.
+const maxUploadBytes = 128 << 20
+
 // APIHandler creates the HTTP handler with JSON API routes and static file serving.
 // The client may be nil (disconnected state).
 // mcpHandler is an optional http.Handler for the MCP SSE endpoint (mounted at /mcp/).
@@ -897,8 +902,18 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "method not allowed", 405)
 			return
 		}
-		// Parse multipart form (max 10MB)
+		// Cap the whole request body: ParseMultipartForm's argument only
+		// bounds the in-memory portion (the rest spills to disk), and the
+		// attachment is read fully into memory below — without this cap a
+		// single oversized POST can OOM the backend and take every live
+		// sync down with it.
+		r.Body = http.MaxBytesReader(w, r.Body, maxUploadBytes)
 		if err := r.ParseMultipartForm(10 << 20); err != nil {
+			var tooLarge *http.MaxBytesError
+			if errors.As(err, &tooLarge) {
+				httpError(w, fmt.Sprintf("attachment too large (limit %d MB)", maxUploadBytes>>20), http.StatusRequestEntityTooLarge)
+				return
+			}
 			httpError(w, "invalid multipart form: "+err.Error(), 400)
 			return
 		}
@@ -920,6 +935,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		data, err := io.ReadAll(file)
 		if err != nil {
+			var tooLarge *http.MaxBytesError
+			if errors.As(err, &tooLarge) {
+				httpError(w, fmt.Sprintf("attachment too large (limit %d MB)", maxUploadBytes>>20), http.StatusRequestEntityTooLarge)
+				return
+			}
 			httpError(w, "read file: "+err.Error(), 500)
 			return
 		}
@@ -1903,8 +1923,31 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "forbidden: API requests must originate from the local OpenMessage app", http.StatusForbidden)
 			return
 		}
+		setSecurityHeaders(w)
 		handler.ServeHTTP(w, r)
 	})
+}
+
+// setSecurityHeaders adds defense-in-depth headers. The UI relies on
+// disciplined manual escaping against XSS; the CSP doesn't stop inline-
+// handler injection (the app uses inline scripts/handlers throughout) but
+// it does contain a missed sink's blast radius: scripts, fetches, images,
+// and media can't reach non-loopback origins, so message history can't be
+// exfiltrated to an attacker host. Fonts are the one external dependency.
+func setSecurityHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Security-Policy",
+		"default-src 'self'; "+
+			"script-src 'self' 'unsafe-inline'; "+
+			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "+
+			"font-src 'self' https://fonts.gstatic.com; "+
+			"img-src 'self' data: blob:; "+
+			"media-src 'self' data: blob:; "+
+			"connect-src 'self'; "+
+			"object-src 'none'; "+
+			"base-uri 'self'; "+
+			"frame-ancestors 'none'")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Referrer-Policy", "no-referrer")
 }
 
 // isLoopbackHost reports whether a bare hostname refers to this machine's
@@ -1927,7 +1970,10 @@ func isLocalAPIRequest(r *http.Request) bool {
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
 	}
-	if host != "" && !isLoopbackHost(host) {
+	// An absent Host header is treated as non-local: browsers always send
+	// one, so an empty value only ever comes from a hand-rolled client —
+	// which must not slip past the loopback check by omission.
+	if host == "" || !isLoopbackHost(host) {
 		return false
 	}
 	origin := r.Header.Get("Origin")

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -2981,3 +2981,98 @@ func TestMarkReadPublishesConversationInvalidation(t *testing.T) {
 		t.Fatalf("stream event = %q, want %q", evt.Event, EventTypeConversations)
 	}
 }
+
+func TestAPIGuardRejectsEmptyHost(t *testing.T) {
+	// Go's HTTP client always sends a Host, so exercise the guard directly
+	// the way a hand-rolled client omitting it would reach it.
+	r := httptest.NewRequest(http.MethodGet, "/api/conversations", nil)
+	r.Host = ""
+	if isLocalAPIRequest(r) {
+		t.Fatal("request with empty Host must not pass the loopback guard")
+	}
+
+	r.Host = "127.0.0.1:7007"
+	if !isLocalAPIRequest(r) {
+		t.Fatal("loopback Host must pass the guard")
+	}
+
+	r.Host = "evil.example.com"
+	if isLocalAPIRequest(r) {
+		t.Fatal("non-loopback Host must not pass the guard")
+	}
+}
+
+func TestSecurityHeadersPresent(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.server.Close()
+
+	resp, err := http.Get(ts.server.URL + "/api/conversations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	csp := resp.Header.Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("Content-Security-Policy header missing")
+	}
+	for _, directive := range []string{"default-src 'self'", "connect-src 'self'", "frame-ancestors 'none'", "object-src 'none'"} {
+		if !strings.Contains(csp, directive) {
+			t.Errorf("CSP missing %q: %s", directive, csp)
+		}
+	}
+	if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+}
+
+func TestSendMediaRejectsOversizedUpload(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.server.Close()
+
+	// Stream a multipart body larger than maxUploadBytes without buffering
+	// it in the test: a 129MB zero-filled part.
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+	go func() {
+		defer pw.Close()
+		_ = mw.WriteField("conversation_id", "conv-1")
+		part, err := mw.CreateFormFile("file", "huge.bin")
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if _, err := io.CopyN(part, zeroReader{}, maxUploadBytes+(1<<20)); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		_ = mw.Close()
+	}()
+
+	req, err := http.NewRequest(http.MethodPost, ts.server.URL+"/api/send-media", pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		// The server may reset the connection once MaxBytesReader trips;
+		// either a clean 413 or a transport error after refusal is
+		// acceptable proof the body was not buffered to completion.
+		t.Logf("transport error after refusal (acceptable): %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", resp.StatusCode)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}


### PR DESCRIPTION
## Summary

Four fixes from the deep review (all verified with new tests):

### Security
- **Upload cap (OOM fix):** `/api/send-media` read the whole attachment into memory with no body bound — `ParseMultipartForm(10MB)` only caps the in-memory portion; the rest spills to disk and `io.ReadAll` pulls it all back. A single oversized POST could OOM the backend and take down every live sync. Now wrapped in `http.MaxBytesReader` (128MB, above all platform attachment limits) returning 413.
- **Empty-Host bypass:** `isLocalAPIRequest` passed requests with no Host header. Browsers always send one, so only hand-rolled clients hit this path — they now fail closed.
- **CSP + nosniff + no-referrer on all responses:** the UI's XSS posture relies on disciplined manual escaping; the CSP contains a missed sink's blast radius by confining scripts/fetches/images/media to loopback (+ Google Fonts), so message history can't be exfiltrated cross-origin even if an escape is missed someday.

### Correctness
- **Unread badge flicker:** Google Messages re-sends conversation snapshots on unrelated events, and the upsert blindly overwrote `unread_count` and `last_message_ts` — re-flagging conversations you'd already read in OpenMessage (the app never pushes read state to the phone) and occasionally regressing list order. New `db.ApplyConversationSnapshot` guards both: recency never moves backward, and a snapshot can only set unread when it actually carries something newer. Phone-side reads still clear unread. (WhatsApp/Signal handlers compute deltas themselves and are untouched.)

### Performance
- **Contacts autocomplete:** `ListContactsFromConversations` JSON-decoded every conversation in the store per keystroke when filtered (no SQL LIMIT, Go-side break rarely hit). Case-insensitive prefilter + LIMIT now pushed into SQL; the prefilter is a strict superset of the Go matching so results are unchanged.

## Tests
- `ApplyConversationSnapshot`: stale/equal/newer/read/new-conversation cases
- Guard: empty, loopback, non-loopback Host
- Headers: CSP directives + nosniff
- Oversized upload: streamed 129MB body → 413 without buffering
- Contacts: case-insensitive name/number matching, no-match, empty-query limit
- `go vet ./...` and full `go test ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)