### PR TITLE
Add compose GIF picker and drag/drop attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,22 @@ The macOS app target lives under `OpenMessage/`.
 | `OPENMESSAGES_MY_NAME` | system user name | Display name for outgoing imported iMessage/WhatsApp messages |
 | `OPENMESSAGES_STARTUP_BACKFILL` | `auto` | Startup history sync mode: `auto`, `shallow`, `deep`, or `off` |
 | `OPENMESSAGES_BACKFILL_DISCOVER_ORPHANS` | `0` | Opt in to deep backfill's Phase C (contact-based orphan discovery). **Off by default** because it creates an empty SMS thread on your phone for each contact without prior message history. Enable with `1`/`true`/`yes`/`on` only if you understand the side effect. |
+| `OPENMESSAGES_KLIPY_API_KEY` | unset | Optional Klipy API key for the web compose GIF picker. GIF search is unavailable until this is set. `KLIPY_API_KEY` is also accepted as a fallback. |
 | `OPENMESSAGES_MACOS_NOTIFICATIONS` | interactive macOS `serve` sessions only | Enable/disable native macOS notifications for fresh inbound live messages (`1`/`0`). Click-through opens the matching thread when `terminal-notifier` is available. The macOS app sets this to `0` and posts its own notifications (with tap-to-open and active-thread suppression) instead. |
 | `OPENMESSAGES_SIGNAL_TMP_SWEEP` | enabled | Set to `0` to disable the cleanup of stale signal-cli temp directories (the app-owned run dirs plus `libsignal*` dirs older than 24h that pre-v0.2.10 builds leaked into the system temp dir — see #27). |
 | `OPENMESSAGES_EXPORT_DIR` | `~/Documents/OpenMessage` | Directory for `generate_viz` / `render_story` HTML outputs and photo inputs when using the default confined export mode. |
 | `OPENMESSAGES_ALLOW_ANY_EXPORT_PATH` | unset (off) | Set to `1`/`true`/`yes`/`on` to allow viz/story tools to read photos from, or write HTML to, arbitrary local paths. |
 | `OPENMESSAGE_TELEMETRY` | unset (off) | Set to `1` to send one anonymous heartbeat per launch (max one per 24h). Reports only: random install ID, version, OS/arch, and which platforms are paired (Google Messages / WhatsApp / Signal). No message content, no contact info, no IP-based identity. See `internal/telemetry/`. |
+
+### GIF picker setup
+
+The web compose GIF picker uses Klipy search. To enable it:
+
+1. Create a Klipy API key.
+2. Start OpenMessage with `OPENMESSAGES_KLIPY_API_KEY=<your key>`.
+3. Open the web UI and use the `GIF` button in a media-capable conversation.
+
+OpenMessage does not include a bundled GIF provider key. Without `OPENMESSAGES_KLIPY_API_KEY`, GIF search endpoints return a setup error and the rest of messaging continues to work normally.
 
 ## Architecture
 

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -867,6 +867,61 @@ test('sends a captioned Signal image as one message, not two', async ({ page }) 
   }
 });
 
