### PR TITLE
Detect a stuck Google Messages session and offer re-pair

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -381,6 +381,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				IdentityName:         identityName,
 				IsConnected:          isConnected,
 				GoogleStatus:         googleStatus,
+				RecordGoogleSend:     a.RecordGoogleSendOutcome,
 				ReconnectGoogle:      a.ReconnectGoogleMessages,
 				Unpair:               a.Unpair,
 				WhatsAppStatus:       func() any { return a.WhatsAppStatus() },

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -1120,3 +1120,24 @@ test('status flap from a flapping bridge does not re-render the main UI', async 
   expect(r.flapStable).toBe(true);   // Signal flapping must not churn the banner
   expect(r.realChanged).toBe(true);  // a genuine Google disconnect still renders
 });
+
+test('a stuck Google session (connected + needs_repair) surfaces a re-pair banner', async ({ page }) => {
+  await page.waitForFunction(() => window.__openMessageTestHooks?.applyAppStatus);
+  const stuck = {
+    connected: true,
+    google: { connected: true, paired: true, needs_pairing: false, needs_repair: true },
+    whatsapp: { connected: true, paired: true },
+    signal: { connected: true, paired: true },
+    backfill: { running: false },
+  };
+  await page.evaluate((s) => window.__openMessageTestHooks.applyAppStatus(s), stuck);
+  await expect(page.locator('#connection-banner')).toBeVisible();
+  await expect(page.locator('#connection-banner-action')).toHaveText('Re-pair');
+  await expect(page.locator('#connection-banner-copy')).toContainText('Re-pair to fix it');
+
+  // Healthy again → banner hides.
+  const healthy = JSON.parse(JSON.stringify(stuck));
+  healthy.google.needs_repair = false;
+  await page.evaluate((s) => window.__openMessageTestHooks.applyAppStatus(s), healthy);
+  await expect(page.locator('#connection-banner')).toBeHidden();
+});

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -142,8 +142,14 @@ type App struct {
 	Signal           *signallive.Bridge
 	statusMu         sync.Mutex
 	googleLastError  string
-	tempDataDir      string
-	pendingMediaMu   sync.Mutex
+	// A lapsed Google Messages linked-device session keeps reporting
+	// Connected=true while every send comes back UNKNOWN (the phone has
+	// silently unlinked us). Count consecutive non-SUCCESS Google sends so
+	// the UI can surface a re-pair affordance even while "connected".
+	googleSendFailures atomic.Int32
+	googleNeedsRepair  atomic.Bool
+	tempDataDir        string
+	pendingMediaMu     sync.Mutex
 	pendingMedia     map[string]struct{}
 }
 
