### PR TITLE
Add favorite conversation shortcuts

### DIFF
--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -505,6 +505,7 @@ test('keeps the thread header compact with actions after search', async ({ page 
       source: rectFor('#chat-header-source'),
       search: rectFor('.thread-search-input-wrap'),
       notification: rectFor('#chat-header-notification-btn'),
+      favorite: rectFor('#chat-header-favorite-btn'),
     };
   });
   const centerY = (rect) => rect.top + rect.height / 2;
@@ -515,19 +516,86 @@ test('keeps the thread header compact with actions after search', async ({ page 
 
   await openConversation(page, 'Sarah Chen');
   const layout = await readHeaderLayout();
-  expect(layout.header.height).toBeLessThanOrEqual(74);
+  expect(layout.header.height).toBeLessThanOrEqual(64);
   expect(Math.abs(centerY(layout.name) - centerY(layout.source))).toBeLessThanOrEqual(12);
   expect(layout.source.left).toBeGreaterThan(layout.name.right);
   expect(layout.notification.left).toBeGreaterThan(layout.search.right);
+  expect(layout.favorite.left).toBeGreaterThan(layout.notification.right);
 
   await page.setViewportSize({ width: 920, height: 700 });
   await page.reload();
   await openConversation(page, 'Sarah Chen');
   const mediumLayout = await readHeaderLayout();
-  for (const rect of [mediumLayout.name, mediumLayout.source, mediumLayout.search, mediumLayout.notification]) {
+  for (const rect of [mediumLayout.name, mediumLayout.source, mediumLayout.search, mediumLayout.notification, mediumLayout.favorite]) {
     expectInsideHeader(mediumLayout, rect);
   }
   expect(mediumLayout.notification.left).toBeGreaterThan(mediumLayout.search.right);
+  expect(mediumLayout.favorite.left).toBeGreaterThan(mediumLayout.notification.right);
+});
+
+test('keeps sidebar search and tabs tightly stacked', async ({ page }) => {
+  const layout = await page.evaluate(() => {
+    const header = document.querySelector('.sidebar-header').getBoundingClientRect();
+    const search = document.querySelector('.search-box').getBoundingClientRect();
+    const tabs = document.querySelector('.sidebar-tabs-row').getBoundingClientRect();
+    return {
+      headerHeight: header.height,
+      headerToSearch: search.top - header.bottom,
+      searchToTabs: tabs.top - search.bottom,
+    };
+  });
+
+  expect(layout.headerHeight).toBeLessThanOrEqual(72);
+  expect(layout.headerToSearch).toBeLessThanOrEqual(10);
+  expect(layout.searchToTabs).toBeLessThanOrEqual(8);
+});
+
+test('favorites conversations from the header and row context menu', async ({ page, request }) => {
+  await request.post('/api/conversations/conv1/favorite', { data: { favorite: false } });
+  await request.post('/api/conversations/conv2/favorite', { data: { favorite: false } });
+  await request.post('/api/mark-read', { data: { conversation_id: 'conv2' } });
+  await page.reload();
+
+  await openConversation(page, 'Sarah Chen');
+  await request.post('/_e2e/messages', {
+    data: {
+      conversation_id: 'conv2',
+      body: `Favorite badge check ${Date.now()}`,
+      sender_name: 'Marcus Johnson',
+      sender_number: '+12125559876',
+      timestamp_ms: 1738956601000,
+    },
+  });
+
+  const headerFavorite = page.locator('#chat-header-favorite-btn');
+  await expect(headerFavorite).toHaveAttribute('aria-pressed', 'false');
+  await headerFavorite.click();
+  await expect(page.locator('#chat-header-favorite-btn')).toHaveAttribute('aria-pressed', 'true');
+
+  const sarahFavorite = page.locator('#favorites-rail .favorite-chip[title="Sarah Chen"]');
+  await expect(sarahFavorite).toBeVisible();
+  await expect(sarahFavorite).toHaveClass(/active/);
+
+  const marcusRow = page.locator('#conversation-list .convo-item').filter({ hasText: 'Marcus Johnson' }).first();
+  await expect(marcusRow.locator('.convo-unread')).toHaveText('1');
+  await marcusRow.click({ button: 'right' });
+  await page.locator('#context-menu .context-menu-item').getByText('Add to favorites', { exact: true }).click();
+
+  const marcusFavorite = page.locator('#favorites-rail .favorite-chip[title="Marcus Johnson"]');
+  await expect(marcusFavorite).toBeVisible();
+  await expect(marcusFavorite.locator('.favorite-unread')).toHaveText('1');
+
+  await marcusFavorite.click();
+  await expect(page.locator('#chat-header-name')).toHaveText('Marcus Johnson');
+  await expect(marcusFavorite).toHaveClass(/active/);
+
+  await page.locator('#chat-header-favorite-btn').click();
+  await expect(page.locator('#favorites-rail .favorite-chip[title="Marcus Johnson"]')).toHaveCount(0);
+
+  await sarahFavorite.click();
+  await expect(page.locator('#chat-header-name')).toHaveText('Sarah Chen');
+  await page.locator('#chat-header-favorite-btn').click();
+  await expect(page.locator('#favorites-rail .favorite-chip[title="Sarah Chen"]')).toHaveCount(0);
 });
 
 test('inserts emoji into the compose message', async ({ page }) => {

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -575,6 +575,16 @@ test('favorites conversations from the header and row context menu', async ({ pa
   const sarahFavorite = page.locator('#favorites-rail .favorite-chip[title="Sarah Chen"]');
   await expect(sarahFavorite).toBeVisible();
   await expect(sarahFavorite).toHaveClass(/active/);
+  await expect(sarahFavorite).toHaveAttribute('aria-current', 'page');
+  await expect
+    .poll(async () => page.evaluate(() => {
+      const tabs = document.querySelector('.sidebar-tabs-row')?.getBoundingClientRect();
+      const rail = document.querySelector('#favorites-rail')?.getBoundingClientRect();
+      const list = document.querySelector('#conversation-list')?.getBoundingClientRect();
+      if (!tabs || !rail || !list) return false;
+      return rail.top >= tabs.bottom - 1 && rail.bottom <= list.top + 1;
+    }))
+    .toBe(true);
 
   const marcusRow = page.locator('#conversation-list .convo-item').filter({ hasText: 'Marcus Johnson' }).first();
   await expect(marcusRow.locator('.convo-unread')).toHaveText('1');

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -608,6 +608,24 @@ test('favorites conversations from the header and row context menu', async ({ pa
   await expect(page.locator('#favorites-rail .favorite-chip[title="Sarah Chen"]')).toHaveCount(0);
 });
 
+test('keeps global search active when favoriting a search result', async ({ page, request }) => {
+  await request.post('/api/conversations/conv2/favorite', { data: { favorite: false } });
+  await page.reload();
+
+  await page.locator('#search-input').fill('Marcus');
+  const marcusRow = page.locator('#conversation-list .convo-item').filter({ hasText: 'Marcus Johnson' }).first();
+  await expect(marcusRow).toBeVisible();
+  await expect(page.locator('#conversation-list')).not.toContainText('Sarah Chen');
+
+  await marcusRow.click({ button: 'right' });
+  await page.locator('#context-menu .context-menu-item').getByText('Add to favorites', { exact: true }).click();
+
+  await expect(page.locator('#search-input')).toHaveValue('Marcus');
+  await expect(page.locator('#conversation-list')).toContainText('Marcus Johnson');
+  await expect(page.locator('#conversation-list')).not.toContainText('Sarah Chen');
+  await expect(page.locator('#favorites-rail .favorite-chip[title="Marcus Johnson"]')).toBeVisible();
+});
+
 test('inserts emoji into the compose message', async ({ page }) => {
   await openConversation(page, 'Sarah Chen');
 

--- a/internal/db/conversations.go
+++ b/internal/db/conversations.go
@@ -186,8 +186,21 @@ func (s *Store) SetConversationNotificationMode(id, mode string) error {
 
 // SetConversationFavorite stores the local favorite state for a thread.
 func (s *Store) SetConversationFavorite(id string, favorite bool) error {
-	_, err := s.db.Exec(`UPDATE conversations SET is_favorite = ? WHERE conversation_id = ?`, favorite, id)
-	return err
+	if strings.TrimSpace(id) == "" {
+		return sql.ErrNoRows
+	}
+	result, err := s.db.Exec(`UPDATE conversations SET is_favorite = ? WHERE conversation_id = ?`, favorite, id)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }
 
 func normalizeDisplayProtocol(protocol string) string {
@@ -249,11 +262,21 @@ func (s *Store) SetConversationsTab(ids []string, tab string) error {
 }
 
 func (s *Store) ListConversations(limit int) ([]*Conversation, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
 	rows, err := s.db.Query(`
+		WITH recent AS (
+			SELECT conversation_id
+			FROM conversations
+			ORDER BY last_message_ts DESC
+			LIMIT ?
+		)
 		SELECT `+conversationColumns+`
 		FROM conversations
+		WHERE conversation_id IN (SELECT conversation_id FROM recent)
+			OR is_favorite = 1
 		ORDER BY last_message_ts DESC
-		LIMIT ?
 	`, limit)
 	if err != nil {
 		return nil, err

--- a/internal/db/conversations.go
+++ b/internal/db/conversations.go
@@ -7,7 +7,7 @@ import (
 )
 
 // conversationColumns is the canonical column list for SELECT queries on conversations.
-const conversationColumns = `conversation_id, name, is_group, participants, last_message_ts, unread_count, source_platform, display_protocol, notification_mode, tab`
+const conversationColumns = `conversation_id, name, is_group, participants, last_message_ts, unread_count, source_platform, display_protocol, is_favorite, notification_mode, tab`
 
 const (
 	NotificationModeAll      = "all"
@@ -58,18 +58,19 @@ func (s *Store) UpsertConversation(c *Conversation) error {
 	c.DisplayProtocol = normalizeDisplayProtocol(c.DisplayProtocol)
 	notificationMode, hasNotificationMode := explicitNotificationMode(c.NotificationMode)
 	_, err := s.db.Exec(`
-		INSERT INTO conversations (conversation_id, name, is_group, participants, last_message_ts, unread_count, source_platform, display_protocol, notification_mode)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?, ''), 'all'))
-		ON CONFLICT(conversation_id) DO UPDATE SET
-			name=excluded.name,
-			is_group=excluded.is_group,
-			participants=excluded.participants,
-			last_message_ts=excluded.last_message_ts,
-			unread_count=excluded.unread_count,
-			source_platform=excluded.source_platform,
-			display_protocol=CASE WHEN excluded.display_protocol != '' THEN excluded.display_protocol ELSE conversations.display_protocol END,
-			notification_mode=CASE WHEN ? != '' THEN ? ELSE conversations.notification_mode END
-	`, c.ConversationID, c.Name, c.IsGroup, c.Participants, c.LastMessageTS, c.UnreadCount, c.SourcePlatform, c.DisplayProtocol, notificationMode, maybeNotificationModeArg(hasNotificationMode, notificationMode), maybeNotificationModeArg(hasNotificationMode, notificationMode))
+			INSERT INTO conversations (conversation_id, name, is_group, participants, last_message_ts, unread_count, source_platform, display_protocol, is_favorite, notification_mode)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?, ''), 'all'))
+			ON CONFLICT(conversation_id) DO UPDATE SET
+				name=excluded.name,
+				is_group=excluded.is_group,
+				participants=excluded.participants,
+				last_message_ts=excluded.last_message_ts,
+				unread_count=excluded.unread_count,
+				source_platform=excluded.source_platform,
+				display_protocol=CASE WHEN excluded.display_protocol != '' THEN excluded.display_protocol ELSE conversations.display_protocol END,
+				is_favorite=CASE WHEN excluded.is_favorite THEN 1 ELSE conversations.is_favorite END,
+				notification_mode=CASE WHEN ? != '' THEN ? ELSE conversations.notification_mode END
+		`, c.ConversationID, c.Name, c.IsGroup, c.Participants, c.LastMessageTS, c.UnreadCount, c.SourcePlatform, c.DisplayProtocol, c.IsFavorite, notificationMode, maybeNotificationModeArg(hasNotificationMode, notificationMode), maybeNotificationModeArg(hasNotificationMode, notificationMode))
 	return err
 }
 
@@ -78,7 +79,7 @@ func (s *Store) GetConversation(id string) (*Conversation, error) {
 	err := s.db.QueryRow(`
 		SELECT `+conversationColumns+`
 		FROM conversations WHERE conversation_id = ?
-	`, id).Scan(&c.ConversationID, &c.Name, &c.IsGroup, &c.Participants, &c.LastMessageTS, &c.UnreadCount, &c.SourcePlatform, &c.DisplayProtocol, &c.NotificationMode, &c.Tab)
+		`, id).Scan(&c.ConversationID, &c.Name, &c.IsGroup, &c.Participants, &c.LastMessageTS, &c.UnreadCount, &c.SourcePlatform, &c.DisplayProtocol, &c.IsFavorite, &c.NotificationMode, &c.Tab)
 	if err != nil {
 		return nil, err
 	}
@@ -180,6 +181,12 @@ func (s *Store) SetConversationNotificationMode(id, mode string) error {
 		return err
 	}
 	_, err = s.db.Exec(`UPDATE conversations SET notification_mode = ? WHERE conversation_id = ?`, normalized, id)
+	return err
+}
+
+// SetConversationFavorite stores the local favorite state for a thread.
+func (s *Store) SetConversationFavorite(id string, favorite bool) error {
+	_, err := s.db.Exec(`UPDATE conversations SET is_favorite = ? WHERE conversation_id = ?`, favorite, id)
 	return err
 }
 
@@ -318,7 +325,7 @@ func scanConversations(rows interface {
 	var convs []*Conversation
 	for rows.Next() {
 		c := &Conversation{}
-		if err := rows.Scan(&c.ConversationID, &c.Name, &c.IsGroup, &c.Participants, &c.LastMessageTS, &c.UnreadCount, &c.SourcePlatform, &c.DisplayProtocol, &c.NotificationMode, &c.Tab); err != nil {
+		if err := rows.Scan(&c.ConversationID, &c.Name, &c.IsGroup, &c.Participants, &c.LastMessageTS, &c.UnreadCount, &c.SourcePlatform, &c.DisplayProtocol, &c.IsFavorite, &c.NotificationMode, &c.Tab); err != nil {
 			return nil, err
 		}
 		c.DisplayProtocol = normalizeDisplayProtocol(c.DisplayProtocol)
@@ -333,7 +340,7 @@ func getConversationTx(tx *sql.Tx, id string) (*Conversation, error) {
 	err := tx.QueryRow(`
 		SELECT `+conversationColumns+`
 		FROM conversations WHERE conversation_id = ?
-	`, id).Scan(&c.ConversationID, &c.Name, &c.IsGroup, &c.Participants, &c.LastMessageTS, &c.UnreadCount, &c.SourcePlatform, &c.DisplayProtocol, &c.NotificationMode, &c.Tab)
+	`, id).Scan(&c.ConversationID, &c.Name, &c.IsGroup, &c.Participants, &c.LastMessageTS, &c.UnreadCount, &c.SourcePlatform, &c.DisplayProtocol, &c.IsFavorite, &c.NotificationMode, &c.Tab)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -352,18 +359,19 @@ func upsertConversationTx(tx *sql.Tx, c *Conversation) error {
 	c.DisplayProtocol = normalizeDisplayProtocol(c.DisplayProtocol)
 	notificationMode, hasNotificationMode := explicitNotificationMode(c.NotificationMode)
 	_, err := tx.Exec(`
-		INSERT INTO conversations (conversation_id, name, is_group, participants, last_message_ts, unread_count, source_platform, display_protocol, notification_mode)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?, ''), 'all'))
-		ON CONFLICT(conversation_id) DO UPDATE SET
-			name=excluded.name,
-			is_group=excluded.is_group,
-			participants=excluded.participants,
-			last_message_ts=excluded.last_message_ts,
-			unread_count=excluded.unread_count,
-			source_platform=excluded.source_platform,
-			display_protocol=CASE WHEN excluded.display_protocol != '' THEN excluded.display_protocol ELSE conversations.display_protocol END,
-			notification_mode=CASE WHEN ? != '' THEN ? ELSE conversations.notification_mode END
-	`, c.ConversationID, c.Name, c.IsGroup, c.Participants, c.LastMessageTS, c.UnreadCount, c.SourcePlatform, c.DisplayProtocol, notificationMode, maybeNotificationModeArg(hasNotificationMode, notificationMode), maybeNotificationModeArg(hasNotificationMode, notificationMode))
+			INSERT INTO conversations (conversation_id, name, is_group, participants, last_message_ts, unread_count, source_platform, display_protocol, is_favorite, notification_mode)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?, ''), 'all'))
+			ON CONFLICT(conversation_id) DO UPDATE SET
+				name=excluded.name,
+				is_group=excluded.is_group,
+				participants=excluded.participants,
+				last_message_ts=excluded.last_message_ts,
+				unread_count=excluded.unread_count,
+				source_platform=excluded.source_platform,
+				display_protocol=CASE WHEN excluded.display_protocol != '' THEN excluded.display_protocol ELSE conversations.display_protocol END,
+				is_favorite=CASE WHEN excluded.is_favorite THEN 1 ELSE conversations.is_favorite END,
+				notification_mode=CASE WHEN ? != '' THEN ? ELSE conversations.notification_mode END
+		`, c.ConversationID, c.Name, c.IsGroup, c.Participants, c.LastMessageTS, c.UnreadCount, c.SourcePlatform, c.DisplayProtocol, c.IsFavorite, notificationMode, maybeNotificationModeArg(hasNotificationMode, notificationMode), maybeNotificationModeArg(hasNotificationMode, notificationMode))
 	return err
 }
 
@@ -390,6 +398,7 @@ func mergeConversationRecords(source, target *Conversation, targetID string) *Co
 	if source.UnreadCount > merged.UnreadCount {
 		merged.UnreadCount = source.UnreadCount
 	}
+	merged.IsFavorite = merged.IsFavorite || source.IsFavorite
 	if merged.SourcePlatform == "" {
 		merged.SourcePlatform = source.SourcePlatform
 	}

--- a/internal/db/conversations_test.go
+++ b/internal/db/conversations_test.go
@@ -148,6 +148,63 @@ func TestConversationNotificationModeLifecycle(t *testing.T) {
 	}
 }
 
+func TestConversationFavoriteLifecycle(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.UpsertConversation(&Conversation{
+		ConversationID: "conv-favorite",
+		Name:           "Favorite",
+		LastMessageTS:  1000,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := store.GetConversation("conv-favorite")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.IsFavorite {
+		t.Fatal("new conversation should not be favorite by default")
+	}
+
+	if err := store.SetConversationFavorite("conv-favorite", true); err != nil {
+		t.Fatalf("SetConversationFavorite(true): %v", err)
+	}
+	got, err = store.GetConversation("conv-favorite")
+	if err != nil {
+		t.Fatalf("get after favorite: %v", err)
+	}
+	if !got.IsFavorite {
+		t.Fatal("conversation should be favorite after set")
+	}
+
+	if err := store.UpsertConversation(&Conversation{
+		ConversationID: "conv-favorite",
+		Name:           "Favorite renamed",
+		LastMessageTS:  2000,
+	}); err != nil {
+		t.Fatalf("upsert update: %v", err)
+	}
+	got, err = store.GetConversation("conv-favorite")
+	if err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+	if !got.IsFavorite {
+		t.Fatal("sync-style upsert should preserve favorite state")
+	}
+
+	if err := store.SetConversationFavorite("conv-favorite", false); err != nil {
+		t.Fatalf("SetConversationFavorite(false): %v", err)
+	}
+	got, err = store.GetConversation("conv-favorite")
+	if err != nil {
+		t.Fatalf("get after unfavorite: %v", err)
+	}
+	if got.IsFavorite {
+		t.Fatal("conversation should not be favorite after clearing")
+	}
+}
+
 func TestGetConversation_NotFound(t *testing.T) {
 	store := newTestStore(t)
 
@@ -321,6 +378,7 @@ func TestMergeConversationIDs(t *testing.T) {
 		LastMessageTS:  3000,
 		UnreadCount:    2,
 		SourcePlatform: "whatsapp",
+		IsFavorite:     true,
 	}); err != nil {
 		t.Fatalf("seed raw conversation: %v", err)
 	}
@@ -372,6 +430,9 @@ func TestMergeConversationIDs(t *testing.T) {
 	}
 	if convo.UnreadCount != 2 {
 		t.Fatalf("unread count = %d, want 2", convo.UnreadCount)
+	}
+	if !convo.IsFavorite {
+		t.Fatal("favorite state should survive conversation merge")
 	}
 
 	msgs, err := store.GetMessagesByConversation("whatsapp:14699991654@s.whatsapp.net", 10)

--- a/internal/db/conversations_test.go
+++ b/internal/db/conversations_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 )
@@ -203,6 +204,10 @@ func TestConversationFavoriteLifecycle(t *testing.T) {
 	if got.IsFavorite {
 		t.Fatal("conversation should not be favorite after clearing")
 	}
+
+	if err := store.SetConversationFavorite("missing-favorite", true); err != sql.ErrNoRows {
+		t.Fatalf("SetConversationFavorite missing = %v, want sql.ErrNoRows", err)
+	}
 }
 
 func TestGetConversation_NotFound(t *testing.T) {
@@ -260,6 +265,22 @@ func TestListConversations_Ordering(t *testing.T) {
 		}
 		if got[1].Name != "New" {
 			t.Errorf("second: got %q, want New", got[1].Name)
+		}
+	})
+
+	t.Run("favorite outside limit is still returned", func(t *testing.T) {
+		if err := store.SetConversationFavorite("c-ancient", true); err != nil {
+			t.Fatalf("favorite ancient: %v", err)
+		}
+		got, err := store.ListConversations(2)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("count: got %d, want 3", len(got))
+		}
+		if got[0].Name != "Newest" || got[1].Name != "New" || got[2].Name != "Ancient" {
+			t.Fatalf("order = [%s %s %s], want [Newest New Ancient]", got[0].Name, got[1].Name, got[2].Name)
 		}
 	})
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -25,6 +25,7 @@ type Conversation struct {
 	LastMessagePreview string `json:"last_message_preview,omitempty"`
 	UnifiedID          string `json:"unified_id,omitempty"`
 	UnifiedName        string `json:"unified_name,omitempty"`
+	IsFavorite         bool   `json:"is_favorite,omitempty"`
 	NotificationMode   string `json:"notification_mode,omitempty"` // all, mentions, muted
 	Tab                string `json:"tab,omitempty"`               // "" = Recent (inbox), "archive", or a custom tab id
 }
@@ -357,6 +358,7 @@ func (s *Store) migrate() error {
 		"ALTER TABLE conversations ADD COLUMN source_platform TEXT NOT NULL DEFAULT 'sms'",
 		"ALTER TABLE conversations ADD COLUMN display_protocol TEXT NOT NULL DEFAULT ''",
 		"ALTER TABLE conversations ADD COLUMN notification_mode TEXT NOT NULL DEFAULT 'all'",
+		"ALTER TABLE conversations ADD COLUMN is_favorite INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE conversations ADD COLUMN tab TEXT NOT NULL DEFAULT ''",
 	} {
 		s.db.Exec(col) // ignore "duplicate column" errors

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -529,6 +529,31 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			writeJSON(w, convo)
 			return
 		}
+		if action == "favorite" {
+			if r.Method != http.MethodPost && r.Method != http.MethodPatch {
+				httpError(w, "method not allowed", 405)
+				return
+			}
+			var req struct {
+				Favorite bool `json:"favorite"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				httpError(w, "invalid JSON: "+err.Error(), 400)
+				return
+			}
+			if err := store.SetConversationFavorite(convID, req.Favorite); err != nil {
+				httpError(w, "set favorite: "+err.Error(), 500)
+				return
+			}
+			convo, err := store.GetConversation(convID)
+			if err != nil {
+				httpError(w, "get conversation: "+err.Error(), 500)
+				return
+			}
+			publishConversations()
+			writeJSON(w, convo)
+			return
+		}
 		if action == "tab" {
 			if r.Method != http.MethodPost && r.Method != http.MethodPatch {
 				httpError(w, "method not allowed", 405)

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"database/sql"
 	"embed"
 	"encoding/hex"
 	"encoding/json"
@@ -93,6 +94,7 @@ type SearchResult struct {
 	UnreadCount     int    `json:"UnreadCount"`
 	SourcePlatform  string `json:"source_platform,omitempty"`
 	DisplayProtocol string `json:"display_protocol,omitempty"`
+	IsFavorite      bool   `json:"is_favorite,omitempty"`
 	UnifiedID       string `json:"unified_id,omitempty"`
 	UnifiedName     string `json:"unified_name,omitempty"`
 	Preview         string `json:"preview,omitempty"`
@@ -535,18 +537,30 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 				return
 			}
 			var req struct {
-				Favorite bool `json:"favorite"`
+				Favorite *bool `json:"favorite"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				httpError(w, "invalid JSON: "+err.Error(), 400)
 				return
 			}
-			if err := store.SetConversationFavorite(convID, req.Favorite); err != nil {
+			if req.Favorite == nil {
+				httpError(w, "favorite is required", 400)
+				return
+			}
+			if err := store.SetConversationFavorite(convID, *req.Favorite); err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					httpError(w, "conversation not found", 404)
+					return
+				}
 				httpError(w, "set favorite: "+err.Error(), 500)
 				return
 			}
 			convo, err := store.GetConversation(convID)
 			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					httpError(w, "conversation not found", 404)
+					return
+				}
 				httpError(w, "get conversation: "+err.Error(), 500)
 				return
 			}
@@ -2288,6 +2302,7 @@ func searchResultForConversation(conv *db.Conversation, timestamp int64, preview
 		UnreadCount:     conv.UnreadCount,
 		SourcePlatform:  conv.SourcePlatform,
 		DisplayProtocol: conv.DisplayProtocol,
+		IsFavorite:      conv.IsFavorite,
 		Preview:         preview,
 	}
 	if identity, ok := unifiedIdentityForConversation(conv, identityIndex); ok {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -231,6 +231,44 @@ func TestSetConversationNotificationMode(t *testing.T) {
 	}
 }
 
+func TestSetConversationFavorite(t *testing.T) {
+	ts := newTestServer(t)
+	if err := ts.store.UpsertConversation(&db.Conversation{
+		ConversationID: "c1",
+		Name:           "Alice",
+		LastMessageTS:  100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Post(ts.server.URL+"/api/conversations/c1/favorite", "application/json", strings.NewReader(`{"favorite":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("got status %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var convo db.Conversation
+	if err := json.NewDecoder(resp.Body).Decode(&convo); err != nil {
+		t.Fatal(err)
+	}
+	if !convo.IsFavorite {
+		t.Fatal("response conversation should be favorite")
+	}
+
+	stored, err := ts.store.GetConversation("c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stored.IsFavorite {
+		t.Fatal("stored conversation should be favorite")
+	}
+}
+
 func TestSetConversationNotificationModeRejectsInvalid(t *testing.T) {
 	ts := newTestServer(t)
 	if err := ts.store.UpsertConversation(&db.Conversation{

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -269,6 +269,54 @@ func TestSetConversationFavorite(t *testing.T) {
 	}
 }
 
+func TestSetConversationFavoriteMissingConversation(t *testing.T) {
+	ts := newTestServer(t)
+
+	resp, err := http.Post(ts.server.URL+"/api/conversations/missing/favorite", "application/json", strings.NewReader(`{"favorite":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("got status %d, want 404: %s", resp.StatusCode, body)
+	}
+}
+
+func TestSetConversationFavoriteRequiresBoolean(t *testing.T) {
+	ts := newTestServer(t)
+	if err := ts.store.UpsertConversation(&db.Conversation{
+		ConversationID: "c1",
+		Name:           "Alice",
+		LastMessageTS:  100,
+		IsFavorite:     true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, body := range []string{`{}`, `{"favorite":null}`} {
+		resp, err := http.Post(ts.server.URL+"/api/conversations/c1/favorite", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			respBody, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("body %s got status %d, want 400: %s", body, resp.StatusCode, respBody)
+		}
+		resp.Body.Close()
+	}
+
+	stored, err := ts.store.GetConversation("c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stored.IsFavorite {
+		t.Fatal("invalid favorite requests should not clear stored favorite state")
+	}
+}
+
 func TestSetConversationNotificationModeRejectsInvalid(t *testing.T) {
 	ts := newTestServer(t)
 	if err := ts.store.UpsertConversation(&db.Conversation{
@@ -699,6 +747,7 @@ func TestSearchMessages(t *testing.T) {
 		Participants:   `[{"name":"Nathan","number":"+12675550100"}]`,
 		LastMessageTS:  200,
 		SourcePlatform: "sms",
+		IsFavorite:     true,
 	})
 	ts.store.UpsertMessage(&db.Message{
 		MessageID: "m1", ConversationID: "c1", Body: "lunch tomorrow?",
@@ -731,6 +780,9 @@ func TestSearchMessages(t *testing.T) {
 	}
 	if results[0].Name != "Nathan" {
 		t.Fatalf("got name %q, want Nathan", results[0].Name)
+	}
+	if !results[0].IsFavorite {
+		t.Fatal("search result should include favorite state")
 	}
 }
 

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -2610,7 +2610,7 @@ body::after {
 .sidebar-header {
   align-items: center;
   gap: 12px;
-  padding: 18px 20px 16px;
+  padding: 14px 20px 12px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -2707,7 +2707,7 @@ body::after {
 }
 
 .search-box {
-  margin: 14px 20px 10px;
+  margin: 7px 20px 6px;
   position: relative;
 }
 
@@ -2761,7 +2761,7 @@ body::after {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 20px 12px;
+  padding: 0 20px 8px;
 }
 
 .sidebar-tabs {
@@ -3173,7 +3173,7 @@ body::after {
 }
 
 .chat-header {
-  padding: 10px 28px;
+  padding: 7px 28px;
   background: var(--bg-elevated);
   border-bottom: 1px solid var(--border);
   backdrop-filter: none;
@@ -3373,9 +3373,91 @@ body::after {
   color: var(--accent-strong);
 }
 
+.chat-header-action-btn.favorite.active {
+  border-color: rgba(245, 158, 11, 0.42);
+  background: rgba(245, 158, 11, 0.12);
+  color: #f59e0b;
+}
+
 .chat-header-action-btn svg {
   width: 14px;
   height: 14px;
+}
+
+.favorites-rail {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 154px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.favorites-rail[hidden] {
+  display: none;
+}
+
+.favorites-rail::-webkit-scrollbar {
+  display: none;
+}
+
+.favorite-chip {
+  position: relative;
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.favorite-chip:hover,
+.favorite-chip.active {
+  border-color: var(--border-accent);
+}
+
+.favorite-avatar {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  overflow: visible;
+}
+
+.favorite-avatar .avatar-face {
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.favorite-avatar .avatar-platform-stack {
+  right: -4px;
+  bottom: -4px;
+  transform: scale(0.82);
+  transform-origin: right bottom;
+}
+
+.favorite-unread {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border: 2px solid var(--bg-elevated);
+  border-radius: 999px;
+  background: var(--accent-strong);
+  color: #fff;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 12px;
+  text-align: center;
 }
 
 .chat-header-source .platform-chip {
@@ -3476,18 +3558,21 @@ body::after {
 
 .convo-avatar.has-photo,
 .chat-header-avatar.has-photo,
+.favorite-avatar.has-photo,
 .msg-avatar.has-photo {
   color: transparent;
 }
 
 .convo-avatar.has-photo .avatar-face,
 .chat-header-avatar.has-photo .avatar-face,
+.favorite-avatar.has-photo .avatar-face,
 .msg-avatar.has-photo .avatar-face {
   background: transparent !important;
 }
 
 .convo-avatar.has-photo img,
 .chat-header-avatar.has-photo img,
+.favorite-avatar.has-photo img,
 .msg-avatar.has-photo img {
   display: block;
   width: 100%;
@@ -4485,7 +4570,7 @@ body::after {
   }
 
   .sidebar-header {
-    padding: 16px;
+    padding: 12px 16px;
   }
 
   .sidebar-header-main {
@@ -4523,7 +4608,7 @@ body::after {
   }
 
   .search-box {
-    margin: 12px 16px 8px;
+    margin: 8px 16px 6px;
   }
 
   .sidebar-section-label {
@@ -4791,6 +4876,7 @@ body::after {
           <div class="thread-search-results" id="thread-search-results" hidden></div>
         </div>
         <div class="chat-header-actions" id="chat-header-actions"></div>
+        <div class="favorites-rail" id="favorites-rail" aria-label="Favorite threads" hidden></div>
       </div>
       <div class="contact-popover" id="contact-popover" hidden role="dialog" aria-label="Contact details"></div>
     </div>
@@ -4946,6 +5032,7 @@ body::after {
   const $chatHeaderName = document.getElementById('chat-header-name');
   const $chatHeaderSource = document.getElementById('chat-header-source');
   const $chatHeaderActions = document.getElementById('chat-header-actions');
+  const $favoritesRail = document.getElementById('favorites-rail');
   const $chatHeaderStatus = document.getElementById('chat-header-status');
   const $threadSearchInput = document.getElementById('thread-search-input');
   const $threadSearchClear = document.getElementById('thread-search-clear');
@@ -5179,6 +5266,11 @@ body::after {
     return normalizeNotificationMode(convo.NotificationMode || convo.notification_mode);
   }
 
+  function conversationFavoriteOf(convo) {
+    if (!convo) return false;
+    return !!(convo.IsFavorite || convo.is_favorite);
+  }
+
   function notificationModeLabel(mode) {
     switch (normalizeNotificationMode(mode)) {
       case NOTIFICATION_MODE_MENTIONS:
@@ -5210,6 +5302,10 @@ body::after {
       default:
         return `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 1 0-12 0v3.2a2 2 0 0 1-.6 1.4L4 17h11"/><path d="M9.5 17a2.5 2.5 0 0 0 5 0"/></svg>`;
     }
+  }
+
+  function favoriteActionIconHTML(isFavorite) {
+    return `<svg viewBox="0 0 24 24" fill="${isFavorite ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>`;
   }
 
   function identityMentionNames() {
@@ -6580,6 +6676,60 @@ body::after {
     return el;
   }
 
+  function renderFavoritesRail(convos = allConversations) {
+    if (!$favoritesRail) return;
+    const favorites = (convos || [])
+      .filter(conversationFavoriteOf)
+      .slice()
+      .sort((a, b) => (b.LastMessageTS || 0) - (a.LastMessageTS || 0));
+
+    if (!favorites.length) {
+      $favoritesRail.hidden = true;
+      $favoritesRail.innerHTML = '';
+      return;
+    }
+
+    $favoritesRail.hidden = false;
+    $favoritesRail.innerHTML = favorites.map((convo) => {
+      const avatarRefs = conversationAvatarRefs(convo);
+      const unread = Number(convo.UnreadCount || convo.unread_count || 0);
+      const unreadLabel = unread > 99 ? '99+' : String(unread);
+      return `
+        <button
+          type="button"
+          class="favorite-chip${convo.ConversationID === activeConvoId ? ' active' : ''}"
+          data-conversation-id="${escapeHtml(convo.ConversationID)}"
+          title="${escapeHtml(convo.Name || 'Favorite thread')}"
+          aria-label="Open ${escapeHtml(convo.Name || 'favorite thread')}"
+          ${convo.ConversationID === activeConvoId ? 'aria-current="page"' : ''}
+        >
+          ${avatarHTML({
+            name: convo.Name,
+            numbers: conversationAvatarNumbers(convo),
+            whatsAppConversationID: conversationAvatarWhatsAppConversationID(convo),
+            avatarSource: avatarRefs.source,
+            participantIDs: avatarRefs.participantIDs,
+            contactIDs: avatarRefs.contactIDs,
+            platforms: avatarPlatformsForConversation(convo),
+            className: 'favorite-avatar',
+            style: `background:${avatarColor(convo.Name)}`,
+          })}
+          ${unread > 0 ? `<span class="favorite-unread">${escapeHtml(unreadLabel)}</span>` : ''}
+        </button>
+      `;
+    }).join('');
+
+    $favoritesRail.querySelectorAll('.favorite-chip').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const convo = conversationByID(btn.dataset.conversationId || '');
+        if (convo) {
+          await revealAndSelectConversation(convo);
+        }
+      });
+    });
+    hydrateNativeAvatars($favoritesRail);
+  }
+
   function updateChatHeaderPlatform(protocolDetail = '') {
     activeProtocolDetail = protocolDetail || displayProtocolOf(activeConversation);
     if (!activeConversation) {
@@ -6595,6 +6745,7 @@ body::after {
       await selectConversation(route);
     });
     const notificationMode = notificationModeOf(activeConversation);
+    const isFavorite = conversationFavoriteOf(activeConversation);
     const leaveButtonHTML = isLeaveableWhatsAppGroup(activeConversation)
       ? `
       <button
@@ -6615,6 +6766,14 @@ body::after {
         title="Notification settings: ${escapeHtml(notificationModeLabel(notificationMode))}"
         aria-label="Notification settings"
       >${notificationActionIconHTML(notificationMode)}</button>
+      <button
+        type="button"
+        class="chat-header-action-btn favorite${isFavorite ? ' active' : ''}"
+        id="chat-header-favorite-btn"
+        title="${isFavorite ? 'Remove from favorites' : 'Add to favorites'}"
+        aria-label="${isFavorite ? 'Remove from favorites' : 'Add to favorites'}"
+        aria-pressed="${isFavorite ? 'true' : 'false'}"
+      >${favoriteActionIconHTML(isFavorite)}</button>
     `;
     const $leaveGroupBtn = document.getElementById('chat-header-leave-group-btn');
     if ($leaveGroupBtn) {
@@ -6633,6 +6792,15 @@ body::after {
         openContextMenuAt(rect.left, rect.bottom + 8, conversationNotificationMenuItems(activeConversation), {
           type: 'conversation',
           conversation: activeConversation,
+        });
+      });
+    }
+    const $favoriteBtn = document.getElementById('chat-header-favorite-btn');
+    if ($favoriteBtn) {
+      $favoriteBtn.addEventListener('click', () => {
+        toggleConversationFavorite(activeConversation).catch(err => {
+          console.error('Failed to update favorite:', err);
+          showThreadFeedback(err.message || 'Failed to update favorite.');
         });
       });
     }
@@ -6677,6 +6845,7 @@ body::after {
 
   function refreshConversationChrome(protocolDetail = activeProtocolDetail) {
     updateChatHeaderPlatform(protocolDetail);
+    renderFavoritesRail();
     refreshComposeRouteUI();
   }
 
@@ -7085,6 +7254,27 @@ body::after {
     }
   }
 
+  async function setConversationFavorite(convo, favorite) {
+    if (!convo) return;
+    const updated = await postJSON(`/api/conversations/${encodeURIComponent(convo.ConversationID)}/favorite`, {
+      favorite: !!favorite,
+    });
+    const isFavorite = !!(updated.IsFavorite || updated.is_favorite || favorite);
+    applyConversationPatch(convo.ConversationID, {
+      IsFavorite: isFavorite,
+      is_favorite: isFavorite,
+    });
+    renderConversations(allConversations);
+    if (activeConversation && activeConversation.ConversationID === convo.ConversationID) {
+      refreshConversationChrome();
+    }
+  }
+
+  async function toggleConversationFavorite(convo) {
+    if (!convo) return;
+    await setConversationFavorite(convo, !conversationFavoriteOf(convo));
+  }
+
   async function leaveWhatsAppGroup(convo = activeConversation) {
     if (!isLeaveableWhatsAppGroup(convo)) return;
     const groupName = String(convo.Name || 'this group').trim() || 'this group';
@@ -7212,10 +7402,15 @@ body::after {
   }
 
   function conversationContextMenuItems(convo) {
+    const isFavorite = conversationFavoriteOf(convo);
     const items = [
       {
         label: 'Open thread',
         action: 'open-thread',
+      },
+      {
+        label: isFavorite ? 'Remove from favorites' : 'Add to favorites',
+        action: 'toggle-favorite',
       },
     ];
     if (isLeaveableWhatsAppGroup(convo)) {
@@ -7501,6 +7696,7 @@ body::after {
     if (!isSearch) {
       allConversations = convos;
     }
+    renderFavoritesRail();
     renderEmptyState();
     renderTabs();
     const tabConvos = isSearch ? convos : filterConversationsByTab(convos);
@@ -10085,6 +10281,12 @@ body::after {
           }
           if (action === 'leave-whatsapp-group') {
             await leaveWhatsAppGroup(context.conversation);
+            return;
+          }
+          if (action === 'toggle-favorite') {
+            const willFavorite = !conversationFavoriteOf(context.conversation);
+            await setConversationFavorite(context.conversation, willFavorite);
+            showThreadFeedback(willFavorite ? 'Added to favorites.' : 'Removed from favorites.');
             return;
           }
           if (action === 'copy-number') {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -2610,7 +2610,7 @@ body::after {
 .sidebar-header {
   align-items: center;
   gap: 12px;
-  padding: 14px 20px 12px;
+  padding: 12px 20px 10px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -3385,11 +3385,12 @@ body::after {
 }
 
 .favorites-rail {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   min-width: 0;
-  max-width: 154px;
+  min-height: 46px;
+  padding: 4px 20px 10px;
   overflow-x: auto;
   scrollbar-width: none;
 }
@@ -3405,8 +3406,8 @@ body::after {
 .favorite-chip {
   position: relative;
   flex: 0 0 auto;
-  width: 30px;
-  height: 30px;
+  width: 36px;
+  height: 36px;
   padding: 0;
   border: 1px solid transparent;
   border-radius: 999px;
@@ -3420,12 +3421,16 @@ body::after {
   border-color: var(--border-accent);
 }
 
+.favorite-chip.active {
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.22);
+}
+
 .favorite-avatar {
   position: relative;
   width: 100%;
   height: 100%;
   border-radius: 999px;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 700;
   overflow: visible;
 }
@@ -4570,7 +4575,7 @@ body::after {
   }
 
   .sidebar-header {
-    padding: 12px 16px;
+    padding: 10px 16px;
   }
 
   .sidebar-header-main {
@@ -4703,6 +4708,7 @@ body::after {
       <div class="sidebar-tabs" id="sidebar-tabs"></div>
       <button class="select-toggle-btn" id="select-toggle-btn" type="button" title="Select threads to organize" aria-label="Select threads to organize">Select</button>
     </div>
+    <div class="favorites-rail" id="favorites-rail" aria-label="Favorite threads" hidden></div>
     <div class="bulk-bar" id="bulk-bar" hidden>
       <span class="bulk-count" id="bulk-count">0 selected</span>
       <div class="bulk-bar-actions">
@@ -4876,7 +4882,6 @@ body::after {
           <div class="thread-search-results" id="thread-search-results" hidden></div>
         </div>
         <div class="chat-header-actions" id="chat-header-actions"></div>
-        <div class="favorites-rail" id="favorites-rail" aria-label="Favorite threads" hidden></div>
       </div>
       <div class="contact-popover" id="contact-popover" hidden role="dialog" aria-label="Contact details"></div>
     </div>

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -5276,6 +5276,16 @@ body::after {
     return !!(convo.IsFavorite || convo.is_favorite);
   }
 
+  function favoriteValueFromResponse(convo, fallback) {
+    if (convo && Object.prototype.hasOwnProperty.call(convo, 'IsFavorite')) {
+      return !!convo.IsFavorite;
+    }
+    if (convo && Object.prototype.hasOwnProperty.call(convo, 'is_favorite')) {
+      return !!convo.is_favorite;
+    }
+    return !!fallback;
+  }
+
   function notificationModeLabel(mode) {
     switch (normalizeNotificationMode(mode)) {
       case NOTIFICATION_MODE_MENTIONS:
@@ -6699,13 +6709,15 @@ body::after {
       const avatarRefs = conversationAvatarRefs(convo);
       const unread = Number(convo.UnreadCount || convo.unread_count || 0);
       const unreadLabel = unread > 99 ? '99+' : String(unread);
+      const labelName = convo.Name || 'favorite thread';
+      const unreadAria = unread > 0 ? `, ${unreadLabel} unread` : '';
       return `
         <button
           type="button"
           class="favorite-chip${convo.ConversationID === activeConvoId ? ' active' : ''}"
           data-conversation-id="${escapeHtml(convo.ConversationID)}"
-          title="${escapeHtml(convo.Name || 'Favorite thread')}"
-          aria-label="Open ${escapeHtml(convo.Name || 'favorite thread')}"
+          title="${escapeHtml(labelName)}"
+          aria-label="${escapeHtml(`Open ${labelName}${unreadAria}`)}"
           ${convo.ConversationID === activeConvoId ? 'aria-current="page"' : ''}
         >
           ${avatarHTML({
@@ -6719,7 +6731,7 @@ body::after {
             className: 'favorite-avatar',
             style: `background:${avatarColor(convo.Name)}`,
           })}
-          ${unread > 0 ? `<span class="favorite-unread">${escapeHtml(unreadLabel)}</span>` : ''}
+          ${unread > 0 ? `<span class="favorite-unread" aria-hidden="true">${escapeHtml(unreadLabel)}</span>` : ''}
         </button>
       `;
     }).join('');
@@ -6776,7 +6788,7 @@ body::after {
         class="chat-header-action-btn favorite${isFavorite ? ' active' : ''}"
         id="chat-header-favorite-btn"
         title="${isFavorite ? 'Remove from favorites' : 'Add to favorites'}"
-        aria-label="${isFavorite ? 'Remove from favorites' : 'Add to favorites'}"
+        aria-label="Favorite thread"
         aria-pressed="${isFavorite ? 'true' : 'false'}"
       >${favoriteActionIconHTML(isFavorite)}</button>
     `;
@@ -7180,13 +7192,20 @@ body::after {
       || null;
   }
 
-  function applyConversationPatch(conversationID, patch) {
-    const apply = (convo) => {
+  function applyConversationPatch(conversationID, patch, fallbackConvo = null) {
+    let patchedAllConversations = false;
+    allConversations = allConversations.map((convo) => {
+      if (!convo || convo.ConversationID !== conversationID) return convo;
+      patchedAllConversations = true;
+      return Object.assign(convo, patch);
+    });
+    conversations = conversations.map((convo) => {
       if (!convo || convo.ConversationID !== conversationID) return convo;
       return Object.assign(convo, patch);
-    };
-    allConversations = allConversations.map(apply);
-    conversations = conversations.map(apply);
+    });
+    if (!patchedAllConversations && fallbackConvo && conversationFavoriteOf(Object.assign({}, fallbackConvo, patch))) {
+      allConversations.push(Object.assign({}, fallbackConvo, patch));
+    }
     if (activeConversation && activeConversation.ConversationID === conversationID) {
       activeConversation = Object.assign(activeConversation, patch);
     }
@@ -7264,12 +7283,13 @@ body::after {
     const updated = await postJSON(`/api/conversations/${encodeURIComponent(convo.ConversationID)}/favorite`, {
       favorite: !!favorite,
     });
-    const isFavorite = !!(updated.IsFavorite || updated.is_favorite || favorite);
-    applyConversationPatch(convo.ConversationID, {
+    const isFavorite = favoriteValueFromResponse(updated, favorite);
+    const patch = {
       IsFavorite: isFavorite,
       is_favorite: isFavorite,
-    });
-    renderConversations(allConversations);
+    };
+    applyConversationPatch(convo.ConversationID, patch, Object.assign({}, convo, updated));
+    await renderConversationListPreservingSearch();
     if (activeConversation && activeConversation.ConversationID === convo.ConversationID) {
       refreshConversationChrome();
     }
@@ -9299,11 +9319,22 @@ body::after {
       UnreadCount: result.UnreadCount || 0,
       source_platform: result.SourcePlatform || result.source_platform,
       DisplayProtocol: result.DisplayProtocol || result.display_protocol || '',
+      IsFavorite: !!(result.IsFavorite || result.is_favorite),
+      is_favorite: !!(result.IsFavorite || result.is_favorite),
       UnifiedID: result.UnifiedID || result.unified_id || '',
       UnifiedName: result.UnifiedName || result.unified_name || '',
       _searchPreview: result.preview || '',
     }));
     renderConversations(searchConvos, true);
+  }
+
+  async function renderConversationListPreservingSearch() {
+    const query = $searchInput.value.trim();
+    if (query) {
+      await renderSearchResults(query);
+      return;
+    }
+    renderConversations(allConversations);
   }
 
   $searchInput.addEventListener('input', () => {


### PR DESCRIPTION
## Summary

- adds persistent favorite state for conversations, preserving favorites across sync/backfill upserts and conversation merges
- adds a header star and conversation context-menu action to favorite or unfavorite a thread
- adds a compact favorites rail under the sidebar tabs with avatars/initials, active-state styling, and unread badges
- keeps favorited conversations available outside the normal recents limit while preserving chronological ordering in the main list

## Review / validation

- OpenMessage PR review skill: no blocking findings
- Secret scan for common key/token patterns: no committed secrets found; existing docs/comments/CSS false positives only
- `git diff --check`
- `go test ./...`
- `npm ci` -> 0 vulnerabilities
- `npx playwright test` -> 66 passed
