### PR TITLE
[codex] Prevent duplicate composer sends

### DIFF
--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -652,6 +652,53 @@ test('sends a Signal image attachment through the compose box', async ({ page })
   await expect(latestMessage.locator('.msg-media-loading')).toHaveCount(0);
 });
 
+test('ignores duplicate composer submissions while media send is in flight', async ({ page }) => {
+  let sendMediaRequests = 0;
+  let releaseSend;
+  const sendBlocked = new Promise(resolve => {
+    releaseSend = resolve;
+  });
+
+  await page.route('**/api/send-media', async route => {
+    sendMediaRequests += 1;
+    await sendBlocked;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        message_id: 'signal:e2e-delayed-media',
+        status: 'SUCCESS',
+        success: true,
+      }),
+    });
+  });
+
+  await openConversation(page, 'Taylor Price');
+  await expect(page.locator('#chat-header-source')).toContainText('Signal');
+  await page.locator('#file-input').setInputFiles({
+    name: 'signal-delayed.png',
+    mimeType: 'image/png',
+    buffer: Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z9wAAAABJRU5ErkJggg==',
+      'base64',
+    ),
+  });
+
+  await expect(page.locator('#attach-preview')).toHaveClass(/active/);
+  await page.locator('#compose-input').press('Enter');
+  await expect.poll(() => sendMediaRequests).toBe(1);
+  await expect(page.locator('#send-btn')).toBeDisabled();
+
+  await page.locator('#compose-input').press('Enter');
+  await page.locator('#compose-input').press('Enter');
+  await page.waitForTimeout(150);
+  expect(sendMediaRequests).toBe(1);
+
+  releaseSend();
+  await expect(page.locator('#attach-preview')).not.toHaveClass(/active/);
+  expect(sendMediaRequests).toBe(1);
+});
+
 test('sends a captioned Signal image as one message, not two', async ({ page }) => {
   const caption = `Signal captioned ${Date.now()}`;
   const sendMediaRequests = [];

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -4964,6 +4964,7 @@ body::after {
   const $attachName = document.getElementById('attach-name');
   const $attachRemove = document.getElementById('attach-remove');
   let pendingFile = null; // { file: File, dataUrl: string }
+  let composeSendInFlight = false;
   const $searchInput = document.getElementById('search-input');
   const $connectionBanner = document.getElementById('connection-banner');
   const $connectionBannerCopy = document.getElementById('connection-banner-copy');
@@ -6647,7 +6648,7 @@ body::after {
     if (!activeConversation) {
       $composeInput.disabled = false;
       if ($composeEmojiBtn) $composeEmojiBtn.disabled = false;
-      $attachBtn.disabled = false;
+      $attachBtn.disabled = composeSendInFlight;
       $attachBtn.title = 'Attach media';
       return;
     }
@@ -6656,7 +6657,7 @@ body::after {
     const canSendMedia = conversationSupportsMediaOutbound(activeConversation);
     $composeInput.disabled = !canSend;
     if ($composeEmojiBtn) $composeEmojiBtn.disabled = !canSend;
-    $attachBtn.disabled = !canSendMedia;
+    $attachBtn.disabled = composeSendInFlight || !canSendMedia;
     $attachBtn.title = canSendMedia
       ? 'Attach media'
       : (sourcePlatformOf(activeConversation) === 'whatsapp'
@@ -8766,6 +8767,9 @@ body::after {
 
   // ─── Send Message ───
   async function sendMessage() {
+    if (composeSendInFlight) {
+      return;
+    }
     if (!activeConversation) {
       return;
     }
@@ -8796,10 +8800,12 @@ body::after {
       || (hasMedia && activePlatform === 'signal');
     if ((!text && !hasMedia) || !sendConvoId) return;
 
+    composeSendInFlight = true;
     clearThreadFeedback();
     $composeInput.value = '';
     composeTextByConversation.delete(sendConvoId);
     $sendBtn.disabled = true;
+    $attachBtn.disabled = true;
     autoResize();
 
     // Optimistic UI: show message immediately before server round-trip
@@ -8863,6 +8869,8 @@ body::after {
       showThreadFeedback(err.message || 'Failed to send message', 'send');
       console.error('Failed to send:', err);
     } finally {
+      composeSendInFlight = false;
+      refreshComposeRouteUI();
       autoResize();
     }
   }
@@ -8893,6 +8901,7 @@ body::after {
     const hasText = !!$composeInput.value.trim();
     const hasMedia = !!pendingFile;
     $sendBtn.disabled = !activeConversation
+      || composeSendInFlight
       || (!hasText && !hasMedia)
       || browserIsOffline()
       || (hasText && !conversationSupportsOutbound(activeConversation))
@@ -9027,6 +9036,10 @@ body::after {
 
   // ─── Attachments (paste + file picker) ───
   function setAttachment(file) {
+    if (composeSendInFlight) {
+      $fileInput.value = '';
+      return;
+    }
     if (!conversationSupportsMediaOutbound(activeConversation)) {
       showThreadFeedback('Attachments are unavailable on this route right now.');
       return;
@@ -9034,7 +9047,7 @@ body::after {
     pendingFile = { file };
     $attachName.textContent = file.name || 'Attachment';
     $attachPreview.classList.add('active');
-    $sendBtn.disabled = false;
+    autoResize();
 
     if (file.type.startsWith('image/')) {
       const reader = new FileReader();


### PR DESCRIPTION
## Summary
- Add an in-flight guard to the web composer send flow so rapid Enter/click submissions are ignored while a send is pending.
- Keep the send and attach controls disabled during the in-flight send, and avoid overwriting pending attachment state mid-upload.
- Add a Playwright regression that holds `/api/send-media` open and verifies repeated Enter submissions still produce one request.

## Root cause
The composer disabled the send button after starting a send, but keyboard submission calls `sendMessage()` directly and the handler had no in-flight state. For attachments, `pendingFile` stayed populated until `/api/send-media` returned, so each re-entry during that async window posted the same media again.

Closes #55

## Validation
- `git diff --check`
- `go test ./...`
- `OPENMESSAGES_E2E_PORT=7025 npx playwright test e2e/ui.spec.js -g "ignores duplicate composer submissions"`
- `OPENMESSAGES_E2E_PORT=7025 npx playwright test e2e/ui.spec.js`

Local OpenMessage PR review: no blocking findings.