### PR TITLE
Notifications: single owner, tap-to-open, foreground suppression; backend auto-restart

### DIFF
--- a/macos/OpenMessage/Sources/BackendManager.swift
+++ b/macos/OpenMessage/Sources/BackendManager.swift
@@ -36,6 +36,20 @@ final class BackendManager: ObservableObject {
     private var healthCheckTask: Task<Void, Never>?
     private var connectionMonitorTask: Task<Void, Never>?
 
+    // ── Bounded auto-restart ──
+    // When the backend exits unexpectedly we retry a few times with exponential
+    // backoff instead of immediately dumping the user into a manual "Try again"
+    // screen. The counter resets once a restarted backend has stayed healthy for
+    // `healthyResetInterval`, so a backend that crashes once an hour doesn't burn
+    // through its budget permanently. Only after the budget is exhausted do we
+    // surface `.error(...)`.
+    private static let maxRestartAttempts = 3
+    private static let restartBackoff: [Duration] = [.seconds(1), .seconds(3), .seconds(9)]
+    private static let healthyResetInterval: Duration = .seconds(60)
+    private var restartAttempts = 0
+    private var pendingRestartTask: Task<Void, Never>?
+    private var healthyResetTask: Task<Void, Never>?
+
     init() {
         // Standard Cmd-Q / app-menu "Quit" terminates via NSApplication without
         // going through the menu-bar button's stop(), which left the spawned
@@ -118,9 +132,19 @@ final class BackendManager: ObservableObject {
         URL(string: "http://127.0.0.1:\(port)")!
     }
 
+    /// User- or lifecycle-initiated start. Resets the auto-restart budget so a
+    /// deliberate (re)start always gets the full retry allowance, then launches.
     func start() {
         guard state != .starting, state != .running else { return }
+        cancelPendingRestart()
+        restartAttempts = 0
+        launchBackend()
+    }
 
+    /// Spawns (or adopts) the backend process. Shared by the public `start()` and
+    /// the auto-restart path, so a restart doesn't trip `start()`'s running/
+    /// starting guard.
+    private func launchBackend() {
         migrateOldDataIfNeeded()
 
         state = .starting
@@ -128,6 +152,7 @@ final class BackendManager: ObservableObject {
         healthCheckTask = nil
         connectionMonitorTask?.cancel()
         connectionMonitorTask = nil
+        cancelHealthyResetTimer()
         if reuseExistingBackendIfNeeded() {
             return
         }
@@ -146,7 +171,14 @@ final class BackendManager: ObservableObject {
             "OPENMESSAGES_DATA_DIR": dir,
             "OPENMESSAGES_LOG_LEVEL": "info",
             "OPENMESSAGES_APP_SANDBOX": "1",
-            "OPENMESSAGES_MACOS_NOTIFICATIONS": "1",
+            // The native app owns notifications when it wraps the backend:
+            // NotificationManager posts UNUserNotificationCenter banners off the
+            // SSE event stream, with tap-to-open and foreground suppression that
+            // the Go side can't do. Disable the backend's own osascript/
+            // terminal-notifier banners so a single inbound message doesn't fire
+            // two notifications. Bare `openmessage serve` in a terminal (no app,
+            // env var unset) still gets Go-side banners via its default logic.
+            "OPENMESSAGES_MACOS_NOTIFICATIONS": "0",
             "HOME": NSHomeDirectory(),
             "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
         ]
@@ -170,14 +202,18 @@ final class BackendManager: ObservableObject {
 
         proc.terminationHandler = { [weak self] proc in
             let manager = self
+            let reason = proc.terminationReason == .uncaughtSignal ? "signal" : "exit"
+            let code = proc.terminationStatus
             Task { @MainActor in
                 guard let manager else { return }
-                let reason = proc.terminationReason == .uncaughtSignal ? "signal" : "exit"
-                manager.logger.warning("Backend terminated via \(reason, privacy: .public) with code \(proc.terminationStatus)")
+                manager.logger.warning("Backend terminated via \(reason, privacy: .public) with code \(code)")
                 guard manager.process === proc else { return }
                 manager.process = nil
+                // Only react to crashes while we believed the backend was up. A
+                // deliberate stop()/quit clears `state` first, so this won't
+                // fight an intentional shutdown.
                 if manager.state == .running || manager.state == .starting {
-                    manager.state = .error("Backend exited unexpectedly (code \(proc.terminationStatus))")
+                    manager.handleUnexpectedTermination(code: code)
                 }
             }
         }
@@ -318,6 +354,8 @@ final class BackendManager: ObservableObject {
     }
 
     func stop() {
+        cancelPendingRestart()
+        restartAttempts = 0
         healthCheckTask?.cancel()
         healthCheckTask = nil
         connectionMonitorTask?.cancel()
@@ -338,6 +376,7 @@ final class BackendManager: ObservableObject {
     /// spawned process to exit so it isn't reparented to launchd (which would
     /// leave it holding the port and the SQLite/session files).
     private func terminateForQuit() {
+        cancelPendingRestart()
         healthCheckTask?.cancel()
         connectionMonitorTask?.cancel()
         if let process, process.isRunning {
@@ -354,6 +393,55 @@ final class BackendManager: ObservableObject {
         }
     }
 
+    // ── Auto-restart plumbing ──
+
+    /// Reacts to the backend dying while we believed it was up: retry with
+    /// backoff until the budget is exhausted, then surface the error UI.
+    private func handleUnexpectedTermination(code: Int32) {
+        guard restartAttempts < Self.maxRestartAttempts else {
+            logger.error("Backend exited (code \(code)) and the restart budget is exhausted")
+            state = .error("Backend exited unexpectedly (code \(code))")
+            return
+        }
+        let delay = Self.restartBackoff[min(restartAttempts, Self.restartBackoff.count - 1)]
+        restartAttempts += 1
+        let attempt = restartAttempts
+        logger.warning("Backend exited (code \(code)); auto-restart \(attempt)/\(Self.maxRestartAttempts) in \(String(describing: delay), privacy: .public)")
+        state = .starting
+        pendingRestartTask?.cancel()
+        pendingRestartTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard let self, !Task.isCancelled else { return }
+            self.pendingRestartTask = nil
+            self.launchBackend()
+        }
+    }
+
+    /// Once a (re)started backend has stayed healthy for a minute, forget
+    /// past crashes so an occasional failure never permanently drains the
+    /// retry budget.
+    private func scheduleRestartBudgetReset() {
+        healthyResetTask?.cancel()
+        healthyResetTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: Self.healthyResetInterval)
+            guard let self, !Task.isCancelled else { return }
+            if self.state == .running {
+                self.restartAttempts = 0
+            }
+            self.healthyResetTask = nil
+        }
+    }
+
+    private func cancelPendingRestart() {
+        pendingRestartTask?.cancel()
+        pendingRestartTask = nil
+    }
+
+    private func cancelHealthyResetTimer() {
+        healthyResetTask?.cancel()
+        healthyResetTask = nil
+    }
+
     /// Poll /api/status until the backend is ready.
     private func startHealthCheck() {
         healthCheckTask = Task {
@@ -368,6 +456,7 @@ final class BackendManager: ObservableObject {
                         _ = json
                         self.state = .running
                         self.logger.info("Backend ready after \(attempt) checks")
+                        self.scheduleRestartBudgetReset()
                         self.startConnectionMonitor()
                         return
                     }

--- a/macos/OpenMessage/Sources/ContentView.swift
+++ b/macos/OpenMessage/Sources/ContentView.swift
@@ -109,6 +109,7 @@ struct WebViewContainer: NSViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.setValue(false, forKey: "drawsBackground") // Transparent during load
         context.coordinator.webView = webView
+        WebViewBridge.shared.webView = webView
         webView.navigationDelegate = context.coordinator
         webView.load(URLRequest(url: url))
         return webView

--- a/macos/OpenMessage/Sources/NotificationManager.swift
+++ b/macos/OpenMessage/Sources/NotificationManager.swift
@@ -134,13 +134,40 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
 
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        let conversationID = notification.request.content.userInfo["conversationID"] as? String ?? ""
+        // Suppress the banner and sound when the user is literally looking
+        // at this conversation — keep it in Notification Center's list only.
+        // On any uncertainty (webview not ready, JS error), fall back to
+        // showing the banner; silently dropping a notification is the worse
+        // failure.
+        if !conversationID.isEmpty {
+            let appActive = await MainActor.run { NSApp.isActive }
+            if appActive {
+                let active = await WebViewBridge.shared.activeConversationID()
+                if active == conversationID {
+                    return [.list]
+                }
+            }
+        }
         if #available(macOS 11.0, *) {
-            completionHandler([.banner, .list, .sound, .badge])
+            return [.banner, .list, .sound, .badge]
         } else {
-            completionHandler([.alert, .sound, .badge])
+            return [.alert, .sound, .badge]
+        }
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let conversationID = response.notification.request.content.userInfo["conversationID"] as? String ?? ""
+        await MainActor.run {
+            NSApp.activate(ignoringOtherApps: true)
+            if !conversationID.isEmpty {
+                WebViewBridge.shared.openConversation(conversationID)
+            }
         }
     }
 

--- a/macos/OpenMessage/Sources/WebViewBridge.swift
+++ b/macos/OpenMessage/Sources/WebViewBridge.swift
@@ -1,0 +1,33 @@
+import Foundation
+import WebKit
+
+/// Lets non-view components (notifications) talk to the app's single
+/// WKWebView: open a conversation on banner tap, and read which
+/// conversation is on screen for foreground suppression. Both directions
+/// ride on contracts the web UI already maintains — it keeps the active
+/// conversation synced into `?conversation=` and restores it from the same
+/// query parameter on load — so no extra JS globals are needed.
+@MainActor
+final class WebViewBridge {
+    static let shared = WebViewBridge()
+
+    weak var webView: WKWebView?
+
+    /// Navigates the UI to a conversation via the existing deep-link path.
+    func openConversation(_ conversationID: String) {
+        guard let webView, !conversationID.isEmpty else { return }
+        let escaped = conversationID.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationID
+        let js = "window.location.href = '/?conversation=" +
+            escaped.replacingOccurrences(of: "'", with: "%27") + "'"
+        webView.evaluateJavaScript(js, completionHandler: nil)
+    }
+
+    /// The conversation currently open in the UI, or nil if none/unknown.
+    func activeConversationID() async -> String? {
+        guard let webView else { return nil }
+        let js = "new URLSearchParams(window.location.search).get('conversation') || ''"
+        let result = try? await webView.evaluateJavaScript(js)
+        guard let id = result as? String, !id.isEmpty else { return nil }
+        return id
+    }
+}


### PR DESCRIPTION
## Summary

Four user-facing fixes to the macOS app's notification handling and backend supervision (the app's most-felt rough edges):

| Problem | Fix |
|---|---|
| **Two banners per message** — the wrapper launched the backend with `OPENMESSAGES_MACOS_NOTIFICATIONS=1`, so Go-side osascript banners fired alongside Swift's `UNUserNotificationCenter` ones (separate dedup caches, neither suppresses the other) | Native app owns notifications when it wraps the backend (env=0). Bare `openmessage serve` in a terminal keeps Go-side banners — its default logic is untouched and covered by existing tests |
| **Tapping a banner did nothing** — `conversationID` was stored in userInfo but no `didReceive` handler existed | New `WebViewBridge` (weak ref to the app's WKWebView); tap activates the app and navigates via the web UI's existing `?conversation=` deep link |
| **Banner + ding for the thread you're looking at** — `willPresent` unconditionally showed everything | Suppress banner/sound (keep Notification Center list entry) when the app is active and the notification's conversation matches the one on screen — read from the URL the web UI already syncs, so no new JS globals. Uncertainty falls back to showing the banner |
| **Backend crash = dead app until you click "Try again"** | Bounded auto-restart: 1s/3s/9s backoff, 3 attempts, budget restored after 60s healthy; deliberate stop/quit cancels pending restarts; error view only after exhaustion |

## Verification

- `swift build` clean (Swift 6 strict concurrency — used the async delegate variants)
- `go test ./cmd ./internal/notify` green (env-var gating for `"0"` already covered)
- Manual verification steps for reviewers: send yourself a message with the thread open (no banner, list-only), with another thread open (banner; tap jumps to the right thread), and `kill -9` the backend process (app recovers within ~1s without the error screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)