### PR TITLE
Schedule send, contacts CRM, inbox tabs, and reliability fixes

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -131,8 +131,31 @@ func RunImport(logger zerolog.Logger, source string, args []string) error {
 		printResult("Signal Desktop", result)
 		return nil
 
+	case "contacts":
+		imp := &importer.MacOSContacts{}
+		result, err := imp.ImportFromAddressBook(a.Store)
+		if err != nil {
+			return fmt.Errorf("import contacts: %w", err)
+		}
+		printContactsResult(result)
+		return nil
+
 	default:
-		return fmt.Errorf("unknown import source: %s\nSupported: gchat, gchat-conversation, imessage, whatsapp, signal", source)
+		return fmt.Errorf("unknown import source: %s\nSupported: gchat, gchat-conversation, imessage, whatsapp, signal, contacts", source)
+	}
+}
+
+func printContactsResult(result *importer.ContactsImportResult) {
+	fmt.Printf("\nmacOS Contacts import complete:\n")
+	fmt.Printf("  Contacts imported: %d\n", result.ContactsImported)
+	fmt.Printf("  Phone numbers:     %d\n", result.PhoneNumbers)
+	fmt.Printf("  Email addresses:   %d\n", result.Emails)
+	fmt.Printf("  Address books:     %d\n", result.Sources)
+	if len(result.Errors) > 0 {
+		fmt.Printf("  Errors:            %d\n", len(result.Errors))
+		for _, e := range result.Errors {
+			fmt.Printf("    - %s\n", e)
+		}
 	}
 }
 

--- a/cmd/send_group.go
+++ b/cmd/send_group.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog"
-	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
 
 	"github.com/maxghenis/openmessage/internal/app"
 )
@@ -26,16 +25,14 @@ func RunSendGroup(logger zerolog.Logger, phones []string, message string) error 
 		return fmt.Errorf("client not connected")
 	}
 
-	convResp, err := cli.GM.GetOrCreateConversation(&gmproto.GetOrCreateConversationRequest{
-		Numbers: app.NewContactNumbers(phones),
-	})
+	convResp, err := app.GetOrCreateConversationForNumbers(cli, app.NewGroupContactNumbers(phones), "")
 	if err != nil {
 		return fmt.Errorf("get/create group conversation: %w", err)
 	}
 
 	conv := convResp.GetConversation()
 	if conv == nil {
-		return fmt.Errorf("no conversation returned")
+		return fmt.Errorf("no conversation returned (status: %s)", convResp.GetStatus().String())
 	}
 
 	payload := app.BuildSendPayload(conv.GetConversationID(), message, "", "", nil)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -141,6 +141,23 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 					runShallowBackfill()
 				}
 			}
+
+			// Pull the Google Messages contact list once on startup. Read-only:
+			// it only lists contacts and never creates conversations, so it
+			// cannot flood the inbox.
+			go func() {
+				for i := 0; i < 30 && !a.Connected.Load(); i++ {
+					time.Sleep(time.Second)
+				}
+				if !a.Connected.Load() {
+					return
+				}
+				if n, err := a.SyncGoogleContacts(); err != nil {
+					logger.Warn().Err(err).Msg("Startup Google contacts sync failed")
+				} else {
+					logger.Info().Int("count", n).Msg("Synced Google Messages contacts")
+				}
+			}()
 		}
 	} else {
 		logger.Info().Msg("Demo mode — skipping phone connection")
@@ -371,6 +388,9 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		return a.GoogleStatus()
 	}
 