+test('sends a GIF through the compose picker', async ({ page }) => {
+  const caption = `GIF caption ${Date.now()}`;
+  let sendGIFPayload = null;
+  await page.route(/\/api\/gifs(?:\/trending)?\?/, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [{
+          title: 'Wave',
+          preview_url: 'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=',
+          url: 'https://media.klipy.com/fake/wave.gif',
+          mime_type: 'image/gif',
+          width: 1,
+          height: 1,
+        }],
+      }),
+    });
+  });
+  await page.route('**/api/send-gif', async route => {
+    sendGIFPayload = JSON.parse(route.request().postData() || '{}');
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'SUCCESS', success: true }),
+    });
+  });
+
+  await openConversation(page, 'Taylor Price');
+  await expect(page.locator('#chat-header-source')).toContainText('Signal');
+  await page.locator('#compose-input').fill(caption);
+  await page.locator('#compose-gif-btn').click();
+  await expect(page.locator('#compose-gif-panel.show')).toBeVisible();
+  await page.locator('#compose-gif-panel .gif-tile').first().click();
+
+  await expect.poll(() => sendGIFPayload).not.toBeNull();
+  expect(sendGIFPayload.conversation_id).toContain('signal:');
+  expect(sendGIFPayload.url).toBe('https://media.klipy.com/fake/wave.gif');
+  expect(sendGIFPayload.caption).toBe(caption);
+});
+
+test('accepts dropped files in the compose box', async ({ page }) => {
+  await openConversation(page, 'Taylor Price');
+  await page.locator('#compose-bar').evaluate((composeBar) => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(new File(['hello from drop'], 'dropped-note.txt', { type: 'text/plain' }));
+    const event = new Event('drop', { bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'dataTransfer', { value: dataTransfer });
+    composeBar.dispatchEvent(event);
+  });
+
+  await expect(page.locator('#attach-preview')).toHaveClass(/active/);
+  await expect(page.locator('#attach-name')).toHaveText('dropped-note.txt');
+});
+
 test('keeps the active thread pinned to the bottom after sending', async ({ page }) => {
   const outbound = `Bottom send ${Date.now()}`;
 

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -908,6 +908,41 @@ test('sends a GIF through the compose picker', async ({ page }) => {
   expect(sendGIFPayload.caption).toBe(caption);
 });
 
+test('debounces GIF search while typing', async ({ page }) => {
+  const gifRequests = [];
+  await page.route(/\/api\/gifs(?:\/trending)?\?/, async route => {
+    gifRequests.push(new URL(route.request().url()));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [{
+          title: 'Wave',
+          preview_url: 'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=',
+          url: 'https://media.klipy.com/fake/wave.gif',
+          mime_type: 'image/gif',
+          width: 1,
+          height: 1,
+        }],
+      }),
+    });
+  });
+
+  await openConversation(page, 'Taylor Price');
+  await page.locator('#compose-gif-btn').click();
+  await expect(page.locator('#compose-gif-panel .gif-tile')).toHaveCount(1);
+
+  gifRequests.length = 0;
+  await page.locator('#compose-gif-search').pressSequentially('cats', { delay: 60 });
+  await page.waitForTimeout(300);
+  expect(gifRequests).toHaveLength(0);
+
+  await page.waitForTimeout(350);
+  expect(gifRequests).toHaveLength(1);
+  expect(gifRequests[0].pathname).toBe('/api/gifs');
+  expect(gifRequests[0].searchParams.get('q')).toBe('cats');
+});
+
 test('accepts dropped files in the compose box', async ({ page }) => {
   await openConversation(page, 'Taylor Price');
   await page.locator('#compose-bar').evaluate((composeBar) => {

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -653,6 +653,26 @@ test('centers the compose card in the bottom input layer', async ({ page }) => {
   expect(Math.abs(gaps.top - gaps.bottom)).toBeLessThanOrEqual(2);
 });
 
+test('keeps compose tool buttons tightly grouped', async ({ page }) => {
+  await openConversation(page, 'Sarah Chen');
+
+  const gaps = await page.evaluate(() => {
+    const rectFor = (selector) => document.querySelector(selector).getBoundingClientRect();
+    const attach = rectFor('#attach-btn');
+    const gif = rectFor('#compose-gif-btn');
+    const emoji = rectFor('#compose-emoji-btn');
+    const input = rectFor('#compose-input');
+    return {
+      attachToGif: gif.left - attach.right,
+      gifToEmoji: emoji.left - gif.right,
+      emojiToInput: input.left - emoji.right,
+    };
+  });
+  expect(gaps.attachToGif).toBeLessThanOrEqual(5);
+  expect(gaps.gifToEmoji).toBeLessThanOrEqual(5);
+  expect(gaps.emojiToInput).toBeGreaterThanOrEqual(8);
+});
+
 test('hydrates cached Google contact photos into avatars', async ({ page, request }) => {
   await request.post('/_e2e/avatar', {
     data: {

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -963,6 +963,80 @@ test('debounces GIF search while typing', async ({ page }) => {
   expect(gifRequests[0].searchParams.get('q')).toBe('cats');
 });
 
+test('loads more GIFs when scrolling the picker', async ({ page }) => {
+  const gifRequests = [];
+  await page.route(/\/api\/gifs(?:\/trending)?\?/, async route => {
+    const url = new URL(route.request().url());
+    gifRequests.push(url);
+    const pageNumber = Number(url.searchParams.get('page') || '1');
+    const results = Array.from({ length: 32 }, (_, index) => ({
+      title: `Wave ${pageNumber}-${index}`,
+      preview_url: 'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=',
+      url: `https://media.klipy.com/fake/wave-${pageNumber}-${index}.gif`,
+      mime_type: 'image/gif',
+      width: 1,
+      height: 1,
+    }));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results,
+        page: pageNumber,
+        has_more: pageNumber < 2,
+      }),
+    });
+  });
+
+  await openConversation(page, 'Taylor Price');
+  await page.locator('#compose-gif-btn').click();
+  await expect(page.locator('#compose-gif-grid .gif-tile')).toHaveCount(32);
+
+  await page.locator('#compose-gif-scroll').evaluate((scroller) => {
+    scroller.scrollTop = scroller.scrollHeight;
+    scroller.dispatchEvent(new Event('scroll'));
+  });
+
+  await expect
+    .poll(() => gifRequests.some(url => url.searchParams.get('page') === '2'))
+    .toBe(true);
+  await expect(page.locator('#compose-gif-grid .gif-tile')).toHaveCount(64);
+});
+
+test('favorites GIFs in the compose picker', async ({ page }) => {
+  await page.route(/\/api\/gifs(?:\/trending)?\?/, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [{
+          title: 'Favorite Wave',
+          preview_url: 'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=',
+          url: 'https://media.klipy.com/fake/favorite-wave.gif',
+          mime_type: 'image/gif',
+          width: 1,
+          height: 1,
+        }],
+        has_more: false,
+      }),
+    });
+  });
+
+  await openConversation(page, 'Taylor Price');
+  await page.locator('#compose-gif-btn').click();
+
+  const firstTile = page.locator('#compose-gif-grid .gif-tile').first();
+  await firstTile.hover();
+  await firstTile.locator('.gif-favorite-toggle').click();
+  await expect(firstTile.locator('.gif-favorite-toggle')).toHaveAttribute('aria-pressed', 'true');
+
+  await page.locator('#compose-gif-btn').click();
+  await page.locator('#compose-gif-btn').click();
+  await expect(page.locator('#compose-gif-favorites')).toBeVisible();
+  await expect(page.locator('#compose-gif-favorites-grid .gif-tile')).toHaveCount(1);
+  await expect(page.locator('#compose-gif-favorites-grid .gif-favorite-toggle')).toHaveAttribute('aria-pressed', 'true');
+});
+
 test('accepts dropped files in the compose box', async ({ page }) => {
   await openConversation(page, 'Taylor Price');
   await page.locator('#compose-bar').evaluate((composeBar) => {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -477,14 +477,12 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		media, err := cli.GM.UploadMedia(data, filename, mimeType)
 		if err != nil {
-			markGoogleAuthExpired(err)
 			httpError(w, googleAPIErrorMessage("upload media", err), 502)
 			return
 		}
 
 		conv, err := cli.GM.GetConversation(convID)
 		if err != nil {
-			markGoogleAuthExpired(err)
 			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
 			return
 		}
@@ -501,7 +499,6 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
-			markGoogleAuthExpired(err)
 			httpError(w, googleAPIErrorMessage("send message", err), 502)
 			return
 		}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1182,6 +1182,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		limit := queryIntClamped(r, "limit", defaultGIFSearchLimit, maxGIFSearchResults)
 		results, err := searchKlipyGIFs(r.Context(), r.URL.Query().Get("q"), limit)
 		if err != nil {
+			if errors.Is(err, errGIFProviderNotConfigured) {
+				httpError(w, err.Error(), 501)
+				return
+			}
 			httpError(w, err.Error(), 502)
 			return
 		}
@@ -1199,6 +1203,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		limit := queryIntClamped(r, "limit", defaultGIFSearchLimit, maxGIFSearchResults)
 		results, err := searchKlipyGIFs(r.Context(), defaultGIFSearchQuery, limit)
 		if err != nil {
+			if errors.Is(err, errGIFProviderNotConfigured) {
+				httpError(w, err.Error(), 501)
+				return
+			}
 			httpError(w, err.Error(), 502)
 			return
 		}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -424,6 +424,130 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	if fetchLinkPreview == nil {
 		fetchLinkPreview = NewLinkPreviewService(logger).Fetch
 	}
+	sendMediaBytes := func(w http.ResponseWriter, convID string, data []byte, filename, mimeType, caption, replyToID string) {
+		if isSignalConversation(convID) {
+			msg, err := sendSignalMedia(convID, data, filename, mimeType, caption, replyToID)
+			switch {
+			case errors.Is(err, errSignalMediaUnavailable):
+				httpError(w, err.Error(), 501)
+				return
+			case errors.Is(err, errSignalLocalStore):
+				httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
+				return
+			case err != nil:
+				httpError(w, err.Error(), 502)
+				return
+			}
+			publishMessages(convID)
+			publishConversations()
+			writeJSON(w, map[string]any{
+				"message_id": msg.MessageID,
+				"status":     "SUCCESS",
+				"success":    true,
+			})
+			return
+		}
+		if isWhatsAppConversation(convID) {
+			msg, err := sendWhatsAppMedia(convID, data, filename, mimeType, caption, replyToID)
+			switch {
+			case errors.Is(err, errWhatsAppMediaUnavailable):
+				httpError(w, err.Error(), 501)
+				return
+			case errors.Is(err, errWhatsAppLocalStore):
+				httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
+				return
+			case err != nil:
+				httpError(w, err.Error(), 502)
+				return
+			}
+			publishMessages(convID)
+			publishConversations()
+			writeJSON(w, map[string]any{
+				"message_id": msg.MessageID,
+				"status":     "SUCCESS",
+				"success":    true,
+			})
+			return
+		}
+		cli := getClient()
+		if cli == nil {
+			httpError(w, app.ErrNotConnected, 503)
+			return
+		}
+
+		media, err := cli.GM.UploadMedia(data, filename, mimeType)
+		if err != nil {
+			markGoogleAuthExpired(err)
+			httpError(w, googleAPIErrorMessage("upload media", err), 502)
+			return
+		}
+
+		conv, err := cli.GM.GetConversation(convID)
+		if err != nil {
+			markGoogleAuthExpired(err)
+			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
+			return
+		}
+
+		myParticipantID, simPayload := app.ExtractSIMAndParticipant(conv)
+		payload := app.BuildSendMediaPayload(convID, media, myParticipantID, simPayload)
+
+		logger.Info().
+			Str("conv_id", convID).
+			Str("mime", mimeType).
+			Str("filename", filename).
+			Int("size", len(data)).
+			Msg("Sending media message")
+
+		resp, err := cli.GM.SendMessage(payload)
+		if err != nil {
+			markGoogleAuthExpired(err)
+			httpError(w, googleAPIErrorMessage("send message", err), 502)
+			return
+		}
+		success := resp.GetStatus() == gmproto.SendMessageResponse_SUCCESS
+		if !success {
+			now := time.Now().UnixMilli()
+			_ = recordOutgoingMessage(&db.Message{
+				MessageID:      payload.TmpID,
+				ConversationID: convID,
+				Body:           "",
+				IsFromMe:       true,
+				TimestampMS:    now,
+				Status:         "OUTGOING_FAILED:" + resp.GetStatus().String(),
+				MediaID:        media.MediaID,
+				MimeType:       media.MimeType,
+				DecryptionKey:  hex.EncodeToString(media.DecryptionKey),
+			}, "")
+			publishMessages(convID)
+			publishConversations()
+			recordGoogleSend(false)
+			httpError(w, googleSendRejectedMessage(resp.GetStatus().String()), 502)
+			return
+		}
+		recordGoogleSend(true)
+		now := time.Now().UnixMilli()
+		if err := recordOutgoingMessage(&db.Message{
+			MessageID:      payload.TmpID,
+			ConversationID: convID,
+			Body:           "",
+			IsFromMe:       true,
+			TimestampMS:    now,
+			Status:         "OUTGOING_SENDING",
+			MediaID:        media.MediaID,
+			MimeType:       media.MimeType,
+			DecryptionKey:  hex.EncodeToString(media.DecryptionKey),
+		}, ""); err != nil {
+			httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
+			return
+		}
+		publishMessages(convID)
+		publishConversations()
+		writeJSON(w, map[string]any{
+			"status":  resp.GetStatus().String(),
+			"success": success,
+		})
+	}
 
 	mux.HandleFunc("/api/events", func(w http.ResponseWriter, r *http.Request) {
 		if opts.Events == nil {
@@ -1053,6 +1177,83 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		})
 	})
 
+	mux.HandleFunc("/api/gifs", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			httpError(w, "method not allowed", 405)
+			return
+		}
+		limit := queryIntClamped(r, "limit", defaultGIFSearchLimit, maxGIFSearchResults)
+		results, err := searchKlipyGIFs(r.Context(), r.URL.Query().Get("q"), limit)
+		if err != nil {
+			httpError(w, err.Error(), 502)
+			return
+		}
+		for i := range results {
+			results[i].PreviewURL = proxyGIFPreviewURL(results[i].PreviewURL)
+		}
+		writeJSON(w, map[string]any{"results": results})
+	})
+
+	mux.HandleFunc("/api/gifs/trending", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			httpError(w, "method not allowed", 405)
+			return
+		}
+		limit := queryIntClamped(r, "limit", defaultGIFSearchLimit, maxGIFSearchResults)
+		results, err := searchKlipyGIFs(r.Context(), defaultGIFSearchQuery, limit)
+		if err != nil {
+			httpError(w, err.Error(), 502)
+			return
+		}
+		for i := range results {
+			results[i].PreviewURL = proxyGIFPreviewURL(results[i].PreviewURL)
+		}
+		writeJSON(w, map[string]any{"results": results})
+	})
+
+	mux.HandleFunc("/api/gifs/preview", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			httpError(w, "method not allowed", 405)
+			return
+		}
+		data, _, mimeType, err := downloadGIFMedia(r.Context(), r.URL.Query().Get("url"), maxGIFPreviewBytes)
+		if err != nil {
+			httpError(w, err.Error(), 400)
+			return
+		}
+		w.Header().Set("Cache-Control", "private, max-age=3600")
+		w.Header().Set("Content-Type", mimeType)
+		_, _ = w.Write(data)
+	})
+
+	mux.HandleFunc("/api/send-gif", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			httpError(w, "method not allowed", 405)
+			return
+		}
+		var req struct {
+			ConversationID string `json:"conversation_id"`
+			URL            string `json:"url"`
+			Caption        string `json:"caption"`
+			ReplyToID      string `json:"reply_to_id"`
+		}
+		if err := json.NewDecoder(io.LimitReader(r.Body, 64<<10)).Decode(&req); err != nil {
+			httpError(w, "invalid JSON: "+err.Error(), 400)
+			return
+		}
+		convID := strings.TrimSpace(req.ConversationID)
+		if convID == "" {
+			httpError(w, "conversation_id is required", 400)
+			return
+		}
+		data, filename, mimeType, err := downloadGIFMedia(r.Context(), req.URL, maxGIFSendBytes)
+		if err != nil {
+			httpError(w, err.Error(), 400)
+			return
+		}
+		sendMediaBytes(w, convID, data, filename, mimeType, strings.TrimSpace(req.Caption), strings.TrimSpace(req.ReplyToID))
+	})
+
 	mux.HandleFunc("/api/send-media", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			httpError(w, "method not allowed", 405)
@@ -1104,128 +1305,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		if mime == "" {
 			mime = "application/octet-stream"
 		}
-		if isSignalConversation(convID) {
-			msg, err := sendSignalMedia(convID, data, header.Filename, mime, caption, replyToID)
-			switch {
-			case errors.Is(err, errSignalMediaUnavailable):
-				httpError(w, err.Error(), 501)
-				return
-			case errors.Is(err, errSignalLocalStore):
-				httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
-				return
-			case err != nil:
-				httpError(w, err.Error(), 502)
-				return
-			}
-			publishMessages(convID)
-			publishConversations()
-			writeJSON(w, map[string]any{
-				"message_id": msg.MessageID,
-				"status":     "SUCCESS",
-				"success":    true,
-			})
-			return
-		}
-		if isWhatsAppConversation(convID) {
-			msg, err := sendWhatsAppMedia(convID, data, header.Filename, mime, caption, replyToID)
-			switch {
-			case errors.Is(err, errWhatsAppMediaUnavailable):
-				httpError(w, err.Error(), 501)
-				return
-			case errors.Is(err, errWhatsAppLocalStore):
-				httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
-				return
-			case err != nil:
-				httpError(w, err.Error(), 502)
-				return
-			}
-			publishMessages(convID)
-			publishConversations()
-			writeJSON(w, map[string]any{
-				"message_id": msg.MessageID,
-				"status":     "SUCCESS",
-				"success":    true,
-			})
-			return
-		}
-		cli := getClient()
-		if cli == nil {
-			httpError(w, app.ErrNotConnected, 503)
-			return
-		}
-
-		// Upload media via libgm
-		media, err := cli.GM.UploadMedia(data, header.Filename, mime)
-		if err != nil {
-			httpError(w, googleAPIErrorMessage("upload media", err), 502)
-			return
-		}
-
-		// Get SIM and participant info
-		conv, err := cli.GM.GetConversation(convID)
-		if err != nil {
-			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
-			return
-		}
-
-		myParticipantID, simPayload := app.ExtractSIMAndParticipant(conv)
-
-		payload := app.BuildSendMediaPayload(convID, media, myParticipantID, simPayload)
-
-		logger.Info().
-			Str("conv_id", convID).
-			Str("mime", mime).
-			Str("filename", header.Filename).
-			Int("size", len(data)).
-			Msg("Sending media message")
-
-		resp, err := cli.GM.SendMessage(payload)
-		if err != nil {
-			httpError(w, googleAPIErrorMessage("send message", err), 502)
-			return
-		}
-		success := resp.GetStatus() == gmproto.SendMessageResponse_SUCCESS
-		if !success {
-			now := time.Now().UnixMilli()
-			_ = recordOutgoingMessage(&db.Message{
-				MessageID:      payload.TmpID,
-				ConversationID: convID,
-				Body:           "",
-				IsFromMe:       true,
-				TimestampMS:    now,
-				Status:         "OUTGOING_FAILED:" + resp.GetStatus().String(),
-				MediaID:        media.MediaID,
-				MimeType:       media.MimeType,
-				DecryptionKey:  hex.EncodeToString(media.DecryptionKey),
-			}, "")
-			publishMessages(convID)
-			publishConversations()
-			recordGoogleSend(false)
-			httpError(w, googleSendRejectedMessage(resp.GetStatus().String()), 502)
-			return
-		}
-		recordGoogleSend(true)
-		now := time.Now().UnixMilli()
-		if err := recordOutgoingMessage(&db.Message{
-			MessageID:      payload.TmpID,
-			ConversationID: convID,
-			Body:           "",
-			IsFromMe:       true,
-			TimestampMS:    now,
-			Status:         "OUTGOING_SENDING",
-			MediaID:        media.MediaID,
-			MimeType:       media.MimeType,
-			DecryptionKey:  hex.EncodeToString(media.DecryptionKey),
-		}, ""); err != nil {
-			httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
-			return
-		}
-		publishMessages(convID)
-		publishConversations()
-		writeJSON(w, map[string]any{
-			"status":  resp.GetStatus().String(),
-			"success": success,
-		})
+		sendMediaBytes(w, convID, data, header.Filename, mime, caption, replyToID)
 	})
 
 	mux.HandleFunc("/api/media/", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1180,7 +1180,8 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return
 		}
 		limit := queryIntClamped(r, "limit", defaultGIFSearchLimit, maxGIFSearchResults)