@@ -151,7 +157,36 @@ type GoogleStatusSnapshot struct {
 	Connected    bool   `json:"connected"`
 	Paired       bool   `json:"paired"`
 	NeedsPairing bool   `json:"needs_pairing"`
-	LastError    string `json:"last_error,omitempty"`
+	// NeedsRepair is set when the session reports connected but sends keep
+	// failing — the phone has likely unlinked the device. The UI should
+	// offer re-pairing even though Connected is true.
+	NeedsRepair bool   `json:"needs_repair,omitempty"`
+	LastError   string `json:"last_error,omitempty"`
+}
+
+// googleRepairThreshold is how many consecutive failed Google sends (with no
+// success in between) flip the session into the "needs re-pair" state.
+const googleRepairThreshold = 3
+
+// RecordGoogleSendOutcome tracks Google Messages send results so a silently
+// unlinked session (Connected=true, every send UNKNOWN) becomes visible. A
+// single success clears the flag.
+func (a *App) RecordGoogleSendOutcome(success bool) {
+	if success {
+		a.googleSendFailures.Store(0)
+		a.googleNeedsRepair.Store(false)
+		return
+	}
+	if a.googleSendFailures.Add(1) >= googleRepairThreshold {
+		a.googleNeedsRepair.Store(true)
+	}
+}
+
+// ClearGoogleRepairFlag resets the stuck-session state, e.g. after a fresh
+// (re)connect or pairing where sends haven't been attempted yet.
+func (a *App) ClearGoogleRepairFlag() {
+	a.googleSendFailures.Store(0)
+	a.googleNeedsRepair.Store(false)
 }
 
 func DefaultDataDir() string {
@@ -317,6 +352,9 @@ func (a *App) setClient(cli *client.Client) {
 }
 
 func (a *App) LoadAndConnect() error {
+	// A fresh load/connect (including right after re-pairing) starts from a
+	// clean slate; don't carry a prior session's stuck-send state forward.
+	a.ClearGoogleRepairFlag()
 	sessionData, err := client.LoadSession(a.SessionPath)
 	if err != nil {
 		a.setGoogleLastError(err.Error())
@@ -512,10 +550,12 @@ func (a *App) GoogleStatus() GoogleStatusSnapshot {
 	a.statusMu.Lock()
 	lastError := a.googleLastError
 	a.statusMu.Unlock()
+	connected := a.Connected.Load()
 	return GoogleStatusSnapshot{
-		Connected:    a.Connected.Load(),
+		Connected:    connected,
 		Paired:       a.GooglePaired(),
-		NeedsPairing: !a.Connected.Load() && !a.GooglePaired(),
+		NeedsPairing: !connected && !a.GooglePaired(),
+		NeedsRepair:  connected && a.googleNeedsRepair.Load(),
 		LastError:    lastError,
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -86,3 +86,42 @@ func TestDemoModeEnvParsing(t *testing.T) {
 		}
 	})
 }
+
+func TestGoogleSendOutcomeRepairFlag(t *testing.T) {
+	a := &App{}
+
+	// Below threshold: not yet flagged.
+	a.RecordGoogleSendOutcome(false)
+	a.RecordGoogleSendOutcome(false)
+	if a.googleNeedsRepair.Load() {
+		t.Fatal("should not flag before threshold")
+	}
+	// Reaching the threshold flags it.
+	a.RecordGoogleSendOutcome(false)
+	if !a.googleNeedsRepair.Load() {
+		t.Fatalf("should flag after %d consecutive failures", googleRepairThreshold)
+	}
+
+	// Surfaced in status only while connected.
+	a.Connected.Store(true)
+	if !a.GoogleStatus().NeedsRepair {
+		t.Fatal("connected + stuck should report needs_repair")
+	}
+	a.Connected.Store(false)
+	if a.GoogleStatus().NeedsRepair {
+		t.Fatal("needs_repair must not surface while disconnected (normal pairing flow handles that)")
+	}
+
+	// A single success clears it.
+	a.Connected.Store(true)
+	a.RecordGoogleSendOutcome(true)
+	if a.googleNeedsRepair.Load() || a.GoogleStatus().NeedsRepair {
+		t.Fatal("a successful send must clear the repair flag")
+	}
+
+	// Counter reset by success: it takes a full threshold run to re-flag.
+	a.RecordGoogleSendOutcome(false)
+	if a.googleNeedsRepair.Load() {
+		t.Fatal("one failure after a success must not immediately re-flag")
+	}
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -55,6 +55,7 @@ type APIOptions struct {
 	IdentityName          string
 	IsConnected           StatusChecker
 	GoogleStatus          func() any
+	RecordGoogleSend      func(success bool) // tracks Google send outcomes for stuck-session detection
 	ReconnectGoogle       func() error
 	Unpair                UnpairFunc
 	WhatsAppStatus        func() any
@@ -143,6 +144,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	publishStatus := func(connected bool) {
 		if opts.Events != nil {
 			opts.Events.PublishStatus(connected)
+		}
+	}
+	recordGoogleSend := func(success bool) {
+		if opts.RecordGoogleSend != nil {
+			opts.RecordGoogleSend(success)
 		}
 	}
 	// Per-platform data-freshness, used to catch "zombie" bridges that report
@@ -872,9 +878,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			}, "")
 			publishMessages(req.ConversationID)
 			publishConversations()
-			httpError(w, "send failed with status "+resp.GetStatus().String()+" (Google Messages rejected the send — check that OpenMessage is still paired and that Messages is your default SMS app)", 502)
+			recordGoogleSend(false)
+			httpError(w, googleSendRejectedMessage(resp.GetStatus().String()), 502)
 			return
 		}
+		recordGoogleSend(true)
 		// Store sent message in DB immediately so UI shows it
 		now := time.Now().UnixMilli()
 		if err := recordOutgoingMessage(&db.Message{
@@ -1044,9 +1052,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			}, "")
 			publishMessages(convID)
 			publishConversations()
-			httpError(w, "send failed with status "+resp.GetStatus().String()+" (Google Messages rejected the media send — check pairing and that Messages is your default SMS app)", 502)
+			recordGoogleSend(false)
+			httpError(w, googleSendRejectedMessage(resp.GetStatus().String()), 502)
 			return
 		}
+		recordGoogleSend(true)
 		now := time.Now().UnixMilli()
 		if err := recordOutgoingMessage(&db.Message{
 			MessageID:      payload.TmpID,
@@ -1476,9 +1486,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			}, "")
 			publishMessages(draft.ConversationID)
 			publishConversations()
