### PR TITLE
Web UI: stop status-flap re-render flicker

### DIFF
--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -1089,3 +1089,34 @@ test('escape closes the platforms overlay without clearing search', async ({ pag
   await expect(page.locator('#wa-overlay')).not.toHaveClass(/show/);
   await expect(page.locator('#search-input')).toHaveValue('hike');
 });
+
+test('status flap from a flapping bridge does not re-render the main UI', async ({ page }) => {
+  await page.waitForFunction(() => window.__openMessageTestHooks?.applyAppStatus);
+  const r = await page.evaluate(() => {
+    const H = window.__openMessageTestHooks;
+    const banner = () => {
+      const b = document.getElementById('connection-banner');
+      const copy = document.getElementById('connection-banner-copy');
+      return JSON.stringify({ disp: b ? getComputedStyle(b).display : null, text: copy ? copy.textContent : null });
+    };
+    const base = {
+      connected: true,
+      google: { connected: true, paired: true, needs_pairing: false },
+      whatsapp: { connected: true, paired: true },
+      signal: { connected: true, paired: true },
+      backfill: { running: false },
+    };
+    const flap = JSON.parse(JSON.stringify(base)); flap.signal.connected = false; // bridge crash; paired stays
+    const gDown = JSON.parse(JSON.stringify(base)); gDown.google.connected = false; gDown.connected = false;
+
+    H.applyAppStatus(base);
+    const sig0 = H.lastStatusRenderSig(); const banner0 = banner();
+    for (let i = 0; i < 6; i++) H.applyAppStatus(i % 2 ? flap : base);
+    const flapStable = sig0 === H.lastStatusRenderSig() && banner0 === banner();
+    H.applyAppStatus(gDown);
+    const realChanged = sig0 !== H.lastStatusRenderSig() && banner0 !== banner();
+    return { flapStable, realChanged };
+  });
+  expect(r.flapStable).toBe(true);   // Signal flapping must not churn the banner
+  expect(r.realChanged).toBe(true);  // a genuine Google disconnect still renders
+});

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -4582,6 +4582,12 @@ body::after {
     contacts_checked: 0,
     errors: 0,
   };
+  // Signature of the last status that actually drove a render. The backend
+  // pushes a status SSE event on every platform state change, and a flapping
+  // bridge (or the 10s fallback poll) can fire many identical ones; rendering
+  // each rebuilds the connection banner + header chrome and visibly flickers.
+  // applyAppStatus skips the render pass when this signature is unchanged.
+  let lastStatusRenderSig = null;
   let whatsAppPollTimer = null;
   const knownMessageIDs = new Set();
   const knownMessageOrder = [];
@@ -8340,6 +8346,24 @@ body::after {
     whatsAppStatus = normalizeWhatsAppStatus(appStatus.whatsapp || {});
     signalStatus = normalizeSignalStatus(appStatus.signal || {});
     backfillStatus = normalizeBackfillStatus(appStatus.backfill || {});
+    // Only re-render when something the always-on UI actually shows changed.
+    // The banner and empty state key off whether secondary platforms are
+    // PAIRED, not their live connected flag — so a Signal/WhatsApp bridge
+    // flapping connected↔disconnected (e.g. a signal-cli crash loop) must not
+    // churn the main UI. Live per-platform detail (connect progress, QR) only
+    // matters while the Platforms dialog is open, so it's folded in only then.
+    // Freshness timestamps are excluded entirely (they tick on every message).
+    const overlayOpen = !!($waOverlay && $waOverlay.classList.contains('show'));
+    const hasSecondaryPaired = whatsAppStatus.paired || whatsAppStatus.connected
+      || signalStatus.paired || signalStatus.connected;
+    const sig = JSON.stringify([
+      googleStatus, hasSecondaryPaired,
+      backfillStatus.running, allConversations.length,
+      browserReportsOnline(), activeConvoId, overlayOpen,
+      overlayOpen ? [whatsAppStatus, signalStatus] : null,
+    ]);
+    if (sig === lastStatusRenderSig) return;
+    lastStatusRenderSig = sig;
     setConnectionState();
     renderWhatsAppButton();
     renderEmptyState();
@@ -9772,6 +9796,12 @@ body::after {
           windowEnd: lastRenderedWindowEnd,
           windowSize: THREAD_RENDER_WINDOW_SIZE,
         };
+      },
+      applyAppStatus(status = {}) {
+        applyAppStatus(status || {});
+      },
+      lastStatusRenderSig() {
+        return lastStatusRenderSig;
       },
     };
   }


### PR DESCRIPTION
## Symptom

Reported live against tonight's deployed build: **"app is flickering every few seconds as it refreshes, unusable."**

## Root cause

Two layers:
1. **signal-cli 0.14.1** threw `NullPointerException: ...getSender() because content is null` on an unparseable incoming envelope, exited 2, and (because it never ACKed) re-hit the same poison message every poll. After 3 failures the Signal bridge tore down `connected` and the 5s watchdog reconnected — a flap every ~6s. **Fixed on the affected machine by upgrading signal-cli to 0.14.5** (no code change; the bridge invokes whatever's on PATH).
2. **The web UI amplified it:** every status SSE event ran `setConnectionState` + `renderEmptyState` + chat-header chrome unconditionally, so each flap rebuilt the banner/header → visible flicker. This PR fixes that amplification so *no* future bridge flap (or the 10s status poll) can do this again.

## Fix

`applyAppStatus` now renders only when a signature of the **visible** state changes. The signature keys secondary platforms off whether they're *paired* (what the banner and empty-state actually read), not their live `connected` flag — so a Signal/WhatsApp connect↔disconnect flap with the Platforms dialog closed is a no-op. Live per-platform detail (connect progress, QR) is included only while that dialog is open; freshness timestamps are excluded so message arrival never rebuilds chrome. Genuine changes (Google connect/disconnect, pairing progress, new QR) still render.

## Verification

New e2e test (52/52 suite green): 6× Signal `connected` flap leaves the connection banner byte-identical and the render signature stable, while a Google disconnect still updates both. Confirmed live: after the signal-cli upgrade the deployed app's SSE status events dropped from ~5/12s to ~0 and the flicker stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)