-		results, err := searchKlipyGIFs(r.Context(), r.URL.Query().Get("q"), limit)
+		page := queryIntClamped(r, "page", 1, 1000)
+		results, err := searchKlipyGIFs(r.Context(), r.URL.Query().Get("q"), limit, page)
 		if err != nil {
 			if errors.Is(err, errGIFProviderNotConfigured) {
 				httpError(w, err.Error(), 501)
@@ -1192,7 +1193,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		for i := range results {
 			results[i].PreviewURL = proxyGIFPreviewURL(results[i].PreviewURL)
 		}
-		writeJSON(w, map[string]any{"results": results})
+		writeJSON(w, map[string]any{
+			"results":  results,
+			"page":     page,
+			"has_more": len(results) >= limit,
+		})
 	})
 
 	mux.HandleFunc("/api/gifs/trending", func(w http.ResponseWriter, r *http.Request) {
@@ -1201,7 +1206,8 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return
 		}
 		limit := queryIntClamped(r, "limit", defaultGIFSearchLimit, maxGIFSearchResults)
-		results, err := searchKlipyGIFs(r.Context(), defaultGIFSearchQuery, limit)
+		page := queryIntClamped(r, "page", 1, 1000)
+		results, err := searchKlipyGIFs(r.Context(), defaultGIFSearchQuery, limit, page)
 		if err != nil {
 			if errors.Is(err, errGIFProviderNotConfigured) {
 				httpError(w, err.Error(), 501)
@@ -1213,7 +1219,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		for i := range results {
 			results[i].PreviewURL = proxyGIFPreviewURL(results[i].PreviewURL)
 		}
-		writeJSON(w, map[string]any{"results": results})
+		writeJSON(w, map[string]any{
+			"results":  results,
+			"page":     page,
+			"has_more": len(results) >= limit,
+		})
 	})
 
 	mux.HandleFunc("/api/gifs/preview", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/gifs.go
+++ b/internal/web/gifs.go
@@ -1,0 +1,288 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"time"
+)
+
+const (
+	defaultKlipyAPIKey            = "AtywYPdjAHtT9HcbzaIi3JR3xxwGFwIiufVXOxjtP9ObHxTdY6uRXqxHcayVSsKm"
+	defaultGIFSearchQuery         = "popular"
+	maxGIFSearchResults           = 48
+	defaultGIFSearchLimit         = 24
+	klipyPreferredSizeLimit       = 3_000_000
+	maxGIFPreviewBytes      int64 = 8 << 20
+	maxGIFSendBytes         int64 = 24 << 20
+)
+
+var (
+	klipySearchEndpoint = "https://api.klipy.com/v2/search"
+	gifHTTPClient       = &http.Client{Timeout: 15 * time.Second}
+)
+
+type gifSearchResult struct {
+	ID         string `json:"id,omitempty"`
+	Title      string `json:"title,omitempty"`
+	PreviewURL string `json:"preview_url"`
+	URL        string `json:"url"`
+	Width      int    `json:"width,omitempty"`
+	Height     int    `json:"height,omitempty"`
+	MimeType   string `json:"mime_type"`
+}
+
+type klipySearchResponse struct {
+	Results []klipyResult `json:"results"`
+}
+
+type klipyResult struct {
+	ID           string                      `json:"id"`
+	Title        string                      `json:"title"`
+	Content      string                      `json:"content_description"`
+	MediaFormats map[string]klipyMediaFormat `json:"media_formats"`
+}
+
+type klipyMediaFormat struct {
+	URL  string `json:"url"`
+	Size int64  `json:"size"`
+	Dims []int  `json:"dims"`
+}
+
+func searchKlipyGIFs(ctx context.Context, query string, limit int) ([]gifSearchResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		query = defaultGIFSearchQuery
+	}
+	if limit <= 0 {
+		limit = defaultGIFSearchLimit
+	}
+	if limit > maxGIFSearchResults {
+		limit = maxGIFSearchResults
+	}
+
+	endpoint, err := url.Parse(klipySearchEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("parse GIF endpoint: %w", err)
+	}
+	params := endpoint.Query()
+	params.Set("q", query)
+	params.Set("key", klipyAPIKey())
+	endpoint.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := gifHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search GIFs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("search GIFs: provider returned %d", resp.StatusCode)
+	}
+
+	var payload klipySearchResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode GIF search: %w", err)
+	}
+
+	results := make([]gifSearchResult, 0, min(limit, len(payload.Results)))
+	for _, item := range payload.Results {
+		result, ok := parseKlipyGIFResult(item)
+		if !ok {
+			continue
+		}
+		results = append(results, result)
+		if len(results) >= limit {
+			break
+		}
+	}
+	return results, nil
+}
+
+func parseKlipyGIFResult(item klipyResult) (gifSearchResult, bool) {
+	formats := item.MediaFormats
+	if len(formats) == 0 {
+		return gifSearchResult{}, false
+	}
+
+	preview, ok := firstKlipyFormat(formats, "tinygif", "nanogif", "mediumgif", "gif", "webp")
+	if !ok || strings.TrimSpace(preview.URL) == "" {
+		return gifSearchResult{}, false
+	}
+
+	full, ok := formats["gif"]
+	mimeType := "image/gif"
+	if !ok || strings.TrimSpace(full.URL) == "" {
+		full, ok = firstKlipyFormat(formats, "mediumgif", "webp", "tinygif", "nanogif")
+		if !ok || strings.TrimSpace(full.URL) == "" {
+			return gifSearchResult{}, false
+		}
+		if strings.Contains(strings.ToLower(full.URL), ".webp") {
+			mimeType = "image/webp"
+		}
+	}
+
+	if medium, ok := formats["mediumgif"]; ok && strings.TrimSpace(medium.URL) != "" && full.Size > klipyPreferredSizeLimit {
+		full = medium
+		mimeType = "image/gif"
+	}
+	if webp, ok := formats["webp"]; ok && strings.TrimSpace(webp.URL) != "" && (full.Size == 0 || webp.Size == 0 || webp.Size < full.Size) {
+		full = webp
+		mimeType = "image/webp"
+	}
+
+	width, height := klipyDimensions(full)
+	if width == 0 || height == 0 {
+		width, height = klipyDimensions(preview)
+	}
+
+	title := strings.TrimSpace(item.Title)
+	if title == "" {
+		title = strings.TrimSpace(item.Content)
+	}
+
+	return gifSearchResult{
+		ID:         strings.TrimSpace(item.ID),
+		Title:      title,
+		PreviewURL: strings.TrimSpace(preview.URL),
+		URL:        strings.TrimSpace(full.URL),
+		Width:      width,
+		Height:     height,
+		MimeType:   mimeType,
+	}, true
+}
+
+func firstKlipyFormat(formats map[string]klipyMediaFormat, names ...string) (klipyMediaFormat, bool) {
+	for _, name := range names {
+		format, ok := formats[name]
+		if ok && strings.TrimSpace(format.URL) != "" {
+			return format, true
+		}
+	}
+	return klipyMediaFormat{}, false
+}
+
+func klipyDimensions(format klipyMediaFormat) (int, int) {
+	if len(format.Dims) < 2 || format.Dims[0] <= 0 || format.Dims[1] <= 0 {
+		return 0, 0
+	}
+	return format.Dims[0], format.Dims[1]
+}
+
+func klipyAPIKey() string {
+	if key := strings.TrimSpace(os.Getenv("KLIPY_API_KEY")); key != "" {
+		return key
+	}
+	return defaultKlipyAPIKey
+}
+
+func proxyGIFPreviewURL(rawURL string) string {
+	return "/api/gifs/preview?url=" + url.QueryEscape(rawURL)
+}
+
+func downloadGIFMedia(ctx context.Context, rawURL string, limit int64) ([]byte, string, string, error) {
+	parsed, err := validateKlipyMediaURL(rawURL)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return nil, "", "", err
+	}
+	resp, err := gifHTTPClient.Do(req)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("download GIF: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", "", fmt.Errorf("download GIF: provider returned %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, "", "", fmt.Errorf("read GIF: %w", err)
+	}
+	if int64(len(data)) > limit {
+		return nil, "", "", fmt.Errorf("GIF too large (limit %d MB)", limit>>20)
+	}
+
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if idx := strings.Index(contentType, ";"); idx >= 0 {
+		contentType = strings.TrimSpace(contentType[:idx])
+	}
+	if contentType == "" || contentType == "application/octet-stream" {
+		contentType = mime.TypeByExtension(path.Ext(parsed.Path))
+	}
+	if contentType == "" {
+		contentType = "image/gif"
+	}
+	if !strings.HasPrefix(strings.ToLower(contentType), "image/") {
+		return nil, "", "", errors.New("GIF provider returned non-image content")
+	}
+
+	filename := gifFilename(parsed, contentType)
+	return data, filename, contentType, nil
+}
+
+func validateKlipyMediaURL(rawURL string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return nil, fmt.Errorf("invalid GIF URL: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return nil, errors.New("GIF URL must use HTTPS")
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host != "klipy.com" && !strings.HasSuffix(host, ".klipy.com") {
+		return nil, errors.New("GIF URL host is not allowed")
+	}
+	return parsed, nil
+}
+
+func gifFilename(parsed *url.URL, mimeType string) string {
+	name := strings.TrimSpace(path.Base(parsed.Path))
+	if name == "." || name == "/" || name == "" {
+		name = "openmessage-gif"
+	}
+	if ext := path.Ext(name); ext == "" {
+		switch strings.ToLower(mimeType) {
+		case "image/webp":
+			name += ".webp"
+		case "image/png":
+			name += ".png"
+		case "image/jpeg":
+			name += ".jpg"
+		default:
+			name += ".gif"
+		}
+	}
+	if decoded, err := url.PathUnescape(name); err == nil && strings.TrimSpace(decoded) != "" {
+		name = decoded
+	}
+	name = strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\', 0:
+			return -1
+		default:
+			return r
+		}
+	}, name)
+	if name == "" {
+		return "openmessage-gif.gif"
+	}
+	return name
+}