+	// Background loop that sends due scheduled ("send later") messages.
+	a.StartScheduler()
+
 	httpEnabled := opts.web || opts.mcpSSE
 	if httpEnabled {
 		httpHandler := http.Handler(nil)
@@ -409,6 +429,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				StartDeepBackfill:     a.StartDeepBackfill,
 				BackfillStatus:        func() any { return a.GetBackfillProgress() },
 				BackfillPhone:         a.BackfillConversationByPhone,
+				SyncGoogleContacts:    a.SyncGoogleContacts,
 			})
 		} else {
 			mux := http.NewServeMux()

--- a/docs/CODEMAP.md
+++ b/docs/CODEMAP.md
@@ -1,0 +1,292 @@
+# OpenMessage — Code Map
+
+A guide to where everything lives and how it fits together. OpenMessage is a
+**local-first universal message inbox**: it pulls messages from several chat
+platforms into one SQLite database, then exposes that inbox three ways — a
+**localhost web UI**, an **MCP server** (for Claude/AI clients), and a **native
+macOS app**.
+
+```
+                       ┌──────────────────── one Go binary (`serve`) ───────────────────┐
+  Android phone ─────▶ │  libgm (Google Messages)  ┐                                     │
+  WhatsApp      ─────▶ │  whatsmeow (live)          ├─▶  internal/db  (SQLite, the inbox)│
+  Signal        ─────▶ │  signal-cli (live)         ┘            ▲                        │
+  Imports       ─────▶ │  internal/importer (gchat/imessage/wa/signal)                    │
+                       │                                          │ reads/writes          │
+                       │   Three surfaces over the same store:    │                        │
+                       │   • internal/web  (HTTP API + SSE + embedded static UI)           │
+                       │   • internal/tools (22 MCP tools over stdio/SSE)                  │
+                       │   • macOS Swift app (wraps the binary, shows the web UI)          │
+                       └──────────────────────────────────────────────────────────────────┘
+```
+
+**Layering / dependency direction** (lower can't import higher):
+
+```
+cmd ─▶ internal/app ─▶ internal/client (libgm)      internal/web ─▶ internal/app, internal/story, internal/db
+                    ─▶ internal/whatsapplive          internal/tools ─▶ internal/app, internal/story, internal/viz, internal/db
+                    ─▶ internal/signallive            internal/story ─▶ internal/db
+                    ─▶ internal/db                     internal/viz   ─▶ internal/story, internal/db
+                    ─▶ internal/importer ─▶ internal/db
+```
+
+---
+
+## 1. Entry point
+
+### `main.go`
+Parses `os.Args[1]` and dispatches to a `cmd.Run*` function. Subcommands:
+`pair`, `serve`, `demo`, `send`, `send-group`, `import`, `debug-media`. Sets the
+build-time `version` and the zerolog logger.
+
+### `cmd/` — CLI commands
+| File | Func(s) | Role |
+|------|---------|------|
+| `serve.go` | `RunServe`, `RunDemo`, `SetVersion`, `Version`, `LogLevel`, `startupBackfillMode` | **The main process.** Builds the `app.App`, connects Google/WhatsApp/Signal, starts the schedule-send loop (`a.StartScheduler`), wires the web HTTP handler (`web.APIHandlerWithOptions`) + SSE broker, registers all MCP tools (`tools.Register`), serves MCP over stdio (when launched by an MCP client) and SSE. Also kicks off startup backfill and the one-time Google contacts sync. |
+| `pair.go` | `RunPair`, QR/Google-cookie helpers | Pairs Google Messages (QR or pasted account cookies). |
+| `send.go` / `send_group.go` | `RunSend`, `RunSendGroup` | One-off SMS / MMS-group sends. `RunSendGroup` uses `app.GetOrCreateConversationForNumbers` (two-step RCS-group flow). |
+| `import.go` | `RunImport`, `printResult`, `printContactsResult`, `hasFlag`, `flagValue` | Routes `import <source>` to the right importer (`gchat`, `gchat-conversation`, `imessage`, `whatsapp`, `signal`, `contacts`). |
+| `debugmedia.go` | `RunDebugMedia` | Dumps media metadata for a conversation. |
+| `e2e-server/main.go` | — | Test server for Playwright (`/_e2e/messages`, `/_e2e/drafts`, seeded fixture). |
+| `genviz/main.go` | — | Standalone viz generator. |
+
+---
+
+## 2. `internal/app` — the coordinator
+
+The `App` struct owns the DB store, the Google Messages client, the WhatsApp/
+Signal bridges, and a set of `On*Change` callbacks that fan events out to the UI.
+
+| File | Key functions | Role |
+|------|---------------|------|
+| `app.go` (34) | `New`, `LoadAndConnect`, `GetClient`, `Unpair`, `Close`, `DefaultDataDir`, `Status`, repair wiring | Bootstrap + lifecycle. On startup runs the repair chain `RepairLegacyArtifacts` → `RepairContentlessRecency` → `RepairTapbacks` → `RepairEmptyStubMessages` → `RepairLegacyMediaPlaceholders`. Holds `EnableContactDiscovery` (off by default — the flooder gate) and the `sendTextOverride`/`sendMediaOverride` test hooks the scheduler uses. |
+| `backfill.go` (17) | `Backfill`, `DeepBackfill`/`deepBackfill`, `paginateFolder`, `deepBackfillConversation*`, `discoverFromContacts`, `reconcileRecentConversations`, `storeConversation`, `storeMessage` | History sync. Folder scan + per-conversation message paging; `discoverFromContacts` (gated off) is what used to flood the phone. `storeConversation` writes participants **with IDs** (for reaction-name resolution); `storeMessage` drops `IsEmptyStubMessage` rows. |
+| `scheduler.go` (11) | `StartScheduler`, `processDueScheduledMessages`, `sendScheduledMessage`, `retryOrFail`, `SendTextToConversation`, `sendScheduledMedia`, `SendMediaToConversation`, `sendSMSMedia`, `sendSMSText`, `conversationPlatform`, `routeReady` | **Schedule-send engine.** Background goroutine: catch-up on startup + 20 s ticker. Atomically claims each due message (pending→sending, exactly-once), checks the route is connected, then sends text or media routed by platform (WhatsApp/Signal carry captions inline; SMS uploads via libgm and sends any caption as a follow-up text). Offline → revert to pending; ≥5 attempts → mark failed. |
+| `contacts.go` (1) | `SyncGoogleContacts` | **Read-only** pull of the Google Messages contact list into the `contacts` table (never creates conversations). |
+| `gm.go` (7) | `NewContactNumbers`, `NewGroupContactNumbers`, `GetOrCreateConversationForNumbers`, `ExtractSIMAndParticipant`, `BuildSendPayload`, `BuildSendMediaPayload` | Google Messages payload helpers. `GetOrCreateConversationForNumbers` does the two-step `CREATE_RCS` group-creation flow. |
+| `gm_iface.go` (5) | `GMClient` interface + `realGMClient` | Abstraction over libgm for testing/backfill. |
+| `whatsapp.go` (14) | `ensureWhatsApp`, `LoadAndConnectWhatsApp`, `StartWhatsAppConnect`, `SendWhatsAppText/Media/Reaction`, `WhatsAppStatus`, `WhatsAppQRCode`, `UnpairWhatsApp`, `LeaveWhatsAppGroup` | WhatsApp bridge lifecycle + send routing. |
+| `signal.go` (12) | `ensureSignal`, `LoadAndConnectSignal`, `StartSignalConnect`, `SendSignalText/Media/Reaction`, `SignalStatus`, `SignalQRCode`, `UnpairSignal`, `ReplaySignalRecoveryQueue` | Signal bridge lifecycle + send routing. |
+
+**Plays with:** `cmd/serve.go` constructs the App and wires its callbacks to the
+SSE broker; `internal/web` and `internal/tools` call App methods; the App calls
+`internal/client`, `whatsapplive`, `signallive`, and writes through `internal/db`.
+
+---
+
+## 3. Platform connectors
+
+### `internal/client` — Google Messages (libgm)
+| File | Key functions | Role |
+|------|---------------|------|
+| `client.go` (9) | `NewFromSession`, `NewForPairing`, `SessionData`, `ExtractMessageBody`, `ExtractMediaInfo`, `ExtractReactions`, `ExtractReplyToID`, `ExtractSenderInfo`, `MessageIsFromMe` | Wraps `*libgm.Client`. `ExtractReactions` returns `Reaction{Emoji,Count,Actors}` (actors = participant IDs, for reaction names). |
+| `events.go` (10) | `Handle`, `handleMessage`, `handleConversation`, `storeConversation`, `handleTyping`, `handleClientReady`, `handleAuthRefresh` | The live event pump. `handleMessage`: build `db.Message` → **`ApplyTapback`** (convert `Loved "…"` to a reaction, skip storing if applied) → `UpsertMessage` → `AdvanceConversationRecency` (content-gated) → fire `On*Change`. |
+| `session.go` (2) | `SaveSession`, `LoadSession` | Persists auth to `session.json`. |
+
+### `internal/whatsapplive/client.go` (115 funcs)
+The whatsmeow-based live WhatsApp bridge: `Bridge` with `New`, `Connect`,
+`Link`, `Unpair`, `SendMessage`, reactions, typing, receipts, profile-photo
+cache, group-leave repair. Reactions stored as `storedReaction{Emoji,Count,Actors}`
+via `updateStoredReactions`.
+
+### `internal/signallive/client.go` (109 funcs)
+The signal-cli-based bridge: `Bridge` with `New`, `Connect`, `Link`, `Unpair`,
+`SendMessage`, `ListContacts`, a receive loop with timeout/recovery, history-sync
+detection, and the same `storedReaction` format.
+
+---
+
+## 4. `internal/db` — SQLite store (the inbox)
+
+`Store` wraps `*sql.DB` (modernc pure-Go SQLite, WAL). Schema + migrations in
+`db.go::migrate()`. Tables: `conversations`, `messages`, `messages_fts` (FTS5),
+`contacts`, `unified_contacts`, `drafts`, `tabs`, `contact_meta`,
+`scheduled_messages`.
+
+| File | Key functions | Role |
+|------|---------------|------|
+| `db.go` (8) | `New`, `migrate`, `SeedDemo`, `Close` | Schema, ALTER migrations, demo seed. Structs `Conversation` (incl. `Tab`), `Message`, `Contact`, `UnifiedContact`, `Draft`. |
+| `messages.go` (25) | `UpsertMessage`, `RecordOutgoingMessage`, `GetMessagesByConversation[s][Before/After/Range]`, `SearchMessages`, `GetMessageByID`, `DeleteMessageByID`, `syncMessageSearchIndex` | Message CRUD + FTS + paging. |
+| `conversations.go` (22) | `UpsertConversation`, `GetConversation`, `ListConversations[ByPlatform]`, `BumpConversationTimestamp`, `MarkConversationRead`, `SetConversationNotificationMode`, `SetConversationTab`, `SetConversationsTab`, `MergeConversationIDs` | Conversation CRUD; `conversationColumns` is the canonical SELECT list. |
+| `recency.go` (3) | `MessageHasContent`, `AdvanceConversationRecency`, `RepairContentlessRecency` | The "contentless stub must not float a conversation up" rule + startup repair. |
+| `tapback.go` (7) | `ParseTapback`, `ApplyTapback`, `RepairTapbacks`, `findTapbackTarget`, `mergeReaction` | iMessage tapback (`Loved "…"`) → emoji reaction on the referenced message. |
+| `stub.go` (2) | `IsEmptyStubMessage`, `RepairEmptyStubMessages` | Detects empty placeholder rows (no body/media/reactions + terminal status, not tombstone/pending) and batch-deletes them (recomputing recency). Used live by `events.go`/`backfill.go` and on startup. |
+| `scheduled.go` (11) | `ValidateScheduleTime`, `CreateScheduledMessage`, `Get`/`List`/`GetDueScheduledMessages`, `GetScheduledMediaData`, `ClaimScheduledMessage`, `Mark…Sent`/`Failed`, `RevertScheduledMessageToPending`, `Cancel`/`DeleteScheduledMessage` | Backs schedule-send. `ScheduledMessage` carries an optional media blob; list/get/due never pull the blob (loaded on demand via `GetScheduledMediaData`). `ClaimScheduledMessage` is the atomic pending→sending claim for exactly-once delivery. |
+| `tabs.go` (5) | `CreateTab`, `ListTabs`, `RenameTab`, `DeleteTab` | Custom inbox tabs (folders). |
+| `people.go` (8) | `ListMessagedPeople`, `PersonByKey`, `PersonMessages`, `realMessageCountsByConversation`, `participantNumbers` | Contacts-CRM person aggregation (group 1:1s by normalized name; real message counts). |
+| `contact_meta.go` (8) | `PersonKey`, `GetContactMeta[Map]`, `SetContactTags`, `SetContactReachOut`, `SetContactSummary` | Per-person CRM metadata (tags, reach-out cadence, cached summary). |
+| `contacts.go` (7) | `UpsertContact`, `ListContacts`, `ListContactsFromConversations`, `UpsertUnifiedContact`, `ListUnifiedContacts` | Contact lookup tables. |
+| `drafts.go` (4) | `UpsertDraft`, `ListDrafts`, `GetDraft`, `DeleteDraft` | AI/local drafts. |
+| `repair.go` (3) | `RepairLegacyArtifacts` | Legacy bridge-bug cleanup (WhatsApp/Signal reaction placeholders, blank rows). |
+
+**Plays with:** everything writes/reads through `Store`. `internal/story` and
+`internal/web`'s people endpoints consume `people.go`/`contact_meta.go`.
+
+---
+
+## 5. `internal/importer` — historical imports
+
+Common `Importer` interface + `ImportResult` (`importer.go`). Each generates
+stable conversation IDs and dedups on `source_platform + source_id`.
+
+| File | Type / entry | Source |
+|------|--------------|--------|
+| `gchat.go` | `GChat.Import`, `ImportGChatDirectory` | Google Chat Takeout |
+| `imessage.go` | `IMessage.ImportFromDB` | `~/Library/Messages/chat.db` (Full Disk Access) |
+| `whatsapp.go` | `WhatsApp.Import` | WhatsApp text export |
+| `whatsapp_native.go` | `WhatsAppNative.ImportFromDB`, `RepairLegacyMediaPlaceholders` | WhatsApp Desktop SQLite |
+| `signal_desktop.go` | `SignalDesktop.Import` | Encrypted Signal Desktop DB |
+| `contacts_macos.go` | `MacOSContacts.ImportFromAddressBook` | macOS AddressBook abcddb (names+numbers+emails) |
+
+---
+
+## 6. `internal/web` — HTTP API + SSE + embedded UI
+
+| File | Key functions | Role |
+|------|---------------|------|
+| `api.go` (14, ~2,400 lines) | `APIHandlerWithOptions(store, cli, logger, mcpHandler, APIOptions)` + ~90 inline handlers | The whole HTTP API. `APIOptions` is a big struct of callbacks wired in `serve.go` (status, send, QR, backfill, `SyncGoogleContacts`, …). Endpoints below. Helpers: `normalizePhoneNumber`, `localContactID`, `buildPersonPayload`, `scheduledID`, `writeJSON`, `httpError`. Serves embedded UI via `//go:embed static/*`. |
+| `events.go` (16) | SSE `EventBroker`: `PublishMessages`, `PublishConversations`, `PublishStatus`, `PublishTyping` | Browser opens `/api/events`; server pushes invalidation events; the UI re-fetches/patches. |
+| `linkpreview.go` (17) | URL metadata fetch (blocks private hosts) | Link preview cards. |
+
+**Endpoint groups** (all in `api.go`): conversations (`/api/conversations`,
+`/api/conversations/{id}/{messages,notification-mode,tab}`, `/api/conversations/move`),
+tabs (`/api/tabs`, `/api/tabs/{id}`), messages (`/api/search`, `/api/send`,
+`/api/send-media`, `/api/react`, `/api/mark-read`, `/api/new-conversation`),
+**schedule-send** (`/api/schedule` GET-list+POST-text, `/api/schedule-media`
+POST-multipart, `/api/schedule/{id}` DELETE-cancel), contacts (`/api/contacts`
+GET+POST, `/api/contacts/sync`), **people/CRM** (`/api/people`,
+`/api/people/{key}/{tags,reach-out,summary}`), drafts, media (`/api/media/{id}`),
+stats/story (`/api/stats/{id}`, `/api/story/{id}`), backfill, status, and the
+`{google,whatsapp,signal}/{connect,qr,unpair,status}` platform controls.
+
+### `internal/web/static/index.html` — the frontend (~10,150 lines, vanilla JS)
+Single embedded file: inline CSS (dark + light theme) and one IIFE `<script>`.
+No framework/build step. Functional areas:
+
+- **Conversation list / sidebar:** `loadConversations`, `renderConversations`,
+  `createConversationRow`, `createContactRow`, `buildConversationRenderItems`
+  (contact clustering), platform filters, **tabs** (`renderTabs`, `setCurrentTab`,
+  `loadTabs`), **multi-select** (`enterSelectionMode`, `moveSelectedToTab`).
+- **Thread view:** `selectConversation`, `loadMessages`, **`renderLoadedMessages`**
+  (keyed-reconcile rendering — reuses unchanged nodes by `data-rk`+`data-rs` to
+  avoid re-render flashes), `messageRenderSignature`, `threadSignature`,
+  reactions (`reactionTooltip`, `reactionActorName`), media (`handleMediaLoad`,
+  `resolveCompletedMedia` — both exposed on `window` for inline handlers).
+- **Compose / send:** `sendMessage`, `sendDraft`, attachments
+  (`setAttachment`/`clearAttachment`, `autoResize` gates send + schedule buttons),
+  **new message** (`openNewMsg`, `updateNewMessageRoutes`,
+  `addNewMsgRecipient`/group recipients, `updateNewMsgButtonLabel`,
+  `saveLocalContact`).
+- **Schedule send:** `openScheduleMenu` (Tomorrow 9 AM / 5 PM / custom),
+  `nextDayAtHour`, `scheduleSend` (JSON for text, multipart for an attached
+  file), `loadScheduledMessages`/`renderScheduledStrip` (pending strip above the
+  composer, 📎 for media), `cancelScheduled`, `formatScheduledWhen`,
+  `show`/`hideScheduleCustom`.
+- **Contacts CRM view:** `openContacts`, `loadPeople`, `sortPeople`,
+  `renderContactsList`, `selectPerson`, `renderPersonDetail` (tags, tickler,
+  summary, **open-conversation**), `wirePersonDetail`.
+- **Realtime:** `startEventStream` (SSE), `scheduleThreadRefresh`,
+  `scheduleConversationsRefresh`.
+- **Infra:** `fetchJSON`/`postJSON`, `escapeHtml`, `avatarHTML`,
+  `hydrateNativeAvatars` (native-app contact photos bridge), context menus.
+
+---
+
+## 7. `internal/tools` — MCP server (22 tools)
+
+`tools.go::Register(server, app)` registers every tool. Each `*.go` defines a
+`xTool()` (schema) + `xHandler(app)` (logic), reading/writing through `app.Store`
+or routing sends through the App.
+
+Tools: `get_messages`, `get_conversation`, `search_messages`, `send_message`,
+`send_to_conversation`, `send_media_to_conversation`, `send_group_message`,
+`react_to_message`, `list_conversations`, `list_contacts`, `get_status`,
+`download_media`, `draft_message`, `import_messages`, `get_person_messages`,
+`get_person_messages_range`, `conversation_stats`, `generate_story`,
+`person_stats`, `generate_person_story`, `generate_viz`, `render_story`.
+
+`story.go` holds the shared `collectPersonMessages` / `findPersonConversations`
+/ `deduplicateMessages` used by the story/viz tools.
+
+---
+
+## 8. `internal/story` + `internal/viz` — analytics & visualization
+
+- **`story/stats.go`** — `ComputeStats(messages, tz) *Stats`: volume-over-time,
+  hour×day heatmap, top phrases (per-sender), sender split, response times,
+  longest gap.
+- **`story/generate.go`** — `Generate(messages, GenerateConfig) *Story`:
+  narrative chapters; uses the Claude API if `APIKey` set, else local generation.
+- **`story/summary.go`** — `RelationshipSummary(messages, name, tz)` (local CRM
+  summary) + `FilterRealMessages`/`isSystemMessage` (drops RCS banners → "No
+  communication").
+- **`viz/`** — `RenderHTML` orchestrator (`render.go`), `VizConfig` + theming
+  (`config.go`), inline Go template (`template.go`), photo date-sort/intersperse
+  (`photos.go`). Produces a self-contained HTML relationship visualization.
+
+---
+
+## 9. Support: `notify`, `telemetry`
+
+- **`internal/notify/macos.go`** — `MacOSNotifier` via `terminal-notifier`, with
+  per-conversation mute/mention filtering and seen-dedup.
+- **`internal/telemetry/telemetry.go`** — opt-in (off by default) anonymous
+  heartbeat (install ID, version, OS, paired platforms — no content).
+
+---
+
+## 10. macOS app (`OpenMessage/` + `macos/`)
+
+Swift wrapper around the same Go binary (duplicated under both dirs):
+
+| File | Role |
+|------|------|
+| `OpenMessageApp.swift` | App entry; owns `BackendManager`, `NotificationManager`, `ContactsManager`. |
+| `BackendManager.swift` | Launches the Go binary as a subprocess, health-checks `:7007`, manages state. |
+| `ContentView.swift` | Routes launch/pairing/error/ready; ready state is a `WKWebView` at the local web UI; bridges `window.OpenMessageNative{Notifications,Contacts,App}`. |
+| `ContactsManager.swift` | Reads macOS Contacts (`CNContactStore`) **for avatar photos only** (permission-gated, in-memory, never persisted/uploaded). |
+| `NotificationManager.swift` | Bridges SSE events → macOS notification center. |
+| `PairingView.swift` / `MenuBarView.swift` | Pairing UI / menu-bar item. |
+
+`macos/build.sh` → universal Go binary → `.app` → `.dmg`.
+
+---
+
+## 11. Cross-cutting data flows
+
+**Receive a message (live, Google Messages):**
+`libgm event` → `client/events.go::handleMessage` → (tapback? → `db.ApplyTapback`,
+then skip if it was applied) → (drop if `db.IsEmptyStubMessage`) →
+`db.UpsertMessage` → `db.AdvanceConversationRecency` → App `On*Change`
+callbacks → `web/events.go` SSE publish → browser `startEventStream` →
+`scheduleThreadRefresh`/`scheduleConversationsRefresh` → `loadMessages` →
+`renderLoadedMessages` (keyed reconcile, no flash).
+
+**Send a message (web UI):**
+`sendMessage` (optimistic node) → `POST /api/send` → `api.go` routes by platform
+(`BuildSendPayload`+libgm, or App's WhatsApp/Signal senders) →
+`db.RecordOutgoingMessage` → SSE echo → reconcile render.
+
+**Start a new (group) conversation:**
+new-message UI → `POST /api/new-conversation` → `normalizePhoneNumber` →
+`app.GetOrCreateConversationForNumbers` (two-step `CREATE_RCS`) →
+`db.UpsertConversation` → SSE.
+
+**Schedule a message (text or media):**
+compose UI → `openScheduleMenu` → `scheduleSend` → `POST /api/schedule` (JSON)
+or `/api/schedule-media` (multipart, blob persisted) → `db.CreateScheduledMessage`
+→ pending strip via `/api/schedule` GET. Later: `scheduler.go` ticker →
+`GetDueScheduledMessages` → `ClaimScheduledMessage` (atomic) → `routeReady`? →
+`SendTextToConversation`/`SendMediaToConversation` (platform-routed) →
+`MarkScheduledMessageSent` (or retry/fail) → SSE. Catch-up on startup covers
+messages whose time passed while the app was closed.
+
+**Contacts CRM:**
+`SyncGoogleContacts` (or contact imports) fill `contacts`; `GET /api/people`
+aggregates via `db.ListMessagedPeople`; detail uses `db.PersonMessages` +
+`story.RelationshipSummary` + `db.GetContactMeta`; tags/cadence persist to
+`contact_meta`.
+
+**Story / viz:**
+MCP tool or HTTP → `collectPersonMessages` → `story.ComputeStats` /
+`story.Generate` → `viz.RenderHTML` → self-contained HTML.

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -1050,3 +1050,28 @@ test('discards an AI draft from the thread banner', async ({ page }) => {
   await page.locator('.draft-discard-btn').click();
   await expect(page.locator('.draft-banner')).toHaveCount(0);
 });
+
+test('reuses existing message nodes on new messages (no full-thread re-render flash)', async ({ page, request, baseURL }) => {
+  await openConversation(page, 'Sarah Chen');
+  await expect.poll(async () => page.locator('#messages-area .msg').count()).toBeGreaterThan(0);
+
+  // Tag every currently-rendered message node so we can detect teardown.
+  const before = await page.locator('#messages-area .msg').evaluateAll((els) => {
+    els.forEach((el, i) => el.setAttribute('data-reuse-test', 'm' + i));
+    return els.length;
+  });
+  expect(before).toBeGreaterThan(0);
+
+  // Inject a new (from-me) message -> SSE -> the thread re-renders. Sending it
+  // as from-me leaves every existing message unchanged, so all should survive.
+  const resp = await request.post(`${baseURL}/_e2e/messages`, {
+    data: { conversation_id: 'conv1', body: 'reuse-test new message', is_from_me: true },
+  });
+  expect(resp.ok()).toBeTruthy();
+  await expect(page.locator('#messages-area')).toContainText('reuse-test new message');
+
+  // The previously-rendered nodes must still carry their marker — i.e. they were
+  // reused, not destroyed and rebuilt. A full innerHTML teardown would drop them.
+  const survived = await page.locator('#messages-area .msg[data-reuse-test]').count();
+  expect(survived).toBe(before);
+});

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -121,6 +121,16 @@ type App struct {
 	SessionPath            string
 	WhatsAppSessionPath    string
 	SignalConfigPath       string
+	// sendTextOverride lets tests substitute the scheduler's send. Nil in prod.
+	sendTextOverride func(conversationID, body, replyToID string) (*db.Message, error)
+	// sendMediaOverride lets tests substitute the scheduler's media send. Nil in prod.
+	sendMediaOverride func(conversationID string, data []byte, filename, mime, caption, replyToID string) (*db.Message, error)
+	// EnableContactDiscovery controls the deep-backfill phase that calls
+	// GetOrCreateConversation for every address-book contact. That phase
+	// CREATES a thread on the phone for each contact, flooding Google Messages
+	// with empty conversations, so it is OFF by default. Conversations that
+	// actually have messages are already covered by the folder scan.
+	EnableContactDiscovery bool
 	Connected              atomic.Bool
 	OnConversationsChange  func()
 	OnIncomingMessage      func(*db.Message)
@@ -241,6 +251,19 @@ func New(logger zerolog.Logger) (*App, error) {
 		logger.Warn().Err(err).Msg("Failed to repair contentless conversation recency")
 	} else if fixed > 0 {
 		logger.Info().Int("fixed", fixed).Msg("Repaired conversations floated up by contentless messages")
+	}
+	// Convert already-stored iMessage tapback texts (`Loved "..."`) into reactions.
+	if converted, err := store.RepairTapbacks(); err != nil {
+		logger.Warn().Err(err).Msg("Failed to convert legacy tapback messages")
+	} else if converted > 0 {
+		logger.Info().Int("converted", converted).Msg("Converted iMessage tapback texts into reactions")
+	}
+	// Remove contentless "Empty message" stubs that group activity leaked into
+	// 1:1 threads, fixing any conversation they were surfacing.
+	if removed, err := store.RepairEmptyStubMessages(); err != nil {
+		logger.Warn().Err(err).Msg("Failed to remove empty stub messages")
+	} else if removed > 0 {
+		logger.Info().Int("removed", removed).Msg("Removed empty stub messages")
 	}
 	if !Sandboxed() {
 		if mediaRepair, err := (&importer.WhatsAppNative{}).RepairLegacyMediaPlaceholders(store); err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -125,13 +125,7 @@ type App struct {
 	sendTextOverride func(conversationID, body, replyToID string) (*db.Message, error)
 	// sendMediaOverride lets tests substitute the scheduler's media send. Nil in prod.
 	sendMediaOverride func(conversationID string, data []byte, filename, mime, caption, replyToID string) (*db.Message, error)
-	// EnableContactDiscovery controls the deep-backfill phase that calls
-	// GetOrCreateConversation for every address-book contact. That phase
-	// CREATES a thread on the phone for each contact, flooding Google Messages
-	// with empty conversations, so it is OFF by default. Conversations that
-	// actually have messages are already covered by the folder scan.
-	EnableContactDiscovery bool
-	Connected              atomic.Bool
+	Connected         atomic.Bool
 	OnConversationsChange  func()
 	OnIncomingMessage      func(*db.Message)
 	OnMessagesChange       func(string)

--- a/internal/app/backfill.go
+++ b/internal/app/backfill.go
@@ -682,6 +682,12 @@ func (a *App) storeMessage(msg *gmproto.Message) {
 	}
 	dbMsg.ReplyToID = client.ExtractReplyToID(msg)
 
+	// Skip completed contentless stubs so they never accumulate (they'd render
+	// as "Empty message" and wrongly surface a conversation).
+	if db.IsEmptyStubMessage(dbMsg) {
+		return
+	}
+
 	if err := a.Store.UpsertMessage(dbMsg); err != nil {
 		a.Logger.Error().Err(err).Str("msg_id", dbMsg.MessageID).Msg("Failed to store backfill message")
 	}

--- a/internal/app/backfill_test.go
+++ b/internal/app/backfill_test.go
@@ -358,7 +358,6 @@ func TestDeepBackfillContactDiscovery(t *testing.T) {
 	}
 
 	a := newTestApp(t, mock)
-	a.EnableContactDiscovery = true
 	a.DeepBackfill()
 
 	convos, _ := a.Store.ListConversations(50)
@@ -396,7 +395,6 @@ func TestDeepBackfillContactDiscoverySkipsAlreadySeen(t *testing.T) {
 	}
 
 	a := newTestApp(t, mock)
-	a.EnableContactDiscovery = true
 	a.DeepBackfill()
 
 	convos, _ := a.Store.ListConversations(50)
@@ -523,7 +521,6 @@ func TestDeepBackfillGetOrCreateError(t *testing.T) {
 	}
 
 	a := newTestApp(t, mock)
-	a.EnableContactDiscovery = true
 	a.DeepBackfill()
 
 	progress := a.GetBackfillProgress()

--- a/internal/app/backfill_test.go
+++ b/internal/app/backfill_test.go
@@ -358,6 +358,7 @@ func TestDeepBackfillContactDiscovery(t *testing.T) {
 	}
 
 	a := newTestApp(t, mock)
+	a.EnableContactDiscovery = true
 	a.DeepBackfill()
 
 	convos, _ := a.Store.ListConversations(50)
@@ -395,6 +396,7 @@ func TestDeepBackfillContactDiscoverySkipsAlreadySeen(t *testing.T) {
 	}
 
 	a := newTestApp(t, mock)
+	a.EnableContactDiscovery = true
 	a.DeepBackfill()
 
 	convos, _ := a.Store.ListConversations(50)
@@ -521,6 +523,7 @@ func TestDeepBackfillGetOrCreateError(t *testing.T) {
 	}
 
 	a := newTestApp(t, mock)
+	a.EnableContactDiscovery = true
 	a.DeepBackfill()
 
 	progress := a.GetBackfillProgress()

--- a/internal/app/contacts.go
+++ b/internal/app/contacts.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+// SyncGoogleContacts pulls the contact list from the linked Google Messages
+// account and caches it locally (name + number).
+//
+// It is intentionally READ-ONLY: it only calls ListContacts and never
+// GetOrCreateConversation, so it does NOT create threads on the phone. This is
+// the safe way to populate contacts — unlike the deep-backfill contact
+// discovery, which floods the inbox by creating a conversation per contact.
+func (a *App) SyncGoogleContacts() (int, error) {
+	cli := a.GetClient()
+	if cli == nil {
+		return 0, fmt.Errorf("not connected to Google Messages")
+	}
+	resp, err := cli.GM.ListContacts()
+	if err != nil {
+		return 0, fmt.Errorf("list contacts: %w", err)
+	}
+
+	count := 0
+	for _, c := range resp.GetContacts() {
+		number := ""
+		if n := c.GetNumber(); n != nil {
+			number = strings.TrimSpace(n.GetNumber())
+		}
+		name := strings.TrimSpace(c.GetName())
+		if number == "" && name == "" {
+			continue
+		}
+		id := c.GetContactID()
+		if id == "" {
+			id = "gm:" + number
+		}
+		if err := a.Store.UpsertContact(&db.Contact{ContactID: id, Name: name, Number: number}); err != nil {
+			a.Logger.Warn().Err(err).Str("contact_id", id).Msg("Failed to cache Google contact")
+			continue
+		}
+		count++
+	}
+	a.Logger.Info().Int("count", count).Msg("Synced Google Messages contacts")
+	return count, nil
+}

--- a/internal/app/gm.go
+++ b/internal/app/gm.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+
+	"github.com/maxghenis/openmessage/internal/client"
 )
 
 var (
@@ -24,6 +26,46 @@ var (
 		return cli.GM.SendMessage(payload)
 	}
 )
+
+// NewGroupContactNumbers builds contact numbers for creating a group chat,
+// using the MysteriousInt value the upstream connector uses for group creation.
+func NewGroupContactNumbers(phones []string) []*gmproto.ContactNumber {
+	numbers := make([]*gmproto.ContactNumber, len(phones))
+	for i, phone := range phones {
+		numbers[i] = &gmproto.ContactNumber{
+			MysteriousInt: 2,
+			Number:        phone,
+			Number2:       phone,
+		}
+	}
+	return numbers
+}
+
+// GetOrCreateConversationForNumbers fetches or creates a conversation for the
+// given recipients. Creating a brand-new RCS group is a two-step flow: the
+// first call returns Status_CREATE_RCS, and the request must be resent with
+// CreateRCSGroup=true (this is what the upstream connector does). Without the
+// retry, the group create returns no conversation.
+func GetOrCreateConversationForNumbers(cli *client.Client, numbers []*gmproto.ContactNumber, groupName string) (*gmproto.GetOrCreateConversationResponse, error) {
+	req := &gmproto.GetOrCreateConversationRequest{Numbers: numbers}
+	if groupName != "" {
+		req.RCSGroupName = &groupName
+	}
+	resp, err := cli.GM.GetOrCreateConversation(req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.GetStatus() == gmproto.GetOrCreateConversationResponse_CREATE_RCS {
+		if req.RCSGroupName == nil {
+			empty := ""
+			req.RCSGroupName = &empty
+		}
+		createGroup := true
+		req.CreateRCSGroup = &createGroup
+		resp, err = cli.GM.GetOrCreateConversation(req)
+	}
+	return resp, err
+}
 
 // ErrNotConnected is the error message returned when an operation requires
 // a Google Messages connection but one is not established.

--- a/internal/app/scheduler.go
+++ b/internal/app/scheduler.go
@@ -1,0 +1,252 @@
+package app
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+const (
+	schedulerTickInterval = 20 * time.Second
+	scheduleMaxAttempts   = 5
+)
+
+// StartScheduler launches the background loop that sends due scheduled messages.
+// It catches up immediately on startup (for messages whose time passed while the
+// app was closed), then ticks.
+func (a *App) StartScheduler() {
+	go func() {
+		a.processDueScheduledMessages()
+		ticker := time.NewTicker(schedulerTickInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			a.processDueScheduledMessages()
+		}
+	}()
+}
+
+func (a *App) processDueScheduledMessages() {
+	due, err := a.Store.GetDueScheduledMessages(time.Now().UnixMilli())
+	if err != nil {
+		a.Logger.Warn().Err(err).Msg("Scheduler: failed to load due messages")
+		return
+	}
+	for _, sm := range due {
+		a.sendScheduledMessage(sm)
+	}
+}
+
+func (a *App) sendScheduledMessage(sm *db.ScheduledMessage) {
+	// Atomic claim — only one worker/tick wins, so a message is sent once.
+	claimed, err := a.Store.ClaimScheduledMessage(sm.ID)
+	if err != nil || !claimed {
+		return
+	}
+
+	// If the route's platform isn't connected, retry later (don't lose it),
+	// unless we've already burned through the attempt budget.
+	if !a.routeReady(sm.ConversationID) {
+		a.retryOrFail(sm, "platform not connected")
+		return
+	}
+
+	var msg *db.Message
+	if sm.MediaFilename != "" {
+		msg, err = a.sendScheduledMedia(sm)
+	} else {
+		send := a.sendScheduledText
+		if a.sendTextOverride != nil {
+			send = a.sendTextOverride
+		}
+		msg, err = send(sm.ConversationID, sm.Body, sm.ReplyToID)
+	}
+	if err != nil {
+		a.Logger.Warn().Err(err).Str("scheduled_id", sm.ID).Msg("Scheduler: send failed")
+		a.retryOrFail(sm, err.Error())
+		return
+	}
+
+	sentID := ""
+	if msg != nil {
+		sentID = msg.MessageID
+	}
+	if err := a.Store.MarkScheduledMessageSent(sm.ID, sentID); err != nil {
+		a.Logger.Warn().Err(err).Str("scheduled_id", sm.ID).Msg("Scheduler: failed to mark sent")
+	}
+	a.emitMessagesChange(sm.ConversationID)
+	a.emitConversationsChange()
+	a.Logger.Info().Str("scheduled_id", sm.ID).Str("conv_id", sm.ConversationID).Msg("Scheduler: sent scheduled message")
+}
+
+// retryOrFail reverts a claimed message to pending (to retry on a later tick),
+// or marks it permanently failed once attempts are exhausted.
+func (a *App) retryOrFail(sm *db.ScheduledMessage, reason string) {
+	if sm.Attempts+1 >= scheduleMaxAttempts {
+		_ = a.Store.MarkScheduledMessageFailed(sm.ID, reason)
+		a.emitConversationsChange()
+		return
+	}
+	_ = a.Store.RevertScheduledMessageToPending(sm.ID, reason)
+}
+
+// sendScheduledText sends a scheduled text message to an existing conversation,
+// routing by platform (WhatsApp / Signal / SMS-RCS). Distinct from the
+// CLI-facing SendTextToConversation in send.go: this one carries a reply-to ID
+// and returns just the message, which is what the scheduler needs.
+func (a *App) sendScheduledText(conversationID, body, replyToID string) (*db.Message, error) {
+	switch a.conversationPlatform(conversationID) {
+	case "whatsapp":
+		return a.SendWhatsAppText(conversationID, body, replyToID)
+	case "signal":
+		return a.SendSignalText(conversationID, body, replyToID)
+	default:
+		return a.sendSMSText(conversationID, body, replyToID)
+	}
+}
+
+// sendScheduledMedia loads the stored blob and dispatches it to the right
+// platform (or the test override).
+func (a *App) sendScheduledMedia(sm *db.ScheduledMessage) (*db.Message, error) {
+	data, err := a.Store.GetScheduledMediaData(sm.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load media: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("scheduled media blob missing")
+	}
+	if a.sendMediaOverride != nil {
+		return a.sendMediaOverride(sm.ConversationID, data, sm.MediaFilename, sm.MediaMime, sm.Body, sm.ReplyToID)
+	}
+	return a.SendMediaToConversation(sm.ConversationID, data, sm.MediaFilename, sm.MediaMime, sm.Body, sm.ReplyToID)
+}
+
+// SendMediaToConversation sends a media attachment (with optional caption) to an
+// existing conversation, routing by platform (WhatsApp / Signal / SMS-RCS).
+func (a *App) SendMediaToConversation(conversationID string, data []byte, filename, mime, caption, replyToID string) (*db.Message, error) {
+	switch a.conversationPlatform(conversationID) {
+	case "whatsapp":
+		return a.SendWhatsAppMedia(conversationID, data, filename, mime, caption, replyToID)
+	case "signal":
+		return a.SendSignalMedia(conversationID, data, filename, mime, caption, replyToID)
+	default:
+		return a.sendSMSMedia(conversationID, data, filename, mime, caption, replyToID)
+	}
+}
+
+// sendSMSMedia uploads and sends a Google Messages (SMS/RCS) media attachment
+// and records it locally. The SMS media payload carries no caption, so a
+// non-empty caption is sent as a follow-up text (lossless).
+func (a *App) sendSMSMedia(conversationID string, data []byte, filename, mime, caption, replyToID string) (*db.Message, error) {
+	cli := a.GetClient()
+	if cli == nil {
+		return nil, errors.New(ErrNotConnected)
+	}
+	media, err := cli.GM.UploadMedia(data, filename, mime)
+	if err != nil {
+		return nil, fmt.Errorf("upload media: %w", err)
+	}
+	conv, err := cli.GM.GetConversation(conversationID)
+	if err != nil {
+		return nil, fmt.Errorf("get conversation: %w", err)
+	}
+	myParticipantID, simPayload := ExtractSIMAndParticipant(conv)
+	payload := BuildSendMediaPayload(conversationID, media, myParticipantID, simPayload)
+	resp, err := cli.GM.SendMessage(payload)
+	if err != nil {
+		return nil, fmt.Errorf("send message: %w", err)
+	}
+	if resp.GetStatus() != gmproto.SendMessageResponse_SUCCESS {
+		return nil, fmt.Errorf("send failed: %s", resp.GetStatus().String())
+	}
+	msg := &db.Message{
+		MessageID:      payload.TmpID,
+		ConversationID: conversationID,
+		Body:           "",
+		IsFromMe:       true,
+		TimestampMS:    time.Now().UnixMilli(),
+		Status:         "OUTGOING_SENDING",
+		ReplyToID:      replyToID,
+		MediaID:        media.MediaID,
+		MimeType:       media.MimeType,
+		DecryptionKey:  hex.EncodeToString(media.DecryptionKey),
+	}
+	if err := a.Store.RecordOutgoingMessage(msg, ""); err != nil {
+		a.Logger.Warn().Err(err).Msg("Scheduler: sent SMS media but failed to record locally")
+	}
+	// Caption can't ride on the SMS media payload — send it as a follow-up text.
+	if c := strings.TrimSpace(caption); c != "" {
+		if _, err := a.sendSMSText(conversationID, c, replyToID); err != nil {
+			a.Logger.Warn().Err(err).Msg("Scheduler: media sent but caption text failed")
+		}
+	}
+	return msg, nil
+}
+
+func (a *App) conversationPlatform(conversationID string) string {
+	switch {
+	case strings.HasPrefix(conversationID, "whatsapp:"):
+		return "whatsapp"
+	case strings.HasPrefix(conversationID, "signal:"), strings.HasPrefix(conversationID, "signal-group:"):
+		return "signal"
+	}
+	if conv, err := a.Store.GetConversation(conversationID); err == nil && conv != nil {
+		switch conv.SourcePlatform {
+		case "whatsapp":
+			return "whatsapp"
+		case "signal":
+			return "signal"
+		}
+	}
+	return "sms"
+}
+
+func (a *App) routeReady(conversationID string) bool {
+	switch a.conversationPlatform(conversationID) {
+	case "whatsapp":
+		return a.WhatsAppStatus().Connected
+	case "signal":
+		return a.SignalStatus().Connected
+	default:
+		return a.Connected.Load()
+	}
+}
+
+// sendSMSText sends a Google Messages (SMS/RCS) text and records it locally.
+func (a *App) sendSMSText(conversationID, body, replyToID string) (*db.Message, error) {
+	cli := a.GetClient()
+	if cli == nil {
+		return nil, errors.New(ErrNotConnected)
+	}
+	conv, err := cli.GM.GetConversation(conversationID)
+	if err != nil {
+		return nil, fmt.Errorf("get conversation: %w", err)
+	}
+	myParticipantID, simPayload := ExtractSIMAndParticipant(conv)
+	payload := BuildSendPayload(conversationID, body, replyToID, myParticipantID, simPayload)
+	resp, err := cli.GM.SendMessage(payload)
+	if err != nil {
+		return nil, fmt.Errorf("send message: %w", err)
+	}
+	if resp.GetStatus() != gmproto.SendMessageResponse_SUCCESS {
+		return nil, fmt.Errorf("send failed: %s", resp.GetStatus().String())
+	}
+	msg := &db.Message{
+		MessageID:      payload.TmpID,
+		ConversationID: conversationID,
+		Body:           body,
+		IsFromMe:       true,
+		TimestampMS:    time.Now().UnixMilli(),
+		Status:         "OUTGOING_SENT",
+		ReplyToID:      replyToID,
+	}
+	if err := a.Store.RecordOutgoingMessage(msg, ""); err != nil {
+		a.Logger.Warn().Err(err).Msg("Scheduler: sent SMS but failed to record locally")
+	}
+	return msg, nil
+}

--- a/internal/app/scheduler_media_test.go
+++ b/internal/app/scheduler_media_test.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+func TestProcessDueScheduledMessages_SendsMedia(t *testing.T) {
+	a := newSchedulerTestApp(t)
+	now := time.Now().UnixMilli()
+	blob := []byte{0x89, 0x50, 0x4e, 0x47, 9, 8, 7}
+	if err := a.Store.CreateScheduledMessage(&db.ScheduledMessage{
+		ID: "sm1", ConversationID: "c1", Body: "caption here", SendAt: now - 1000,
+		Status: db.ScheduleStatusPending, CreatedAt: now,
+		MediaData: blob, MediaFilename: "pic.png", MediaMime: "image/png",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var (
+		gotData    []byte
+		gotName    string
+		gotMime    string
+		gotCaption string
+	)
+	textCalled := false
+	a.sendTextOverride = func(cid, body, rt string) (*db.Message, error) {
+		textCalled = true
+		return &db.Message{MessageID: "wrong"}, nil
+	}
+	a.sendMediaOverride = func(cid string, data []byte, filename, mime, caption, rt string) (*db.Message, error) {
+		gotData, gotName, gotMime, gotCaption = data, filename, mime, caption
+		return &db.Message{MessageID: "mm99"}, nil
+	}
+
+	a.processDueScheduledMessages()
+
+	if textCalled {
+		t.Error("media message must not be sent via the text path")
+	}
+	if !bytes.Equal(gotData, blob) {
+		t.Errorf("media blob mismatch: got %v", gotData)
+	}
+	if gotName != "pic.png" || gotMime != "image/png" || gotCaption != "caption here" {
+		t.Errorf("media args wrong: name=%q mime=%q caption=%q", gotName, gotMime, gotCaption)
+	}
+	got, _ := a.Store.GetScheduledMessage("sm1")
+	if got.Status != db.ScheduleStatusSent || got.SentMessageID != "mm99" {
+		t.Errorf("after send = %+v, want sent with mm99", got)
+	}
+}

--- a/internal/app/scheduler_test.go
+++ b/internal/app/scheduler_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+func newSchedulerTestApp(t *testing.T) *App {
+	t.Helper()
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.UpsertConversation(&db.Conversation{ConversationID: "c1", SourcePlatform: "sms"}); err != nil {
+		t.Fatalf("conv: %v", err)
+	}
+	a := &App{Store: store, Logger: zerolog.Nop()}
+	a.Connected.Store(true) // SMS route "ready"
+	return a
+}
+
+func seedDue(t *testing.T, a *App, id string) {
+	t.Helper()
+	now := time.Now().UnixMilli()
+	if err := a.Store.CreateScheduledMessage(&db.ScheduledMessage{
+		ID: id, ConversationID: "c1", Body: "scheduled hi", SendAt: now - 1000,
+		Status: db.ScheduleStatusPending, CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func TestProcessDueScheduledMessages_Sends(t *testing.T) {
+	a := newSchedulerTestApp(t)
+	seedDue(t, a, "s1")
+	var gotBody string
+	a.sendTextOverride = func(cid, body, rt string) (*db.Message, error) {
+		gotBody = body
+		return &db.Message{MessageID: "m99"}, nil
+	}
+
+	a.processDueScheduledMessages()
+
+	if gotBody != "scheduled hi" {
+		t.Errorf("send called with body=%q, want %q", gotBody, "scheduled hi")
+	}
+	got, _ := a.Store.GetScheduledMessage("s1")
+	if got.Status != db.ScheduleStatusSent || got.SentMessageID != "m99" {
+		t.Errorf("after send = %+v, want sent with m99", got)
+	}
+}
+
+func TestProcessDueScheduledMessages_OfflineRetries(t *testing.T) {
+	a := newSchedulerTestApp(t)
+	a.Connected.Store(false) // SMS route NOT ready
+	seedDue(t, a, "s1")
+	called := false
+	a.sendTextOverride = func(cid, body, rt string) (*db.Message, error) {
+		called = true
+		return &db.Message{MessageID: "x"}, nil
+	}
+
+	a.processDueScheduledMessages()
+
+	if called {
+		t.Error("send must not be attempted while the route is offline")
+	}
+	got, _ := a.Store.GetScheduledMessage("s1")
+	if got.Status != db.ScheduleStatusPending || got.Attempts != 1 {
+		t.Errorf("offline message should revert to pending (attempt 1), got %+v", got)
+	}
+}
+
+func TestProcessDueScheduledMessages_FailsAfterMaxAttempts(t *testing.T) {
+	a := newSchedulerTestApp(t)
+	seedDue(t, a, "s1")
+	a.sendTextOverride = func(cid, body, rt string) (*db.Message, error) {
+		return nil, fmt.Errorf("send rejected")
+	}
+
+	// Each tick claims, fails, and either retries or (eventually) marks failed.
+	for i := 0; i < scheduleMaxAttempts+1; i++ {
+		a.processDueScheduledMessages()
+	}
+
+	got, _ := a.Store.GetScheduledMessage("s1")
+	if got.Status != db.ScheduleStatusFailed {
+		t.Errorf("after exhausting retries, status = %q, want failed", got.Status)
+	}
+	if got.LastError == "" {
+		t.Errorf("expected a recorded error")
+	}
+}

--- a/internal/client/events.go
+++ b/internal/client/events.go
@@ -149,6 +149,30 @@ func (h *EventHandler) handleMessage(evt *libgm.WrappedMessage) {
 	}
 	dbMsg.ReplyToID = ExtractReplyToID(msg)
 
+	// iMessage tapbacks (e.g. `Loved "see you then"`) arrive from iPhones as
+	// plain SMS/RCS text. Convert them into an emoji reaction on the message
+	// they refer to instead of storing them as a separate message.
+	if applied, err := h.Store.ApplyTapback(dbMsg); err != nil {
+		h.Logger.Warn().Err(err).Str("msg_id", dbMsg.MessageID).Msg("Failed to apply tapback")
+	} else if applied {
+		h.Logger.Debug().Str("msg_id", dbMsg.MessageID).Str("conv_id", dbMsg.ConversationID).Msg("Applied tapback as reaction")
+		if h.OnMessagesChange != nil {
+			h.OnMessagesChange(dbMsg.ConversationID)
+		}
+		if h.OnConversationsChange != nil {
+			h.OnConversationsChange()
+		}
+		return
+	}
+
+	// Drop completed contentless stubs (e.g. an empty message that group
+	// activity leaks into a 1:1 thread). They would render as "Empty message"
+	// and wrongly surface the conversation in recents.
+	if db.IsEmptyStubMessage(dbMsg) {
+		h.Logger.Debug().Str("msg_id", dbMsg.MessageID).Str("conv_id", dbMsg.ConversationID).Msg("Skipped empty stub message")
+		return
+	}
+
 	if err := h.Store.UpsertMessage(dbMsg); err != nil {
 		h.Logger.Error().Err(err).Str("msg_id", dbMsg.MessageID).Msg("Failed to store message")
 		return

--- a/internal/db/contact_meta.go
+++ b/internal/db/contact_meta.go
@@ -1,0 +1,145 @@
+package db
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// ContactMeta holds per-person CRM metadata: free-form tags, an optional
+// reach-out cadence (in days), and a cached relationship summary.
+type ContactMeta struct {
+	PersonKey    string   `json:"person_key"`
+	DisplayName  string   `json:"display_name"`
+	Tags         []string `json:"tags"`
+	ReachOutDays int      `json:"reach_out_days"`
+	Summary      string   `json:"summary"`
+	SummaryAt    int64    `json:"summary_at"`
+	UpdatedAt    int64    `json:"updated_at"`
+}
+
+// PersonKey normalizes a display name into a stable key used to group a person
+// across conversations and to key their CRM metadata.
+func PersonKey(name string) string {
+	var b strings.Builder
+	prevSpace := false
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			prevSpace = false
+		} else if !prevSpace {
+			b.WriteByte(' ')
+			prevSpace = true
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// GetContactMeta returns the metadata for a person key, or a zero-value
+// ContactMeta (with empty tags) if none has been saved yet.
+func (s *Store) GetContactMeta(key string) (*ContactMeta, error) {
+	m := &ContactMeta{PersonKey: key, Tags: []string{}}
+	var tagsJSON string
+	err := s.db.QueryRow(`
+		SELECT display_name, tags, reach_out_days, summary, summary_at, updated_at
+		FROM contact_meta WHERE person_key = ?
+	`, key).Scan(&m.DisplayName, &tagsJSON, &m.ReachOutDays, &m.Summary, &m.SummaryAt, &m.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return m, nil
+		}
+		return nil, err
+	}
+	m.Tags = parseTags(tagsJSON)
+	return m, nil
+}
+
+// GetContactMetaMap loads all saved metadata at once, keyed by person key, for
+// efficient list rendering.
+func (s *Store) GetContactMetaMap() (map[string]*ContactMeta, error) {
+	rows, err := s.db.Query(`SELECT person_key, display_name, tags, reach_out_days, summary, summary_at, updated_at FROM contact_meta`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]*ContactMeta{}
+	for rows.Next() {
+		m := &ContactMeta{}
+		var tagsJSON string
+		if err := rows.Scan(&m.PersonKey, &m.DisplayName, &tagsJSON, &m.ReachOutDays, &m.Summary, &m.SummaryAt, &m.UpdatedAt); err != nil {
+			return nil, err
+		}
+		m.Tags = parseTags(tagsJSON)
+		out[m.PersonKey] = m
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) ensureContactMeta(key, displayName string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO contact_meta (person_key, display_name, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(person_key) DO UPDATE SET
+			display_name = CASE WHEN excluded.display_name != '' THEN excluded.display_name ELSE contact_meta.display_name END
+	`, key, displayName, time.Now().UnixMilli())
+	return err
+}
+
+// SetContactTags replaces the tag list for a person.
+func (s *Store) SetContactTags(key, displayName string, tags []string) error {
+	if err := s.ensureContactMeta(key, displayName); err != nil {
+		return err
+	}
+	clean := make([]string, 0, len(tags))
+	seen := map[string]bool{}
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t == "" || seen[strings.ToLower(t)] {
+			continue
+		}
+		seen[strings.ToLower(t)] = true
+		clean = append(clean, t)
+	}
+	b, _ := json.Marshal(clean)
+	_, err := s.db.Exec(`UPDATE contact_meta SET tags = ?, updated_at = ? WHERE person_key = ?`, string(b), time.Now().UnixMilli(), key)
+	return err
+}
+
+// SetContactReachOut sets how often (in days) the user wants to reach out to a
+// person. 0 disables the reminder.
+func (s *Store) SetContactReachOut(key, displayName string, days int) error {
+	if days < 0 {
+		days = 0
+	}
+	if err := s.ensureContactMeta(key, displayName); err != nil {
+		return err
+	}
+	_, err := s.db.Exec(`UPDATE contact_meta SET reach_out_days = ?, updated_at = ? WHERE person_key = ?`, days, time.Now().UnixMilli(), key)
+	return err
+}
+
+// SetContactSummary caches a generated relationship summary.
+func (s *Store) SetContactSummary(key, displayName, summary string, at int64) error {
+	if err := s.ensureContactMeta(key, displayName); err != nil {
+		return err
+	}
+	_, err := s.db.Exec(`UPDATE contact_meta SET summary = ?, summary_at = ?, updated_at = ? WHERE person_key = ?`, summary, at, time.Now().UnixMilli(), key)
+	return err
+}
+
+func parseTags(jsonStr string) []string {
+	jsonStr = strings.TrimSpace(jsonStr)
+	if jsonStr == "" || jsonStr == "null" {
+		return []string{}
+	}
+	var tags []string
+	if err := json.Unmarshal([]byte(jsonStr), &tags); err != nil {
+		return []string{}
+	}
+	if tags == nil {
+		return []string{}
+	}
+	return tags
+}

--- a/internal/db/conversations.go
+++ b/internal/db/conversations.go
@@ -64,7 +64,14 @@ func (s *Store) UpsertConversation(c *Conversation) error {
 			is_group=excluded.is_group,
 			participants=excluded.participants,
 			last_message_ts=excluded.last_message_ts,
-			unread_count=excluded.unread_count,
+			-- Only honor an incoming unread flag when the event carries genuinely
+			-- new activity (a message newer than the user's read watermark).
+			-- Otherwise force 0, so Google's stale unread re-syncs can't
+			-- resurrect a badge the user already cleared.
+			unread_count=CASE
+				WHEN excluded.last_message_ts > conversations.last_read_ts THEN excluded.unread_count
+				ELSE 0
+			END,
 			source_platform=excluded.source_platform,
 			notification_mode=CASE WHEN ? != '' THEN ? ELSE conversations.notification_mode END
 	`, c.ConversationID, c.Name, c.IsGroup, c.Participants, c.LastMessageTS, c.UnreadCount, c.SourcePlatform, notificationMode, maybeNotificationModeArg(hasNotificationMode, notificationMode), maybeNotificationModeArg(hasNotificationMode, notificationMode))
@@ -167,7 +174,10 @@ func (s *Store) DeleteConversation(id string) error {
 }
 
 func (s *Store) MarkConversationRead(id string) error {
-	_, err := s.db.Exec(`UPDATE conversations SET unread_count = 0 WHERE conversation_id = ?`, id)
+	// Clear the badge and advance the read watermark to the latest message, so a
+	// stale conversation re-sync from Google (same last_message_ts, unread flag
+	// still set on the phone) can't resurrect the unread badge.
+	_, err := s.db.Exec(`UPDATE conversations SET unread_count = 0, last_read_ts = last_message_ts WHERE conversation_id = ?`, id)
 	return err
 }
 
@@ -333,7 +343,14 @@ func upsertConversationTx(tx *sql.Tx, c *Conversation) error {
 			is_group=excluded.is_group,
 			participants=excluded.participants,
 			last_message_ts=excluded.last_message_ts,
-			unread_count=excluded.unread_count,
+			-- Only honor an incoming unread flag when the event carries genuinely
+			-- new activity (a message newer than the user's read watermark).
+			-- Otherwise force 0, so Google's stale unread re-syncs can't
+			-- resurrect a badge the user already cleared.
+			unread_count=CASE
+				WHEN excluded.last_message_ts > conversations.last_read_ts THEN excluded.unread_count
+				ELSE 0
+			END,
 			source_platform=excluded.source_platform,
 			notification_mode=CASE WHEN ? != '' THEN ? ELSE conversations.notification_mode END
 	`, c.ConversationID, c.Name, c.IsGroup, c.Participants, c.LastMessageTS, c.UnreadCount, c.SourcePlatform, notificationMode, maybeNotificationModeArg(hasNotificationMode, notificationMode), maybeNotificationModeArg(hasNotificationMode, notificationMode))

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -251,6 +251,7 @@ func (s *Store) migrate() error {
 		participants TEXT NOT NULL DEFAULT '[]',
 		last_message_ts INTEGER NOT NULL DEFAULT 0,
 		unread_count INTEGER NOT NULL DEFAULT 0,
+		last_read_ts INTEGER NOT NULL DEFAULT 0,
 		notification_mode TEXT NOT NULL DEFAULT 'all',
 		tab TEXT NOT NULL DEFAULT ''
 	);
@@ -318,9 +319,19 @@ func (s *Store) migrate() error {
 		"ALTER TABLE conversations ADD COLUMN source_platform TEXT NOT NULL DEFAULT 'sms'",
 		"ALTER TABLE conversations ADD COLUMN notification_mode TEXT NOT NULL DEFAULT 'all'",
 		"ALTER TABLE conversations ADD COLUMN tab TEXT NOT NULL DEFAULT ''",
+		// Local read watermark: highest last_message_ts the user has read. A
+		// conversation event only re-marks unread when it carries a newer
+		// message, so Google's stale unread re-syncs can't resurrect the badge.
+		"ALTER TABLE conversations ADD COLUMN last_read_ts INTEGER NOT NULL DEFAULT 0",
 	} {
 		s.db.Exec(col) // ignore "duplicate column" errors
 	}
+
+	// Seed the read watermark for already-read conversations so existing installs
+	// are protected from stale unread re-syncs immediately (not only after the
+	// next local read). Unread conversations (unread_count > 0) are left at 0 so
+	// they stay visible.
+	s.db.Exec(`UPDATE conversations SET last_read_ts = last_message_ts WHERE unread_count = 0 AND last_read_ts < last_message_ts`)
 
 	// Unified contacts table
 	s.db.Exec(`CREATE TABLE IF NOT EXISTS unified_contacts (
@@ -328,6 +339,40 @@ func (s *Store) migrate() error {
 		display_name TEXT NOT NULL DEFAULT '',
 		identifiers TEXT NOT NULL DEFAULT '[]'
 	)`)
+
+	// Per-person CRM metadata (tags, reach-out cadence, cached relationship
+	// summary), keyed by a normalized person key. See contact_meta.go.
+	s.db.Exec(`CREATE TABLE IF NOT EXISTS contact_meta (
+		person_key TEXT PRIMARY KEY,
+		display_name TEXT NOT NULL DEFAULT '',
+		tags TEXT NOT NULL DEFAULT '[]',
+		reach_out_days INTEGER NOT NULL DEFAULT 0,
+		summary TEXT NOT NULL DEFAULT '',
+		summary_at INTEGER NOT NULL DEFAULT 0,
+		updated_at INTEGER NOT NULL DEFAULT 0
+	)`)
+
+	// Scheduled (send-later) messages. See scheduled.go.
+	s.db.Exec(`CREATE TABLE IF NOT EXISTS scheduled_messages (
+		id TEXT PRIMARY KEY,
+		conversation_id TEXT NOT NULL DEFAULT '',
+		body TEXT NOT NULL DEFAULT '',
+		reply_to_id TEXT NOT NULL DEFAULT '',
+		send_at INTEGER NOT NULL DEFAULT 0,
+		status TEXT NOT NULL DEFAULT 'pending',
+		attempts INTEGER NOT NULL DEFAULT 0,
+		last_error TEXT NOT NULL DEFAULT '',
+		created_at INTEGER NOT NULL DEFAULT 0,
+		sent_message_id TEXT NOT NULL DEFAULT '',
+		media_data BLOB,
+		media_filename TEXT NOT NULL DEFAULT '',
+		media_mime TEXT NOT NULL DEFAULT ''
+	)`)
+	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_scheduled_due ON scheduled_messages(status, send_at)`)
+	// Add media columns to scheduled_messages on already-created DBs.
+	s.db.Exec(`ALTER TABLE scheduled_messages ADD COLUMN media_data BLOB`)
+	s.db.Exec(`ALTER TABLE scheduled_messages ADD COLUMN media_filename TEXT NOT NULL DEFAULT ''`)
+	s.db.Exec(`ALTER TABLE scheduled_messages ADD COLUMN media_mime TEXT NOT NULL DEFAULT ''`)
 
 	// Index for dedup on import
 	s.db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_source ON messages(source_platform, source_id) WHERE source_id != ''`)

--- a/internal/db/people.go
+++ b/internal/db/people.go
@@ -1,0 +1,211 @@
+package db
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// Person aggregates a single human you've messaged, merged across their 1:1
+// conversations (and platforms) by normalized name.
+type Person struct {
+	Key             string   `json:"key"`
+	Name            string   `json:"name"`
+	Numbers         []string `json:"numbers"`
+	Platforms       []string `json:"platforms"`
+	LastContactedTS int64    `json:"last_contacted_ts"`
+	MessageCount    int      `json:"message_count"`
+	ConversationIDs []string `json:"-"`
+}
+
+// realMessageCountsByConversation counts real (non-system, content-bearing)
+// messages per conversation in a single query, mirroring story.FilterRealMessages
+// closely enough for list ordering.
+func (s *Store) realMessageCountsByConversation() (map[string]int, error) {
+	rows, err := s.db.Query(`
+		SELECT conversation_id, COUNT(*) FROM messages
+		WHERE (TRIM(body) != '' OR TRIM(COALESCE(media_id,'')) != '')
+		  AND lower(body) NOT LIKE 'rcs chat with%'
+		  AND lower(body) NOT LIKE 'this rcs chat is now%'
+		  AND lower(body) NOT LIKE 'you created this rcs%'
+		  AND lower(body) NOT LIKE 'you started an rcs%'
+		  AND lower(body) NOT LIKE 'this chat is now%'
+		  AND lower(body) NOT LIKE 'sms/mms with%'
+		GROUP BY conversation_id
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]int{}
+	for rows.Next() {
+		var id string
+		var n int
+		if err := rows.Scan(&id, &n); err != nil {
+			return nil, err
+		}
+		out[id] = n
+	}
+	return out, rows.Err()
+}
+
+// ListMessagedPeople returns everyone with 1:1 message history, grouped by
+// normalized name and ordered by most recently contacted.
+func (s *Store) ListMessagedPeople() ([]*Person, error) {
+	convs, err := s.ListConversations(5000)
+	if err != nil {
+		return nil, err
+	}
+	byKey := map[string]*Person{}
+	var order []string
+	for _, c := range convs {
+		if c.IsGroup {
+			continue
+		}
+		name := strings.TrimSpace(c.Name)
+		nums := participantNumbers(c.Participants)
+		if name == "" {
+			if len(nums) > 0 {
+				name = nums[0]
+			} else {
+				continue
+			}
+		}
+		key := PersonKey(name)
+		if key == "" {
+			continue
+		}
+		p := byKey[key]
+		if p == nil {
+			p = &Person{Key: key, Name: name}
+			byKey[key] = p
+			order = append(order, key)
+		}
+		for _, n := range nums {
+			p.Numbers = appendUniqueStr(p.Numbers, n)
+		}
+		p.Platforms = appendUniqueStr(p.Platforms, platformOrSMS(c.SourcePlatform))
+		if c.LastMessageTS > p.LastContactedTS {
+			p.LastContactedTS = c.LastMessageTS
+		}
+		p.ConversationIDs = append(p.ConversationIDs, c.ConversationID)
+	}
+	people := make([]*Person, 0, len(order))
+	for _, k := range order {
+		people = append(people, byKey[k])
+	}
+	if counts, err := s.realMessageCountsByConversation(); err == nil {
+		for _, p := range people {
+			total := 0
+			for _, cid := range p.ConversationIDs {
+				total += counts[cid]
+			}
+			p.MessageCount = total
+		}
+	}
+	sort.SliceStable(people, func(i, j int) bool {
+		return people[i].LastContactedTS > people[j].LastContactedTS
+	})
+	return people, nil
+}
+
+// PersonByKey resolves a normalized person key back to the aggregated person.
+func (s *Store) PersonByKey(key string) (*Person, error) {
+	people, err := s.ListMessagedPeople()
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range people {
+		if p.Key == key {
+			return p, nil
+		}
+	}
+	return nil, nil
+}
+
+// PersonMessages returns the deduplicated messages across a person's
+// conversations, ordered chronologically.
+func (s *Store) PersonMessages(conversationIDs []string) ([]*Message, error) {
+	if len(conversationIDs) == 0 {
+		return nil, nil
+	}
+	msgs, err := s.GetMessagesByConversations(conversationIDs, 500000)
+	if err != nil {
+		return nil, err
+	}
+	return dedupePersonMessages(msgs), nil
+}
+
+func participantNumbers(participantsJSON string) []string {
+	participantsJSON = strings.TrimSpace(participantsJSON)
+	if participantsJSON == "" || participantsJSON == "[]" {
+		return nil
+	}
+	var ps []struct {
+		Number string `json:"number"`
+		IsMe   bool   `json:"is_me"`
+	}
+	if err := json.Unmarshal([]byte(participantsJSON), &ps); err != nil {
+		return nil
+	}
+	var out []string
+	for _, p := range ps {
+		if p.IsMe {
+			continue
+		}
+		if n := strings.TrimSpace(p.Number); n != "" {
+			out = appendUniqueStr(out, n)
+		}
+	}
+	return out
+}
+
+func platformOrSMS(p string) string {
+	if strings.TrimSpace(p) == "" {
+		return "sms"
+	}
+	return p
+}
+
+func appendUniqueStr(list []string, v string) []string {
+	for _, x := range list {
+		if strings.EqualFold(x, v) {
+			return list
+		}
+	}
+	return append(list, v)
+}
+
+// dedupePersonMessages removes near-duplicate cross-platform messages (same body
+// + sender within 2s), keeping the first occurrence.
+func dedupePersonMessages(msgs []*Message) []*Message {
+	if len(msgs) <= 1 {
+		return msgs
+	}
+	sort.SliceStable(msgs, func(i, j int) bool {
+		return msgs[i].TimestampMS < msgs[j].TimestampMS
+	})
+	var result []*Message
+	for _, m := range msgs {
+		dup := false
+		start := len(result) - 20
+		if start < 0 {
+			start = 0
+		}
+		for i := len(result) - 1; i >= start; i-- {
+			prev := result[i]
+			diff := m.TimestampMS - prev.TimestampMS
+			if diff > 2000 {
+				break
+			}
+			if diff >= 0 && m.Body == prev.Body && m.IsFromMe == prev.IsFromMe {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			result = append(result, m)
+		}
+	}
+	return result
+}

--- a/internal/db/scheduled.go
+++ b/internal/db/scheduled.go
@@ -1,0 +1,199 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Scheduled-message statuses.
+const (
+	ScheduleStatusPending  = "pending"
+	ScheduleStatusSending  = "sending"
+	ScheduleStatusSent     = "sent"
+	ScheduleStatusFailed   = "failed"
+	ScheduleStatusCanceled = "canceled"
+)
+
+const (
+	scheduleMinLeadMS  = 10_000                    // must be at least 10s out
+	scheduleMaxAheadMS = 365 * 24 * 60 * 60 * 1000 // at most ~1 year out
+)
+
+// ScheduledMessage is a message queued to send at a future time.
+type ScheduledMessage struct {
+	ID             string `json:"id"`
+	ConversationID string `json:"conversation_id"`
+	Body           string `json:"body"`
+	ReplyToID      string `json:"reply_to_id,omitempty"`
+	SendAt         int64  `json:"send_at"`
+	Status         string `json:"status"`
+	Attempts       int    `json:"attempts"`
+	LastError      string `json:"last_error,omitempty"`
+	CreatedAt      int64  `json:"created_at"`
+	SentMessageID  string `json:"sent_message_id,omitempty"`
+	// Media fields. MediaData (the blob) is only set on create and loaded via
+	// GetScheduledMediaData — it is never returned by Get/List/GetDue.
+	MediaData     []byte `json:"-"`
+	MediaFilename string `json:"media_filename,omitempty"`
+	MediaMime     string `json:"media_mime,omitempty"`
+}
+
+// ValidateScheduleTime checks a requested send time against "now" (both epoch
+// ms): it must be comfortably in the future and not absurdly far out.
+func ValidateScheduleTime(sendAt, now int64) error {
+	if sendAt <= 0 {
+		return fmt.Errorf("a send time is required")
+	}
+	if sendAt < now+scheduleMinLeadMS {
+		return fmt.Errorf("scheduled time must be in the future")
+	}
+	if sendAt > now+scheduleMaxAheadMS {
+		return fmt.Errorf("scheduled time is too far in the future")
+	}
+	return nil
+}
+
+// scheduledColumns deliberately omits media_data so list/get/due queries never
+// pull the blob; load it separately via GetScheduledMediaData.
+const scheduledColumns = `id, conversation_id, body, reply_to_id, send_at, status, attempts, last_error, created_at, sent_message_id, media_filename, media_mime`
+
+func scanScheduled(s interface{ Scan(...any) error }) (*ScheduledMessage, error) {
+	m := &ScheduledMessage{}
+	if err := s.Scan(&m.ID, &m.ConversationID, &m.Body, &m.ReplyToID, &m.SendAt, &m.Status, &m.Attempts, &m.LastError, &m.CreatedAt, &m.SentMessageID, &m.MediaFilename, &m.MediaMime); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// CreateScheduledMessage stores a new pending scheduled message.
+func (s *Store) CreateScheduledMessage(m *ScheduledMessage) error {
+	if m.Status == "" {
+		m.Status = ScheduleStatusPending
+	}
+	var mediaData any
+	if len(m.MediaData) > 0 {
+		mediaData = m.MediaData
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO scheduled_messages (id, conversation_id, body, reply_to_id, send_at, status, attempts, last_error, created_at, sent_message_id, media_data, media_filename, media_mime)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, m.ID, m.ConversationID, m.Body, m.ReplyToID, m.SendAt, m.Status, m.Attempts, m.LastError, m.CreatedAt, m.SentMessageID, mediaData, m.MediaFilename, m.MediaMime)
+	return err
+}
+
+// GetScheduledMediaData loads just the media blob for a scheduled message. The
+// scheduler calls this at send time so the blob never travels through the
+// list/get paths. Returns (nil, nil) when there is no media.
+func (s *Store) GetScheduledMediaData(id string) ([]byte, error) {
+	var data []byte
+	err := s.db.QueryRow(`SELECT media_data FROM scheduled_messages WHERE id = ?`, id).Scan(&data)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return data, err
+}
+
+// GetScheduledMessage returns one by ID, or (nil, nil) if not found.
+func (s *Store) GetScheduledMessage(id string) (*ScheduledMessage, error) {
+	row := s.db.QueryRow(`SELECT `+scheduledColumns+` FROM scheduled_messages WHERE id = ?`, id)
+	m, err := scanScheduled(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return m, err
+}
+
+// ListScheduledMessages returns the active (pending/sending/failed) scheduled
+// messages for a conversation, oldest send time first. Sent/canceled ones are
+// excluded — they're done.
+func (s *Store) ListScheduledMessages(conversationID string) ([]*ScheduledMessage, error) {
+	rows, err := s.db.Query(`
+		SELECT `+scheduledColumns+` FROM scheduled_messages
+		WHERE conversation_id = ? AND status IN (?, ?, ?)
+		ORDER BY send_at ASC
+	`, conversationID, ScheduleStatusPending, ScheduleStatusSending, ScheduleStatusFailed)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return collectScheduled(rows)
+}
+
+// GetDueScheduledMessages returns pending messages whose time has arrived.
+func (s *Store) GetDueScheduledMessages(now int64) ([]*ScheduledMessage, error) {
+	rows, err := s.db.Query(`
+		SELECT `+scheduledColumns+` FROM scheduled_messages
+		WHERE status = ? AND send_at <= ?
+		ORDER BY send_at ASC
+	`, ScheduleStatusPending, now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return collectScheduled(rows)
+}
+
+func collectScheduled(rows *sql.Rows) ([]*ScheduledMessage, error) {
+	var out []*ScheduledMessage
+	for rows.Next() {
+		m, err := scanScheduled(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// ClaimScheduledMessage atomically transitions pending -> sending. It returns
+// true only for the caller that won the claim, guaranteeing exactly-once sends.
+func (s *Store) ClaimScheduledMessage(id string) (bool, error) {
+	res, err := s.db.Exec(`UPDATE scheduled_messages SET status = ? WHERE id = ? AND status = ?`,
+		ScheduleStatusSending, id, ScheduleStatusPending)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// MarkScheduledMessageSent records a successful send.
+func (s *Store) MarkScheduledMessageSent(id, sentMessageID string) error {
+	_, err := s.db.Exec(`UPDATE scheduled_messages SET status = ?, sent_message_id = ?, last_error = '' WHERE id = ?`,
+		ScheduleStatusSent, sentMessageID, id)
+	return err
+}
+
+// MarkScheduledMessageFailed records a permanent failure (and counts the attempt).
+func (s *Store) MarkScheduledMessageFailed(id, errMsg string) error {
+	_, err := s.db.Exec(`UPDATE scheduled_messages SET status = ?, last_error = ?, attempts = attempts + 1 WHERE id = ?`,
+		ScheduleStatusFailed, errMsg, id)
+	return err
+}
+
+// RevertScheduledMessageToPending puts a claimed message back to pending so it
+// is retried later (e.g. the platform was offline). Counts the attempt.
+func (s *Store) RevertScheduledMessageToPending(id, errMsg string) error {
+	_, err := s.db.Exec(`UPDATE scheduled_messages SET status = ?, last_error = ?, attempts = attempts + 1 WHERE id = ?`,
+		ScheduleStatusPending, errMsg, id)
+	return err
+}
+
+// CancelScheduledMessage cancels a still-pending message. Returns false if it
+// wasn't pending (already sending/sent/canceled).
+func (s *Store) CancelScheduledMessage(id string) (bool, error) {
+	res, err := s.db.Exec(`UPDATE scheduled_messages SET status = ? WHERE id = ? AND status = ?`,
+		ScheduleStatusCanceled, id, ScheduleStatusPending)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// DeleteScheduledMessage removes a scheduled-message row entirely.
+func (s *Store) DeleteScheduledMessage(id string) error {
+	_, err := s.db.Exec(`DELETE FROM scheduled_messages WHERE id = ?`, id)
+	return err
+}

--- a/internal/db/scheduled_media_test.go
+++ b/internal/db/scheduled_media_test.go
@@ -1,0 +1,53 @@
+package db
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestScheduledMessageMedia(t *testing.T) {
+	store := newTestStore(t)
+	now := int64(1_700_000_000_000)
+	blob := []byte{0x89, 0x50, 0x4e, 0x47, 1, 2, 3}
+
+	m := &ScheduledMessage{
+		ID: "m1", ConversationID: "c1", Body: "look at this", SendAt: now + 60_000, CreatedAt: now,
+		MediaData: blob, MediaFilename: "photo.png", MediaMime: "image/png",
+	}
+	if err := store.CreateScheduledMessage(m); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Get returns the metadata but NOT the (potentially large) blob.
+	got, err := store.GetScheduledMessage("m1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.MediaFilename != "photo.png" || got.MediaMime != "image/png" || got.Body != "look at this" {
+		t.Errorf("metadata wrong: %+v", got)
+	}
+	if len(got.MediaData) != 0 {
+		t.Errorf("GetScheduledMessage should not load the media blob")
+	}
+
+	// The blob loads on demand (used by the scheduler at send time).
+	data, err := store.GetScheduledMediaData("m1")
+	if err != nil {
+		t.Fatalf("media data: %v", err)
+	}
+	if !bytes.Equal(data, blob) {
+		t.Errorf("blob mismatch: got %v want %v", data, blob)
+	}
+
+	// The list (UI) carries metadata but not the blob.
+	list, err := store.ListScheduledMessages("c1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 || list[0].MediaFilename != "photo.png" {
+		t.Fatalf("list metadata wrong: %+v", list)
+	}
+	if len(list[0].MediaData) != 0 {
+		t.Errorf("list must not include the media blob")
+	}
+}

--- a/internal/db/scheduled_test.go
+++ b/internal/db/scheduled_test.go
@@ -1,0 +1,129 @@
+package db
+
+import "testing"
+
+func TestValidateScheduleTime(t *testing.T) {
+	now := int64(1_000_000_000_000)
+	cases := []struct {
+		name   string
+		sendAt int64
+		ok     bool
+	}{
+		{"comfortably future", now + 60_000, true},
+		{"exactly now", now, false},
+		{"in the past", now - 1, false},
+		{"under the 10s floor", now + 5_000, false},
+		{"just over the floor", now + 11_000, true},
+		{"zero", 0, false},
+		{"too far (over a year)", now + 400*24*60*60*1000, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateScheduleTime(tc.sendAt, now)
+			if (err == nil) != tc.ok {
+				t.Errorf("ValidateScheduleTime(%d) err=%v, want ok=%v", tc.sendAt, err, tc.ok)
+			}
+		})
+	}
+}
+
+func TestScheduledMessageLifecycle(t *testing.T) {
+	store := newTestStore(t)
+	now := int64(1_700_000_000_000)
+
+	m := &ScheduledMessage{
+		ID: "s1", ConversationID: "c1", Body: "later text", SendAt: now + 60_000, CreatedAt: now,
+	}
+	if err := store.CreateScheduledMessage(m); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Lists for the conversation.
+	list, err := store.ListScheduledMessages("c1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "s1" || list[0].Status != ScheduleStatusPending {
+		t.Fatalf("list = %+v, want one pending s1", list)
+	}
+
+	// Not due yet.
+	if due, _ := store.GetDueScheduledMessages(now); len(due) != 0 {
+		t.Errorf("should not be due before send_at, got %d", len(due))
+	}
+	// Due once the time has passed.
+	due, err := store.GetDueScheduledMessages(now + 60_001)
+	if err != nil {
+		t.Fatalf("getdue: %v", err)
+	}
+	if len(due) != 1 || due[0].ID != "s1" {
+		t.Fatalf("due = %+v, want s1", due)
+	}
+
+	// Atomic claim: first claim succeeds, second fails (exactly-once).
+	claimed, err := store.ClaimScheduledMessage("s1")
+	if err != nil || !claimed {
+		t.Fatalf("first claim should succeed, got claimed=%v err=%v", claimed, err)
+	}
+	claimedAgain, _ := store.ClaimScheduledMessage("s1")
+	if claimedAgain {
+		t.Errorf("second claim must fail (already sending)")
+	}
+	// A claimed (sending) message is no longer "due".
+	if due, _ := store.GetDueScheduledMessages(now + 60_001); len(due) != 0 {
+		t.Errorf("claimed message should not be due, got %d", len(due))
+	}
+
+	// Mark sent.
+	if err := store.MarkScheduledMessageSent("s1", "msg-123"); err != nil {
+		t.Fatalf("mark sent: %v", err)
+	}
+	got, _ := store.GetScheduledMessage("s1")
+	if got == nil || got.Status != ScheduleStatusSent || got.SentMessageID != "msg-123" {
+		t.Errorf("after sent = %+v", got)
+	}
+}
+
+func TestScheduledMessageCancelAndFail(t *testing.T) {
+	store := newTestStore(t)
+	now := int64(1_700_000_000_000)
+	mk := func(id string) {
+		if err := store.CreateScheduledMessage(&ScheduledMessage{ID: id, ConversationID: "c1", Body: "x", SendAt: now + 60_000, CreatedAt: now}); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+
+	// Cancel a pending message succeeds; cancelling again fails (not pending).
+	mk("p1")
+	if ok, err := store.CancelScheduledMessage("p1"); err != nil || !ok {
+		t.Fatalf("cancel pending should succeed, ok=%v err=%v", ok, err)
+	}
+	if ok, _ := store.CancelScheduledMessage("p1"); ok {
+		t.Errorf("cancelling an already-cancelled message must fail")
+	}
+	// A cancelled message never becomes due.
+	if due, _ := store.GetDueScheduledMessages(now + 60_001); len(due) != 0 {
+		t.Errorf("cancelled message should not be due")
+	}
+
+	// Failure path: claim, then mark failed with an error + attempt count.
+	mk("f1")
+	store.ClaimScheduledMessage("f1")
+	if err := store.MarkScheduledMessageFailed("f1", "route unavailable"); err != nil {
+		t.Fatalf("mark failed: %v", err)
+	}
+	got, _ := store.GetScheduledMessage("f1")
+	if got.Status != ScheduleStatusFailed || got.Attempts != 1 || got.LastError != "route unavailable" {
+		t.Errorf("after failure = %+v", got)
+	}
+
+	// Transient revert: claim, revert to pending — becomes due again.
+	mk("r1")
+	store.ClaimScheduledMessage("r1")
+	if err := store.RevertScheduledMessageToPending("r1", "offline"); err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+	if due, _ := store.GetDueScheduledMessages(now + 60_001); len(due) != 1 || due[0].ID != "r1" {
+		t.Errorf("reverted message should be due again, got %+v", due)
+	}
+}

--- a/internal/db/stub.go
+++ b/internal/db/stub.go
@@ -1,0 +1,102 @@
+package db
+
+import "strings"
+
+// pendingStatusMarkers indicate a message whose content may still arrive (media
+// downloading, message sending, etc.). An empty body for one of these is a
+// placeholder, not a stub, so it must be kept.
+var pendingStatusMarkers = []string{
+	"DOWNLOADING", "UPLOADING", "SENDING", "YET_TO_SEND",
+	"PROCESSING", "VALIDATING", "RESENDING", "QUEUED",
+}
+
+// IsEmptyStubMessage reports whether a message is a contentless "stub": no body,
+// no media, and no reactions, with a terminal/complete status. These show up as
+// "Empty message" in the thread (and wrongly surface conversations) and arise
+// when group activity leaks an empty message into a 1:1 thread. Placeholders
+// (still downloading/sending), system tombstones, and unknown-status messages
+// are NOT stubs.
+func IsEmptyStubMessage(m *Message) bool {
+	if m == nil {
+		return false
+	}
+	if strings.TrimSpace(m.Body) != "" ||
+		strings.TrimSpace(m.MediaID) != "" ||
+		strings.TrimSpace(m.Reactions) != "" {
+		return false
+	}
+	status := strings.ToUpper(strings.TrimSpace(m.Status))
+	if status == "" || strings.HasPrefix(status, "TOMBSTONE") {
+		return false
+	}
+	for _, marker := range pendingStatusMarkers {
+		if strings.Contains(status, marker) {
+			return false
+		}
+	}
+	return true
+}
+
+// emptyStubSQLPredicate is the SQL form of IsEmptyStubMessage, used for the bulk
+// repair. Keep it in sync with IsEmptyStubMessage / pendingStatusMarkers above.
+const emptyStubSQLPredicate = `
+	TRIM(body) = '' AND TRIM(COALESCE(media_id,'')) = '' AND TRIM(COALESCE(reactions,'')) = ''
+	AND TRIM(status) != ''
+	AND upper(status) NOT LIKE 'TOMBSTONE%'
+	AND upper(status) NOT LIKE '%DOWNLOADING%' AND upper(status) NOT LIKE '%UPLOADING%'
+	AND upper(status) NOT LIKE '%SENDING%' AND upper(status) NOT LIKE '%YET_TO_SEND%'
+	AND upper(status) NOT LIKE '%PROCESSING%' AND upper(status) NOT LIKE '%VALIDATING%'
+	AND upper(status) NOT LIKE '%RESENDING%' AND upper(status) NOT LIKE '%QUEUED%'
+`
+
+// RepairEmptyStubMessages deletes existing empty-stub messages (in a single
+// batched statement) and recomputes the recency of conversations they were
+// inflating. Conversations whose last_message_ts sits above the deleted stubs
+// (e.g. legitimately ahead from metadata) are left alone. Returns the count.
+func (s *Store) RepairEmptyStubMessages() (int, error) {
+	// Affected conversations and the newest stub timestamp in each, BEFORE delete.
+	rows, err := s.db.Query(`SELECT conversation_id, MAX(timestamp_ms) FROM messages WHERE ` + emptyStubSQLPredicate + ` GROUP BY conversation_id`)
+	if err != nil {
+		return 0, err
+	}
+	maxStubTS := map[string]int64{}
+	for rows.Next() {
+		var conv string
+		var ts int64
+		if err := rows.Scan(&conv, &ts); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		maxStubTS[conv] = ts
+	}
+	rows.Close()
+	if len(maxStubTS) == 0 {
+		return 0, nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	res, err := s.deleteMessages(tx, emptyStubSQLPredicate)
+	if err != nil {
+		return 0, err
+	}
+	// Recompute recency only where a stub was at/above the current recency.
+	for conv, stubTS := range maxStubTS {
+		if _, err := tx.Exec(`
+			UPDATE conversations
+			SET last_message_ts = COALESCE((SELECT MAX(timestamp_ms) FROM messages WHERE conversation_id = ?), 0)
+			WHERE conversation_id = ? AND last_message_ts <= ?
+		`, conv, conv, stubTS); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}

--- a/internal/db/stub_test.go
+++ b/internal/db/stub_test.go
@@ -1,0 +1,95 @@
+package db
+
+import "testing"
+
+func TestIsEmptyStubMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  *Message
+		want bool
+	}{
+		{"completed empty incoming", &Message{Body: "", Status: "INCOMING_COMPLETE"}, true},
+		{"completed empty delivered", &Message{Body: "", Status: "DELIVERED"}, true},
+		{"whitespace-only body", &Message{Body: "   ", Status: "INCOMING_COMPLETE"}, true},
+		{"auto-downloading placeholder", &Message{Body: "", Status: "INCOMING_AUTO_DOWNLOADING"}, false},
+		{"sending placeholder", &Message{Body: "", Status: "OUTGOING_SENDING"}, false},
+		{"has body", &Message{Body: "hey", Status: "INCOMING_COMPLETE"}, false},
+		{"has media", &Message{MediaID: "m1", Status: "INCOMING_COMPLETE"}, false},
+		{"has reactions", &Message{Reactions: `[{"emoji":"❤️","count":1}]`, Status: "INCOMING_COMPLETE"}, false},
+		{"tombstone/system", &Message{Body: "", Status: "TOMBSTONE_ENCRYPTED"}, false},
+		{"unknown status", &Message{Body: "", Status: ""}, false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsEmptyStubMessage(tc.msg); got != tc.want {
+				t.Errorf("IsEmptyStubMessage = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRepairEmptyStubMessages(t *testing.T) {
+	store := newTestStore(t)
+	must := func(m *Message) {
+		if err := store.UpsertMessage(m); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+	}
+	seedConv := func(id string, lastTS int64) {
+		if err := store.UpsertConversation(&Conversation{ConversationID: id, LastMessageTS: lastTS}); err != nil {
+			t.Fatalf("seed conv: %v", err)
+		}
+	}
+
+	// c1: a real message + a completed empty stub that's setting recency.
+	seedConv("c1", 5000)
+	must(&Message{MessageID: "c1-real", ConversationID: "c1", Body: "hi", TimestampMS: 1000, Status: "INCOMING_COMPLETE"})
+	must(&Message{MessageID: "c1-stub", ConversationID: "c1", Body: "", TimestampMS: 5000, Status: "INCOMING_COMPLETE"})
+
+	// c2 (the Joey case): only empty stubs.
+	seedConv("c2", 3000)
+	must(&Message{MessageID: "c2-s1", ConversationID: "c2", Body: "", TimestampMS: 2000, Status: "INCOMING_COMPLETE"})
+	must(&Message{MessageID: "c2-s2", ConversationID: "c2", Body: "", TimestampMS: 3000, Status: "INCOMING_COMPLETE"})
+
+	// c3: only real messages — untouched.
+	seedConv("c3", 4000)
+	must(&Message{MessageID: "c3-real", ConversationID: "c3", Body: "yo", TimestampMS: 4000, Status: "INCOMING_COMPLETE"})
+
+	// c4: an auto-downloading placeholder — kept (content may still arrive).
+	seedConv("c4", 6000)
+	must(&Message{MessageID: "c4-ph", ConversationID: "c4", Body: "", TimestampMS: 6000, Status: "INCOMING_AUTO_DOWNLOADING"})
+
+	n, err := store.RepairEmptyStubMessages()
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("deleted = %d, want 3 (c1-stub + c2 x2)", n)
+	}
+
+	// Stubs gone, real/placeholder messages kept.
+	for _, gone := range []string{"c1-stub", "c2-s1", "c2-s2"} {
+		if m, _ := store.GetMessageByID(gone); m != nil {
+			t.Errorf("%s should be deleted", gone)
+		}
+	}
+	for _, kept := range []string{"c1-real", "c3-real", "c4-ph"} {
+		if m, _ := store.GetMessageByID(kept); m == nil {
+			t.Errorf("%s should be kept", kept)
+		}
+	}
+
+	// Recency recomputed for affected conversations.
+	want := map[string]int64{"c1": 1000, "c2": 0, "c3": 4000, "c4": 6000}
+	for id, exp := range want {
+		c, _ := store.GetConversation(id)
+		if c == nil || c.LastMessageTS != exp {
+			got := int64(-1)
+			if c != nil {
+				got = c.LastMessageTS
+			}
+			t.Errorf("%s last_message_ts = %d, want %d", id, got, exp)
+		}
+	}
+}

--- a/internal/db/tapback.go
+++ b/internal/db/tapback.go
@@ -1,0 +1,251 @@
+package db
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// Tapback is an iMessage-style reaction that arrived as SMS/RCS text, e.g.
+// `Loved "see you then"`. iPhones send these as plain messages to Android, and
+// we convert them into an emoji reaction on the message they refer to.
+type Tapback struct {
+	Emoji  string
+	Quoted string // the referenced message text (may be truncated with an ellipsis)
+	Remove bool   // true when the reaction was removed
+}
+
+type tapbackPattern struct {
+	re     *regexp.Regexp
+	emoji  string
+	remove bool
+}
+
+// Quote class matches both straight ("...") and iMessage's curly (“...”) quotes.
+const tbQuoteOpen = "[\"“]"
+const tbQuoteClose = "[\"”]"
+
+func tbVerb(verb string) *regexp.Regexp {
+	return regexp.MustCompile("(?s)^" + verb + " " + tbQuoteOpen + "(.+)" + tbQuoteClose + "$")
+}
+
+var tapbackPatterns = []tapbackPattern{
+	{tbVerb("Loved"), "❤️", false},
+	{tbVerb("Liked"), "👍", false},
+	{tbVerb("Disliked"), "👎", false},
+	{tbVerb("Laughed at"), "😂", false},
+	{tbVerb("Emphasized"), "‼️", false},
+	{tbVerb("Questioned"), "❓", false},
+	{tbVerb("Removed a heart from"), "❤️", true},
+	{tbVerb("Removed a like from"), "👍", true},
+	{tbVerb("Removed a dislike from"), "👎", true},
+	{tbVerb("Removed a laugh from"), "😂", true},
+	{tbVerb("Removed an exclamation from"), "‼️", true},
+	{tbVerb("Removed a question mark from"), "❓", true},
+}
+
+// Newer iOS sends the actual emoji: `Reacted 🎉 to "we did it"`.
+var reactedPattern = regexp.MustCompile("(?s)^Reacted (.+?) to " + tbQuoteOpen + "(.+)" + tbQuoteClose + "$")
+
+// ParseTapback detects an iMessage tapback in a message body and returns the
+// emoji, the quoted (referenced) text, and whether it was a removal.
+func ParseTapback(body string) (*Tapback, bool) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return nil, false
+	}
+	for _, p := range tapbackPatterns {
+		if m := p.re.FindStringSubmatch(body); m != nil {
+			return &Tapback{Emoji: p.emoji, Quoted: strings.TrimSpace(m[1]), Remove: p.remove}, true
+		}
+	}
+	if m := reactedPattern.FindStringSubmatch(body); m != nil {
+		return &Tapback{Emoji: strings.TrimSpace(m[1]), Quoted: strings.TrimSpace(m[2])}, true
+	}
+	return nil, false
+}
+
+// ApplyTapback detects whether m is a tapback and, if so, applies it as an
+// emoji reaction on the message it refers to (instead of a standalone text).
+// It returns true when handled — the caller should then NOT store m as a
+// regular message. It returns false (so the caller stores m normally) when m
+// isn't a tapback or no matching target message can be found.
+func (s *Store) ApplyTapback(m *Message) (bool, error) {
+	if m == nil {
+		return false, nil
+	}
+	tb, ok := ParseTapback(m.Body)
+	if !ok {
+		return false, nil
+	}
+	target, err := s.findTapbackTarget(m.ConversationID, tb.Quoted, m.TimestampMS)
+	if err != nil {
+		return false, err
+	}
+	if target == nil {
+		return false, nil
+	}
+	actor := strings.TrimSpace(m.SenderNumber)
+	if m.IsFromMe {
+		actor = "me"
+	} else if actor == "" {
+		actor = strings.TrimSpace(m.SenderName)
+	}
+	next, changed, err := mergeReaction(target.Reactions, tb.Emoji, actor, tb.Remove)
+	if err != nil {
+		return false, err
+	}
+	if changed {
+		if _, err := s.db.Exec(`UPDATE messages SET reactions = ? WHERE message_id = ?`, next, target.MessageID); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// findTapbackTarget locates the message a tapback refers to: the most recent
+// message in the conversation (at or before the tapback) whose body equals the
+// quoted text, or — for truncated quotes — starts with it.
+func (s *Store) findTapbackTarget(conversationID, quoted string, beforeTS int64) (*Message, error) {
+	quoted = strings.TrimRight(strings.TrimSpace(quoted), ". …")
+	if quoted == "" {
+		return nil, nil
+	}
+	rows, err := s.db.Query(
+		`SELECT message_id, body, reactions FROM messages
+		 WHERE conversation_id = ? AND timestamp_ms <= ? AND TRIM(body) != ''
+		 ORDER BY timestamp_ms DESC LIMIT 200`,
+		conversationID, beforeTS,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, body, reactions string
+		if err := rows.Scan(&id, &body, &reactions); err != nil {
+			return nil, err
+		}
+		b := strings.TrimSpace(body)
+		if b == quoted || strings.HasPrefix(b, quoted) {
+			return &Message{MessageID: id, Body: body, Reactions: reactions}, nil
+		}
+	}
+	return nil, rows.Err()
+}
+
+type tapbackReaction struct {
+	Emoji  string   `json:"emoji"`
+	Count  int      `json:"count"`
+	Actors []string `json:"actors,omitempty"`
+}
+
+// mergeReaction adds or removes an actor's reaction for an emoji in the stored
+// reactions JSON ([{emoji,count,actors}]). It's idempotent: re-adding the same
+// actor/emoji is a no-op.
+func mergeReaction(existingJSON, emoji, actor string, remove bool) (string, bool, error) {
+	existingJSON = strings.TrimSpace(existingJSON)
+	var reactions []tapbackReaction
+	if existingJSON != "" && existingJSON != "null" {
+		_ = json.Unmarshal([]byte(existingJSON), &reactions)
+	}
+	changed := false
+	if remove {
+		for i := range reactions {
+			if reactions[i].Emoji != emoji {
+				continue
+			}
+			if idx := indexOfString(reactions[i].Actors, actor); idx >= 0 {
+				reactions[i].Actors = append(reactions[i].Actors[:idx], reactions[i].Actors[idx+1:]...)
+				if reactions[i].Count > 0 {
+					reactions[i].Count--
+				}
+				changed = true
+			}
+		}
+	} else {
+		found := false
+		for i := range reactions {
+			if reactions[i].Emoji != emoji {
+				continue
+			}
+			found = true
+			if indexOfString(reactions[i].Actors, actor) < 0 {
+				reactions[i].Actors = append(reactions[i].Actors, actor)
+				reactions[i].Count++
+				changed = true
+			}
+			break
+		}
+		if !found {
+			reactions = append(reactions, tapbackReaction{Emoji: emoji, Count: 1, Actors: []string{actor}})
+			changed = true
+		}
+	}
+	if !changed {
+		return existingJSON, false, nil
+	}
+	compacted := make([]tapbackReaction, 0, len(reactions))
+	for _, r := range reactions {
+		if r.Count > 0 && strings.TrimSpace(r.Emoji) != "" {
+			compacted = append(compacted, r)
+		}
+	}
+	if len(compacted) == 0 {
+		return "", true, nil
+	}
+	b, err := json.Marshal(compacted)
+	if err != nil {
+		return existingJSON, false, err
+	}
+	return string(b), true, nil
+}
+
+// RepairTapbacks converts already-stored tapback text messages into reactions
+// on their referenced messages and removes the standalone tapback rows. Returns
+// the number converted.
+func (s *Store) RepairTapbacks() (int, error) {
+	rows, err := s.db.Query(`
+		SELECT message_id, conversation_id, sender_name, sender_number, body, timestamp_ms, is_from_me
+		FROM messages
+		WHERE body LIKE 'Loved %' OR body LIKE 'Liked %' OR body LIKE 'Disliked %'
+		   OR body LIKE 'Laughed at %' OR body LIKE 'Emphasized %' OR body LIKE 'Questioned %'
+		   OR body LIKE 'Removed a %' OR body LIKE 'Reacted %'
+	`)
+	if err != nil {
+		return 0, err
+	}
+	var candidates []*Message
+	for rows.Next() {
+		m := &Message{}
+		if err := rows.Scan(&m.MessageID, &m.ConversationID, &m.SenderName, &m.SenderNumber, &m.Body, &m.TimestampMS, &m.IsFromMe); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		if _, ok := ParseTapback(m.Body); ok {
+			candidates = append(candidates, m)
+		}
+	}
+	rows.Close()
+
+	count := 0
+	for _, m := range candidates {
+		applied, err := s.ApplyTapback(m)
+		if err != nil || !applied {
+			continue
+		}
+		if err := s.DeleteMessageByID(m.MessageID); err == nil {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func indexOfString(list []string, v string) int {
+	for i, x := range list {
+		if x == v {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/db/tapback_test.go
+++ b/internal/db/tapback_test.go
@@ -1,0 +1,128 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTapback(t *testing.T) {
+	cases := []struct {
+		body   string
+		emoji  string
+		quoted string
+		remove bool
+		ok     bool
+	}{
+		{`Loved "Great news!"`, "❤️", "Great news!", false, true},
+		{`Liked "ok sounds good"`, "👍", "ok sounds good", false, true},
+		{`Disliked "no way"`, "👎", "no way", false, true},
+		{`Laughed at "lol"`, "😂", "lol", false, true},
+		{`Emphasized "this is important"`, "‼️", "this is important", false, true},
+		{`Questioned "really?"`, "❓", "really?", false, true},
+		// Curly quotes (what iMessage actually sends)
+		{"Loved “hello there”", "❤️", "hello there", false, true},
+		// Removal
+		{`Removed a heart from "hello"`, "❤️", "hello", true, true},
+		// Newer iOS sends the actual emoji
+		{`Reacted 🎉 to "we did it"`, "🎉", "we did it", false, true},
+		// Not tapbacks
+		{`Loved it`, "", "", false, false},
+		{`Hey, are you free tonight?`, "", "", false, false},
+		{``, "", "", false, false},
+	}
+	for _, tc := range cases {
+		tb, ok := ParseTapback(tc.body)
+		if ok != tc.ok {
+			t.Errorf("ParseTapback(%q) ok = %v, want %v", tc.body, ok, tc.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if tb.Emoji != tc.emoji || tb.Quoted != tc.quoted || tb.Remove != tc.remove {
+			t.Errorf("ParseTapback(%q) = {%q, %q, remove=%v}, want {%q, %q, remove=%v}",
+				tc.body, tb.Emoji, tb.Quoted, tb.Remove, tc.emoji, tc.quoted, tc.remove)
+		}
+	}
+}
+
+func TestApplyTapback(t *testing.T) {
+	store := newTestStore(t)
+	mustUpsert := func(m *Message) {
+		if err := store.UpsertMessage(m); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+	}
+
+	// Original message in the thread.
+	mustUpsert(&Message{MessageID: "m1", ConversationID: "c1", SenderName: "Me", Body: "dinner at 7?", TimestampMS: 1000, IsFromMe: true})
+
+	// An iPhone "Loved" tapback arrives as SMS text.
+	applied, err := store.ApplyTapback(&Message{
+		MessageID: "t1", ConversationID: "c1", SenderName: "Sarah", SenderNumber: "+15551234567",
+		Body: `Loved "dinner at 7?"`, TimestampMS: 2000,
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !applied {
+		t.Fatal("expected tapback to be applied")
+	}
+	target, _ := store.GetMessageByID("m1")
+	if target == nil || !strings.Contains(target.Reactions, "❤️") {
+		t.Errorf("expected ❤️ reaction on m1, got reactions=%q", target.Reactions)
+	}
+	// The tapback text itself must NOT be stored as a standalone message.
+	if got, _ := store.GetMessageByID("t1"); got != nil {
+		t.Errorf("tapback message should not be stored as a regular message")
+	}
+
+	// Plain text is not a tapback.
+	if applied, _ := store.ApplyTapback(&Message{ConversationID: "c1", Body: "see you then", TimestampMS: 3000}); applied {
+		t.Error("plain text should not be treated as a tapback")
+	}
+
+	// A tapback whose quoted text matches nothing is not applied (caller keeps it).
+	if applied, _ := store.ApplyTapback(&Message{ConversationID: "c1", Body: `Liked "nonexistent message"`, TimestampMS: 4000}); applied {
+		t.Error("tapback with no matching target should not be applied")
+	}
+
+	// Truncated quote (long original) matches by prefix.
+	mustUpsert(&Message{MessageID: "m2", ConversationID: "c1", Body: "This is a much longer message that iMessage truncates", TimestampMS: 5000})
+	applied2, _ := store.ApplyTapback(&Message{ConversationID: "c1", SenderNumber: "+15551234567", Body: "Laughed at “This is a much longer message that…”", TimestampMS: 6000})
+	if !applied2 {
+		t.Error("expected truncated-quote tapback to match the original by prefix")
+	}
+}
+
+func TestRepairTapbacks(t *testing.T) {
+	store := newTestStore(t)
+	must := func(m *Message) {
+		if err := store.UpsertMessage(m); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+	}
+	must(&Message{MessageID: "a", ConversationID: "c1", Body: "great idea", TimestampMS: 1000, IsFromMe: true})
+	must(&Message{MessageID: "b", ConversationID: "c1", SenderNumber: "+1555", Body: `Loved "great idea"`, TimestampMS: 2000})
+	must(&Message{MessageID: "c", ConversationID: "c1", Body: "a normal reply", TimestampMS: 3000})
+	must(&Message{MessageID: "d", ConversationID: "c1", SenderNumber: "+1555", Body: `Liked "no such message"`, TimestampMS: 4000}) // no target
+
+	n, err := store.RepairTapbacks()
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("repaired = %d, want 1", n)
+	}
+	// The matched tapback row is gone, its reaction lives on the target.
+	if got, _ := store.GetMessageByID("b"); got != nil {
+		t.Error("converted tapback message should be deleted")
+	}
+	if target, _ := store.GetMessageByID("a"); target == nil || !strings.Contains(target.Reactions, "❤️") {
+		t.Error("expected ❤️ reaction on the target message")
+	}
+	// The unmatched tapback and normal messages are untouched.
+	if got, _ := store.GetMessageByID("d"); got == nil {
+		t.Error("unmatched tapback should be kept as a normal message")
+	}
+}

--- a/internal/db/unread_test.go
+++ b/internal/db/unread_test.go
@@ -1,0 +1,105 @@
+package db
+
+import "testing"
+
+// TestUnreadSurvivesStaleConversationResync reproduces the recurring-unread bug:
+// the user reads a conversation locally (mark-read → unread_count=0), but Google
+// Messages keeps its own unread flag set and re-broadcasts the same conversation
+// (same last_message_ts, GetUnread()==true) on every periodic sync. That stale
+// re-sync must NOT resurrect the unread badge.
+func TestUnreadSurvivesStaleConversationResync(t *testing.T) {
+	store := newTestStore(t)
+
+	// A genuinely unread conversation arrives from Google.
+	if err := store.UpsertConversation(&Conversation{
+		ConversationID: "c1", Name: "559 316-5695",
+		LastMessageTS: 1000, UnreadCount: 1,
+	}); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+	if got, _ := store.GetConversation("c1"); got.UnreadCount != 1 {
+		t.Fatalf("fresh unread: got %d, want 1", got.UnreadCount)
+	}
+
+	// User opens the thread → marked read locally.
+	if err := store.MarkConversationRead("c1"); err != nil {
+		t.Fatalf("mark read: %v", err)
+	}
+	if got, _ := store.GetConversation("c1"); got.UnreadCount != 0 {
+		t.Fatalf("after mark-read: got %d, want 0", got.UnreadCount)
+	}
+
+	// Google re-syncs the SAME conversation, still flagged unread (no new
+	// message — same last_message_ts). This is the periodic resync that keeps
+	// resurrecting the badge.
+	if err := store.UpsertConversation(&Conversation{
+		ConversationID: "c1", Name: "559 316-5695",
+		LastMessageTS: 1000, UnreadCount: 1,
+	}); err != nil {
+		t.Fatalf("stale resync: %v", err)
+	}
+	if got, _ := store.GetConversation("c1"); got.UnreadCount != 0 {
+		t.Errorf("BUG: stale resync resurrected unread badge: got %d, want 0", got.UnreadCount)
+	}
+}
+
+// TestUnreadRaisedByGenuinelyNewMessage guards that the fix does NOT suppress
+// real new activity: a conversation event carrying a newer last_message_ts must
+// still mark the thread unread, even after it was previously read.
+func TestUnreadRaisedByGenuinelyNewMessage(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.UpsertConversation(&Conversation{
+		ConversationID: "c1", Name: "Bob", LastMessageTS: 1000, UnreadCount: 1,
+	}); err != nil {
+		t.Fatalf("initial: %v", err)
+	}
+	if err := store.MarkConversationRead("c1"); err != nil {
+		t.Fatalf("mark read: %v", err)
+	}
+
+	// A genuinely new message arrives → newer last_message_ts, unread flag set.
+	if err := store.UpsertConversation(&Conversation{
+		ConversationID: "c1", Name: "Bob", LastMessageTS: 2000, UnreadCount: 1,
+	}); err != nil {
+		t.Fatalf("new message upsert: %v", err)
+	}
+	if got, _ := store.GetConversation("c1"); got.UnreadCount != 1 {
+		t.Errorf("genuinely new message should mark unread: got %d, want 1", got.UnreadCount)
+	}
+
+	// Read it, then another stale resync at the same ts → stays read.
+	if err := store.MarkConversationRead("c1"); err != nil {
+		t.Fatalf("mark read 2: %v", err)
+	}
+	if err := store.UpsertConversation(&Conversation{
+		ConversationID: "c1", Name: "Bob", LastMessageTS: 2000, UnreadCount: 1,
+	}); err != nil {
+		t.Fatalf("stale resync 2: %v", err)
+	}
+	if got, _ := store.GetConversation("c1"); got.UnreadCount != 0 {
+		t.Errorf("stale resync after second read: got %d, want 0", got.UnreadCount)
+	}
+}
+
+// TestUnreadClearedByUpstreamRead guards that when Google itself reports the
+// conversation as read (GetUnread()==false), we honor it even without a newer
+// message — e.g. the user read it on their phone.
+func TestUnreadClearedByUpstreamRead(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.UpsertConversation(&Conversation{
+		ConversationID: "c1", Name: "Carol", LastMessageTS: 1000, UnreadCount: 1,
+	}); err != nil {
+		t.Fatalf("initial: %v", err)
+	}
+	// Google reports it read (unread=0) at the same ts.
+	if err := store.UpsertConversation(&Conversation{
+		ConversationID: "c1", Name: "Carol", LastMessageTS: 1000, UnreadCount: 0,
+	}); err != nil {
+		t.Fatalf("upstream read: %v", err)
+	}
+	if got, _ := store.GetConversation("c1"); got.UnreadCount != 0 {
+		t.Errorf("upstream read should clear unread: got %d, want 0", got.UnreadCount)
+	}
+}

--- a/internal/importer/contacts_macos.go
+++ b/internal/importer/contacts_macos.go
@@ -1,0 +1,321 @@
+package importer
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/maxghenis/openmessage/internal/db"
+
+	_ "modernc.org/sqlite"
+)
+
+// ContactsImportResult summarizes a macOS address-book import.
+type ContactsImportResult struct {
+	ContactsImported int
+	PhoneNumbers     int
+	Emails           int
+	Sources          int
+	Errors           []string
+}
+
+// MacOSContacts imports the local macOS address book into the contacts and
+// unified_contacts tables. It reads the AddressBook SQLite databases directly
+// (like the iMessage importer reads chat.db) and therefore needs Full Disk
+// Access to ~/Library/Application Support/AddressBook.
+//
+// Photos are intentionally not imported here: macOS keeps contact images
+// outside these databases (often fetched from iCloud on demand), so the Go
+// importer can't reliably read them. The native macOS app still renders contact
+// photos live via the Contacts framework.
+type MacOSContacts struct {
+	// Paths optionally lists abcddb files to read. When empty, the importer
+	// auto-discovers them under ~/Library/Application Support/AddressBook.
+	Paths []string
+}
+
+type abContact struct {
+	name    string
+	numbers []string
+	emails  []string
+}
+
+// ImportFromAddressBook reads every discovered address-book database, merges
+// duplicate people across sources, and upserts them into the store.
+func (m *MacOSContacts) ImportFromAddressBook(store *db.Store) (*ContactsImportResult, error) {
+	paths, err := m.dbPaths()
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no macOS AddressBook database found (Full Disk Access may be required)")
+	}
+
+	result := &ContactsImportResult{}
+	merged := map[string]*abContact{}
+	var order []string
+
+	for _, p := range paths {
+		contacts, err := readAddressBookDB(p)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", filepath.Base(filepath.Dir(p)), err))
+			continue
+		}
+		result.Sources++
+		for _, c := range contacts {
+			key := contactDedupKey(c)
+			if key == "" {
+				continue
+			}
+			if existing, ok := merged[key]; ok {
+				existing.numbers = mergeUnique(existing.numbers, c.numbers)
+				existing.emails = mergeUnique(existing.emails, c.emails)
+				if existing.name == "" {
+					existing.name = c.name
+				}
+				continue
+			}
+			cp := c
+			merged[key] = &cp
+			order = append(order, key)
+		}
+	}
+
+	for _, key := range order {
+		if err := storeContact(store, merged[key], result); err != nil {
+			result.Errors = append(result.Errors, err.Error())
+		}
+	}
+	return result, nil
+}
+
+func (m *MacOSContacts) dbPaths() ([]string, error) {
+	if len(m.Paths) > 0 {
+		return m.Paths, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	base := filepath.Join(home, "Library", "Application Support", "AddressBook")
+	var paths []string
+	top := filepath.Join(base, "AddressBook-v22.abcddb")
+	if fileExists(top) {
+		paths = append(paths, top)
+	}
+	matches, _ := filepath.Glob(filepath.Join(base, "Sources", "*", "AddressBook-v22.abcddb"))
+	paths = append(paths, matches...)
+	return paths, nil
+}
+
+func readAddressBookDB(path string) ([]abContact, error) {
+	conn, err := sql.Open("sqlite", path+"?mode=ro")
+	if err != nil {
+		return nil, fmt.Errorf("open: %w", err)
+	}
+	defer conn.Close()
+	conn.SetMaxOpenConns(1)
+
+	phones, err := loadOwnedValues(conn, "ZABCDPHONENUMBER", "ZFULLNUMBER")
+	if err != nil {
+		return nil, fmt.Errorf("phones: %w", err)
+	}
+	emails, err := loadOwnedValues(conn, "ZABCDEMAILADDRESS", "ZADDRESS")
+	if err != nil {
+		return nil, fmt.Errorf("emails: %w", err)
+	}
+
+	rows, err := conn.Query(`SELECT Z_PK, ZFIRSTNAME, ZMIDDLENAME, ZLASTNAME, ZNICKNAME, ZORGANIZATION FROM ZABCDRECORD`)
+	if err != nil {
+		return nil, fmt.Errorf("records: %w", err)
+	}
+	defer rows.Close()
+
+	var contacts []abContact
+	for rows.Next() {
+		var pk int64
+		var first, middle, last, nick, org sql.NullString
+		if err := rows.Scan(&pk, &first, &middle, &last, &nick, &org); err != nil {
+			return nil, err
+		}
+		name := buildContactName(first.String, middle.String, last.String, nick.String, org.String)
+		nums := phones[pk]
+		mails := emails[pk]
+		// Skip contacts with no way to reach them — a bare name is useless for
+		// a messaging inbox and would just clutter the picker.
+		if len(nums) == 0 && len(mails) == 0 {
+			continue
+		}
+		contacts = append(contacts, abContact{name: name, numbers: nums, emails: mails})
+	}
+	return contacts, rows.Err()
+}
+
+// loadOwnedValues returns a map of ZABCDRECORD.Z_PK -> []value for a child table
+// (phone numbers or email addresses) keyed by its ZOWNER column.
+func loadOwnedValues(conn *sql.DB, table, valueCol string) (map[int64][]string, error) {
+	rows, err := conn.Query(fmt.Sprintf(`SELECT ZOWNER, %s FROM %s WHERE %s IS NOT NULL`, valueCol, table, valueCol))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[int64][]string{}
+	for rows.Next() {
+		var owner sql.NullInt64
+		var value sql.NullString
+		if err := rows.Scan(&owner, &value); err != nil {
+			return nil, err
+		}
+		v := strings.TrimSpace(value.String)
+		if !owner.Valid || v == "" {
+			continue
+		}
+		out[owner.Int64] = appendUnique(out[owner.Int64], v)
+	}
+	return out, rows.Err()
+}
+
+func storeContact(store *db.Store, c *abContact, result *ContactsImportResult) error {
+	c.numbers = dedupeNumbersByDigits(c.numbers)
+	name := c.name
+	if name == "" {
+		if len(c.numbers) > 0 {
+			name = c.numbers[0]
+		} else if len(c.emails) > 0 {
+			name = c.emails[0]
+		}
+	}
+	id := "macos:" + shortHash(contactDedupKey(*c))
+
+	type identifier struct {
+		Platform string `json:"platform"`
+		Value    string `json:"value"`
+	}
+	idents := make([]identifier, 0, len(c.numbers)+len(c.emails))
+	for _, n := range c.numbers {
+		idents = append(idents, identifier{Platform: "phone", Value: n})
+	}
+	for _, e := range c.emails {
+		idents = append(idents, identifier{Platform: "email", Value: e})
+	}
+	identJSON, err := json.Marshal(idents)
+	if err != nil {
+		return err
+	}
+	if err := store.UpsertUnifiedContact(&db.UnifiedContact{
+		UnifiedID:   id,
+		DisplayName: name,
+		Identifiers: string(identJSON),
+	}); err != nil {
+		return err
+	}
+	result.ContactsImported++
+
+	for i, n := range c.numbers {
+		if err := store.UpsertContact(&db.Contact{
+			ContactID: fmt.Sprintf("%s:p%d", id, i),
+			Name:      name,
+			Number:    n,
+		}); err != nil {
+			return err
+		}
+		result.PhoneNumbers++
+	}
+	result.Emails += len(c.emails)
+	return nil
+}
+
+func buildContactName(first, middle, last, nick, org string) string {
+	parts := make([]string, 0, 3)
+	for _, p := range []string{first, middle, last} {
+		if s := strings.TrimSpace(p); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, " ")
+	}
+	if s := strings.TrimSpace(nick); s != "" {
+		return s
+	}
+	return strings.TrimSpace(org)
+}
+
+// contactDedupKey produces a stable key so the same person across multiple
+// address-book sources (iCloud, On My Mac, ...) merges into one entry. Named
+// contacts merge by normalized name; nameless ones fall back to their numbers
+// then emails.
+func contactDedupKey(c abContact) string {
+	if name := strings.ToLower(strings.TrimSpace(c.name)); name != "" {
+		return "name:" + name
+	}
+	nums := make([]string, 0, len(c.numbers))
+	for _, n := range c.numbers {
+		if d := digitsOnly(n); d != "" {
+			nums = append(nums, d)
+		}
+	}
+	sort.Strings(nums)
+	if joined := strings.Join(nums, ","); joined != "" {
+		return "num:" + joined
+	}
+	mails := append([]string{}, c.emails...)
+	for i := range mails {
+		mails[i] = strings.ToLower(strings.TrimSpace(mails[i]))
+	}
+	sort.Strings(mails)
+	if joined := strings.Join(mails, ","); joined != "" {
+		return "email:" + joined
+	}
+	return ""
+}
+
+// dedupeNumbersByDigits collapses numbers that are the same once formatting is
+// stripped (e.g. "+1 (310) 555-0000" and "+13105550000"), keeping the first
+// formatting seen.
+func dedupeNumbersByDigits(numbers []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(numbers))
+	for _, n := range numbers {
+		d := digitsOnly(n)
+		if d == "" || seen[d] {
+			continue
+		}
+		seen[d] = true
+		out = append(out, n)
+	}
+	return out
+}
+
+func digitsOnly(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func shortHash(s string) string {
+	h := fnv.New64a()
+	h.Write([]byte(s))
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+func mergeUnique(a, b []string) []string {
+	for _, v := range b {
+		a = appendUnique(a, v)
+	}
+	return a
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/importer/contacts_macos_test.go
+++ b/internal/importer/contacts_macos_test.go
@@ -1,0 +1,122 @@
+package importer
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/db"
+
+	_ "modernc.org/sqlite"
+)
+
+// makeFakeAddressBook writes a minimal abcddb with the tables/columns the
+// importer reads, so we can exercise it without a real macOS address book.
+func makeFakeAddressBook(t *testing.T, path string, stmts []string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open fake abcddb: %v", err)
+	}
+	defer conn.Close()
+	schema := []string{
+		`CREATE TABLE ZABCDRECORD (Z_PK INTEGER PRIMARY KEY, ZFIRSTNAME TEXT, ZMIDDLENAME TEXT, ZLASTNAME TEXT, ZNICKNAME TEXT, ZORGANIZATION TEXT)`,
+		`CREATE TABLE ZABCDPHONENUMBER (Z_PK INTEGER PRIMARY KEY, ZOWNER INTEGER, ZFULLNUMBER TEXT)`,
+		`CREATE TABLE ZABCDEMAILADDRESS (Z_PK INTEGER PRIMARY KEY, ZOWNER INTEGER, ZADDRESS TEXT)`,
+	}
+	for _, s := range append(schema, stmts...) {
+		if _, err := conn.Exec(s); err != nil {
+			t.Fatalf("exec %q: %v", s, err)
+		}
+	}
+}
+
+func TestMacOSContactsImport(t *testing.T) {
+	dir := t.TempDir()
+	abPath := filepath.Join(dir, "AddressBook-v22.abcddb")
+	makeFakeAddressBook(t, abPath, []string{
+		// Sarah Chen: two numbers + one email.
+		`INSERT INTO ZABCDRECORD (Z_PK, ZFIRSTNAME, ZLASTNAME) VALUES (1,'Sarah','Chen')`,
+		`INSERT INTO ZABCDPHONENUMBER (Z_PK, ZOWNER, ZFULLNUMBER) VALUES (10,1,'+1 (415) 555-1234')`,
+		`INSERT INTO ZABCDPHONENUMBER (Z_PK, ZOWNER, ZFULLNUMBER) VALUES (11,1,'+14155559999')`,
+		`INSERT INTO ZABCDEMAILADDRESS (Z_PK, ZOWNER, ZADDRESS) VALUES (20,1,'sarah@example.com')`,
+		// Organization-only contact with one number -> name falls back to org.
+		`INSERT INTO ZABCDRECORD (Z_PK, ZORGANIZATION) VALUES (2,'Acme Inc')`,
+		`INSERT INTO ZABCDPHONENUMBER (Z_PK, ZOWNER, ZFULLNUMBER) VALUES (12,2,'+18005551212')`,
+		// Name only, no reachable identifier -> skipped.
+		`INSERT INTO ZABCDRECORD (Z_PK, ZFIRSTNAME) VALUES (3,'Ghost')`,
+	})
+
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	defer store.Close()
+
+	res, err := (&MacOSContacts{Paths: []string{abPath}}).ImportFromAddressBook(store)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	if res.ContactsImported != 2 {
+		t.Errorf("ContactsImported = %d, want 2 (Ghost has no number/email and is skipped)", res.ContactsImported)
+	}
+	if res.PhoneNumbers != 3 {
+		t.Errorf("PhoneNumbers = %d, want 3", res.PhoneNumbers)
+	}
+	if res.Emails != 1 {
+		t.Errorf("Emails = %d, want 1", res.Emails)
+	}
+
+	// Sarah is searchable in the contacts table (drives the compose picker / list_contacts).
+	contacts, err := store.ListContacts("Sarah", 10)
+	if err != nil {
+		t.Fatalf("list contacts: %v", err)
+	}
+	if len(contacts) != 2 || contacts[0].Name != "Sarah Chen" {
+		t.Errorf("expected 2 Sarah Chen rows (one per number), got %d", len(contacts))
+	}
+
+	// Unified contact carries both phone and email identifiers.
+	us, err := store.ListUnifiedContacts("Sarah", 10)
+	if err != nil {
+		t.Fatalf("list unified: %v", err)
+	}
+	if len(us) != 1 {
+		t.Fatalf("unified contacts for Sarah = %d, want 1", len(us))
+	}
+	if !strings.Contains(us[0].Identifiers, "sarah@example.com") || !strings.Contains(us[0].Identifiers, `"phone"`) {
+		t.Errorf("identifiers missing phone/email: %s", us[0].Identifiers)
+	}
+}
+
+func TestMacOSContactsImport_DedupesAcrossSources(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.abcddb")
+	b := filepath.Join(dir, "b.abcddb")
+	makeFakeAddressBook(t, a, []string{
+		`INSERT INTO ZABCDRECORD (Z_PK, ZFIRSTNAME, ZLASTNAME) VALUES (1,'Max','G')`,
+		`INSERT INTO ZABCDPHONENUMBER (Z_PK, ZOWNER, ZFULLNUMBER) VALUES (10,1,'+13105550000')`,
+	})
+	// Same person in a second source, formatted differently + an extra number.
+	makeFakeAddressBook(t, b, []string{
+		`INSERT INTO ZABCDRECORD (Z_PK, ZFIRSTNAME, ZLASTNAME) VALUES (1,'Max','G')`,
+		`INSERT INTO ZABCDPHONENUMBER (Z_PK, ZOWNER, ZFULLNUMBER) VALUES (10,1,'+1 (310) 555-0000')`,
+		`INSERT INTO ZABCDPHONENUMBER (Z_PK, ZOWNER, ZFULLNUMBER) VALUES (11,1,'+13105551111')`,
+	})
+
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	defer store.Close()
+
+	res, err := (&MacOSContacts{Paths: []string{a, b}}).ImportFromAddressBook(store)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if res.ContactsImported != 1 {
+		t.Errorf("ContactsImported = %d, want 1 (same person merged across sources)", res.ContactsImported)
+	}
+}

--- a/internal/story/summary.go
+++ b/internal/story/summary.go
@@ -1,0 +1,148 @@
+package story
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+// RelationshipSummary builds a short, human-readable description of a
+// relationship from message history, using only local stats (no API key). It is
+// a few sentences covering volume, time span, who initiates, responsiveness,
+// the longest quiet stretch, and common words.
+func RelationshipSummary(messages []*db.Message, name string, tz *time.Location) string {
+	if name == "" {
+		name = "this person"
+	}
+	real := FilterRealMessages(messages)
+	if len(real) == 0 {
+		return "No communication with " + name + " yet."
+	}
+	if tz == nil {
+		tz = time.UTC
+	}
+	stats := ComputeStats(real, tz)
+
+	var sb strings.Builder
+	span := ""
+	if stats.DateRange.Start != "" && stats.DateRange.End != "" {
+		if stats.DateRange.Start == stats.DateRange.End {
+			span = " on " + stats.DateRange.Start
+		} else {
+			span = " between " + stats.DateRange.Start + " and " + stats.DateRange.End
+		}
+	}
+	fmt.Fprintf(&sb, "You and %s have exchanged %s%s.", name, plural(stats.TotalMessages, "message"), span)
+
+	mine := stats.SenderSplit["me"]
+	theirs := 0
+	for k, v := range stats.SenderSplit {
+		if k != "me" {
+			theirs += v
+		}
+	}
+	if total := mine + theirs; total > 0 {
+		switch {
+		case mine > theirs:
+			fmt.Fprintf(&sb, " You send a bit more — about %d%% of messages are from you.", pct(mine, total))
+		case theirs > mine:
+			fmt.Fprintf(&sb, " %s sends a bit more — about %d%% are from them.", name, pct(theirs, total))
+		default:
+			sb.WriteString(" It's an even back-and-forth.")
+		}
+	}
+
+	if mins, ok := stats.AvgResponseTimes["me"]; ok && mins > 0 {
+		fmt.Fprintf(&sb, " You usually reply within %s.", humanizeMinutes(mins))
+	}
+
+	if stats.LongestGap.Days >= 14 && stats.LongestGap.Start != "" {
+		fmt.Fprintf(&sb, " Your longest quiet stretch was %d days (%s to %s).", stats.LongestGap.Days, stats.LongestGap.Start, stats.LongestGap.End)
+	}
+
+	if len(stats.TopPhrases) > 0 {
+		words := make([]string, 0, 6)
+		for i, p := range stats.TopPhrases {
+			if i >= 6 {
+				break
+			}
+			words = append(words, p.Phrase)
+		}
+		if len(words) > 0 {
+			fmt.Fprintf(&sb, " Recurring words: %s.", strings.Join(words, ", "))
+		}
+	}
+
+	return sb.String()
+}
+
+// FilterRealMessages drops messages that aren't actual person-to-person
+// communication: RCS/system notifications ("RCS chat with Abby", "This RCS chat
+// is now end-to-end encrypted") and contentless stubs (no body, no media). It's
+// used so the count and summary reflect real conversation, not protocol noise.
+func FilterRealMessages(messages []*db.Message) []*db.Message {
+	out := make([]*db.Message, 0, len(messages))
+	for _, m := range messages {
+		if m == nil || isSystemMessage(m.Body) {
+			continue
+		}
+		if strings.TrimSpace(m.Body) == "" && strings.TrimSpace(m.MediaID) == "" {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// isSystemMessage reports whether a body is an RCS/SMS system notification
+// rather than something a person typed.
+func isSystemMessage(body string) bool {
+	b := strings.ToLower(strings.TrimSpace(body))
+	if b == "" {
+		return false
+	}
+	prefixes := []string{
+		"rcs chat with",
+		"sms/mms with",
+		"you created this rcs",
+		"you started an rcs",
+		"this rcs chat is now",
+		"this chat is now",
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(b, p) {
+			return true
+		}
+	}
+	// Catch-all for short RCS chat banners.
+	if strings.Contains(b, "rcs chat") && len(b) < 60 {
+		return true
+	}
+	return false
+}
+
+func plural(n int, word string) string {
+	if n == 1 {
+		return "1 " + word
+	}
+	return fmt.Sprintf("%d %ss", n, word)
+}
+
+func pct(part, total int) int {
+	if total == 0 {
+		return 0
+	}
+	return int(float64(part)/float64(total)*100 + 0.5)
+}
+
+func humanizeMinutes(mins int) string {
+	if mins < 60 {
+		return plural(mins, "minute")
+	}
+	if mins < 60*24 {
+		return plural(mins/60, "hour")
+	}
+	return plural(mins/(60*24), "day")
+}

--- a/internal/story/summary_test.go
+++ b/internal/story/summary_test.go
@@ -1,0 +1,50 @@
+package story
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+func TestRelationshipSummary_SystemMessagesOnlyIsNoCommunication(t *testing.T) {
+	// All RCS system banners — not real conversation.
+	msgs := []*db.Message{
+		{Body: "RCS chat with Robert", TimestampMS: 1000},
+		{Body: "This RCS chat is now end-to-end encrypted", TimestampMS: 2000},
+		{Body: "You created this RCS group chat", TimestampMS: 3000},
+		{Body: "", TimestampMS: 4000}, // contentless stub
+	}
+	got := RelationshipSummary(msgs, "Robert", nil)
+	if !strings.Contains(strings.ToLower(got), "no communication") {
+		t.Errorf("expected a 'no communication' summary, got: %q", got)
+	}
+}
+
+func TestRelationshipSummary_RealMessagesProduceSummary(t *testing.T) {
+	msgs := []*db.Message{
+		{Body: "RCS chat with Robert", TimestampMS: 1000}, // filtered out
+		{Body: "hey are we still on for friday", IsFromMe: true, TimestampMS: 2000},
+		{Body: "yes! see you then", SenderName: "Robert", TimestampMS: 3000},
+	}
+	got := RelationshipSummary(msgs, "Robert", nil)
+	if strings.Contains(strings.ToLower(got), "no communication") {
+		t.Errorf("expected a real summary, got no-communication: %q", got)
+	}
+	if !strings.Contains(got, "2 messages") {
+		t.Errorf("expected 2 real messages counted, got: %q", got)
+	}
+}
+
+func TestFilterRealMessages(t *testing.T) {
+	msgs := []*db.Message{
+		{Body: "RCS chat with Abby"},
+		{Body: "real text"},
+		{Body: ""},                 // contentless
+		{Body: "", MediaID: "m1"},  // media counts as real
+	}
+	got := FilterRealMessages(msgs)
+	if len(got) != 2 {
+		t.Fatalf("FilterRealMessages = %d, want 2 (real text + media)", len(got))
+	}
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1,11 +1,13 @@
 package web
 
 import (
+	"crypto/rand"
 	"embed"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"io/fs"
 	"net"
@@ -75,6 +77,7 @@ type APIOptions struct {
 	StartDeepBackfill     func() bool
 	BackfillStatus        func() any         // returns a JSON-serializable backfill progress snapshot
 	BackfillPhone         func(string) error // targeted backfill for a single phone number
+	SyncGoogleContacts    func() (int, error) // read-only pull of Google Messages contacts
 }
 
 type SearchResult struct {
@@ -671,6 +674,36 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	})
 
 	mux.HandleFunc("/api/contacts", func(w http.ResponseWriter, r *http.Request) {
+		// POST creates a local contact (name + number). This is stored only in
+		// this app's database — it is not pushed to your Google account, since
+		// the linked Google Messages protocol has no create-contact API.
+		if r.Method == http.MethodPost {
+			var req struct {
+				Name   string `json:"name"`
+				Number string `json:"number"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				httpError(w, "invalid JSON: "+err.Error(), 400)
+				return
+			}
+			name := strings.TrimSpace(req.Name)
+			number := strings.TrimSpace(req.Number)
+			if name == "" && number == "" {
+				httpError(w, "name or number is required", 400)
+				return
+			}
+			contact := &db.Contact{
+				ContactID: "local:" + localContactID(name, number),
+				Name:      name,
+				Number:    number,
+			}
+			if err := store.UpsertContact(contact); err != nil {
+				httpError(w, "add contact: "+err.Error(), 500)
+				return
+			}
+			writeJSON(w, contact)
+			return
+		}
 		q := strings.TrimSpace(r.URL.Query().Get("q"))
 		limit := queryInt(r, "limit", 20)
 		if limit <= 0 || limit > 100 {
@@ -709,6 +742,310 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			contacts = []*db.Contact{}
 		}
 		writeJSON(w, contacts)
+	})
+
+	// Pull contacts from the linked Google Messages account. Read-only — it only
+	// lists contacts and never creates conversations, so it can't flood the inbox.
+	mux.HandleFunc("/api/contacts/sync", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			httpError(w, "method not allowed", 405)
+			return
+		}
+		if opts.SyncGoogleContacts == nil {
+			httpError(w, "contact sync unavailable", 501)
+			return
+		}
+		n, err := opts.SyncGoogleContacts()
+		if err != nil {
+			httpError(w, "sync contacts: "+err.Error(), 500)
+			return
+		}
+		writeJSON(w, map[string]any{"synced": n})
+	})
+
+	// ── People / CRM view ─────────────────────────────────────────────────
+	// GET /api/people — everyone you've messaged, with tags + reach-out status.
+	mux.HandleFunc("/api/people", func(w http.ResponseWriter, r *http.Request) {
+		people, err := store.ListMessagedPeople()
+		if err != nil {
+			httpError(w, "list people: "+err.Error(), 500)
+			return
+		}
+		metaMap, _ := store.GetContactMetaMap()
+		now := time.Now().UnixMilli()
+		q := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("q")))
+		out := make([]*personPayload, 0, len(people))
+		for _, p := range people {
+			if q != "" && !strings.Contains(strings.ToLower(p.Name), q) {
+				match := false
+				for _, num := range p.Numbers {
+					if strings.Contains(num, q) {
+						match = true
+						break
+					}
+				}
+				if !match {
+					continue
+				}
+			}
+			out = append(out, buildPersonPayload(p, metaMap[p.Key], now))
+		}
+		writeJSON(w, out)
+	})
+
+	// /api/people/{key} and /api/people/{key}/{action}
+	mux.HandleFunc("/api/people/", func(w http.ResponseWriter, r *http.Request) {
+		rest := strings.TrimPrefix(r.URL.Path, "/api/people/")
+		if rest == "" {
+			httpError(w, "person key required", 400)
+			return
+		}
+		parts := strings.SplitN(rest, "/", 2)
+		key, err := url.PathUnescape(parts[0])
+		if err != nil {
+			key = parts[0]
+		}
+		action := ""
+		if len(parts) > 1 {
+			action = parts[1]
+		}
+
+		person, err := store.PersonByKey(key)
+		if err != nil {
+			httpError(w, "lookup person: "+err.Error(), 500)
+			return
+		}
+		if person == nil {
+			httpError(w, "person not found", 404)
+			return
+		}
+		displayName := person.Name
+
+		switch action {
+		case "tags":
+			var req struct {
+				Tags []string `json:"tags"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				httpError(w, "invalid JSON: "+err.Error(), 400)
+				return
+			}
+			if err := store.SetContactTags(key, displayName, req.Tags); err != nil {
+				httpError(w, "set tags: "+err.Error(), 500)
+				return
+			}
+		case "reach-out":
+			var req struct {
+				Days int `json:"days"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				httpError(w, "invalid JSON: "+err.Error(), 400)
+				return
+			}
+			if err := store.SetContactReachOut(key, displayName, req.Days); err != nil {
+				httpError(w, "set reach-out: "+err.Error(), 500)
+				return
+			}
+		case "summary":
+			// Regenerate the relationship summary from message history.
+			msgs, err := store.PersonMessages(person.ConversationIDs)
+			if err != nil {
+				httpError(w, "load messages: "+err.Error(), 500)
+				return
+			}
+			summary := story.RelationshipSummary(msgs, displayName, time.Local)
+			if err := store.SetContactSummary(key, displayName, summary, time.Now().UnixMilli()); err != nil {
+				httpError(w, "save summary: "+err.Error(), 500)
+				return
+			}
+		case "":
+			// GET detail — fall through below.
+		default:
+			httpError(w, "not found", 404)
+			return
+		}
+
+		// Build the (possibly updated) detail payload.
+		meta, _ := store.GetContactMeta(key)
+		msgs, _ := store.PersonMessages(person.ConversationIDs)
+		// Generate a summary on first view if none cached yet.
+		if meta != nil && meta.Summary == "" && len(msgs) > 0 {
+			meta.Summary = story.RelationshipSummary(msgs, displayName, time.Local)
+			meta.SummaryAt = time.Now().UnixMilli()
+			_ = store.SetContactSummary(key, displayName, meta.Summary, meta.SummaryAt)
+		}
+		payload := buildPersonPayload(person, meta, time.Now().UnixMilli())
+		payload.MessageCount = len(story.FilterRealMessages(msgs))
+		if meta != nil {
+			payload.Summary = meta.Summary
+			payload.SummaryAt = meta.SummaryAt
+		}
+		writeJSON(w, payload)
+	})
+
+	// ── Scheduled (send-later) messages ───────────────────────────────────
+	// GET  /api/schedule?conversation_id=  — list active scheduled messages
+	// POST /api/schedule                   — schedule a message
+	mux.HandleFunc("/api/schedule", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			convID := strings.TrimSpace(r.URL.Query().Get("conversation_id"))
+			if convID == "" {
+				httpError(w, "conversation_id is required", 400)
+				return
+			}
+			list, err := store.ListScheduledMessages(convID)
+			if err != nil {
+				httpError(w, "list scheduled: "+err.Error(), 500)
+				return
+			}
+			if list == nil {
+				list = []*db.ScheduledMessage{}
+			}
+			writeJSON(w, list)
+		case http.MethodPost:
+			var req struct {
+				ConversationID string `json:"conversation_id"`
+				Body           string `json:"body"`
+				ReplyToID      string `json:"reply_to_id"`
+				SendAt         int64  `json:"send_at"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				httpError(w, "invalid JSON: "+err.Error(), 400)
+				return
+			}
+			if strings.TrimSpace(req.ConversationID) == "" || strings.TrimSpace(req.Body) == "" {
+				httpError(w, "conversation_id and body are required", 400)
+				return
+			}
+			if err := db.ValidateScheduleTime(req.SendAt, time.Now().UnixMilli()); err != nil {
+				httpError(w, err.Error(), 400)
+				return
+			}
+			if conv, _ := store.GetConversation(req.ConversationID); conv == nil {
+				httpError(w, "conversation not found", 400)
+				return
+			}
+			sm := &db.ScheduledMessage{
+				ID:             scheduledID(),
+				ConversationID: req.ConversationID,
+				Body:           strings.TrimSpace(req.Body),
+				ReplyToID:      strings.TrimSpace(req.ReplyToID),
+				SendAt:         req.SendAt,
+				Status:         db.ScheduleStatusPending,
+				CreatedAt:      time.Now().UnixMilli(),
+			}
+			if err := store.CreateScheduledMessage(sm); err != nil {
+				httpError(w, "schedule message: "+err.Error(), 500)
+				return
+			}
+			publishMessages(req.ConversationID)
+			publishConversations()
+			writeJSON(w, sm)
+		default:
+			httpError(w, "method not allowed", 405)
+		}
+	})
+
+	// DELETE /api/schedule/{id} — cancel a still-pending scheduled message.
+	mux.HandleFunc("/api/schedule/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			httpError(w, "method not allowed", 405)
+			return
+		}
+		id := strings.TrimPrefix(r.URL.Path, "/api/schedule/")
+		if id == "" {
+			httpError(w, "scheduled message id required", 400)
+			return
+		}
+		sm, _ := store.GetScheduledMessage(id)
+		if sm == nil {
+			httpError(w, "scheduled message not found", 404)
+			return
+		}
+		ok, err := store.CancelScheduledMessage(id)
+		if err != nil {
+			httpError(w, "cancel: "+err.Error(), 500)
+			return
+		}
+		if !ok {
+			httpError(w, "message is already sending, sent, or canceled", 409)
+			return
+		}
+		publishMessages(sm.ConversationID)
+		publishConversations()
+		writeJSON(w, map[string]any{"canceled": id})
+	})
+
+	// POST /api/schedule-media — schedule a media attachment (with optional
+	// caption) to send at a future time. Multipart, mirrors /api/send-media.
+	mux.HandleFunc("/api/schedule-media", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			httpError(w, "method not allowed", 405)
+			return
+		}
+		if err := r.ParseMultipartForm(25 << 20); err != nil {
+			httpError(w, "invalid multipart form: "+err.Error(), 400)
+			return
+		}
+		convID := strings.TrimSpace(r.FormValue("conversation_id"))
+		caption := strings.TrimSpace(r.FormValue("caption"))
+		replyToID := strings.TrimSpace(r.FormValue("reply_to_id"))
+		if convID == "" {
+			httpError(w, "conversation_id is required", 400)
+			return
+		}
+		sendAt, err := strconv.ParseInt(strings.TrimSpace(r.FormValue("send_at")), 10, 64)
+		if err != nil {
+			httpError(w, "send_at must be an epoch-ms integer", 400)
+			return
+		}
+		if err := db.ValidateScheduleTime(sendAt, time.Now().UnixMilli()); err != nil {
+			httpError(w, err.Error(), 400)
+			return
+		}
+		if conv, _ := store.GetConversation(convID); conv == nil {
+			httpError(w, "conversation not found", 400)
+			return
+		}
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			httpError(w, "file is required: "+err.Error(), 400)
+			return
+		}
+		defer file.Close()
+		data, err := io.ReadAll(file)
+		if err != nil {
+			httpError(w, "read file: "+err.Error(), 500)
+			return
+		}
+		if len(data) == 0 {
+			httpError(w, "file is empty", 400)
+			return
+		}
+		mime := header.Header.Get("Content-Type")
+		if mime == "" {
+			mime = "application/octet-stream"
+		}
+		sm := &db.ScheduledMessage{
+			ID:             scheduledID(),
+			ConversationID: convID,
+			Body:           caption,
+			ReplyToID:      replyToID,
+			SendAt:         sendAt,
+			Status:         db.ScheduleStatusPending,
+			CreatedAt:      time.Now().UnixMilli(),
+			MediaData:      data,
+			MediaFilename:  header.Filename,
+			MediaMime:      mime,
+		}
+		if err := store.CreateScheduledMessage(sm); err != nil {
+			httpError(w, "schedule media: "+err.Error(), 500)
+			return
+		}
+		publishMessages(convID)
+		publishConversations()
+		writeJSON(w, sm)
 	})
 
 	mux.HandleFunc("/api/search", func(w http.ResponseWriter, r *http.Request) {
@@ -1244,14 +1581,37 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return
 		}
 		var req struct {
-			PhoneNumber string `json:"phone_number"`
+			PhoneNumber  string   `json:"phone_number"`
+			PhoneNumbers []string `json:"phone_numbers"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			httpError(w, "invalid JSON: "+err.Error(), 400)
 			return
 		}
-		if req.PhoneNumber == "" {
-			httpError(w, "phone_number is required", 400)
+		// Collect + dedupe recipients. Two or more makes a group conversation.
+		raw := req.PhoneNumbers
+		if req.PhoneNumber != "" {
+			raw = append(raw, req.PhoneNumber)
+		}
+		var numbers []string
+		seen := map[string]bool{}
+		for _, n := range raw {
+			n = normalizePhoneNumber(n)
+			if n == "" {
+				continue
+			}
+			key := digitsOnly(n)
+			if key == "" {
+				key = n
+			}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			numbers = append(numbers, n)
+		}
+		if len(numbers) == 0 {
+			httpError(w, "at least one phone number is required", 400)
 			return
 		}
 		cli := getClient()
@@ -1260,37 +1620,52 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return
 		}
 
-		convResp, err := cli.GM.GetOrCreateConversation(&gmproto.GetOrCreateConversationRequest{
-			Numbers: app.NewContactNumbers([]string{req.PhoneNumber}),
-		})
+		// Two or more recipients = a group: use the group MysteriousInt and the
+		// two-step CREATE_RCS flow that Google Messages requires for new groups.
+		contactNums := app.NewContactNumbers(numbers)
+		if len(numbers) > 1 {
+			contactNums = app.NewGroupContactNumbers(numbers)
+		}
+		convResp, err := app.GetOrCreateConversationForNumbers(cli, contactNums, "")
 		if err != nil {
 			httpError(w, googleAPIErrorMessage("failed to get/create conversation", err), 502)
 			return
 		}
 		conv := convResp.GetConversation()
 		if conv == nil {
-			httpError(w, "no conversation returned", 502)
+			httpError(w, "Google Messages didn't return a conversation (status: "+convResp.GetStatus().String()+") — a recipient may not be reachable via SMS/RCS.", 502)
 			return
 		}
 
 		convoID := conv.GetConversationID()
-		name := req.PhoneNumber
-		// Try to get a name from participants
+		isGroup := conv.GetIsGroupChat() || len(numbers) > 1
+		// Build a display name. For a group, join the other participants' names;
+		// for a 1:1, use the single participant's name/number.
+		var others []string
 		for _, p := range conv.GetParticipants() {
-			if !p.GetIsMe() {
-				if fn := p.GetFormattedNumber(); fn != "" {
-					name = fn
-				}
-				if cn := p.GetFullName(); cn != "" {
-					name = cn
-				}
+			if p.GetIsMe() {
+				continue
 			}
+			label := p.GetFullName()
+			if label == "" {
+				label = p.GetFormattedNumber()
+			}
+			if label != "" {
+				others = append(others, label)
+			}
+		}
+		name := strings.Join(numbers, ", ")
+		if len(others) > 0 {
+			name = strings.Join(others, ", ")
+		} else if len(numbers) == 1 {
+			name = numbers[0]
 		}
 
 		// Upsert into local DB so it shows in the sidebar
 		store.UpsertConversation(&db.Conversation{
 			ConversationID: convoID,
 			Name:           name,
+			IsGroup:        isGroup,
 			LastMessageTS:  time.Now().UnixMilli(),
 		})
 		publishConversations()
@@ -2225,6 +2600,45 @@ func isGoogleNetworkError(err error) bool {
 // normalizeContactKey returns a stable dedup key for a contact entry. We
 // fold names case-insensitively and reduce phone numbers to digits-only so
 // that "+1 (650) 555-1234", "16505551234", and "650-555-1234" all collide.
+func digitsOnly(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}
+
+// normalizePhoneNumber best-effort converts a phone string to E.164 so Google
+// Messages can resolve it. Numbers already starting with '+' keep their digits;
+// bare North-American 10/11-digit numbers get a country code; short codes (which
+// have too few digits) are left untouched.
+func normalizePhoneNumber(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	hasPlus := strings.HasPrefix(s, "+")
+	digits := digitsOnly(s)
+	if digits == "" {
+		return ""
+	}
+	if hasPlus {
+		return "+" + digits
+	}
+	switch {
+	case len(digits) == 11 && strings.HasPrefix(digits, "1"):
+		return "+" + digits
+	case len(digits) == 10:
+		return "+1" + digits
+	case len(digits) >= 11:
+		return "+" + digits
+	default:
+		return s // short codes / unusual — pass through unchanged
+	}
+}
+
 func normalizeContactKey(name, number string) string {
 	digits := make([]byte, 0, len(number))
 	for i := 0; i < len(number); i++ {
@@ -2234,6 +2648,70 @@ func normalizeContactKey(name, number string) string {
 		}
 	}
 	return strings.ToLower(strings.TrimSpace(name)) + "|" + string(digits)
+}
+
+// localContactID derives a stable ID for a user-added local contact so that
+// re-adding the same name+number updates rather than duplicates it.
+func localContactID(name, number string) string {
+	h := fnv.New64a()
+	h.Write([]byte(normalizeContactKey(name, number)))
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+func scheduledID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return "sched:" + hex.EncodeToString(b)
+}
+
+// personPayload is the JSON shape for the Contacts/CRM view.
+type personPayload struct {
+	Key             string   `json:"key"`
+	Name            string   `json:"name"`
+	Numbers         []string `json:"numbers"`
+	Platforms       []string `json:"platforms"`
+	LastContactedTS int64    `json:"last_contacted_ts"`
+	Tags            []string `json:"tags"`
+	ReachOutDays    int      `json:"reach_out_days"`
+	NextDueTS       int64    `json:"next_due_ts"`
+	Overdue         bool     `json:"overdue"`
+	MessageCount    int      `json:"message_count"`
+	Summary         string   `json:"summary"`
+	SummaryAt       int64    `json:"summary_at"`
+	ConversationIDs []string `json:"conversation_ids"`
+}
+
+func buildPersonPayload(p *db.Person, meta *db.ContactMeta, now int64) *personPayload {
+	pp := &personPayload{
+		Key:             p.Key,
+		Name:            p.Name,
+		Numbers:         p.Numbers,
+		Platforms:       p.Platforms,
+		LastContactedTS: p.LastContactedTS,
+		MessageCount:    p.MessageCount,
+		Tags:            []string{},
+		ConversationIDs: p.ConversationIDs,
+	}
+	if pp.ConversationIDs == nil {
+		pp.ConversationIDs = []string{}
+	}
+	if pp.Numbers == nil {
+		pp.Numbers = []string{}
+	}
+	if pp.Platforms == nil {
+		pp.Platforms = []string{}
+	}
+	if meta != nil {
+		if meta.Tags != nil {
+			pp.Tags = meta.Tags
+		}
+		pp.ReachOutDays = meta.ReachOutDays
+		if meta.ReachOutDays > 0 && p.LastContactedTS > 0 {
+			pp.NextDueTS = p.LastContactedTS + int64(meta.ReachOutDays)*86400000
+			pp.Overdue = now > pp.NextDueTS
+		}
+	}
+	return pp
 }
 
 func queryInt(r *http.Request, key string, defaultVal int) int {

--- a/internal/web/phone_test.go
+++ b/internal/web/phone_test.go
@@ -1,0 +1,21 @@
+package web
+
+import "testing"
+
+func TestNormalizePhoneNumber(t *testing.T) {
+	cases := map[string]string{
+		"15629249581":      "+15629249581", // 11 digits, no plus (the bug)
+		"+13106194153":     "+13106194153", // already E.164
+		"+1 (310) 619-4153": "+13106194153", // formatted with plus
+		"(310) 555-1234":   "+13105551234", // 10-digit US, formatted
+		"3105551234":       "+13105551234", // bare 10-digit US
+		"57527":            "57527",         // short code — left alone
+		"":                 "",
+		"   ":              "",
+	}
+	for in, want := range cases {
+		if got := normalizePhoneNumber(in); got != want {
+			t.Errorf("normalizePhoneNumber(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/web/schedule_media_test.go
+++ b/internal/web/schedule_media_test.go
@@ -1,0 +1,133 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+func newScheduleMediaServer(t *testing.T) (*httptest.Server, *db.Store) {
+	t.Helper()
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.UpsertConversation(&db.Conversation{ConversationID: "c1", SourcePlatform: "sms"}); err != nil {
+		t.Fatal(err)
+	}
+	h := APIHandlerWithOptions(store, nil, zerolog.Nop(), nil, APIOptions{})
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv, store
+}
+
+func postScheduleMedia(t *testing.T, url string, fields map[string]string, filename string, fileData []byte) *http.Response {
+	t.Helper()
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	for k, v := range fields {
+		_ = mw.WriteField(k, v)
+	}
+	if filename != "" {
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", `form-data; name="file"; filename="`+filename+`"`)
+		h.Set("Content-Type", "image/png")
+		fw, err := mw.CreatePart(h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fw.Write(fileData)
+	}
+	mw.Close()
+	resp, err := http.Post(url+"/api/schedule-media", mw.FormDataContentType(), &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestScheduleMedia_CreatesPendingWithBlob(t *testing.T) {
+	srv, store := newScheduleMediaServer(t)
+	sendAt := time.Now().Add(2 * time.Hour).UnixMilli()
+	blob := []byte{0x89, 0x50, 0x4e, 0x47, 5, 5, 5}
+
+	resp := postScheduleMedia(t, srv.URL, map[string]string{
+		"conversation_id": "c1",
+		"caption":         "hello pic",
+		"send_at":         strconv.FormatInt(sendAt, 10),
+	}, "pic.png", blob)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var sm db.ScheduledMessage
+	if err := json.NewDecoder(resp.Body).Decode(&sm); err != nil {
+		t.Fatal(err)
+	}
+	if sm.MediaFilename != "pic.png" || sm.Body != "hello pic" {
+		t.Errorf("response metadata wrong: %+v", sm)
+	}
+
+	// The blob persisted and is loadable for the scheduler.
+	data, err := store.GetScheduledMediaData(sm.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, blob) {
+		t.Errorf("stored blob mismatch: %v", data)
+	}
+	list, _ := store.ListScheduledMessages("c1")
+	if len(list) != 1 || list[0].MediaMime != "image/png" {
+		t.Errorf("list wrong: %+v", list)
+	}
+}
+
+func TestScheduleMedia_RejectsMissingFile(t *testing.T) {
+	srv, _ := newScheduleMediaServer(t)
+	sendAt := time.Now().Add(2 * time.Hour).UnixMilli()
+	resp := postScheduleMedia(t, srv.URL, map[string]string{
+		"conversation_id": "c1",
+		"send_at":         strconv.FormatInt(sendAt, 10),
+	}, "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestScheduleMedia_RejectsPastTime(t *testing.T) {
+	srv, _ := newScheduleMediaServer(t)
+	past := time.Now().Add(-time.Hour).UnixMilli()
+	resp := postScheduleMedia(t, srv.URL, map[string]string{
+		"conversation_id": "c1",
+		"send_at":         strconv.FormatInt(past, 10),
+	}, "pic.png", []byte{1, 2, 3})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestScheduleMedia_RejectsUnknownConversation(t *testing.T) {
+	srv, _ := newScheduleMediaServer(t)
+	sendAt := time.Now().Add(2 * time.Hour).UnixMilli()
+	resp := postScheduleMedia(t, srv.URL, map[string]string{
+		"conversation_id": "nope",
+		"send_at":         strconv.FormatInt(sendAt, 10),
+	}, "pic.png", []byte{1, 2, 3})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -233,6 +233,11 @@ html, body {
   border-color: var(--border-accent);
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
+.new-msg-recipients { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
+.new-msg-recipients[hidden] { display: none; }
+.new-msg-recipient-chip { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border-radius: 999px; background: var(--accent-dim); border: 1px solid var(--border-accent); color: var(--text-primary); font-size: 13px; font-weight: 600; }
+.new-msg-recipient-chip button { background: none; border: 0; color: var(--text-muted); cursor: pointer; font-size: 15px; line-height: 1; padding: 0; }
+.new-msg-recipient-chip button:hover { color: var(--text-primary); }
 .new-msg-go {
   margin-top: 12px;
   width: 100%;
@@ -2737,6 +2742,76 @@ body::after {
   background: var(--accent-dim);
 }
 
+/* ─── Contacts / CRM overlay ─── */
+.contacts-overlay { position: fixed; inset: 0; z-index: 1500; display: none; background: var(--bg-deep); }
+.contacts-overlay.show { display: flex; }
+.contacts-pane-left { width: 340px; flex: 0 0 340px; display: flex; flex-direction: column; border-right: 1px solid var(--border); background: var(--bg-surface); }
+.contacts-left-header { display: flex; align-items: center; justify-content: space-between; padding: 20px 20px 12px; }
+.contacts-left-header h2 { margin: 0; font-size: 20px; color: var(--text-primary); }
+.contacts-search { display: flex; align-items: center; gap: 8px; margin: 0 16px 12px; padding: 9px 12px; border: 1px solid var(--border); border-radius: 12px; background: var(--bg-elevated); }
+.contacts-search svg { width: 16px; height: 16px; color: var(--text-muted); flex: 0 0 auto; }
+.contacts-search input { border: 0; background: transparent; outline: none; width: 100%; color: var(--text-primary); font: inherit; }
+.contacts-sort { display: flex; gap: 6px; padding: 0 16px 12px; }
+.contacts-sort-btn { flex: 1; padding: 7px 8px; border: 1px solid var(--border); border-radius: 999px; background: var(--bg-elevated); color: var(--text-secondary); font-family: var(--font-sans); font-size: 12px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: background 0.16s ease, color 0.16s ease, border-color 0.16s ease; }
+.contacts-sort-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.contacts-sort-btn.active { background: var(--accent-dim); border-color: var(--border-accent); color: var(--text-primary); }
+.contacts-list { flex: 1; overflow-y: auto; padding: 0 10px 16px; }
+.contact-row { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border-radius: 12px; cursor: pointer; }
+.contact-row:hover { background: var(--bg-hover); }
+.contact-row.active { background: var(--accent-dim); }
+.contact-row .convo-avatar { width: 40px; height: 40px; flex: 0 0 40px; }
+.contact-row-meta { flex: 1; min-width: 0; }
+.contact-row-name { color: var(--text-primary); font-weight: 600; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.contact-row-sub { color: var(--text-muted); font-size: 12px; margin-top: 2px; }
+.contact-row-due { flex: 0 0 auto; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; padding: 3px 7px; border-radius: 999px; background: rgba(229, 72, 77, 0.16); color: #ff6b6b; }
+.contacts-pane-right { flex: 1; overflow-y: auto; padding: 32px 40px; }
+.contacts-detail-empty { color: var(--text-muted); font-size: 14px; margin-top: 80px; text-align: center; }
+.contacts-detail-body { max-width: 640px; }
+.cd-head { display: flex; align-items: center; gap: 18px; margin-bottom: 24px; }
+.cd-head .convo-avatar { width: 72px; height: 72px; flex: 0 0 72px; font-size: 26px; }
+.cd-name { font-size: 26px; font-weight: 700; color: var(--text-primary); }
+.cd-sub { color: var(--text-secondary); font-size: 13px; margin-top: 4px; }
+.cd-section { margin-bottom: 26px; }
+.cd-label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); margin-bottom: 10px; }
+.cd-info-row { color: var(--text-primary); font-size: 14px; padding: 7px 0; border-bottom: 1px solid var(--border); display: flex; gap: 10px; }
+.cd-info-row .k { color: var(--text-muted); width: 130px; flex: 0 0 130px; }
+.cd-tags { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.cd-tag { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border-radius: 999px; background: var(--accent-dim); border: 1px solid var(--border-accent); color: var(--text-primary); font-size: 12px; font-weight: 600; }
+.cd-tag button { background: none; border: 0; color: var(--text-muted); cursor: pointer; font-size: 14px; line-height: 1; padding: 0; }
+.cd-tag-input { padding: 6px 10px; border: 1px dashed var(--border); border-radius: 999px; background: var(--bg-elevated); color: var(--text-primary); font: inherit; font-size: 12px; width: 110px; outline: none; }
+.cd-summary { color: var(--text-secondary); font-size: 14px; line-height: 1.65; }
+.cd-tickler { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.cd-tickler input { width: 70px; padding: 8px 10px; border: 1px solid var(--border); border-radius: 10px; background: var(--bg-elevated); color: var(--text-primary); font: inherit; outline: none; }
+.cd-tickler .muted { color: var(--text-muted); font-size: 13px; }
+.cd-btn { padding: 8px 14px; border: 1px solid var(--border); border-radius: 10px; background: var(--bg-elevated); color: var(--text-secondary); font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; }
+.cd-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.cd-btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.cd-due-pill { display: inline-block; padding: 4px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; margin-left: 4px; }
+.cd-due-pill.overdue { background: rgba(229, 72, 77, 0.16); color: #ff6b6b; }
+.cd-due-pill.ok { background: rgba(60, 200, 120, 0.14); color: #36c47a; }
+
+/* ─── Scheduled (send-later) messages ─── */
+.schedule-btn { background: transparent; border: 0; color: var(--text-muted); cursor: pointer; padding: 8px; border-radius: 10px; display: inline-flex; align-items: center; justify-content: center; }
+.schedule-btn svg { width: 20px; height: 20px; }
+.schedule-btn:hover:not(:disabled) { background: var(--bg-hover); color: var(--text-primary); }
+.schedule-btn:disabled { opacity: 0.4; cursor: default; }
+.scheduled-strip { display: flex; flex-direction: column; gap: 6px; padding: 0 16px 6px; }
+.scheduled-strip:empty { display: none; padding: 0; }
+.scheduled-item { display: flex; align-items: center; gap: 10px; padding: 8px 12px; border: 1px solid var(--border-accent); border-radius: 12px; background: var(--accent-dim); }
+.scheduled-item > svg { width: 15px; height: 15px; color: var(--accent); flex: 0 0 auto; }
+.scheduled-item.failed { border-color: rgba(229, 72, 77, 0.4); background: rgba(229, 72, 77, 0.1); }
+.scheduled-item.failed > svg { color: #ff6b6b; }
+.scheduled-item-body { flex: 1; min-width: 0; }
+.scheduled-item-text { color: var(--text-primary); font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.scheduled-item-when { color: var(--text-muted); font-size: 11px; margin-top: 2px; }
+.scheduled-item.failed .scheduled-item-when { color: #ff6b6b; }
+.scheduled-item-cancel { background: none; border: 0; color: var(--text-muted); cursor: pointer; font-size: 17px; line-height: 1; padding: 2px 6px; }
+.scheduled-item-cancel:hover { color: var(--text-primary); }
+.schedule-custom { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 10px 16px; }
+.schedule-custom[hidden] { display: none; }
+.schedule-custom label { color: var(--text-muted); font-size: 13px; }
+.schedule-custom input { padding: 7px 10px; border: 1px solid var(--border); border-radius: 10px; background: var(--bg-elevated); color: var(--text-primary); font: inherit; }
+
 .sidebar-source-filters {
   display: flex;
   gap: 8px;
@@ -4273,6 +4348,9 @@ body::after {
             </div>
           </div>
         <div class="sidebar-actions">
+          <button class="new-msg-btn" id="contacts-btn" type="button" title="Contacts" aria-label="Contacts">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+          </button>
           <button class="new-msg-btn notif-btn" id="notif-btn" type="button" title="Enable desktop notifications" aria-label="Enable desktop notifications" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 1 0-12 0v3.2a2 2 0 0 1-.6 1.4L4 17h5"/><path d="M9.5 17a2.5 2.5 0 0 0 5 0"/></svg>
           </button>
@@ -4309,6 +4387,7 @@ body::after {
       </div>
       <div class="new-msg-input-area">
         <label>To</label>
+        <div class="new-msg-recipients" id="new-msg-recipients" hidden></div>
         <input
           type="text"
           class="new-msg-phone"
@@ -4324,6 +4403,37 @@ body::after {
         <div class="new-msg-routes" id="new-msg-routes"></div>
         <button class="new-msg-go" id="new-msg-go">Start conversation</button>
         <div class="new-msg-error" id="new-msg-error"></div>
+
+        <div style="height:1px;background:var(--border);margin:18px 0 14px;"></div>
+        <label>Save a contact</label>
+        <input type="text" class="new-msg-phone" id="add-contact-name" placeholder="Name" autocomplete="off" autocapitalize="words" spellcheck="false">
+        <input type="text" class="new-msg-phone" id="add-contact-number" placeholder="Phone number" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" inputmode="tel" style="margin-top:8px;">
+        <div class="new-msg-helper">Saved locally in this app. It won't be added to your Google account.</div>
+        <button class="new-msg-go" id="add-contact-go">Save contact</button>
+        <div class="new-msg-error" id="add-contact-msg"></div>
+      </div>
+    </div>
+
+    <div class="contacts-overlay" id="contacts-overlay">
+      <div class="contacts-pane-left">
+        <div class="contacts-left-header">
+          <h2>Contacts</h2>
+          <button class="new-msg-close" id="contacts-close" aria-label="Close contacts">&times;</button>
+        </div>
+        <div class="contacts-search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <input type="text" id="contacts-search-input" placeholder="Search contacts" autocomplete="off" spellcheck="false">
+        </div>
+        <div class="contacts-sort" id="contacts-sort">
+          <button type="button" class="contacts-sort-btn active" data-sort="recent">Recent</button>
+          <button type="button" class="contacts-sort-btn" data-sort="alpha">A–Z</button>
+          <button type="button" class="contacts-sort-btn" data-sort="messages">Most messages</button>
+        </div>
+        <div class="contacts-list" id="contacts-list"></div>
+      </div>
+      <div class="contacts-pane-right">
+        <div class="contacts-detail-empty" id="contacts-detail-empty">Select a contact to see their details, tags, and relationship summary.</div>
+        <div class="contacts-detail-body" id="contacts-detail-body" hidden></div>
       </div>
     </div>
 
@@ -4466,6 +4576,13 @@ body::after {
       <span class="attach-name" id="attach-name"></span>
       <button class="attach-remove" id="attach-remove" aria-label="Remove attachment">&times;</button>
     </div>
+    <div class="scheduled-strip" id="scheduled-strip"></div>
+    <div class="schedule-custom" id="schedule-custom" hidden>
+      <label for="schedule-custom-input">Send at</label>
+      <input type="datetime-local" id="schedule-custom-input">
+      <button class="cd-btn primary" id="schedule-custom-go">Schedule</button>
+      <button class="cd-btn" id="schedule-custom-cancel" type="button">Cancel</button>
+    </div>
     <div class="compose-bar" id="compose-bar" style="display:none">
       <div class="compose-row">
         <input type="file" id="file-input" accept="image/*,video/*,audio/*" style="display:none">
@@ -4473,6 +4590,9 @@ body::after {
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
         </button>
         <textarea class="compose-input" id="compose-input" placeholder="Write a message..." rows="1" aria-label="Message"></textarea>
+        <button class="schedule-btn" id="schedule-btn" title="Schedule send" aria-label="Schedule send" disabled>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+        </button>
         <button class="send-btn" id="send-btn" disabled aria-label="Send message">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
         </button>
@@ -4600,6 +4720,12 @@ body::after {
   const $composeBar = document.getElementById('compose-bar');
   const $composeInput = document.getElementById('compose-input');
   const $sendBtn = document.getElementById('send-btn');
+  const $scheduleBtn = document.getElementById('schedule-btn');
+  const $scheduledStrip = document.getElementById('scheduled-strip');
+  const $scheduleCustom = document.getElementById('schedule-custom');
+  const $scheduleCustomInput = document.getElementById('schedule-custom-input');
+  const $scheduleCustomGo = document.getElementById('schedule-custom-go');
+  const $scheduleCustomCancel = document.getElementById('schedule-custom-cancel');
   const $fileInput = document.getElementById('file-input');
   const $attachBtn = document.getElementById('attach-btn');
   const $attachPreview = document.getElementById('attach-preview');
@@ -4659,6 +4785,10 @@ body::after {
   const $newMsgRoutes = document.getElementById('new-msg-routes');
   const $newMsgGo = document.getElementById('new-msg-go');
   const $newMsgError = document.getElementById('new-msg-error');
+  const $addContactName = document.getElementById('add-contact-name');
+  const $addContactNumber = document.getElementById('add-contact-number');
+  const $addContactGo = document.getElementById('add-contact-go');
+  const $addContactMsg = document.getElementById('add-contact-msg');
   const $newMsgSuggestions = document.getElementById('new-msg-suggestions');
   const $emptyStateCta = document.getElementById('empty-state-cta');
 
@@ -5220,6 +5350,29 @@ body::after {
       label.textContent = kind === 'video' ? 'Video unavailable' : 'Image unavailable';
     }
   }
+
+  // When messages are (re)rendered via innerHTML, an already-cached image can
+  // finish loading before — or without — its inline onload handler running,
+  // which would leave the spinner stuck on an image that's already visible.
+  // After each render, proactively resolve any image that's already complete so
+  // cached images never show a loading animation.
+  function resolveCompletedMedia(root = document) {
+    if (!root || !root.querySelectorAll) return;
+    root.querySelectorAll('.msg-media img').forEach((img) => {
+      if (!img.complete) return; // still loading (incl. off-screen lazy) — onload handles it
+      if (img.naturalWidth > 0) {
+        handleMediaLoad(img);
+      } else {
+        handleMediaError(img, 'image');
+      }
+    });
+  }
+
+  // The app runs inside an IIFE, but inline onload/onerror attributes execute in
+  // the global scope — so the media handlers must be reachable on window, or the
+  // loader would never be removed and every image would show a stuck spinner.
+  window.handleMediaLoad = handleMediaLoad;
+  window.handleMediaError = handleMediaError;
 
   function renderAvatarElement(el, { name = '', numbers = [], whatsAppConversationID = '', platforms = [], text = initials(name) || '?', background = avatarColor(name) } = {}) {
     if (!el) return;
@@ -7104,6 +7257,7 @@ body::after {
     $messagesArea.setAttribute('aria-busy', 'true');
     renderThreadPlaceholder('Loading messages...');
     await loadMessages(convo.ConversationID, {reset: true});
+    loadScheduledMessages(convo.ConversationID);
   }
 
   // ─── Load Messages ───
@@ -7493,7 +7647,9 @@ body::after {
     lastThreadSignature = sig;
 
     captureDraftEdits();
-    $messagesArea.innerHTML = '';
+    // Build into a fragment and reconcile against the existing DOM (below) so
+    // unchanged messages keep their nodes — a status update or a single new
+    // message must not tear down and re-flash the whole thread.
     const fragment = document.createDocumentFragment();
     const draftTextareasToAutosize = [];
     let lastDate = 0;
@@ -7505,6 +7661,8 @@ body::after {
           const divider = document.createElement('div');
           divider.className = 'date-divider';
           divider.textContent = formatDateDivider(m.TimestampMS);
+          divider.dataset.rk = 'date:' + new Date(m.TimestampMS).toDateString();
+          divider.dataset.rs = divider.textContent;
           fragment.appendChild(divider);
           lastDate = m.TimestampMS;
         }
@@ -7520,6 +7678,8 @@ body::after {
             sysText = '💬 ' + sysText;
           }
           sysEl.textContent = sysText;
+          sysEl.dataset.rk = 'sys:' + (m.MessageID || ('i' + absoluteMessageIndex));
+          sysEl.dataset.rs = (m.Status || '') + '|' + sysText;
           fragment.appendChild(sysEl);
           return;
         }
@@ -7694,8 +7854,12 @@ body::after {
           });
           row.appendChild(avatarDiv);
           row.appendChild(el);
+          row.dataset.rk = 'msg:' + (m.MessageID || ('i' + absoluteMessageIndex));
+          row.dataset.rs = messageRenderSignature(m) + '|mix' + (showMixedSourceChips ? '1' : '0') + '|snd' + (canSendActiveRoute ? '1' : '0') + '|last' + (isLastFromSender ? '1' : '0');
           fragment.appendChild(row);
         } else {
+          el.dataset.rk = 'msg:' + (m.MessageID || ('i' + absoluteMessageIndex));
+          el.dataset.rs = messageRenderSignature(m) + '|mix' + (showMixedSourceChips ? '1' : '0') + '|snd' + (canSendActiveRoute ? '1' : '0');
           fragment.appendChild(el);
         }
       });
@@ -7723,7 +7887,28 @@ body::after {
         });
       });
 
-      $messagesArea.appendChild(fragment);
+      // Reconcile: reuse any currently-rendered node whose key + signature is
+      // unchanged (so its DOM — and any already-loaded images — survive),
+      // replacing only what actually changed. This removes the multi-flash
+      // teardown when sending/receiving. Untagged nodes (drafts, optimistic
+      // sends) are always rebuilt.
+      const prevByKey = new Map();
+      Array.from($messagesArea.children).forEach((ch) => {
+        const k = ch.dataset.rk;
+        if (k) prevByKey.set(k, ch);
+      });
+      const finalEls = Array.from(fragment.children).map((fresh) => {
+        const k = fresh.dataset.rk;
+        if (k) {
+          const prev = prevByKey.get(k);
+          if (prev && prev.dataset.rs === fresh.dataset.rs) {
+            prevByKey.delete(k);
+            return prev;
+          }
+        }
+        return fresh;
+      });
+      $messagesArea.replaceChildren(...finalEls);
       draftTextareasToAutosize.forEach(autosizeDraftTextarea);
 
       // Update protocol indicator in header from most recent tombstone
@@ -7741,6 +7926,8 @@ body::after {
       hydrateLinkPreviews();
       hydrateNativeAvatars($messagesArea);
       scheduleMediaLoaderLabels($messagesArea);
+      resolveCompletedMedia($messagesArea);
+      requestAnimationFrame(() => resolveCompletedMedia($messagesArea));
       observeThreadContentResize();
       observeThreadViewportResize();
 
@@ -8055,6 +8242,12 @@ body::after {
       || browserIsOffline()
       || (hasText && !conversationSupportsOutbound(activeConversation))
       || (hasMedia && !conversationSupportsMediaOutbound(activeConversation));
+    // Schedule supports text and media attachments.
+    if ($scheduleBtn) {
+      const canScheduleText = hasText && conversationSupportsOutbound(activeConversation);
+      const canScheduleMedia = hasMedia && conversationSupportsMediaOutbound(activeConversation);
+      $scheduleBtn.disabled = !activeConversation || (!canScheduleText && !canScheduleMedia);
+    }
   }
 
   $composeInput.addEventListener('input', () => {
@@ -8078,7 +8271,7 @@ body::after {
     pendingFile = { file };
     $attachName.textContent = file.name || 'Attachment';
     $attachPreview.classList.add('active');
-    $sendBtn.disabled = false;
+    autoResize();
 
     if (file.type.startsWith('image/')) {
       const reader = new FileReader();
@@ -8820,7 +9013,10 @@ body::after {
     clearTimeout(threadRefreshTimer);
     threadRefreshTimer = setTimeout(() => {
       threadRefreshTimer = null;
-      if (activeConvoId) loadMessages(activeConvoId, {poll: true});
+      if (activeConvoId) {
+        loadMessages(activeConvoId, {poll: true});
+        loadScheduledMessages(activeConvoId);
+      }
     }, delay);
   }
 
@@ -9039,7 +9235,7 @@ body::after {
       document.querySelectorAll('.emoji-picker.show').forEach(p => p.classList.remove('show'));
       document.querySelectorAll('.emoji-full-panel.show').forEach(p => p.classList.remove('show'));
     }
-    if ($contextMenu && !$contextMenu.hidden && !e.target.closest('.context-menu') && !e.target.closest('.chat-header-action-btn') && !e.target.closest('#bulk-move-btn')) {
+    if ($contextMenu && !$contextMenu.hidden && !e.target.closest('.context-menu') && !e.target.closest('.chat-header-action-btn') && !e.target.closest('#bulk-move-btn') && !e.target.closest('#schedule-btn')) {
       closeContextMenu();
     }
   });
@@ -9087,6 +9283,11 @@ body::after {
         if (context.type === 'tab' && context.tabId) {
           if (action === 'rename-tab') { await renameTabFlow(context.tabId); return; }
           if (action === 'delete-tab') { await deleteTabFlow(context.tabId); return; }
+        }
+        if (context.type === 'schedule') {
+          if (action === 'sched:9') { scheduleSend(nextDayAtHour(9)); return; }
+          if (action === 'sched:17') { scheduleSend(nextDayAtHour(17)); return; }
+          if (action === 'sched:custom') { showScheduleCustom(); return; }
         }
         if (context.type === 'message' && context.message) {
           const message = context.message;
@@ -9221,6 +9422,8 @@ body::after {
     activeConvoId = null;
     activeConvoIsGroup = false;
     activeConversation = null;
+    if ($scheduledStrip) $scheduledStrip.innerHTML = '';
+    hideScheduleCustom();
     syncConversationURL('');
     activeProtocolDetail = '';
     clearTimeout(threadRefreshTimer);
@@ -9367,8 +9570,8 @@ body::after {
     if (!phone || !routes.length) {
       $newMsgRoutes.classList.remove('active');
       $newMsgRoutes.innerHTML = '';
-      $newMsgHelper.textContent = 'New conversations start on SMS. If this number already exists on another route, choose it explicitly below.';
-      $newMsgGo.textContent = 'Start conversation';
+      $newMsgHelper.textContent = '';
+      updateNewMsgButtonLabel();
       return;
     }
 
@@ -9393,9 +9596,13 @@ body::after {
     $newMsgError.style.display = 'none';
     $newMsgGo.disabled = false;
     $newMsgGo.textContent = 'Start conversation';
-    $newMsgHelper.textContent = 'Type a name from your contacts, or paste a phone number.';
+    $newMsgHelper.textContent = 'Add one person, or add several (Enter after each) to start a group.';
     $newMsgRoutes.classList.remove('active');
     $newMsgRoutes.innerHTML = '';
+    resetNewMsgRecipients();
+    if ($addContactName) $addContactName.value = '';
+    if ($addContactNumber) $addContactNumber.value = '';
+    if ($addContactMsg) $addContactMsg.style.display = 'none';
     hideSuggestions();
     setTimeout(() => $newMsgPhone.focus(), 100);
   }
@@ -9404,6 +9611,37 @@ body::after {
     $newMsgOverlay.classList.remove('show');
     hideSuggestions();
   }
+
+  // ── Save a local contact (name + number) ──
+  async function saveLocalContact() {
+    if (!$addContactGo) return;
+    const name = ($addContactName.value || '').trim();
+    const number = ($addContactNumber.value || '').trim();
+    if (!name && !number) return;
+    $addContactGo.disabled = true;
+    try {
+      await postJSON('/api/contacts', { name, number });
+      $addContactName.value = '';
+      $addContactNumber.value = '';
+      if ($addContactMsg) {
+        $addContactMsg.style.display = 'block';
+        $addContactMsg.style.color = 'var(--text-secondary)';
+        $addContactMsg.textContent = `Saved ${name || number}.`;
+      }
+    } catch (err) {
+      if ($addContactMsg) {
+        $addContactMsg.style.display = 'block';
+        $addContactMsg.style.color = '';
+        $addContactMsg.textContent = err.message || 'Failed to save contact.';
+      }
+    } finally {
+      $addContactGo.disabled = false;
+    }
+  }
+  if ($addContactGo) $addContactGo.addEventListener('click', saveLocalContact);
+  if ($addContactNumber) $addContactNumber.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); saveLocalContact(); }
+  });
 
   // ── Contact autocomplete ──
   // When the user types a name (anything that isn't pure phone-number chars),
@@ -9446,10 +9684,8 @@ body::after {
         // mousedown so we fire before the input loses focus
         e.preventDefault();
         const phone = c.number || c.Number || '';
-        $newMsgPhone.value = phone;
-        hideSuggestions();
-        updateNewMessageRoutes();
-        $newMsgPhone.focus();
+        const display = c.name || c.Name || phone;
+        addNewMsgRecipient(display, phone);
       });
       $newMsgSuggestions.appendChild(row);
     });
@@ -9512,50 +9748,94 @@ body::after {
       : 'Connection check complete.');
   }
 
-  async function startNewConversation() {
+  // ── Recipients (supports multiple → group conversations) ──
+  let newMsgRecipients = []; // [{ display, number }]
+  const $newMsgRecipients = document.getElementById('new-msg-recipients');
+
+  function recipientNumberKey(num) {
+    return String(num || '').replace(/\D/g, '') || String(num || '');
+  }
+
+  function renderNewMsgRecipients() {
+    if ($newMsgRecipients) {
+      if (!newMsgRecipients.length) {
+        $newMsgRecipients.hidden = true;
+        $newMsgRecipients.innerHTML = '';
+      } else {
+        $newMsgRecipients.hidden = false;
+        $newMsgRecipients.innerHTML = newMsgRecipients.map((r, i) =>
+          `<span class="new-msg-recipient-chip">${escapeHtml(r.display)}<button type="button" data-idx="${i}" aria-label="Remove">&times;</button></span>`
+        ).join('');
+        $newMsgRecipients.querySelectorAll('button[data-idx]').forEach(btn => {
+          btn.addEventListener('click', () => removeNewMsgRecipient(parseInt(btn.dataset.idx, 10)));
+        });
+      }
+    }
+    // Keep the helper area clean while choosing recipients. When there are no
+    // recipients, leave the helper to updateNewMessageRoutes (route detection)
+    // and openNewMsg (the initial hint).
+    if ($newMsgHelper && newMsgRecipients.length) {
+      $newMsgHelper.textContent = '';
+    }
+    updateNewMsgButtonLabel();
+  }
+
+  function updateNewMsgButtonLabel() {
+    // When route detection is showing existing routes for a single number, it
+    // owns the button label ("Open SMS route"); don't override it.
+    if ($newMsgRoutes && $newMsgRoutes.classList.contains('active')) return;
+    const pending = $newMsgPhone.value.trim();
+    const count = newMsgRecipients.length + (pending && looksLikePhoneNumber(pending) ? 1 : 0);
+    $newMsgGo.textContent = count >= 2 ? 'Start group conversation' : 'Start conversation';
+  }
+
+  function addNewMsgRecipient(display, number) {
+    const num = String(number || '').trim();
+    if (!num) return;
+    const key = recipientNumberKey(num);
+    if (!newMsgRecipients.some(r => recipientNumberKey(r.number) === key)) {
+      newMsgRecipients.push({ display: String(display || num).trim(), number: num });
+    }
+    $newMsgPhone.value = '';
+    hideSuggestions();
+    $newMsgRoutes.classList.remove('active');
+    $newMsgRoutes.innerHTML = '';
+    renderNewMsgRecipients();
+    $newMsgPhone.focus();
+  }
+
+  function removeNewMsgRecipient(idx) {
+    newMsgRecipients.splice(idx, 1);
+    renderNewMsgRecipients();
+    $newMsgPhone.focus();
+  }
+
+  // Commit whatever is typed into the input as a recipient chip. Returns false
+  // only when the text is a name with no contact match (can't be a recipient).
+  function commitPendingRecipient() {
     const raw = $newMsgPhone.value.trim();
-    if (!raw) return;
+    if (!raw) return true;
+    if (!looksLikePhoneNumber(raw)) return false;
+    addNewMsgRecipient(raw.replace(/[\s\-()]/g, ''), raw.replace(/[\s\-()]/g, ''));
+    return true;
+  }
 
-    // If they typed a name and there's a suggestion visible, prefer that.
-    if (!looksLikePhoneNumber(raw) && $newMsgSuggestions && !$newMsgSuggestions.hidden) {
-      const first = $newMsgSuggestions.querySelector('.new-msg-suggestion');
-      if (first) { first.dispatchEvent(new MouseEvent('mousedown')); return; }
-    }
+  function resetNewMsgRecipients() {
+    newMsgRecipients = [];
+    renderNewMsgRecipients();
+  }
 
-    // If they typed a name with no matching contact, refuse rather than
-    // sending an unparseable string to the new-conversation endpoint.
-    if (!looksLikePhoneNumber(raw)) {
-      $newMsgError.textContent = 'No matching contact. Type a phone number to start a new thread.';
-      $newMsgError.style.display = 'block';
-      return;
-    }
-
-    const phone = raw.replace(/[\s\-()]/g, '');
-    const existingReplyRoute = preferredReplyRoute(matchingRoutesForPhone(phone));
-    if (existingReplyRoute) {
-      closeNewMsg();
-      await revealAndSelectConversation(existingReplyRoute);
-      return;
-    }
-    if (browserIsOffline()) {
-      $newMsgError.textContent = offlineFeedbackMessage('start-conversation');
-      $newMsgError.style.display = 'block';
-      return;
-    }
-
+  async function createConversationRequest(body, fallbackName) {
     $newMsgGo.disabled = true;
     $newMsgGo.innerHTML = '<span class="spinner" aria-hidden="true"></span>Connecting...';
     $newMsgError.style.display = 'none';
-
-    // Hard timeout so the button never hangs forever if the backend stalls.
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 15000);
-
     try {
       const resp = await fetch(API + '/api/new-conversation', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone_number: phone }),
+        body: JSON.stringify(body),
         signal: controller.signal,
       });
       if (!resp.ok) {
@@ -9563,17 +9843,12 @@ body::after {
       }
       const data = await resp.json();
       closeNewMsg();
-      // Refresh conversation list and select the new one
       await loadConversations();
       const convo = conversations.find(c => c.ConversationID === data.conversation_id);
       if (convo) {
         revealAndSelectConversation(convo);
       } else {
-        // Conversation might not be in the list yet, create a minimal one
-        revealAndSelectConversation({
-          ConversationID: data.conversation_id,
-          Name: data.name || phone,
-        });
+        revealAndSelectConversation({ ConversationID: data.conversation_id, Name: data.name || fallbackName });
       }
     } catch (err) {
       const isAbort = err && err.name === 'AbortError';
@@ -9582,10 +9857,50 @@ body::after {
         : (userFacingErrorMessage(err, 'start-conversation') || 'Failed to start conversation');
       $newMsgError.style.display = 'block';
       $newMsgGo.disabled = false;
-      $newMsgGo.textContent = 'Start conversation';
+      updateNewMsgButtonLabel();
     } finally {
       clearTimeout(timeoutId);
     }
+  }
+
+  async function startNewConversation() {
+    // Pull in whatever is still typed in the box.
+    const raw = $newMsgPhone.value.trim();
+    if (raw && !commitPendingRecipient()) {
+      if ($newMsgSuggestions && !$newMsgSuggestions.hidden) {
+        const first = $newMsgSuggestions.querySelector('.new-msg-suggestion');
+        if (first) { first.dispatchEvent(new MouseEvent('mousedown')); return; }
+      }
+      $newMsgError.textContent = 'No matching contact. Type a phone number to add a recipient.';
+      $newMsgError.style.display = 'block';
+      return;
+    }
+
+    const recipients = newMsgRecipients.slice();
+    if (!recipients.length) {
+      $newMsgError.textContent = 'Add at least one recipient.';
+      $newMsgError.style.display = 'block';
+      return;
+    }
+
+    if (recipients.length === 1) {
+      // 1:1 — reuse an existing route if this number already has a thread.
+      const phone = recipients[0].number;
+      const existingReplyRoute = preferredReplyRoute(matchingRoutesForPhone(phone));
+      if (existingReplyRoute) {
+        closeNewMsg();
+        await revealAndSelectConversation(existingReplyRoute);
+        return;
+      }
+      await createConversationRequest({ phone_number: phone }, phone);
+      return;
+    }
+
+    // Group conversation.
+    await createConversationRequest(
+      { phone_numbers: recipients.map(r => r.number) },
+      recipients.map(r => r.display).join(', '),
+    );
   }
 
   $newMsgBtn.addEventListener('click', openNewMsg);
@@ -9617,13 +9932,14 @@ body::after {
   $newMsgClose.addEventListener('click', closeNewMsg);
   $newMsgGo.addEventListener('click', startNewConversation);
   $newMsgPhone.addEventListener('input', () => {
-    updateNewMessageRoutes();
+    if (!newMsgRecipients.length) updateNewMessageRoutes();
+    updateNewMsgButtonLabel();
     scheduleContactSearch();
   });
   $newMsgPhone.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
-      // If suggestions are visible, pick the first one
+      // If suggestions are visible, pick the first one (adds it as a recipient).
       const firstSuggestion = $newMsgSuggestions && !$newMsgSuggestions.hidden
         ? $newMsgSuggestions.querySelector('.new-msg-suggestion')
         : null;
@@ -9631,7 +9947,18 @@ body::after {
         firstSuggestion.dispatchEvent(new MouseEvent('mousedown'));
         return;
       }
-      startNewConversation();
+      // Commit the typed number as a recipient chip; keep the box open to add more.
+      if ($newMsgPhone.value.trim()) {
+        if (commitPendingRecipient()) return;
+      }
+      // Empty box + Enter starts the conversation with the recipients added so far.
+      if (e.key === 'Enter') startNewConversation();
+      return;
+    }
+    if (e.key === 'Backspace' && !$newMsgPhone.value && newMsgRecipients.length) {
+      e.preventDefault();
+      removeNewMsgRecipient(newMsgRecipients.length - 1);
+      return;
     }
     if (e.key === 'Escape') {
       e.preventDefault();
@@ -9698,6 +10025,356 @@ body::after {
     };
   }
 
+  // ─── Contacts / CRM view ───
+  const $contactsBtn = document.getElementById('contacts-btn');
+  const $contactsOverlay = document.getElementById('contacts-overlay');
+  const $contactsClose = document.getElementById('contacts-close');
+  const $contactsSearchInput = document.getElementById('contacts-search-input');
+  const $contactsList = document.getElementById('contacts-list');
+  const $contactsDetailEmpty = document.getElementById('contacts-detail-empty');
+  const $contactsDetailBody = document.getElementById('contacts-detail-body');
+  let contactsCurrentKey = null;
+  let contactsSearchTimer = null;
+  let contactsPeople = [];
+  let contactsSortMode = 'recent';
+
+  function openContacts() {
+    if (!$contactsOverlay) return;
+    $contactsOverlay.classList.add('show');
+    loadPeople('');
+    if ($contactsSearchInput) { $contactsSearchInput.value = ''; setTimeout(() => $contactsSearchInput.focus(), 80); }
+  }
+  function closeContacts() {
+    if ($contactsOverlay) $contactsOverlay.classList.remove('show');
+  }
+
+  function formatLastContacted(ts) {
+    if (!ts) return 'Never contacted';
+    const days = Math.floor((Date.now() - ts) / 86400000);
+    if (days <= 0) return 'Today';
+    if (days === 1) return 'Yesterday';
+    if (days < 30) return `${days} days ago`;
+    if (days < 365) return `${Math.floor(days / 30)} mo ago`;
+    return new Date(ts).toLocaleDateString([], { year: 'numeric', month: 'short' });
+  }
+
+  async function loadPeople(q) {
+    if (!$contactsList) return;
+    try {
+      const people = await fetchJSON(`/api/people${q ? `?q=${encodeURIComponent(q)}` : ''}`);
+      contactsPeople = Array.isArray(people) ? people : [];
+      renderContactsList(sortPeople(contactsPeople));
+    } catch (err) {
+      $contactsList.innerHTML = `<div style="padding:24px;color:var(--text-muted);font-size:13px">Failed to load contacts.</div>`;
+    }
+  }
+
+  function personHasName(p) {
+    return /[a-z]/i.test(String(p.name || ''));
+  }
+
+  // Sort the loaded people by the active mode without re-fetching.
+  function sortPeople(people) {
+    const list = people.slice();
+    if (contactsSortMode === 'alpha') {
+      // Named contacts A–Z first; "numbers only" names sorted last.
+      list.sort((a, b) => {
+        const an = personHasName(a), bn = personHasName(b);
+        if (an !== bn) return an ? -1 : 1;
+        return String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base' });
+      });
+    } else if (contactsSortMode === 'messages') {
+      list.sort((a, b) => (b.message_count || 0) - (a.message_count || 0) || (b.last_contacted_ts || 0) - (a.last_contacted_ts || 0));
+    } else {
+      list.sort((a, b) => (b.last_contacted_ts || 0) - (a.last_contacted_ts || 0));
+    }
+    return list;
+  }
+
+  function setContactsSort(mode) {
+    if (contactsSortMode === mode) return;
+    contactsSortMode = mode;
+    document.querySelectorAll('#contacts-sort .contacts-sort-btn').forEach(b => b.classList.toggle('active', b.dataset.sort === mode));
+    renderContactsList(sortPeople(contactsPeople));
+  }
+
+  function renderContactsList(people) {
+    if (!people.length) {
+      $contactsList.innerHTML = `<div style="padding:24px;color:var(--text-muted);font-size:13px">No contacts found.</div>`;
+      return;
+    }
+    $contactsList.innerHTML = '';
+    people.forEach(p => {
+      const el = document.createElement('div');
+      el.className = 'contact-row' + (p.key === contactsCurrentKey ? ' active' : '');
+      el.dataset.key = p.key;
+      const due = p.overdue ? '<span class="contact-row-due">Due</span>' : '';
+      el.innerHTML = `
+        ${avatarHTML({ name: p.name, numbers: p.numbers || [], className: 'convo-avatar', style: `background:${avatarColor(p.name)}` })}
+        <div class="contact-row-meta">
+          <div class="contact-row-name">${escapeHtml(p.name)}</div>
+          <div class="contact-row-sub">${escapeHtml(formatLastContacted(p.last_contacted_ts))} · ${p.message_count || 0} msg${p.message_count === 1 ? '' : 's'}</div>
+        </div>
+        ${due}
+      `;
+      el.addEventListener('click', () => selectPerson(p.key));
+      $contactsList.appendChild(el);
+    });
+    hydrateNativeAvatars($contactsList);
+  }
+
+  async function selectPerson(key) {
+    contactsCurrentKey = key;
+    $contactsList.querySelectorAll('.contact-row').forEach(r => r.classList.toggle('active', r.dataset.key === key));
+    $contactsDetailEmpty.style.display = 'none';
+    $contactsDetailBody.hidden = false;
+    $contactsDetailBody.innerHTML = `<div style="color:var(--text-muted);font-size:13px">Loading…</div>`;
+    try {
+      const p = await fetchJSON(`/api/people/${encodeURIComponent(key)}`);
+      renderPersonDetail(p);
+    } catch (err) {
+      $contactsDetailBody.innerHTML = `<div style="color:var(--text-muted)">Failed to load contact.</div>`;
+    }
+  }
+
+  function renderPersonDetail(p) {
+    const numbers = p.numbers || [];
+    const platforms = p.platforms || [];
+    const tags = p.tags || [];
+    let dueHtml = '';
+    if (p.reach_out_days > 0) {
+      dueHtml = p.overdue
+        ? `<span class="cd-due-pill overdue">Overdue</span>`
+        : `<span class="cd-due-pill ok">On track</span>`;
+    }
+    let infoRows = '';
+    if (numbers.length) infoRows += `<div class="cd-info-row"><span class="k">Phone</span><span>${numbers.map(escapeHtml).join('<br>')}</span></div>`;
+    if (platforms.length) infoRows += `<div class="cd-info-row"><span class="k">Platforms</span><span>${platforms.map(escapeHtml).join(', ')}</span></div>`;
+    infoRows += `<div class="cd-info-row"><span class="k">Last contacted</span><span>${escapeHtml(formatLastContacted(p.last_contacted_ts))}</span></div>`;
+    infoRows += `<div class="cd-info-row"><span class="k">Messages</span><span>${p.message_count || 0}</span></div>`;
+
+    const tagsHtml = tags.map((t, i) => `<span class="cd-tag">${escapeHtml(t)}<button data-tag-idx="${i}" title="Remove">&times;</button></span>`).join('');
+
+    $contactsDetailBody.innerHTML = `
+      <div class="cd-head">
+        ${avatarHTML({ name: p.name, numbers: numbers, className: 'convo-avatar', style: `background:${avatarColor(p.name)}` })}
+        <div>
+          <div class="cd-name">${escapeHtml(p.name)}</div>
+          <div class="cd-sub">${escapeHtml(formatLastContacted(p.last_contacted_ts))} · ${p.message_count || 0} messages</div>
+        </div>
+      </div>
+      ${(p.conversation_ids && p.conversation_ids.length) ? `<div class="cd-section"><button class="cd-btn primary" id="cd-open-convo">Open conversation${p.conversation_ids.length > 1 ? 's' : ''}</button></div>` : ''}
+      <div class="cd-section">
+        <div class="cd-label">Contact information</div>
+        ${infoRows}
+      </div>
+      <div class="cd-section">
+        <div class="cd-label">Tags</div>
+        <div class="cd-tags" id="cd-tags">
+          ${tagsHtml}
+          <input type="text" class="cd-tag-input" id="cd-tag-input" placeholder="Add tag…" autocomplete="off">
+        </div>
+      </div>
+      <div class="cd-section">
+        <div class="cd-label">Reach-out reminder ${dueHtml}</div>
+        <div class="cd-tickler">
+          <span class="muted">Remind me to reach out every</span>
+          <input type="number" id="cd-reachout-input" min="0" max="3650" value="${p.reach_out_days || ''}" placeholder="0">
+          <span class="muted">days</span>
+          <button class="cd-btn primary" id="cd-reachout-save">Save</button>
+        </div>
+      </div>
+      <div class="cd-section">
+        <div class="cd-label">Relationship summary</div>
+        <div class="cd-summary" id="cd-summary">${escapeHtml(p.summary || 'No summary yet.')}</div>
+        <div style="margin-top:12px"><button class="cd-btn" id="cd-summary-regen">Regenerate</button></div>
+      </div>
+    `;
+    wirePersonDetail(p);
+  }
+
+  async function openPersonConversation(p) {
+    const ids = (p && p.conversation_ids) || [];
+    if (!ids.length) return;
+    closeContacts();
+    let convo = null;
+    for (const id of ids) { // ids are most-recent-first
+      convo = allConversations.find(c => c.ConversationID === id);
+      if (convo) break;
+    }
+    if (!convo) {
+      // Not in the loaded set yet — reload conversations, then try again.
+      await loadConversations();
+      convo = allConversations.find(c => ids.includes(c.ConversationID)) || null;
+    }
+    if (convo) await revealAndSelectConversation(convo);
+  }
+
+  function wirePersonDetail(p) {
+    const key = p.key;
+    const tags = (p.tags || []).slice();
+    const openBtn = document.getElementById('cd-open-convo');
+    if (openBtn) openBtn.addEventListener('click', () => openPersonConversation(p));
+    const refresh = () => { selectPerson(key); loadPeople($contactsSearchInput.value.trim()); };
+    const saveTags = async (next) => {
+      try { await postJSON(`/api/people/${encodeURIComponent(key)}/tags`, { tags: next }); refresh(); }
+      catch (err) { showThreadFeedback(err.message || 'Failed to save tags.'); }
+    };
+    const tagInput = document.getElementById('cd-tag-input');
+    if (tagInput) tagInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); const v = tagInput.value.trim(); if (v) saveTags([...tags, v]); }
+    });
+    document.querySelectorAll('#cd-tags .cd-tag button').forEach(btn => {
+      btn.addEventListener('click', () => { const idx = parseInt(btn.dataset.tagIdx, 10); saveTags(tags.filter((_, i) => i !== idx)); });
+    });
+    const reachSave = document.getElementById('cd-reachout-save');
+    if (reachSave) reachSave.addEventListener('click', async () => {
+      const days = parseInt(document.getElementById('cd-reachout-input').value, 10) || 0;
+      try { await postJSON(`/api/people/${encodeURIComponent(key)}/reach-out`, { days }); refresh(); }
+      catch (err) { showThreadFeedback(err.message || 'Failed to save reminder.'); }
+    });
+    const regen = document.getElementById('cd-summary-regen');
+    if (regen) regen.addEventListener('click', async () => {
+      regen.disabled = true; regen.textContent = 'Generating…';
+      try { const updated = await postJSON(`/api/people/${encodeURIComponent(key)}/summary`, {}); document.getElementById('cd-summary').textContent = updated.summary || 'No summary.'; }
+      catch (err) { showThreadFeedback(err.message || 'Failed to generate summary.'); }
+      finally { regen.disabled = false; regen.textContent = 'Regenerate'; }
+    });
+  }
+
+  // ─── Scheduled (send-later) messages ───
+  function nextDayAtHour(hour) {
+    const d = new Date();
+    d.setDate(d.getDate() + 1);
+    d.setHours(hour, 0, 0, 0);
+    return d.getTime();
+  }
+
+  function openScheduleMenu() {
+    if (!$scheduleBtn || $scheduleBtn.disabled) return;
+    const rect = $scheduleBtn.getBoundingClientRect();
+    openContextMenuAt(rect.left - 60, rect.top - 8, [
+      { label: 'Tomorrow 9:00 AM', action: 'sched:9' },
+      { label: 'Tomorrow 5:00 PM', action: 'sched:17' },
+      { type: 'divider' },
+      { label: 'Custom date & time…', action: 'sched:custom' },
+    ], { type: 'schedule' });
+  }
+
+  function formatScheduledWhen(ts) {
+    const d = new Date(ts);
+    const now = new Date();
+    const opts = { hour: 'numeric', minute: '2-digit' };
+    const tomorrow = new Date(now); tomorrow.setDate(now.getDate() + 1);
+    if (d.toDateString() === now.toDateString()) return `Today ${d.toLocaleTimeString([], opts)}`;
+    if (d.toDateString() === tomorrow.toDateString()) return `Tomorrow ${d.toLocaleTimeString([], opts)}`;
+    return d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' }) + ' ' + d.toLocaleTimeString([], opts);
+  }
+
+  async function scheduleSend(sendAt) {
+    if (!activeConvoId) return;
+    const text = $composeInput.value.trim();
+    const hasMedia = !!pendingFile;
+    if (!text && !hasMedia) { showThreadFeedback('Type a message or attach a file to schedule.'); return; }
+    if (!Number.isFinite(sendAt) || sendAt < Date.now() + 10000) {
+      showThreadFeedback('Pick a time at least a moment in the future.');
+      return;
+    }
+    const replyId = replyToMsg ? replyToMsg.MessageID : '';
+    try {
+      if (hasMedia) {
+        const form = new FormData();
+        form.append('conversation_id', activeConvoId);
+        form.append('file', pendingFile.file);
+        form.append('caption', text);
+        form.append('reply_to_id', replyId);
+        form.append('send_at', String(sendAt));
+        const resp = await fetch(API + '/api/schedule-media', { method: 'POST', body: form });
+        if (!resp.ok) {
+          const msg = await resp.text();
+          throw new Error(msg || 'Failed to schedule attachment.');
+        }
+        clearAttachment();
+      } else {
+        await postJSON('/api/schedule', {
+          conversation_id: activeConvoId,
+          body: text,
+          reply_to_id: replyId,
+          send_at: sendAt,
+        });
+      }
+      $composeInput.value = '';
+      autoResize();
+      if (replyToMsg) clearReply();
+      hideScheduleCustom();
+      showThreadFeedback(`Scheduled for ${formatScheduledWhen(sendAt)}.`);
+      loadScheduledMessages(activeConvoId);
+    } catch (err) {
+      showThreadFeedback(err.message || 'Failed to schedule message.');
+    }
+  }
+
+  async function loadScheduledMessages(convId) {
+    if (!$scheduledStrip) return;
+    if (!convId) { $scheduledStrip.innerHTML = ''; return; }
+    try {
+      const list = await fetchJSON(`/api/schedule?conversation_id=${encodeURIComponent(convId)}`);
+      if (activeConvoId !== convId) return;
+      renderScheduledStrip(Array.isArray(list) ? list : []);
+    } catch (err) {
+      $scheduledStrip.innerHTML = '';
+    }
+  }
+
+  function renderScheduledStrip(list) {
+    if (!$scheduledStrip) return;
+    const clock = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>';
+    $scheduledStrip.innerHTML = list.map(s => {
+      const failed = s.status === 'failed';
+      const when = failed
+        ? `Couldn't send: ${escapeHtml(s.last_error || 'failed')}`
+        : `Scheduled for ${escapeHtml(formatScheduledWhen(s.send_at))}`;
+      const paperclip = '<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px;"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>';
+      let textHtml;
+      if (s.media_filename) {
+        const cap = s.body ? escapeHtml(s.body) : escapeHtml(s.media_filename);
+        textHtml = `${paperclip}${cap}`;
+      } else {
+        textHtml = escapeHtml(s.body);
+      }
+      return `<div class="scheduled-item${failed ? ' failed' : ''}">
+        ${clock}
+        <div class="scheduled-item-body">
+          <div class="scheduled-item-text">${textHtml}</div>
+          <div class="scheduled-item-when">${when}</div>
+        </div>
+        <button class="scheduled-item-cancel" data-id="${escapeHtml(s.id)}" title="Cancel" aria-label="Cancel scheduled message">&times;</button>
+      </div>`;
+    }).join('');
+    $scheduledStrip.querySelectorAll('.scheduled-item-cancel').forEach(btn => {
+      btn.addEventListener('click', () => cancelScheduled(btn.dataset.id));
+    });
+  }
+
+  async function cancelScheduled(id) {
+    try {
+      await fetch(API + `/api/schedule/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    } catch (err) { /* ignore */ }
+    loadScheduledMessages(activeConvoId);
+  }
+
+  function showScheduleCustom() {
+    if (!$scheduleCustom || !$scheduleCustomInput) return;
+    const d = new Date(nextDayAtHour(9));
+    const pad = n => String(n).padStart(2, '0');
+    $scheduleCustomInput.value = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    $scheduleCustom.hidden = false;
+    setTimeout(() => $scheduleCustomInput.focus(), 50);
+  }
+  function hideScheduleCustom() {
+    if ($scheduleCustom) $scheduleCustom.hidden = true;
+  }
+
   // ─── Init ───
   syncNotificationButton();
   refreshNativeNotificationState()
@@ -9707,6 +10384,25 @@ body::after {
   if ($selectToggleBtn) $selectToggleBtn.addEventListener('click', toggleSelectionMode);
   if ($bulkCancelBtn) $bulkCancelBtn.addEventListener('click', exitSelectionMode);
   if ($bulkMoveBtn) $bulkMoveBtn.addEventListener('click', openBulkMoveMenu);
+  if ($scheduleBtn) $scheduleBtn.addEventListener('click', openScheduleMenu);
+  if ($scheduleCustomCancel) $scheduleCustomCancel.addEventListener('click', hideScheduleCustom);
+  if ($scheduleCustomGo) $scheduleCustomGo.addEventListener('click', () => {
+    const v = $scheduleCustomInput && $scheduleCustomInput.value;
+    if (!v) { showThreadFeedback('Pick a date and time.'); return; }
+    scheduleSend(new Date(v).getTime());
+  });
+  if ($contactsBtn) $contactsBtn.addEventListener('click', openContacts);
+  if ($contactsClose) $contactsClose.addEventListener('click', closeContacts);
+  if ($contactsSearchInput) $contactsSearchInput.addEventListener('input', () => {
+    clearTimeout(contactsSearchTimer);
+    contactsSearchTimer = setTimeout(() => loadPeople($contactsSearchInput.value.trim()), 200);
+  });
+  document.querySelectorAll('#contacts-sort .contacts-sort-btn').forEach(btn => {
+    btn.addEventListener('click', () => setContactsSort(btn.dataset.sort));
+  });
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && $contactsOverlay && $contactsOverlay.classList.contains('show')) closeContacts();
+  });
   startEventStream();
   loadTabs();
   loadConversations();

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "  import imessage [db-path]                 - Import iMessage (needs Full Disk Access)")
 		fmt.Fprintln(os.Stderr, "  import whatsapp <chat.txt> [--name You]   - Import WhatsApp text export")
 		fmt.Fprintln(os.Stderr, "  import signal [support-dir]               - Import Signal Desktop history")
+		fmt.Fprintln(os.Stderr, "  import contacts                          - Import macOS Contacts (needs Full Disk Access)")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
A batch of new features and reliability fixes for the inbox, all local-first and test-covered.

## ✨ Features

- **Schedule send (text + rich media)** — compose a message or attach a file, pick *Tomorrow 9 AM / 5 PM / custom*, and it sends at that time. New `scheduled_messages` table, a background scheduler (startup catch-up + 20s ticker, atomic exactly-once claim, offline-retry/fail, per-platform routing), `/api/schedule` + `/api/schedule-media` endpoints, and a pending strip above the composer with cancel.
- **Contacts CRM** — a person-icon view: everyone you've messaged on the left; detail on the right with photo, all contact info, last-contacted, tags, a reach-out tickler/cadence, and an auto-generated relationship summary. Open a person's thread from their card; sort alphabetically (numbers last) or by most-messaged. Plus read-only Google Messages contact sync (no inbox flooding) and add-local-contact.
- **Inbox tabs + reaction reactor names** — custom inbox tabs with multi-select move, and reaction tooltips that name who reacted.
- **Architecture code map** — `docs/CODEMAP.md`.

## 🔧 Repairs

- **Recurring unread badges** — reads no longer get resurrected by Google's stale conversation re-syncs (new `last_read_ts` watermark; migration auto-protects already-read threads).
- **iMessage tapbacks** — `Loved "…"` texts convert into emoji reactions instead of cluttering threads.
- **"Empty message" stubs** — empty placeholder rows with wrong dates are detected and removed (live + startup repair).
- **Three white flashes on send/receive** — replaced full-thread re-render with keyed reconcile.
- **Images stuck on a loading spinner** — media load/error handlers resolve correctly.
- **Group-message creation failure** — two-step RCS-group (`CREATE_RCS`) flow + E.164 phone normalization.
- **Recents ordering** — contentless group-reaction stubs no longer float 1:1 threads to the top.

## Notes

- Layered, buildable commits: store → backend → web → docs.
- Full Go suite green (`go test ./internal/... ./cmd/`); `staticcheck` clean on changed packages.
- Branch is currently a few commits behind upstream `main`; happy to rebase if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)