### PR TITLE
Treat Google auth-401 as needs-repair, not an infinite reconnect loop

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -214,7 +214,11 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 			defer ticker.Stop()
 			for range ticker.C {
 				g := a.GoogleStatus()
-				if !g.Paired || g.Connected || g.NeedsPairing {
+				// Skip reconnect when the credentials are dead (NeedsRepair):
+				// retrying a 401'd session just spams the log every 15s and
+				// never recovers. The UI shows a "Re-pair" banner instead; a
+				// successful re-pair clears the flag and reconnect resumes.
+				if !g.Paired || g.Connected || g.NeedsPairing || g.NeedsRepair {
 					continue
 				}
 				logger.Info().Msg("Google Messages disconnected — attempting reconnect")

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -1141,3 +1141,28 @@ test('a stuck Google session (connected + needs_repair) surfaces a re-pair banne
   await page.evaluate((s) => window.__openMessageTestHooks.applyAppStatus(s), healthy);
   await expect(page.locator('#connection-banner')).toBeHidden();
 });
+
+test('an auth-dead Google session (disconnected + needs_repair) shows Re-pair, not Reconnect', async ({ page }) => {
+  await page.waitForFunction(() => window.__openMessageTestHooks?.applyAppStatus);
+  // connected=false (the 401 case) but paired + needs_repair.
+  await page.evaluate(() => window.__openMessageTestHooks.applyAppStatus({
+    connected: false,
+    google: { connected: false, paired: true, needs_pairing: false, needs_repair: true },
+    whatsapp: { connected: true, paired: true },
+    signal: { connected: true, paired: true },
+    backfill: { running: false },
+  }));
+  await expect(page.locator('#connection-banner')).toBeVisible();
+  await expect(page.locator('#connection-banner-action')).toHaveText('Re-pair');
+  await expect(page.locator('#connection-banner-copy')).toContainText('unlinked OpenMessage');
+
+  // A plain disconnected (no needs_repair) still says Reconnect.
+  await page.evaluate(() => window.__openMessageTestHooks.applyAppStatus({
+    connected: false,
+    google: { connected: false, paired: true, needs_pairing: false, needs_repair: false },
+    whatsapp: { connected: true, paired: true },
+    signal: { connected: true, paired: true },
+    backfill: { running: false },
+  }));
+  await expect(page.locator('#connection-banner-action')).toHaveText('Reconnect');
+});

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -352,9 +352,6 @@ func (a *App) setClient(cli *client.Client) {
 }
 
 func (a *App) LoadAndConnect() error {
-	// A fresh load/connect (including right after re-pairing) starts from a
-	// clean slate; don't carry a prior session's stuck-send state forward.
-	a.ClearGoogleRepairFlag()
 	sessionData, err := client.LoadSession(a.SessionPath)
 	if err != nil {
 		a.setGoogleLastError(err.Error())
@@ -428,13 +425,38 @@ func (a *App) LoadAndConnect() error {
 
 	if err := cli.GM.Connect(); err != nil {
 		a.setGoogleLastError(err.Error())
+		// A 401/UNAUTHENTICATED on connect or token refresh means the session
+		// is genuinely dead — the phone unlinked this device. Retrying can't
+		// recover it, so flag it for re-pair (the reconnect watchdog backs off
+		// on this, and the UI surfaces a "Re-pair" banner) instead of looping
+		// "reconnecting…" forever with a bare 401 the user can't act on.
+		if isGoogleAuthInvalid(err) {
+			a.googleNeedsRepair.Store(true)
+		}
 		return fmt.Errorf("connect: %w", err)
 	}
+	// A clean connect proves the session is alive; clear any prior stuck/dead
+	// state (also covers the path right after re-pairing).
+	a.ClearGoogleRepairFlag()
 	a.Connected.Store(true)
 	a.setGoogleLastError("")
 	a.emitStatusChange(true)
 	a.Logger.Info().Msg("Connected to Google Messages")
 	return nil
+}
+
+// isGoogleAuthInvalid reports whether a Google Messages connect/refresh error
+// means the stored credentials are dead (re-pair required) rather than a
+// transient network failure (reconnect will recover).
+func isGoogleAuthInvalid(err error) bool {
+	if err == nil {
+		return false
+	}
+	m := strings.ToLower(err.Error())
+	return strings.Contains(m, "invalid authentication credentials") ||
+		strings.Contains(m, "unauthenticated") ||
+		strings.Contains(m, "http 401") ||
+		(strings.Contains(m, "refresh auth token") && strings.Contains(m, "401"))
 }
 
 // Unpair deletes the session file so the app can re-pair.
@@ -551,12 +573,18 @@ func (a *App) GoogleStatus() GoogleStatusSnapshot {
 	lastError := a.googleLastError
 	a.statusMu.Unlock()
 	connected := a.Connected.Load()
+	paired := a.GooglePaired()
 	return GoogleStatusSnapshot{
 		Connected:    connected,
-		Paired:       a.GooglePaired(),
-		NeedsPairing: !connected && !a.GooglePaired(),
-		NeedsRepair:  connected && a.googleNeedsRepair.Load(),
-		LastError:    lastError,
+		Paired:       paired,
+		NeedsPairing: !connected && !paired,
+		// needs_repair surfaces whenever the session is known-bad and a session
+		// file still exists — whether that's a zombie (connected, sends fail)
+		// or a dead-credentials disconnect (auth 401). Either way the fix is
+		// re-pair, not reconnect; gating on `connected` alone would hide the
+		// 401 case (which is disconnected).
+		NeedsRepair: paired && a.googleNeedsRepair.Load(),
+		LastError:   lastError,
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -89,6 +90,11 @@ func TestDemoModeEnvParsing(t *testing.T) {
 
 func TestGoogleSendOutcomeRepairFlag(t *testing.T) {
 	a := &App{}
+	// A session file makes GooglePaired() true so NeedsRepair can surface.
+	a.SessionPath = filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(a.SessionPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	// Below threshold: not yet flagged.
 	a.RecordGoogleSendOutcome(false)
@@ -102,18 +108,26 @@ func TestGoogleSendOutcomeRepairFlag(t *testing.T) {
 		t.Fatalf("should flag after %d consecutive failures", googleRepairThreshold)
 	}
 
-	// Surfaced in status only while connected.
+	// Surfaces whenever paired — both the zombie (connected) and the
+	// dead-credentials (disconnected) cases, since the fix is re-pair either way.
 	a.Connected.Store(true)
 	if !a.GoogleStatus().NeedsRepair {
 		t.Fatal("connected + stuck should report needs_repair")
 	}
 	a.Connected.Store(false)
-	if a.GoogleStatus().NeedsRepair {
-		t.Fatal("needs_repair must not surface while disconnected (normal pairing flow handles that)")
+	if !a.GoogleStatus().NeedsRepair {
+		t.Fatal("needs_repair must still surface while disconnected (auth-dead session)")
 	}
 
+	// Not surfaced when there's no session at all (the normal pairing flow).
+	prev := a.SessionPath
+	a.SessionPath = filepath.Join(t.TempDir(), "missing.json")
+	if a.GoogleStatus().NeedsRepair {
+		t.Fatal("needs_repair must not surface when unpaired")
+	}
+	a.SessionPath = prev
+
 	// A single success clears it.
-	a.Connected.Store(true)
 	a.RecordGoogleSendOutcome(true)
 	if a.googleNeedsRepair.Load() || a.GoogleStatus().NeedsRepair {
 		t.Fatal("a successful send must clear the repair flag")
@@ -123,5 +137,26 @@ func TestGoogleSendOutcomeRepairFlag(t *testing.T) {
 	a.RecordGoogleSendOutcome(false)
 	if a.googleNeedsRepair.Load() {
 		t.Fatal("one failure after a success must not immediately re-flag")
+	}
+}
+
+func TestIsGoogleAuthInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"the real 401", errors.New("connect: failed to refresh auth token: HTTP 401: 16: Request had invalid authentication credentials."), true},
+		{"unauthenticated", errors.New("rpc error: code = Unauthenticated desc = ..."), true},
+		{"transient network", errors.New("dial tcp: i/o timeout"), false},
+		{"unrelated 500", errors.New("HTTP 500 internal server error"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isGoogleAuthInvalid(c.err); got != c.want {
+				t.Fatalf("isGoogleAuthInvalid(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
 	}
 }

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -8276,7 +8276,15 @@ body::after {
     }
     $connectionBanner.className = 'connection-banner disconnected';
     $connectionBanner.style.display = 'flex';
-    if (googleStatus.paired && !googleStatus.needs_pairing) {
+    if (googleStatus.paired && googleStatus.needs_repair) {
+      // Disconnected because the credentials are dead (auth 401) — reconnect
+      // won't recover it, so steer to re-pair rather than a "Reconnect" that
+      // just 401s again.
+      $connectionBannerCopy.textContent = 'Google Messages disconnected — your phone unlinked OpenMessage. Re-pair to fix it.';
+      $connectionBannerAction.textContent = 'Re-pair';
+      $connectionBannerAction.dataset.action = 'open-platforms';
+      $connectionBannerAction.style.display = '';
+    } else if (googleStatus.paired && !googleStatus.needs_pairing) {
       $connectionBannerCopy.textContent = 'Google Messages sync is paused';
       $connectionBannerAction.textContent = 'Reconnect';
       $connectionBannerAction.dataset.action = 'reconnect-google';


### PR DESCRIPTION
## Motivation (hit live)

When a Google Messages linked-device session's credentials die — the phone unlinks the device — `cli.GM.Connect()` returns `failed to refresh auth token: HTTP 401: 16: Request had invalid authentication credentials`. The app set that as `last_error` and the 15s reconnect watchdog just called `LoadAndConnect()` again **forever**: 401 every 15s, never recovering, and the UI showed a "Reconnect" banner that only 401s again. There was no path to the actual fix (re-pair).

This is the connection-level sibling of #42 (which detected the *send*-failure zombie while `connected=true`). This one is `connected=false`, so #42's `connected`-gated `needs_repair` was hidden.

## Fix

- `isGoogleAuthInvalid(err)` classifies a definitive dead-credentials error (401 / UNAUTHENTICATED / "refresh auth token"+401) vs a transient network drop.
- On a `Connect()` auth-invalid error, set the existing `needs_repair` flag; a clean connect (or a successful send) clears it.
- `GoogleStatus.NeedsRepair` now surfaces whenever a **session file still exists** (gated on `paired`, not `connected`) — covering both the zombie (connected, sends fail) and the auth-dead (disconnected) cases.
- The reconnect watchdog skips a `NeedsRepair` session (stops the 15s 401 spam; a successful re-pair clears the flag and reconnect resumes).
- Web UI: a disconnected-but-paired session with `needs_repair` shows **"Re-pair"** (→ Platforms → Pair again) instead of "Reconnect"; a plain disconnect still says "Reconnect".

## Tests

- Go: `isGoogleAuthInvalid` classification; `needs_repair` surfaces disconnected-but-paired, not when unpaired; success clears.
- e2e: disconnected+needs_repair banner says "Re-pair", plain disconnect says "Reconnect" (suite 54/54).
- `go vet ./...` clean.

Follow-up #44 (surface `PhoneNotResponding`) and #43 (native Platforms re-pair affordance) still stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)