### PR TITLE
Raise SSE test-helper deadline to deflake CI

### DIFF
--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -96,7 +96,10 @@ func readSSEEvent(t *testing.T, reader *bufio.Reader) sseEvent {
 			t.Fatal(res.err)
 		}
 		return res.evt
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
+		// Generous on purpose: events arrive within milliseconds when
+		// healthy, but a loaded CI runner can stall the goroutine past a
+		// tight deadline and turn this helper into a flake.
 		t.Fatal("timed out waiting for SSE event")
 		return sseEvent{}
 	}


### PR DESCRIPTION
TestEventsStreamPublishesStatusAndMessages flaked on PR #32's Go Test job ("timed out waiting for SSE event") while the Race job running the same test passed — a loaded runner stalling past the helper's 2s deadline. Events arrive in milliseconds when healthy; a 10s ceiling costs nothing and removes the flake. Verified locally with -count=3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)