-			httpError(w, "send failed with status "+resp.GetStatus().String()+" (Google Messages rejected the draft send — check pairing and that Messages is your default SMS app)", 502)
+			recordGoogleSend(false)
+			httpError(w, googleSendRejectedMessage(resp.GetStatus().String()), 502)
 			return
 		}
+		recordGoogleSend(true)
 		now := time.Now().UnixMilli()
 		if err := recordOutgoingMessage(&db.Message{
 			MessageID:      payload.TmpID,
@@ -2236,6 +2248,16 @@ func googleAPIErrorMessage(action string, err error) string {
 		return "Google Messages is offline. Check your internet connection, then try again."
 	}
 	return action + ": " + err.Error()
+}
+
+// googleSendRejectedMessage builds the user-facing error for a non-SUCCESS
+// Google send. UNKNOWN is what a silently-unlinked linked device returns on
+// every send, so the message points at re-pairing rather than leaving the
+// user with a bare status code.
+func googleSendRejectedMessage(status string) string {
+	return "send failed (Google Messages returned " + status + "). If this keeps happening your phone has " +
+		"likely unlinked OpenMessage — open Platforms → Google Messages → Pair again. " +
+		"Also confirm Messages is set as your phone's default SMS app."
 }
 
 func isGoogleNetworkError(err error) bool {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -8242,6 +8242,7 @@ body::after {
       connected: !!raw.connected,
       paired: raw.paired === undefined ? !!raw.connected : !!raw.paired,
       needs_pairing: !!raw.needs_pairing,
+      needs_repair: !!raw.needs_repair,
       last_error: raw.last_error || '',
     };
   }
@@ -8254,6 +8255,18 @@ body::after {
       $connectionBannerCopy.textContent = 'No internet connection. Local history is available, but new messages will wait until you are back online.';
       $connectionBannerAction.textContent = 'Retry';
       $connectionBannerAction.dataset.action = 'retry-connection';
+      $connectionBannerAction.style.display = '';
+      return;
+    }
+    // A stuck session reports connected=true but every send fails because the
+    // phone has unlinked the device. Surface a re-pair affordance the user
+    // would otherwise have no way to reach while "connected".
+    if (googleStatus.connected && googleStatus.needs_repair) {
+      $connectionBanner.className = 'connection-banner disconnected';
+      $connectionBanner.style.display = 'flex';
+      $connectionBannerCopy.textContent = 'Google Messages isn’t sending — your phone may have unlinked OpenMessage. Re-pair to fix it.';
+      $connectionBannerAction.textContent = 'Re-pair';
+      $connectionBannerAction.dataset.action = 'open-platforms';
       $connectionBannerAction.style.display = '';
       return;
     }


### PR DESCRIPTION
## Motivation

Real incident: a Google Messages linked-device session lapsed (the phone silently unlinked OpenMessage — happens after travel/network changes). The app kept reporting `connected: true` while **every send failed with `UNKNOWN`**, and there was **no way to re-pair from the UI** — the "connected" state only showed "Open inbox / Sync history", never a pairing option. Recovering it required manually deleting session files. The send error was also just a bare status code with no guidance.

## Fix

The backend now tracks consecutive non-SUCCESS Google sends. After `googleRepairThreshold` (3) with no success in between, `GoogleStatusSnapshot.NeedsRepair` is set — **only while `Connected`**, since a disconnected session already routes through the normal pairing flow. A single successful send, or a fresh connect/re-pair (`LoadAndConnect` clears it), resets the state.

- **Actionable send error** — all three Google send paths (text/media/draft) now return *"send failed (Google Messages returned UNKNOWN). If this keeps happening your phone has likely unlinked OpenMessage — open Platforms → Google Messages → Pair again…"* instead of a bare status.
- **Re-pair banner** — the web UI shows *"Google Messages isn't sending — Re-pair"* when `connected && needs_repair`, giving a reachable re-pair path that didn't exist while the app believed it was connected. (`open-platforms` → the Platforms overlay's "Pair again".)

## Tests

- Go: `TestGoogleSendOutcomeRepairFlag` — threshold, success-clears, counter-reset, and disconnected-suppression.
- e2e: banner appears on `connected + needs_repair` and clears when healthy (suite 53/53).
- `go vet ./...` clean; `go test ./internal/app ./internal/web ./cmd` green.

## Follow-ups (filed separately)

The native macOS Platforms view should grow the same re-pair affordance, and `PhoneNotResponding` should be surfaced — see linked issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)