--- a/internal/web/gifs.go
+++ b/internal/web/gifs.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -57,7 +58,7 @@ type klipyMediaFormat struct {
 	Dims []int  `json:"dims"`
 }
 
-func searchKlipyGIFs(ctx context.Context, query string, limit int) ([]gifSearchResult, error) {
+func searchKlipyGIFs(ctx context.Context, query string, limit, page int) ([]gifSearchResult, error) {
 	query = strings.TrimSpace(query)
 	if query == "" {
 		query = defaultGIFSearchQuery
@@ -67,6 +68,9 @@ func searchKlipyGIFs(ctx context.Context, query string, limit int) ([]gifSearchR
 	}
 	if limit > maxGIFSearchResults {
 		limit = maxGIFSearchResults
+	}
+	if page <= 0 {
+		page = 1
 	}
 	apiKey := klipyAPIKey()
 	if apiKey == "" {
@@ -80,6 +84,8 @@ func searchKlipyGIFs(ctx context.Context, query string, limit int) ([]gifSearchR
 	params := endpoint.Query()
 	params.Set("q", query)
 	params.Set("key", apiKey)
+	params.Set("page", strconv.Itoa(page))
+	params.Set("per_page", strconv.Itoa(limit))
 	endpoint.RawQuery = params.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)

--- a/internal/web/gifs.go
+++ b/internal/web/gifs.go
@@ -25,8 +25,9 @@ const (
 )
 
 var (
-	klipySearchEndpoint = "https://api.klipy.com/v2/search"
-	gifHTTPClient       = &http.Client{Timeout: 15 * time.Second}
+	errGIFProviderNotConfigured = errors.New("GIF search is not configured; set OPENMESSAGES_KLIPY_API_KEY")
+	klipySearchEndpoint         = "https://api.klipy.com/v2/search"
+	gifHTTPClient               = &http.Client{Timeout: 15 * time.Second}
 )
 
 type gifSearchResult struct {
@@ -69,7 +70,7 @@ func searchKlipyGIFs(ctx context.Context, query string, limit int) ([]gifSearchR
 	}
 	apiKey := klipyAPIKey()
 	if apiKey == "" {
-		return nil, errors.New("GIF search is not configured; set OPENMESSAGES_KLIPY_API_KEY")
+		return nil, errGIFProviderNotConfigured
 	}
 
 	endpoint, err := url.Parse(klipySearchEndpoint)

--- a/internal/web/gifs.go
+++ b/internal/web/gifs.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	defaultKlipyAPIKey            = "AtywYPdjAHtT9HcbzaIi3JR3xxwGFwIiufVXOxjtP9ObHxTdY6uRXqxHcayVSsKm"
 	defaultGIFSearchQuery         = "popular"
 	maxGIFSearchResults           = 48
 	defaultGIFSearchLimit         = 24
@@ -68,6 +67,10 @@ func searchKlipyGIFs(ctx context.Context, query string, limit int) ([]gifSearchR
 	if limit > maxGIFSearchResults {
 		limit = maxGIFSearchResults
 	}
+	apiKey := klipyAPIKey()
+	if apiKey == "" {
+		return nil, errors.New("GIF search is not configured; set OPENMESSAGES_KLIPY_API_KEY")
+	}
 
 	endpoint, err := url.Parse(klipySearchEndpoint)
 	if err != nil {
@@ -75,7 +78,7 @@ func searchKlipyGIFs(ctx context.Context, query string, limit int) ([]gifSearchR
 	}
 	params := endpoint.Query()
 	params.Set("q", query)
-	params.Set("key", klipyAPIKey())
+	params.Set("key", apiKey)
 	endpoint.RawQuery = params.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
@@ -182,10 +185,13 @@ func klipyDimensions(format klipyMediaFormat) (int, int) {
 }
 
 func klipyAPIKey() string {
+	if key := strings.TrimSpace(os.Getenv("OPENMESSAGES_KLIPY_API_KEY")); key != "" {
+		return key
+	}
 	if key := strings.TrimSpace(os.Getenv("KLIPY_API_KEY")); key != "" {
 		return key
 	}
-	return defaultKlipyAPIKey
+	return ""
 }
 
 func proxyGIFPreviewURL(rawURL string) string {

--- a/internal/web/gifs_test.go
+++ b/internal/web/gifs_test.go
@@ -27,6 +27,12 @@ func TestGIFSearchEndpointReturnsProxiedKlipyResults(t *testing.T) {
 		if got := r.URL.Query().Get("key"); got != "test-klipy-key" {
 			t.Fatalf("provider API key = %q, want test-klipy-key", got)
 		}
+		if got := r.URL.Query().Get("page"); got != "2" {
+			t.Fatalf("provider page = %q, want 2", got)
+		}
+		if got := r.URL.Query().Get("per_page"); got != "5" {
+			t.Fatalf("provider per_page = %q, want 5", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"results": [{
@@ -53,7 +59,7 @@ func TestGIFSearchEndpointReturnsProxiedKlipyResults(t *testing.T) {
 	})
 
 	ts := newTestServer(t)
-	resp, err := http.Get(ts.server.URL + "/api/gifs?q=thumbs%20up&limit=5")
+	resp, err := http.Get(ts.server.URL + "/api/gifs?q=thumbs%20up&limit=5&page=2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,12 +71,20 @@ func TestGIFSearchEndpointReturnsProxiedKlipyResults(t *testing.T) {
 
 	var payload struct {
 		Results []gifSearchResult `json:"results"`
+		Page    int               `json:"page"`
+		HasMore bool              `json:"has_more"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatal(err)
 	}
 	if len(payload.Results) != 1 {
 		t.Fatalf("got %d results, want 1", len(payload.Results))
+	}
+	if payload.Page != 2 {
+		t.Fatalf("page = %d, want 2", payload.Page)
+	}
+	if payload.HasMore {
+		t.Fatal("has_more should be false when fewer results than limit are returned")
 	}
 	result := payload.Results[0]
 	if result.URL != "https://media.klipy.com/full.webp" {

--- a/internal/web/gifs_test.go
+++ b/internal/web/gifs_test.go
@@ -88,12 +88,22 @@ func TestGIFSearchEndpointRequiresKlipyAPIKey(t *testing.T) {
 	t.Setenv("OPENMESSAGES_KLIPY_API_KEY", "")
 	t.Setenv("KLIPY_API_KEY", "")
 
-	results, err := searchKlipyGIFs(context.Background(), "thumbs up", 5)
-	if err == nil {
-		t.Fatalf("expected missing API key error, got results: %#v", results)
+	ts := newTestServer(t)
+	resp, err := http.Get(ts.server.URL + "/api/gifs?q=thumbs%20up&limit=5")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "OPENMESSAGES_KLIPY_API_KEY") {
-		t.Fatalf("error = %q, want setup hint", err.Error())
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotImplemented {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 501: %s", resp.StatusCode, string(raw))
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "OPENMESSAGES_KLIPY_API_KEY") {
+		t.Fatalf("body = %q, want setup hint", string(raw))
 	}
 }
 

--- a/internal/web/gifs_test.go
+++ b/internal/web/gifs_test.go
@@ -1,0 +1,173 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestGIFSearchEndpointReturnsProxiedKlipyResults(t *testing.T) {
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("q"); got != "thumbs up" {
+			t.Fatalf("query = %q, want thumbs up", got)
+		}
+		if got := r.URL.Query().Get("key"); got == "" {
+			t.Fatal("provider request missing API key")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"results": [{
+				"id": "gif-1",
+				"title": "Thumbs up",
+				"media_formats": {
+					"tinygif": {"url": "https://media.klipy.com/preview.gif", "size": 12000, "dims": [120, 90]},
+					"gif": {"url": "https://media.klipy.com/full.gif", "size": 4000000, "dims": [640, 480]},
+					"mediumgif": {"url": "https://media.klipy.com/medium.gif", "size": 2200000, "dims": [320, 240]},
+					"webp": {"url": "https://media.klipy.com/full.webp", "size": 900000, "dims": [640, 480]}
+				}
+			}]
+		}`))
+	}))
+	defer provider.Close()
+
+	oldEndpoint := klipySearchEndpoint
+	oldClient := gifHTTPClient
+	klipySearchEndpoint = provider.URL
+	gifHTTPClient = provider.Client()
+	t.Cleanup(func() {
+		klipySearchEndpoint = oldEndpoint
+		gifHTTPClient = oldClient
+	})
+
+	ts := newTestServer(t)
+	resp, err := http.Get(ts.server.URL + "/api/gifs?q=thumbs%20up&limit=5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, string(raw))
+	}
+
+	var payload struct {
+		Results []gifSearchResult `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Results) != 1 {
+		t.Fatalf("got %d results, want 1", len(payload.Results))
+	}
+	result := payload.Results[0]
+	if result.URL != "https://media.klipy.com/full.webp" {
+		t.Fatalf("selected URL = %q, want smaller webp", result.URL)
+	}
+	if result.MimeType != "image/webp" {
+		t.Fatalf("mime = %q, want image/webp", result.MimeType)
+	}
+	if !strings.HasPrefix(result.PreviewURL, "/api/gifs/preview?url=") {
+		t.Fatalf("preview URL = %q, want local proxy path", result.PreviewURL)
+	}
+}
+
+func TestDownloadGIFMediaRejectsNonKlipyURL(t *testing.T) {
+	if _, _, _, err := downloadGIFMedia(context.Background(), "https://example.com/not-allowed.gif", maxGIFSendBytes); err == nil {
+		t.Fatal("expected non-Klipy GIF URL to be rejected")
+	}
+}
+
+func TestSendGIFUsesSignalMediaSender(t *testing.T) {
+	oldClient := gifHTTPClient
+	gifHTTPClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() != "https://media.klipy.com/fake/openmessage.gif" {
+			t.Fatalf("download URL = %s", r.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"image/gif"}},
+			Body:       io.NopCloser(strings.NewReader("GIF89a")),
+			Request:    r,
+		}, nil
+	})}
+	t.Cleanup(func() {
+		gifHTTPClient = oldClient
+	})
+
+	var gotConversationID, gotFilename, gotMIME, gotCaption, gotReplyToID string
+	var gotData []byte
+	ts := newTestServerWithOptions(t, APIOptions{
+		SendSignalMedia: func(conversationID string, data []byte, filename, mime, caption, replyToID string) (*db.Message, error) {
+			gotConversationID = conversationID
+			gotFilename = filename
+			gotMIME = mime
+			gotCaption = caption
+			gotReplyToID = replyToID
+			gotData = append([]byte(nil), data...)
+			return &db.Message{
+				MessageID:      "signal:local:gif-1",
+				ConversationID: conversationID,
+				Body:           caption,
+				IsFromMe:       true,
+				TimestampMS:    1234,
+				Status:         "sent",
+				MediaID:        "signallocal:gif",
+				MimeType:       mime,
+				ReplyToID:      replyToID,
+				SourcePlatform: "signal",
+			}, nil
+		},
+	})
+	if err := ts.store.UpsertConversation(&db.Conversation{
+		ConversationID: "signal:+15551234567",
+		Name:           "Taylor Price",
+		SourcePlatform: "signal",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Post(ts.server.URL+"/api/send-gif", "application/json", strings.NewReader(`{
+		"conversation_id": "signal:+15551234567",
+		"url": "https://media.klipy.com/fake/openmessage.gif",
+		"caption": "gif caption",
+		"reply_to_id": "signal:reply-1"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, string(raw))
+	}
+	if gotConversationID != "signal:+15551234567" {
+		t.Fatalf("conversation_id = %q", gotConversationID)
+	}
+	if gotFilename != "openmessage.gif" {
+		t.Fatalf("filename = %q, want openmessage.gif", gotFilename)
+	}
+	if gotMIME != "image/gif" {
+		t.Fatalf("mime = %q, want image/gif", gotMIME)
+	}
+	if gotCaption != "gif caption" {
+		t.Fatalf("caption = %q, want gif caption", gotCaption)
+	}
+	if gotReplyToID != "signal:reply-1" {
+		t.Fatalf("reply_to_id = %q, want signal:reply-1", gotReplyToID)
+	}
+	if string(gotData) != "GIF89a" {
+		t.Fatalf("data = %q, want GIF89a", string(gotData))
+	}
+}

--- a/internal/web/gifs_test.go
+++ b/internal/web/gifs_test.go
@@ -19,12 +19,13 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 func TestGIFSearchEndpointReturnsProxiedKlipyResults(t *testing.T) {
+	t.Setenv("OPENMESSAGES_KLIPY_API_KEY", "test-klipy-key")
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("q"); got != "thumbs up" {
 			t.Fatalf("query = %q, want thumbs up", got)
 		}
-		if got := r.URL.Query().Get("key"); got == "" {
-			t.Fatal("provider request missing API key")
+		if got := r.URL.Query().Get("key"); got != "test-klipy-key" {
+			t.Fatalf("provider API key = %q, want test-klipy-key", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -80,6 +81,19 @@ func TestGIFSearchEndpointReturnsProxiedKlipyResults(t *testing.T) {
 	}
 	if !strings.HasPrefix(result.PreviewURL, "/api/gifs/preview?url=") {
 		t.Fatalf("preview URL = %q, want local proxy path", result.PreviewURL)
+	}
+}
+
+func TestGIFSearchEndpointRequiresKlipyAPIKey(t *testing.T) {
+	t.Setenv("OPENMESSAGES_KLIPY_API_KEY", "")
+	t.Setenv("KLIPY_API_KEY", "")
+
+	results, err := searchKlipyGIFs(context.Background(), "thumbs up", 5)
+	if err == nil {
+		t.Fatalf("expected missing API key error, got results: %#v", results)
+	}
+	if !strings.Contains(err.Error(), "OPENMESSAGES_KLIPY_API_KEY") {
+		t.Fatalf("error = %q, want setup hint", err.Error())
 	}
 }
 

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -5175,7 +5175,7 @@ body::after {
     </div>
     <div class="compose-bar" id="compose-bar" style="display:none">
       <div class="compose-row">
-        <input type="file" id="file-input" style="display:none">
+        <input type="file" id="file-input" accept="image/*,video/*,audio/*" style="display:none">
         <button class="attach-btn" id="attach-btn" title="Attach media" aria-label="Attach media">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
         </button>
@@ -9917,7 +9917,7 @@ body::after {
 	    } catch (err) {
 	      if (requestID !== gifSearchRequestID) return;
 	      status.hidden = false;
-	      status.textContent = 'GIF search failed.';
+	      status.textContent = userFacingErrorMessage(err) || 'GIF search failed.';
 	      throw err;
 	    }
 	  }

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -4463,6 +4463,11 @@ body::after {
   color: var(--text-secondary);
 }
 
+.attach-btn + .gif-compose-btn,
+.gif-compose-btn + .emoji-compose-btn {
+  margin-left: -6px;
+}
+
 .attach-btn:hover,
 .gif-compose-btn:hover,
 .emoji-compose-btn:hover {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -4518,8 +4518,8 @@ body::after {
   bottom: calc(100% + 8px);
   z-index: 72;
   display: none;
-  width: min(560px, calc(100vw - 96px));
-  max-height: min(430px, calc(100vh - 260px));
+  width: min(720px, calc(100vw - 96px));
+  max-height: min(520px, calc(100vh - 220px));
   overflow: hidden;
   flex-direction: column;
   border: 1px solid var(--border);
@@ -4533,7 +4533,8 @@ body::after {
 }
 
 .gif-search {
-  padding: 12px;
+  flex: 0 0 auto;
+  padding: 12px 14px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -4553,23 +4554,75 @@ body::after {
   border-color: var(--border-accent);
 }
 
+.gif-results-scroll {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 14px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.55) transparent;
+}
+
+.gif-results-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.gif-results-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.gif-results-scroll::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.58);
+  background-clip: padding-box;
+}
+
+.gif-results-scroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(203, 213, 225, 0.72);
+  background-clip: padding-box;
+}
+
+.gif-favorites {
+  margin-bottom: 14px;
+}
+
+.gif-favorites[hidden] {
+  display: none;
+}
+
+.gif-section-label {
+  margin: 0 0 8px;
+  color: var(--text-muted);
+  font: 700 10px/1 var(--font-mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.gif-favorites-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(136px, 1fr));
+  gap: 12px;
+}
+
 .gif-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
-  gap: 8px;
-  overflow-y: auto;
-  padding: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(136px, 1fr));
+  gap: 12px;
+  overflow: visible;
+  padding: 0;
 }
 
 .gif-tile {
+  position: relative;
   min-width: 0;
-  aspect-ratio: 1.1;
+  aspect-ratio: 1.08;
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 12px;
   background: var(--bg-surface);
   cursor: pointer;
   padding: 0;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.14);
 }
 
 .gif-tile:hover,
@@ -4585,10 +4638,55 @@ body::after {
   object-fit: cover;
 }
 
+.gif-favorite-toggle {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.68);
+  color: rgba(226, 232, 240, 0.92);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease, transform 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.gif-tile:hover .gif-favorite-toggle,
+.gif-tile:focus-within .gif-favorite-toggle,
+.gif-favorite-toggle.active {
+  opacity: 1;
+}
+
+.gif-favorite-toggle:hover,
+.gif-favorite-toggle:focus-visible,
+.gif-favorite-toggle.active {
+  background: rgba(15, 23, 42, 0.84);
+  color: #f59e0b;
+  outline: none;
+  transform: scale(1.04);
+}
+
+.gif-favorite-toggle svg {
+  width: 15px;
+  height: 15px;
+}
+
 .gif-status {
   padding: 18px 12px;
   color: var(--text-muted);
   font-size: 13px;
+  text-align: center;
+}
+
+.gif-load-status {
+  padding: 12px 0 2px;
+  color: var(--text-muted);
+  font-size: 12px;
   text-align: center;
 }
 
@@ -9834,9 +9932,91 @@ body::after {
 	  }
 
 	  const GIF_SEARCH_DEBOUNCE_MS = 500;
+	  const GIF_PAGE_SIZE = 32;
+	  const GIF_FAVORITES_STORAGE_KEY = 'openmessage.gifFavorites.v1';
+	  const GIF_FAVORITES_LIMIT = 72;
 	  let gifSearchTimeout = null;
 	  let gifSearchRequestID = 0;
 	  let gifSending = false;
+	  let gifLoading = false;
+	  let gifQuery = '';
+	  let gifPage = 0;
+	  let gifHasMore = true;
+	  let gifResults = [];
+	  let gifFavorites = loadGifFavorites();
+
+	  function normalizeGifResult(result) {
+	    if (!result || !result.url || !result.preview_url) return null;
+	    return {
+	      id: String(result.id || ''),
+	      title: String(result.title || 'GIF'),
+	      preview_url: String(result.preview_url || ''),
+	      url: String(result.url || ''),
+	      mime_type: String(result.mime_type || 'image/gif'),
+	      width: Number(result.width || 0),
+	      height: Number(result.height || 0),
+	    };
+	  }
+
+	  function gifKey(result) {
+	    return String(result && result.url || '').trim();
+	  }
+
+	  function loadGifFavorites() {
+	    try {
+	      const raw = window.localStorage ? window.localStorage.getItem(GIF_FAVORITES_STORAGE_KEY) : '';
+	      const parsed = raw ? JSON.parse(raw) : [];
+	      if (!Array.isArray(parsed)) return [];
+	      return parsed.map(normalizeGifResult).filter(Boolean).slice(0, GIF_FAVORITES_LIMIT);
+	    } catch {
+	      return [];
+	    }
+	  }
+
+	  function saveGifFavorites() {
+	    try {
+	      if (window.localStorage) {
+	        window.localStorage.setItem(GIF_FAVORITES_STORAGE_KEY, JSON.stringify(gifFavorites.slice(0, GIF_FAVORITES_LIMIT)));
+	      }
+	    } catch {}
+	  }
+
+	  function isFavoriteGif(result) {
+	    const key = gifKey(result);
+	    return !!key && gifFavorites.some(item => gifKey(item) === key);
+	  }
+
+	  function gifFavoriteIconHTML(active) {
+	    return `<svg viewBox="0 0 24 24" fill="${active ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>`;
+	  }
+
+	  function updateGifFavoriteButtons(root = $composeGifPanel) {
+	    if (!root) return;
+	    root.querySelectorAll('.gif-favorite-toggle').forEach(btn => {
+	      const active = gifFavorites.some(item => gifKey(item) === btn.dataset.gifUrl);
+	      btn.classList.toggle('active', active);
+	      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+	      btn.title = active ? 'Remove from favorite GIFs' : 'Add to favorite GIFs';
+	      btn.setAttribute('aria-label', btn.title);
+	      btn.innerHTML = gifFavoriteIconHTML(active);
+	    });
+	  }
+
+	  function toggleGifFavorite(result) {
+	    const normalized = normalizeGifResult(result);
+	    if (!normalized) return;
+	    const key = gifKey(normalized);
+	    const existing = gifFavorites.findIndex(item => gifKey(item) === key);
+	    if (existing >= 0) {
+	      gifFavorites.splice(existing, 1);
+	    } else {
+	      gifFavorites.unshift(normalized);
+	      gifFavorites = gifFavorites.slice(0, GIF_FAVORITES_LIMIT);
+	    }
+	    saveGifFavorites();
+	    renderGifFavorites();
+	    updateGifFavoriteButtons();
+	  }
 
 	  function buildComposeGifPanel() {
 	    if (!$composeGifPanel || $composeGifPanel.dataset.hydrated === 'true') return;
@@ -9844,14 +10024,26 @@ body::after {
 	      <div class="gif-search">
 	        <input type="text" id="compose-gif-search" placeholder="Search GIFs..." aria-label="Search GIFs" autocomplete="off">
 	      </div>
-	      <div class="gif-status" id="compose-gif-status"></div>
-	      <div class="gif-grid" id="compose-gif-grid" aria-live="polite"></div>
+	      <div class="gif-results-scroll" id="compose-gif-scroll">
+	        <div class="gif-favorites" id="compose-gif-favorites" hidden>
+	          <div class="gif-section-label">Favorites</div>
+	          <div class="gif-favorites-grid" id="compose-gif-favorites-grid"></div>
+	        </div>
+	        <div class="gif-status" id="compose-gif-status"></div>
+	        <div class="gif-grid" id="compose-gif-grid" aria-live="polite"></div>
+	        <div class="gif-load-status" id="compose-gif-load-status" hidden></div>
+	      </div>
 	    `;
 	    $composeGifPanel.dataset.hydrated = 'true';
 	    const search = document.getElementById('compose-gif-search');
 	    if (search) {
 	      search.addEventListener('input', () => scheduleComposeGifSearch(search.value));
 	    }
+	    const scroller = document.getElementById('compose-gif-scroll');
+	    if (scroller) {
+	      scroller.addEventListener('scroll', maybeLoadMoreComposeGifs);
+	    }
+	    renderGifFavorites();
 	  }
 
 	  function scheduleComposeGifSearch(query) {
@@ -9886,6 +10078,7 @@ body::after {
 	    $composeGifPanel.classList.toggle('show', willOpen);
 	    $composeGifBtn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
 	    if (willOpen) {
+	      renderGifFavorites();
 	      const input = document.getElementById('compose-gif-search');
 	      if (input) input.focus();
 	      if ($composeGifPanel.dataset.loaded !== 'true') {
@@ -9894,66 +10087,166 @@ body::after {
 	    }
 	  }
 
-	  async function loadComposeGifs(query) {
-	    if (!$composeGifPanel) return;
-	    const requestID = ++gifSearchRequestID;
+	  function maybeLoadMoreComposeGifs() {
+	    const scroller = document.getElementById('compose-gif-scroll');
+	    if (!scroller || gifLoading || !gifHasMore) return;
+	    const remaining = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+	    if (remaining <= 160) {
+	      loadComposeGifs(gifQuery, {append: true}).catch(err => console.error('GIF search failed:', err));
+	    }
+	  }
+
+	  async function loadComposeGifs(query, options = {}) {
+	    if (!$composeGifPanel || gifLoading) return;
+	    const append = !!options.append;
 	    const trimmed = String(query || '').trim();
+	    if (append && (!gifHasMore || trimmed !== gifQuery)) return;
+
+	    const requestID = ++gifSearchRequestID;
+	    const page = append ? gifPage + 1 : 1;
 	    const status = document.getElementById('compose-gif-status');
 	    const grid = document.getElementById('compose-gif-grid');
+	    const loadStatus = document.getElementById('compose-gif-load-status');
 	    if (!status || !grid) return;
-	    status.hidden = false;
-	    status.textContent = 'Loading GIFs...';
-	    grid.innerHTML = '';
+
+	    gifLoading = true;
+	    if (!append) {
+	      gifQuery = trimmed;
+	      gifPage = 0;
+	      gifHasMore = true;
+	      gifResults = [];
+	      grid.innerHTML = '';
+	      status.hidden = false;
+	      status.textContent = 'Loading GIFs...';
+	      const scroller = document.getElementById('compose-gif-scroll');
+	      if (scroller) scroller.scrollTop = 0;
+	    } else if (loadStatus) {
+	      loadStatus.hidden = false;
+	      loadStatus.textContent = 'Loading more GIFs...';
+	    }
 
 	    const endpoint = trimmed
-	      ? `/api/gifs?q=${encodeURIComponent(trimmed)}&limit=32`
-	      : '/api/gifs/trending?limit=32';
+	      ? `/api/gifs?q=${encodeURIComponent(trimmed)}&limit=${GIF_PAGE_SIZE}&page=${page}`
+	      : `/api/gifs/trending?limit=${GIF_PAGE_SIZE}&page=${page}`;
 	    try {
 	      const payload = await fetchJSON(endpoint);
 	      if (requestID !== gifSearchRequestID) return;
-	      const results = Array.isArray(payload) ? payload : (payload.results || []);
-	      renderComposeGifs(results);
+	      const incoming = (Array.isArray(payload) ? payload : (payload.results || []))
+	        .map(normalizeGifResult)
+	        .filter(Boolean);
+	      const existing = new Set(gifResults.map(gifKey));
+	      let added = 0;
+	      for (const result of incoming) {
+	        const key = gifKey(result);
+	        if (!key || existing.has(key)) continue;
+	        existing.add(key);
+	        gifResults.push(result);
+	        added += 1;
+	      }
+	      gifPage = page;
+	      gifHasMore = added > 0 && (payload && payload.has_more !== false) && incoming.length >= GIF_PAGE_SIZE;
+	      renderComposeGifs(gifResults);
 	      $composeGifPanel.dataset.loaded = 'true';
+	      requestAnimationFrame(() => {
+	        const scroller = document.getElementById('compose-gif-scroll');
+	        if (gifHasMore && scroller && scroller.scrollHeight <= scroller.clientHeight + 8) {
+	          maybeLoadMoreComposeGifs();
+	        }
+	      });
 	    } catch (err) {
 	      if (requestID !== gifSearchRequestID) return;
 	      status.hidden = false;
 	      status.textContent = userFacingErrorMessage(err) || 'GIF search failed.';
 	      throw err;
+	    } finally {
+	      if (requestID === gifSearchRequestID) {
+	        gifLoading = false;
+	        if (loadStatus) loadStatus.hidden = true;
+	      }
 	    }
+	  }
+
+	  function renderGifTile(result) {
+	    const normalized = normalizeGifResult(result);
+	    if (!normalized) return null;
+	    const tile = document.createElement('div');
+	    tile.className = 'gif-tile';
+	    tile.tabIndex = 0;
+	    tile.setAttribute('role', 'button');
+	    tile.title = normalized.title;
+	    tile.setAttribute('aria-label', normalized.title);
+
+	    const img = document.createElement('img');
+	    img.src = normalized.preview_url;
+	    img.alt = normalized.title;
+	    img.loading = 'lazy';
+	    tile.appendChild(img);
+
+	    const favorite = document.createElement('button');
+	    favorite.type = 'button';
+	    favorite.className = 'gif-favorite-toggle';
+	    favorite.dataset.gifUrl = normalized.url;
+	    favorite.addEventListener('click', (event) => {
+	      event.preventDefault();
+	      event.stopPropagation();
+	      toggleGifFavorite(normalized);
+	    });
+	    tile.appendChild(favorite);
+	    updateGifFavoriteButtons(tile);
+
+	    const send = () => {
+	      sendComposeGif(normalized).catch(err => console.error('Failed to send GIF:', err));
+	    };
+	    tile.addEventListener('click', send);
+	    tile.addEventListener('keydown', (event) => {
+	      if (event.key === 'Enter' || event.key === ' ') {
+	        event.preventDefault();
+	        send();
+	      }
+	    });
+	    return tile;
+	  }
+
+	  function renderGifFavorites() {
+	    const section = document.getElementById('compose-gif-favorites');
+	    const grid = document.getElementById('compose-gif-favorites-grid');
+	    if (!section || !grid) return;
+	    grid.innerHTML = '';
+	    if (!gifFavorites.length) {
+	      section.hidden = true;
+	      return;
+	    }
+	    section.hidden = false;
+	    gifFavorites.forEach(result => {
+	      const tile = renderGifTile(result);
+	      if (tile) grid.appendChild(tile);
+	    });
 	  }
 
 	  function renderComposeGifs(results) {
 	    const status = document.getElementById('compose-gif-status');
 	    const grid = document.getElementById('compose-gif-grid');
+	    const loadStatus = document.getElementById('compose-gif-load-status');
 	    if (!status || !grid) return;
 	    grid.innerHTML = '';
 	    if (!Array.isArray(results) || results.length === 0) {
 	      status.hidden = false;
 	      status.textContent = 'No GIFs found.';
+	      if (loadStatus) loadStatus.hidden = true;
 	      return;
 	    }
 	    status.hidden = true;
 	    results.forEach(result => {
-	      if (!result || !result.preview_url || !result.url) return;
-	      const btn = document.createElement('button');
-	      btn.type = 'button';
-	      btn.className = 'gif-tile';
-	      const title = result.title || 'GIF';
-	      btn.title = title;
-	      btn.setAttribute('aria-label', title);
-	      const img = document.createElement('img');
-	      img.src = result.preview_url;
-	      img.alt = title;
-	      img.loading = 'lazy';
-	      btn.appendChild(img);
-	      btn.addEventListener('click', () => {
-	        sendComposeGif(result).catch(err => console.error('Failed to send GIF:', err));
-	      });
-	      grid.appendChild(btn);
+	      const tile = renderGifTile(result);
+	      if (tile) grid.appendChild(tile);
 	    });
 	    if (!grid.children.length) {
 	      status.hidden = false;
 	      status.textContent = 'No GIFs found.';
+	    }
+	    if (loadStatus) {
+	      loadStatus.hidden = !gifHasMore;
+	      loadStatus.textContent = gifHasMore ? 'Scroll for more GIFs' : '';
 	    }
 	  }
 

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -9828,6 +9828,7 @@ body::after {
 	    });
 	  }
 
+	  const GIF_SEARCH_DEBOUNCE_MS = 500;
 	  let gifSearchTimeout = null;
 	  let gifSearchRequestID = 0;
 	  let gifSending = false;
@@ -9844,17 +9845,24 @@ body::after {
 	    $composeGifPanel.dataset.hydrated = 'true';
 	    const search = document.getElementById('compose-gif-search');
 	    if (search) {
-	      search.addEventListener('input', () => {
-	        if (gifSearchTimeout) clearTimeout(gifSearchTimeout);
-	        gifSearchTimeout = setTimeout(() => {
-	          loadComposeGifs(search.value).catch(err => console.error('GIF search failed:', err));
-	        }, 250);
-	      });
+	      search.addEventListener('input', () => scheduleComposeGifSearch(search.value));
 	    }
+	  }
+
+	  function scheduleComposeGifSearch(query) {
+	    if (gifSearchTimeout) clearTimeout(gifSearchTimeout);
+	    gifSearchTimeout = setTimeout(() => {
+	      gifSearchTimeout = null;
+	      loadComposeGifs(query).catch(err => console.error('GIF search failed:', err));
+	    }, GIF_SEARCH_DEBOUNCE_MS);
 	  }
 
 	  function closeComposeGifPanel() {
 	    if (!$composeGifPanel) return;
+	    if (gifSearchTimeout) {
+	      clearTimeout(gifSearchTimeout);
+	      gifSearchTimeout = null;
+	    }
 	    $composeGifPanel.classList.remove('show');
 	    if ($composeGifBtn) $composeGifBtn.setAttribute('aria-expanded', 'false');
 	  }

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -4438,6 +4438,7 @@ body::after {
 }
 
 .attach-btn,
+.gif-compose-btn,
 .emoji-compose-btn,
 .send-btn {
   width: 46px;
@@ -4447,6 +4448,7 @@ body::after {
 }
 
 .attach-btn:disabled,
+.gif-compose-btn:disabled,
 .emoji-compose-btn:disabled,
 .send-btn:disabled {
   opacity: 0.45;
@@ -4454,6 +4456,7 @@ body::after {
 }
 
 .attach-btn,
+.gif-compose-btn,
 .emoji-compose-btn {
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -4461,14 +4464,25 @@ body::after {
 }
 
 .attach-btn:hover,
+.gif-compose-btn:hover,
 .emoji-compose-btn:hover {
   background: var(--bg-hover);
   color: var(--text-primary);
 }
 
+.gif-compose-btn {
+  font: 700 11px/1 var(--font-sans);
+  letter-spacing: 0.02em;
+}
+
 .emoji-compose-btn svg {
   width: 20px;
   height: 20px;
+}
+
+.compose-bar.drag-over {
+  border-color: var(--border-accent);
+  background: var(--bg-hover);
 }
 
 .compose-emoji-panel {
@@ -4490,6 +4504,87 @@ body::after {
   width: 100%;
   min-width: 0;
   aspect-ratio: 1;
+}
+
+.gif-compose-panel {
+  position: absolute;
+  left: 58px;
+  right: auto;
+  bottom: calc(100% + 8px);
+  z-index: 72;
+  display: none;
+  width: min(560px, calc(100vw - 96px));
+  max-height: min(430px, calc(100vh - 260px));
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-soft);
+}
+
+.gif-compose-panel.show {
+  display: flex;
+}
+
+.gif-search {
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.gif-search input {
+  width: 100%;
+  height: 42px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font: 500 14px/1 var(--font-sans);
+  outline: none;
+}
+
+.gif-search input:focus {
+  border-color: var(--border-accent);
+}
+
+.gif-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+  gap: 8px;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.gif-tile {
+  min-width: 0;
+  aspect-ratio: 1.1;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-surface);
+  cursor: pointer;
+  padding: 0;
+}
+
+.gif-tile:hover,
+.gif-tile:focus-visible {
+  border-color: var(--border-accent);
+  outline: none;
+}
+
+.gif-tile img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.gif-status {
+  padding: 18px 12px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
 }
 
 .send-btn {
@@ -4522,11 +4617,13 @@ body::after {
 }
 
 @media (max-width: 520px) {
-  .thread-search-results {
+  .thread-search-results,
+  .gif-compose-panel {
     width: min(320px, calc(100vw - 32px));
   }
 
-  .compose-emoji-panel {
+  .compose-emoji-panel,
+  .gif-compose-panel {
     left: 0;
     right: 0;
     width: auto;
@@ -5073,10 +5170,11 @@ body::after {
     </div>
     <div class="compose-bar" id="compose-bar" style="display:none">
       <div class="compose-row">
-        <input type="file" id="file-input" accept="image/*,video/*,audio/*" style="display:none">
+        <input type="file" id="file-input" style="display:none">
         <button class="attach-btn" id="attach-btn" title="Attach media" aria-label="Attach media">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
         </button>
+        <button class="gif-compose-btn" id="compose-gif-btn" type="button" title="Search GIFs" aria-label="Search GIFs" aria-expanded="false" aria-controls="compose-gif-panel">GIF</button>
         <button class="emoji-compose-btn" id="compose-emoji-btn" type="button" title="Insert emoji" aria-label="Insert emoji" aria-expanded="false" aria-controls="compose-emoji-panel">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>
         </button>
@@ -5086,6 +5184,7 @@ body::after {
         </button>
       </div>
       <div class="emoji-full-panel compose-emoji-panel" id="compose-emoji-panel" role="dialog" aria-label="Emoji picker"></div>
+      <div class="gif-compose-panel" id="compose-gif-panel" role="dialog" aria-label="GIF picker"></div>
     </div>
   </div>
 </div>
@@ -5239,6 +5338,8 @@ body::after {
   const $messagesArea = document.getElementById('messages-area');
   const $composeBar = document.getElementById('compose-bar');
   const $composeInput = document.getElementById('compose-input');
+  const $composeGifBtn = document.getElementById('compose-gif-btn');
+  const $composeGifPanel = document.getElementById('compose-gif-panel');
   const $composeEmojiBtn = document.getElementById('compose-emoji-btn');
   const $composeEmojiPanel = document.getElementById('compose-emoji-panel');
   const $sendBtn = document.getElementById('send-btn');
@@ -7106,8 +7207,10 @@ body::after {
     if (!activeConversation) {
       $composeInput.disabled = false;
       if ($composeEmojiBtn) $composeEmojiBtn.disabled = false;
+      if ($composeGifBtn) $composeGifBtn.disabled = composeSendInFlight;
       $attachBtn.disabled = composeSendInFlight;
       $attachBtn.title = 'Attach media';
+      if ($composeGifBtn) $composeGifBtn.title = 'Search GIFs';
       return;
     }
 
@@ -7115,12 +7218,20 @@ body::after {
     const canSendMedia = conversationSupportsMediaOutbound(activeConversation);
     $composeInput.disabled = !canSend;
     if ($composeEmojiBtn) $composeEmojiBtn.disabled = !canSend;
+    if ($composeGifBtn) $composeGifBtn.disabled = composeSendInFlight || !canSendMedia;
     $attachBtn.disabled = composeSendInFlight || !canSendMedia;
     $attachBtn.title = canSendMedia
       ? 'Attach media'
       : (sourcePlatformOf(activeConversation) === 'whatsapp'
         ? 'Reconnect WhatsApp to send attachments on this route'
         : 'Attachments unavailable on this route');
+    if ($composeGifBtn) {
+      $composeGifBtn.title = canSendMedia
+        ? 'Search GIFs'
+        : (sourcePlatformOf(activeConversation) === 'whatsapp'
+          ? 'Reconnect WhatsApp to send GIFs on this route'
+          : 'GIFs unavailable on this route');
+    }
     $composeInput.placeholder = canSend ? 'Write a message...' : routeUnavailablePlaceholder(activeConversation);
     if (!canSendMedia && pendingFile) {
       clearAttachment();
@@ -7130,6 +7241,9 @@ body::after {
     }
     if (!canSend) {
       closeComposeEmojiPanel();
+    }
+    if (!canSendMedia) {
+      closeComposeGifPanel();
     }
     autoResize();
   }
@@ -9673,13 +9787,14 @@ body::after {
     if ($composeEmojiBtn) $composeEmojiBtn.setAttribute('aria-expanded', 'false');
   }
 
-  function toggleComposeEmojiPanel() {
-    if (!$composeEmojiPanel || !$composeEmojiBtn) return;
-    buildComposeEmojiPanel();
-    const willOpen = !$composeEmojiPanel.classList.contains('show');
-    document.querySelectorAll('.emoji-picker.show').forEach(p => p.classList.remove('show'));
-    document.querySelectorAll('.emoji-full-panel.show').forEach(p => {
-      if (p !== $composeEmojiPanel) p.classList.remove('show');
+	  function toggleComposeEmojiPanel() {
+	    if (!$composeEmojiPanel || !$composeEmojiBtn) return;
+	    buildComposeEmojiPanel();
+	    const willOpen = !$composeEmojiPanel.classList.contains('show');
+	    closeComposeGifPanel();
+	    document.querySelectorAll('.emoji-picker.show').forEach(p => p.classList.remove('show'));
+	    document.querySelectorAll('.emoji-full-panel.show').forEach(p => {
+	      if (p !== $composeEmojiPanel) p.classList.remove('show');
     });
     $composeEmojiPanel.classList.toggle('show', willOpen);
     $composeEmojiBtn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
@@ -9706,14 +9821,211 @@ body::after {
     $composeInput.focus();
   }
 
-  if ($composeEmojiBtn) {
-    $composeEmojiBtn.addEventListener('click', (event) => {
-      event.stopPropagation();
-      toggleComposeEmojiPanel();
-    });
-  }
+	  if ($composeEmojiBtn) {
+	    $composeEmojiBtn.addEventListener('click', (event) => {
+	      event.stopPropagation();
+	      toggleComposeEmojiPanel();
+	    });
+	  }
 
-  if ($threadSearchInput) {
+	  let gifSearchTimeout = null;
+	  let gifSearchRequestID = 0;
+	  let gifSending = false;
+
+	  function buildComposeGifPanel() {
+	    if (!$composeGifPanel || $composeGifPanel.dataset.hydrated === 'true') return;
+	    $composeGifPanel.innerHTML = `
+	      <div class="gif-search">
+	        <input type="text" id="compose-gif-search" placeholder="Search GIFs..." aria-label="Search GIFs" autocomplete="off">
+	      </div>
+	      <div class="gif-status" id="compose-gif-status"></div>
+	      <div class="gif-grid" id="compose-gif-grid" aria-live="polite"></div>
+	    `;
+	    $composeGifPanel.dataset.hydrated = 'true';
+	    const search = document.getElementById('compose-gif-search');
+	    if (search) {
+	      search.addEventListener('input', () => {
+	        if (gifSearchTimeout) clearTimeout(gifSearchTimeout);
+	        gifSearchTimeout = setTimeout(() => {
+	          loadComposeGifs(search.value).catch(err => console.error('GIF search failed:', err));
+	        }, 250);
+	      });
+	    }
+	  }
+
+	  function closeComposeGifPanel() {
+	    if (!$composeGifPanel) return;
+	    $composeGifPanel.classList.remove('show');
+	    if ($composeGifBtn) $composeGifBtn.setAttribute('aria-expanded', 'false');
+	  }
+
+	  function toggleComposeGifPanel() {
+	    if (!$composeGifPanel || !$composeGifBtn) return;
+	    if (!conversationSupportsMediaOutbound(activeConversation)) {
+	      showThreadFeedback('GIFs are unavailable on this route right now.');
+	      return;
+	    }
+	    buildComposeGifPanel();
+	    const willOpen = !$composeGifPanel.classList.contains('show');
+	    closeComposeEmojiPanel();
+	    document.querySelectorAll('.emoji-picker.show').forEach(p => p.classList.remove('show'));
+	    document.querySelectorAll('.emoji-full-panel.show').forEach(p => p.classList.remove('show'));
+	    $composeGifPanel.classList.toggle('show', willOpen);
+	    $composeGifBtn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+	    if (willOpen) {
+	      const input = document.getElementById('compose-gif-search');
+	      if (input) input.focus();
+	      if ($composeGifPanel.dataset.loaded !== 'true') {
+	        loadComposeGifs('').catch(err => console.error('GIF search failed:', err));
+	      }
+	    }
+	  }
+
+	  async function loadComposeGifs(query) {
+	    if (!$composeGifPanel) return;
+	    const requestID = ++gifSearchRequestID;
+	    const trimmed = String(query || '').trim();
+	    const status = document.getElementById('compose-gif-status');
+	    const grid = document.getElementById('compose-gif-grid');
+	    if (!status || !grid) return;
+	    status.hidden = false;
+	    status.textContent = 'Loading GIFs...';
+	    grid.innerHTML = '';
+
+	    const endpoint = trimmed
+	      ? `/api/gifs?q=${encodeURIComponent(trimmed)}&limit=32`
+	      : '/api/gifs/trending?limit=32';
+	    try {
+	      const payload = await fetchJSON(endpoint);
+	      if (requestID !== gifSearchRequestID) return;
+	      const results = Array.isArray(payload) ? payload : (payload.results || []);
+	      renderComposeGifs(results);
+	      $composeGifPanel.dataset.loaded = 'true';
+	    } catch (err) {
+	      if (requestID !== gifSearchRequestID) return;
+	      status.hidden = false;
+	      status.textContent = 'GIF search failed.';
+	      throw err;
+	    }
+	  }
+
+	  function renderComposeGifs(results) {
+	    const status = document.getElementById('compose-gif-status');
+	    const grid = document.getElementById('compose-gif-grid');
+	    if (!status || !grid) return;
+	    grid.innerHTML = '';
+	    if (!Array.isArray(results) || results.length === 0) {
+	      status.hidden = false;
+	      status.textContent = 'No GIFs found.';
+	      return;
+	    }
+	    status.hidden = true;
+	    results.forEach(result => {
+	      if (!result || !result.preview_url || !result.url) return;
+	      const btn = document.createElement('button');
+	      btn.type = 'button';
+	      btn.className = 'gif-tile';
+	      const title = result.title || 'GIF';
+	      btn.title = title;
+	      btn.setAttribute('aria-label', title);
+	      const img = document.createElement('img');
+	      img.src = result.preview_url;
+	      img.alt = title;
+	      img.loading = 'lazy';
+	      btn.appendChild(img);
+	      btn.addEventListener('click', () => {
+	        sendComposeGif(result).catch(err => console.error('Failed to send GIF:', err));
+	      });
+	      grid.appendChild(btn);
+	    });
+	    if (!grid.children.length) {
+	      status.hidden = false;
+	      status.textContent = 'No GIFs found.';
+	    }
+	  }
+
+	  async function sendComposeGif(result) {
+	    if (gifSending) return;
+	    if (!activeConversation || !activeConvoId) return;
+	    if (browserIsOffline()) {
+	      showThreadFeedback(offlineFeedbackMessage('send'), 'send');
+	      return;
+	    }
+	    if (!conversationSupportsMediaOutbound(activeConversation)) {
+	      showThreadFeedback('GIFs are unavailable on this route right now.');
+	      return;
+	    }
+	    if (pendingFile) {
+	      showThreadFeedback('Send or remove the current attachment before choosing a GIF.');
+	      return;
+	    }
+
+	    const sendConvoId = activeConvoId;
+	    const sendConversation = activeConversation;
+	    const activePlatform = sourcePlatformOf(sendConversation);
+	    const text = $composeInput.value.trim();
+	    const originalText = $composeInput.value;
+	    const supportsMediaCaption = activePlatform === 'whatsapp' || activePlatform === 'signal';
+
+	    clearThreadFeedback();
+	    gifSending = true;
+	    $composeInput.value = '';
+	    composeTextByConversation.delete(sendConvoId);
+	    autoResize();
+
+	    try {
+	      const payload = {
+	        conversation_id: sendConvoId,
+	        url: result.url,
+	      };
+	      if (supportsMediaCaption && text) payload.caption = text;
+	      if (supportsMediaCaption && replyToMsg) payload.reply_to_id = replyToMsg.MessageID;
+	      await postJSON('/api/send-gif', payload);
+
+	      if (text && !supportsMediaCaption) {
+	        const textPayload = {
+	          conversation_id: sendConvoId,
+	          message: text,
+	        };
+	        if (replyToMsg) textPayload.reply_to_id = replyToMsg.MessageID;
+	        await postJSON('/api/send', textPayload);
+	      }
+
+	      closeComposeGifPanel();
+	      clearReply();
+	      if (activeConvoId === sendConvoId) {
+	        if (threadSearchMode === 'centered') {
+	          clearThreadSearchUI();
+	          resetLoadedThreadState();
+	          await loadMessages(sendConvoId, {reset: true, forceBottom: true});
+	        } else {
+	          await loadMessages(sendConvoId, {poll: true, forceBottom: true});
+	        }
+	      }
+	      await loadConversations();
+	    } catch (err) {
+	      if (text) {
+	        if (activeConvoId === sendConvoId) {
+	          $composeInput.value = originalText;
+	        }
+	        rememberComposeText(sendConvoId, originalText);
+	      }
+	      showThreadFeedback(err.message || 'Failed to send GIF', 'send');
+	      throw err;
+	    } finally {
+	      gifSending = false;
+	      autoResize();
+	    }
+	  }
+
+	  if ($composeGifBtn) {
+	    $composeGifBtn.addEventListener('click', (event) => {
+	      event.stopPropagation();
+	      toggleComposeGifPanel();
+	    });
+	  }
+
+	  if ($threadSearchInput) {
     $threadSearchInput.addEventListener('input', scheduleThreadSearch);
     $threadSearchInput.addEventListener('keydown', async (event) => {
       if (event.key === 'Enter') {
@@ -9771,22 +10083,61 @@ body::after {
     autoResize();
   }
 
-  // Paste handler: Ctrl+V / Cmd+V with image data
-  $composeInput.addEventListener('paste', e => {
-    const items = e.clipboardData?.items;
-    if (!items) return;
+	  // Paste handler: Ctrl+V / Cmd+V with image data
+	  $composeInput.addEventListener('paste', e => {
+	    const items = e.clipboardData?.items;
+	    if (!items) return;
     for (const item of items) {
       if (item.kind === 'file' && item.type.startsWith('image/')) {
         e.preventDefault();
         const file = item.getAsFile();
         if (file) setAttachment(file);
         return;
-      }
-    }
-  });
+	      }
+	    }
+	  });
 
-  // File picker button
-  $attachBtn.addEventListener('click', () => {
+	  let composeDragDepth = 0;
+
+	  function dragEventHasFiles(event) {
+	    const types = event.dataTransfer?.types;
+	    return !!types && Array.from(types).includes('Files');
+	  }
+
+	  function setComposeDragOver(active) {
+	    if (!$composeBar) return;
+	    $composeBar.classList.toggle('drag-over', !!active);
+	  }
+
+	  if ($composeBar) {
+	    $composeBar.addEventListener('dragenter', event => {
+	      if (!dragEventHasFiles(event)) return;
+	      event.preventDefault();
+	      composeDragDepth += 1;
+	      setComposeDragOver(true);
+	    });
+	    $composeBar.addEventListener('dragover', event => {
+	      if (!dragEventHasFiles(event)) return;
+	      event.preventDefault();
+	      event.dataTransfer.dropEffect = conversationSupportsMediaOutbound(activeConversation) ? 'copy' : 'none';
+	    });
+	    $composeBar.addEventListener('dragleave', event => {
+	      if (!dragEventHasFiles(event)) return;
+	      composeDragDepth = Math.max(0, composeDragDepth - 1);
+	      if (composeDragDepth === 0) setComposeDragOver(false);
+	    });
+	    $composeBar.addEventListener('drop', event => {
+	      if (!dragEventHasFiles(event)) return;
+	      event.preventDefault();
+	      composeDragDepth = 0;
+	      setComposeDragOver(false);
+	      const file = event.dataTransfer?.files?.[0];
+	      if (file) setAttachment(file);
+	    });
+	  }
+
+	  // File picker button
+	  $attachBtn.addEventListener('click', () => {
     if (!conversationSupportsMediaOutbound(activeConversation)) {
       showThreadFeedback('Attachments are unavailable on this route right now.');
       return;
@@ -10703,10 +11054,11 @@ body::after {
   }
 
   // ─── Reactions ───
-  window.sendReaction = async function(messageId, emoji) {
-    // Close pickers
-    document.querySelectorAll('.emoji-picker.show').forEach(p => p.classList.remove('show'));
-    document.querySelectorAll('.emoji-full-panel.show').forEach(p => p.classList.remove('show'));
+	  window.sendReaction = async function(messageId, emoji) {
+	    // Close pickers
+	    document.querySelectorAll('.emoji-picker.show').forEach(p => p.classList.remove('show'));
+	    document.querySelectorAll('.emoji-full-panel.show').forEach(p => p.classList.remove('show'));
+	    closeComposeGifPanel();
     try {
       await postJSON('/api/react', {
         message_id: messageId,
@@ -10781,12 +11133,13 @@ body::after {
   };
 
   // Close react picker and full panel when clicking elsewhere
-  document.addEventListener('click', (e) => {
-    if (!e.target.closest('.emoji-picker') && !e.target.closest('.emoji-full-panel') && !e.target.closest('.msg-actions') && !e.target.closest('#compose-emoji-btn')) {
-      document.querySelectorAll('.emoji-picker.show').forEach(p => p.classList.remove('show'));
-      document.querySelectorAll('.emoji-full-panel.show').forEach(p => p.classList.remove('show'));
-      if ($composeEmojiBtn) $composeEmojiBtn.setAttribute('aria-expanded', 'false');
-    }
+	  document.addEventListener('click', (e) => {
+	    if (!e.target.closest('.emoji-picker') && !e.target.closest('.emoji-full-panel') && !e.target.closest('.gif-compose-panel') && !e.target.closest('.msg-actions') && !e.target.closest('#compose-emoji-btn') && !e.target.closest('#compose-gif-btn')) {
+	      document.querySelectorAll('.emoji-picker.show').forEach(p => p.classList.remove('show'));
+	      document.querySelectorAll('.emoji-full-panel.show').forEach(p => p.classList.remove('show'));
+	      if ($composeEmojiBtn) $composeEmojiBtn.setAttribute('aria-expanded', 'false');
+	      closeComposeGifPanel();
+	    }
     if ($threadSearchResults && !$threadSearchResults.hidden && !e.target.closest('.thread-search')) {
       clearThreadSearchResults();
     }
@@ -10920,12 +11273,13 @@ body::after {
     $replyIndicator.classList.remove('show');
   }
 
-  function clearTransientComposerState() {
-    clearReply();
-    if (pendingFile) {
-      clearAttachment();
-    }
-  }
+	  function clearTransientComposerState() {
+	    clearReply();
+	    if (pendingFile) {
+	      clearAttachment();
+	    }
+	    closeComposeGifPanel();
+	  }
 
   $replyClose.addEventListener('click', clearReply);
 
@@ -11060,6 +11414,7 @@ body::after {
       // Close fullscreen image viewer if open
       const fullscreen = document.querySelector('.msg-image-fullscreen');
       if (fullscreen) { fullscreen.remove(); return; }
+      if ($composeGifPanel && $composeGifPanel.classList.contains('show')) { closeComposeGifPanel(); return; }
       // Close any open emoji pickers or full panels
       const openPanels = document.querySelectorAll('.emoji-full-panel.show');
       if (openPanels.length) {


### PR DESCRIPTION
## Summary

- adds a compose GIF picker with trending/search results, caption preservation, debounced search, and send support through the existing media send paths
- adds compose drag-and-drop attachment handling and keeps the attach/GIF/emoji buttons tightly grouped
- proxies GIF previews and validates outbound GIF media URLs so only Klipy-hosted HTTPS media is fetched/sent
- documents the required GIF provider configuration without committing a bundled provider key

## GIF setup

This PR intentionally does not include a Klipy API key. To enable GIF search, set one of these before starting OpenMessage:

```bash
OPENMESSAGES_KLIPY_API_KEY=<your Klipy key> openmessage serve
```

`KLIPY_API_KEY` is also accepted as a fallback. Without a key, GIF search endpoints return a setup error and normal messaging continues to work.

## Review / validation

- OpenMessage PR review skill: no blocking findings after fixes
- Secret scan for common key/token patterns: no committed secrets found; only CSS/comment false positives
- `git diff --check`
- `go test ./...`
- `npx playwright test` -> 67 passed
