### PR TITLE
Harden MCP and export tool surfaces

### DIFF
--- a/.claude/commands/generate-story.md
+++ b/.claude/commands/generate-story.md
@@ -87,7 +87,7 @@ Don't inspect all 100+ photos individually. Be efficient:
 
 ### Output
 
-Build a JSON array of the selected photo file paths (absolute paths). You'll pass this to `render_story` via the `photo_paths` parameter.
+Build a JSON array of selected photo file paths under `OPENMESSAGES_EXPORT_DIR` (default `~/Documents/OpenMessage`). If the user intentionally wants to read photos from elsewhere, explain that `OPENMESSAGES_ALLOW_ANY_EXPORT_PATH=1` is required before passing those absolute paths to `render_story`.
 
 ## Phase 4: render
 
@@ -117,9 +117,9 @@ Assemble the Story JSON and call `render_story`. The JSON format:
 Call `render_story` with:
 - `name`: the person's name
 - `story_json`: the JSON string above
-- `output_path`: `/tmp/{name_lowercase}_story.html`
+- `output_path`: `stories/{name_lowercase}_story.html` (written under `OPENMESSAGES_EXPORT_DIR`, default `~/Documents/OpenMessage`)
 - `timezone`: "America/New_York" (or ask the user if unsure)
-- `photo_paths`: JSON array of curated photo file paths (from Phase 3.5)
+- `photo_paths`: JSON array of curated photo file paths from Phase 3.5. By default, these must be inside `OPENMESSAGES_EXPORT_DIR`; set `OPENMESSAGES_ALLOW_ANY_EXPORT_PATH=1` only for an explicit outside-directory export.
 
 Photos are automatically sorted chronologically by date in their filename, and interspersed between sections so early photos appear near early chapters and recent photos near recent ones.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Generates a self-contained HTML file combining data dashboards with narrative ch
 
 **Sections**: password gate, hero, timeline nav, narrative chapters (early/middle/late), monthly volume chart (Chart.js), sender split donut, response times, hour-of-week heatmap, phrase cloud (colored by sender ratio), longest gap callout, interspersed photo breaks (chronologically aligned), interludes, closing.
 
-**Key parameters**: `name` (person to search), `output_path`, `timezone` (default ET), `password`, `api_key` (for Claude-generated narrative), colors (`primary_color`, `secondary_color`, etc.).
+**Key parameters**: `name` (person to search), `output_path` (relative to `OPENMESSAGES_EXPORT_DIR`, default `~/Documents/OpenMessage`, unless `OPENMESSAGES_ALLOW_ANY_EXPORT_PATH=1` is set), `timezone` (default ET), `password`, `api_key` (for Claude-generated narrative), colors (`primary_color`, `secondary_color`, etc.).
 
 **Architecture**:
 - `internal/viz/config.go` — `VizConfig` struct, section ordering, color theming

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ The macOS app target lives under `OpenMessage/`.
 | `OPENMESSAGES_BACKFILL_DISCOVER_ORPHANS` | `0` | Opt in to deep backfill's Phase C (contact-based orphan discovery). **Off by default** because it creates an empty SMS thread on your phone for each contact without prior message history. Enable with `1`/`true`/`yes`/`on` only if you understand the side effect. |
 | `OPENMESSAGES_MACOS_NOTIFICATIONS` | interactive macOS `serve` sessions only | Enable/disable native macOS notifications for fresh inbound live messages (`1`/`0`). Click-through opens the matching thread when `terminal-notifier` is available. The macOS app sets this to `0` and posts its own notifications (with tap-to-open and active-thread suppression) instead. |
 | `OPENMESSAGES_SIGNAL_TMP_SWEEP` | enabled | Set to `0` to disable the cleanup of stale signal-cli temp directories (the app-owned run dirs plus `libsignal*` dirs older than 24h that pre-v0.2.10 builds leaked into the system temp dir — see #27). |
+| `OPENMESSAGES_EXPORT_DIR` | `~/Documents/OpenMessage` | Directory for `generate_viz` / `render_story` HTML outputs and photo inputs when using the default confined export mode. |
+| `OPENMESSAGES_ALLOW_ANY_EXPORT_PATH` | unset (off) | Set to `1`/`true`/`yes`/`on` to allow viz/story tools to read photos from, or write HTML to, arbitrary local paths. |
 | `OPENMESSAGE_TELEMETRY` | unset (off) | Set to `1` to send one anonymous heartbeat per launch (max one per 24h). Reports only: random install ID, version, OS/arch, and which platforms are paired (Google Messages / WhatsApp / Signal). No message content, no contact info, no IP-based identity. See `internal/telemetry/`. |
 
 ## Architecture

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -421,7 +421,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 			if sseSrv != nil {
 				mux.Handle("/mcp/", sseSrv)
 			}
-			httpHandler = mux
+			httpHandler = web.ProtectLocalControl(mux)
 		}
 
 		ln, err := net.Listen("tcp", listenAddr)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -360,12 +360,9 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	)
 	tools.Register(mcpSrv, a)
 
-	var sseSrv http.Handler
+	var mcpHTTPHandler http.Handler
 	if opts.mcpSSE {
-		sseSrv = mcpserver.NewSSEServer(mcpSrv,
-			mcpserver.WithBaseURL(baseURL),
-			mcpserver.WithStaticBasePath("/mcp"),
-		)
+		mcpHTTPHandler = newMCPHTTPHandler(mcpSrv, baseURL)
 	}
 
 	googleStatus := func() any {
@@ -379,7 +376,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	if httpEnabled {
 		httpHandler := http.Handler(nil)
 		if opts.web {
-			httpHandler = web.APIHandlerWithOptions(a.Store, nil, logger, sseSrv, web.APIOptions{
+			httpHandler = web.APIHandlerWithOptions(a.Store, nil, logger, mcpHTTPHandler, web.APIOptions{
 				Client:               a.GetClient,
 				Events:               events,
 				IdentityName:         identityName,
@@ -417,11 +414,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				SyncGoogleContacts:    a.SyncGoogleContacts,
 			})
 		} else {
-			mux := http.NewServeMux()
-			if sseSrv != nil {
-				mux.Handle("/mcp/", sseSrv)
-			}
-			httpHandler = web.ProtectLocalControl(mux)
+			httpHandler = web.ProtectLocalControl(mcpHTTPHandler)
 		}
 
 		ln, err := net.Listen("tcp", listenAddr)
@@ -471,6 +464,18 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	<-sigCh
 	logger.Info().Msg("Shutting down")
 	return nil
+}
+
+func newMCPHTTPHandler(mcpSrv *mcpserver.MCPServer, baseURL string) http.Handler {
+	streamableSrv := mcpserver.NewStreamableHTTPServer(mcpSrv, mcpserver.WithEndpointPath("/mcp"))
+	sseSrv := mcpserver.NewSSEServer(mcpSrv,
+		mcpserver.WithBaseURL(baseURL),
+		mcpserver.WithStaticBasePath("/mcp"),
+	)
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", streamableSrv)
+	mux.Handle("/mcp/", sseSrv)
+	return mux
 }
 
 // telemetrySnapshot extracts the minimal pairing-status data sent in heartbeats.

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,12 +1,17 @@
 package cmd
 
 import (
+	"bytes"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
+
+	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
 func TestHTTPServerSurvivesIndependently(t *testing.T) {
@@ -46,6 +51,35 @@ func TestHTTPServerSurvivesIndependently(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	if string(body) != "ok" {
 		t.Fatalf("got %q, want %q", body, "ok")
+	}
+}
+
+func TestMCPHTTPHandlerServesCodexAndClaudeTransports(t *testing.T) {
+	mcpSrv := mcpserver.NewMCPServer("test-openmessage", "test", mcpserver.WithToolCapabilities(true))
+	srv := httptest.NewServer(newMCPHTTPHandler(mcpSrv, "http://example.test"))
+	defer srv.Close()
+
+	initBody := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}`)
+	resp, err := http.Post(srv.URL+"/mcp", "application/json", bytes.NewReader(initBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("streamable HTTP /mcp status = %d, want 200", resp.StatusCode)
+	}
+
+	req, _ := http.NewRequest("GET", srv.URL+"/mcp/sse", nil)
+	resp2, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("SSE /mcp/sse status = %d, want 200", resp2.StatusCode)
+	}
+	if ct := resp2.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("SSE content-type = %q, want text/event-stream", ct)
 	}
 }
 

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -13,6 +13,11 @@ const messageColumns = `message_id, conversation_id, sender_name, sender_number,
 
 var ErrMessageNotFound = errors.New("message not found")
 
+const (
+	MaxTranscriptBytes      = 64 << 10
+	MaxTranscriptModelBytes = 128
+)
+
 func (s *Store) UpsertMessage(m *Message) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -796,6 +801,9 @@ func (s *Store) SetMessageTranscript(messageID, transcript string, model *string
 	if messageID == "" {
 		return fmt.Errorf("SetMessageTranscript: empty message_id")
 	}
+	if err := ValidateMessageTranscript(transcript, model); err != nil {
+		return err
+	}
 	msg, err := s.GetMessageByID(messageID)
 	if err != nil {
 		return fmt.Errorf("SetMessageTranscript: get message: %w", err)
@@ -838,6 +846,16 @@ func (s *Store) SetMessageTranscript(messageID, transcript string, model *string
 	}
 	if n == 0 {
 		return ErrMessageNotFound
+	}
+	return nil
+}
+
+func ValidateMessageTranscript(transcript string, model *string) error {
+	if len(transcript) > MaxTranscriptBytes {
+		return fmt.Errorf("transcript exceeds %d bytes", MaxTranscriptBytes)
+	}
+	if model != nil && len(*model) > MaxTranscriptModelBytes {
+		return fmt.Errorf("transcript model exceeds %d bytes", MaxTranscriptModelBytes)
 	}
 	return nil
 }

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -701,6 +701,29 @@ func TestSetMessageTranscript(t *testing.T) {
 	}
 }
 
+func TestSetMessageTranscriptRejectsOversizedValues(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.UpsertMessage(&Message{
+		MessageID:      "audio-oversized",
+		ConversationID: "c1",
+		Body:           "[Voice note]",
+		MediaID:        "media-x",
+		MimeType:       "audio/ogg",
+		TimestampMS:    1000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	tooLongTranscript := strings.Repeat("x", MaxTranscriptBytes+1)
+	if err := store.SetMessageTranscript("audio-oversized", tooLongTranscript, nil); err == nil {
+		t.Fatal("expected oversized transcript error")
+	}
+	tooLongModel := strings.Repeat("m", MaxTranscriptModelBytes+1)
+	if err := store.SetMessageTranscript("audio-oversized", "ok", &tooLongModel); err == nil {
+		t.Fatal("expected oversized model error")
+	}
+}
+
 func TestSearchMessages_Comprehensive(t *testing.T) {
 	store := newTestStore(t)
 

--- a/internal/tools/export_paths.go
+++ b/internal/tools/export_paths.go
@@ -1,0 +1,189 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	exportDirEnv       = "OPENMESSAGES_EXPORT_DIR"
+	allowAnyExportPath = "OPENMESSAGES_ALLOW_ANY_EXPORT_PATH"
+)
+
+func resolveExportWritePath(requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return "", fmt.Errorf("output_path is required")
+	}
+	if allowAnyExportPaths() {
+		return filepath.Abs(requested)
+	}
+	return resolvePathInsideExportRoot(requested, true)
+}
+
+func resolveExportReadPath(requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if allowAnyExportPaths() {
+		return filepath.Abs(requested)
+	}
+	return resolvePathInsideExportRoot(requested, false)
+}
+
+func writePrivateExportFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".openmessage-export-*")
+	if err != nil {
+		return fmt.Errorf("create temp output: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp output: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp output: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp output: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace output: %w", err)
+	}
+	return nil
+}
+
+func allowAnyExportPaths() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(allowAnyExportPath))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func resolvePathInsideExportRoot(requested string, forWrite bool) (string, error) {
+	root, err := exportRoot()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return "", fmt.Errorf("create export root: %w", err)
+	}
+	candidate := requested
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(root, candidate)
+	}
+	candidate, err = filepath.Abs(candidate)
+	if err != nil {
+		return "", err
+	}
+	if err := ensureInside(root, candidate); err != nil {
+		return "", err
+	}
+	if forWrite {
+		if err := ensureWritableParentInside(root, candidate); err != nil {
+			return "", err
+		}
+	} else {
+		if err := ensureRealPathInside(root, candidate, false); err != nil {
+			return "", err
+		}
+	}
+	return candidate, nil
+}
+
+func exportRoot() (string, error) {
+	root := strings.TrimSpace(os.Getenv(exportDirEnv))
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		root = filepath.Join(home, "Documents", "OpenMessage")
+	}
+	return filepath.Abs(root)
+}
+
+func ensureRealPathInside(root, candidate string, forWrite bool) error {
+	rootEval, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("resolve export root: %w", err)
+	}
+	parent := candidate
+	if forWrite {
+		parent = filepath.Dir(candidate)
+	}
+	parentEval, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return fmt.Errorf("resolve path: %w", err)
+	}
+	if err := ensureInside(rootEval, parentEval); err != nil {
+		return err
+	}
+	if st, err := os.Lstat(candidate); err == nil && st.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("path must not be a symlink: %s", candidate)
+	}
+	return nil
+}
+
+func ensureWritableParentInside(root, candidate string) error {
+	rootEval, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("resolve export root: %w", err)
+	}
+	parent := filepath.Dir(candidate)
+	existing := parent
+	for {
+		if st, err := os.Lstat(existing); err == nil {
+			if st.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("path must not traverse a symlink: %s", existing)
+			}
+			if !st.IsDir() {
+				return fmt.Errorf("path parent is not a directory: %s", existing)
+			}
+			break
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect path: %w", err)
+		}
+		next := filepath.Dir(existing)
+		if next == existing {
+			return fmt.Errorf("resolve path parent: %s", parent)
+		}
+		existing = next
+	}
+	existingEval, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return fmt.Errorf("resolve path: %w", err)
+	}
+	if err := ensureInside(rootEval, existingEval); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	if st, err := os.Lstat(candidate); err == nil && st.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("path must not be a symlink: %s", candidate)
+	}
+	return nil
+}
+
+func ensureInside(root, candidate string) error {
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %s is outside export root %s; set %s=1 to override", candidate, root, allowAnyExportPath)
+	}
+	return nil
+}

--- a/internal/tools/render_story.go
+++ b/internal/tools/render_story.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -21,7 +20,7 @@ func renderStoryTool() mcp.Tool {
 		mcp.WithDescription("Render a pre-built Story (title, summary, chapters with quotes) into a self-contained HTML visualization with data dashboards. The story JSON is provided by the caller; stats are computed from all messages with the person. Use this after agentically writing a story to produce the final HTML."),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Person's name (for stats computation from all messages)")),
 		mcp.WithString("story_json", mcp.Required(), mcp.Description("JSON string of Story struct: {title, summary, chapters: [{title, content, period, quotes: [{sender, text, timestamp}]}]}")),
-		mcp.WithString("output_path", mcp.Required(), mcp.Description("File path to write the HTML output (e.g. /tmp/viz.html)")),
+		mcp.WithString("output_path", mcp.Required(), mcp.Description("Path to write the HTML output. Relative paths are written under OPENMESSAGES_EXPORT_DIR or ~/Documents/OpenMessage; set OPENMESSAGES_ALLOW_ANY_EXPORT_PATH=1 to allow arbitrary paths.")),
 		mcp.WithString("person1", mcp.Description("First person's display name (default: 'Max')")),
 		mcp.WithString("person2", mcp.Description("Second person's display name (default: matched name)")),
 		mcp.WithString("timezone", mcp.Description("Timezone for heatmap and dates (default: America/New_York)")),
@@ -51,6 +50,10 @@ func renderStoryHandler(a *app.App) server.ToolHandlerFunc {
 		outputPath := strArg(args, "output_path")
 		if outputPath == "" {
 			return errorResult("output_path is required"), nil
+		}
+		outputPath, err := resolveExportWritePath(outputPath)
+		if err != nil {
+			return errorResult(err.Error()), nil
 		}
 
 		// Parse story JSON
@@ -119,12 +122,24 @@ func renderStoryHandler(a *app.App) server.ToolHandlerFunc {
 			if err := json.Unmarshal([]byte(photoPathsJSON), &paths); err != nil {
 				return errorResult(fmt.Sprintf("invalid photo_paths JSON: %v", err)), nil
 			}
+			for i, path := range paths {
+				resolved, err := resolveExportReadPath(path)
+				if err != nil {
+					return errorResult(fmt.Sprintf("photo_paths[%d]: %v", i, err)), nil
+				}
+				paths[i] = resolved
+			}
 			photos, err := viz.EncodePhotosFromPaths(paths)
 			if err != nil {
 				return errorResult(fmt.Sprintf("encode photos: %v", err)), nil
 			}
 			config.Photos = photos
 		} else if photosDir != "" {
+			resolved, err := resolveExportReadPath(photosDir)
+			if err != nil {
+				return errorResult(fmt.Sprintf("photos_dir: %v", err)), nil
+			}
+			photosDir = resolved
 			maxPhotos := intArg(args, "max_photos", 20)
 			photos, err := viz.EncodePhotosFromDir(photosDir, maxPhotos)
 			if err != nil {
@@ -139,15 +154,8 @@ func renderStoryHandler(a *app.App) server.ToolHandlerFunc {
 			return errorResult(fmt.Sprintf("render HTML: %v", err)), nil
 		}
 
-		// Ensure output directory exists
-		if dir := filepath.Dir(outputPath); dir != "" {
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				return errorResult(fmt.Sprintf("create output dir: %v", err)), nil
-			}
-		}
-
 		// Write file
-		if err := os.WriteFile(outputPath, html, 0o644); err != nil {
+		if err := writePrivateExportFile(outputPath, html); err != nil {
 			return errorResult(fmt.Sprintf("write file: %v", err)), nil
 		}
 

--- a/internal/tools/set_message_transcript.go
+++ b/internal/tools/set_message_transcript.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/db"
 )
 
 func setMessageTranscriptTool() mcp.Tool {
@@ -28,7 +29,8 @@ func setMessageTranscriptTool() mcp.Tool {
 			mcp.Description("Free-form model identifier (for example faster-whisper:base.en)."),
 		),
 		mcp.WithReadOnlyHintAnnotation(false),
-		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
 	)
 }
 
@@ -54,6 +56,9 @@ func setMessageTranscriptHandler(a *app.App) server.ToolHandlerFunc {
 		}
 		if messageID == "" {
 			return errorResult("set_message_transcript: message_id is required"), nil
+		}
+		if err := db.ValidateMessageTranscript(transcript, model); err != nil {
+			return errorResult(fmt.Sprintf("set_message_transcript: %v", err)), nil
 		}
 		if err := a.Store.SetMessageTranscript(messageID, transcript, model); err != nil {
 			return errorResult(fmt.Sprintf("set_message_transcript: %v", err)), nil

--- a/internal/tools/viz.go
+++ b/internal/tools/viz.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -23,7 +22,7 @@ func generateVizTool() mcp.Tool {
 	return mcp.NewTool("generate_viz",
 		mcp.WithDescription("Generate a self-contained HTML visualization of a relationship. Combines data dashboards (charts, heatmap, phrase cloud) with narrative chapters. Output is a single HTML file deployable to Vercel or viewable locally."),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Person's name to search for (case-insensitive partial match)")),
-		mcp.WithString("output_path", mcp.Required(), mcp.Description("File path to write the HTML output (e.g. /tmp/viz.html)")),
+		mcp.WithString("output_path", mcp.Required(), mcp.Description("Path to write the HTML output. Relative paths are written under OPENMESSAGES_EXPORT_DIR or ~/Documents/OpenMessage; set OPENMESSAGES_ALLOW_ANY_EXPORT_PATH=1 to allow arbitrary paths.")),
 		mcp.WithString("person1", mcp.Description("First person's display name (default: 'Max')")),
 		mcp.WithString("person2", mcp.Description("Second person's display name (default: matched name)")),
 		mcp.WithString("timezone", mcp.Description("Timezone for heatmap and dates (default: America/New_York)")),
@@ -48,6 +47,10 @@ func generateVizHandler(a *app.App) server.ToolHandlerFunc {
 		outputPath := strArg(args, "output_path")
 		if outputPath == "" {
 			return errorResult("output_path is required"), nil
+		}
+		outputPath, err := resolveExportWritePath(outputPath)
+		if err != nil {
+			return errorResult(err.Error()), nil
 		}
 
 		// Collect messages across all platforms
@@ -125,15 +128,8 @@ func generateVizHandler(a *app.App) server.ToolHandlerFunc {
 			return errorResult(fmt.Sprintf("render HTML: %v", err)), nil
 		}
 
-		// Ensure output directory exists
-		if dir := filepath.Dir(outputPath); dir != "" {
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				return errorResult(fmt.Sprintf("create output dir: %v", err)), nil
-			}
-		}
-
 		// Write the file
-		if err := os.WriteFile(outputPath, html, 0o644); err != nil {
+		if err := writePrivateExportFile(outputPath, html); err != nil {
 			return errorResult(fmt.Sprintf("write file: %v", err)), nil
 		}
 

--- a/internal/tools/viz_test.go
+++ b/internal/tools/viz_test.go
@@ -1,6 +1,11 @@
 package tools
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestJoinNames(t *testing.T) {
 	tests := []struct {
@@ -17,5 +22,49 @@ func TestJoinNames(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("joinNames(%v) = %q, want %q", tt.names, got, tt.want)
 		}
+	}
+}
+
+func TestResolveExportWritePathConfinement(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(exportDirEnv, root)
+
+	got, err := resolveExportWritePath("stories/out.html")
+	if err != nil {
+		t.Fatalf("resolve relative output: %v", err)
+	}
+	wantPrefix := filepath.Join(root, "stories") + string(filepath.Separator)
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("resolved path = %q, want under %q", got, wantPrefix)
+	}
+
+	if _, err := resolveExportWritePath("../escape.html"); err == nil {
+		t.Fatal("expected traversal outside export root to fail")
+	}
+
+	outside := filepath.Join(t.TempDir(), "out.html")
+	t.Setenv(allowAnyExportPath, "1")
+	got, err = resolveExportWritePath(outside)
+	if err != nil {
+		t.Fatalf("resolve override output: %v", err)
+	}
+	if got != outside {
+		t.Fatalf("override path = %q, want %q", got, outside)
+	}
+}
+
+func TestResolveExportWritePathRejectsSymlinkParentBeforeCreatingDirs(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	t.Setenv(exportDirEnv, root)
+
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := resolveExportWritePath("link/new/out.html"); err == nil {
+		t.Fatal("expected symlink parent to be rejected")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "new")); !os.IsNotExist(err) {
+		t.Fatalf("outside directory was created despite rejection: %v", err)
 	}
 }

--- a/internal/viz/photos.go
+++ b/internal/viz/photos.go
@@ -14,6 +14,11 @@ import (
 	"github.com/maxghenis/openmessage/internal/db"
 )
 
+const (
+	maxPhotoBytes      = 15 << 20
+	maxTotalPhotoBytes = 120 << 20
+)
+
 // Photo holds a photo's data URI and metadata for chronological placement.
 type Photo struct {
 	DataURI  string    `json:"data_uri"`
@@ -52,6 +57,9 @@ func EncodePhotosFromDir(dir string, maxPhotos int) ([]Photo, error) {
 		if e.IsDir() {
 			continue
 		}
+		if e.Type()&os.ModeSymlink != 0 {
+			continue
+		}
 		ext := strings.ToLower(filepath.Ext(e.Name()))
 		switch ext {
 		case ".jpg", ".jpeg", ".png", ".webp", ".gif":
@@ -82,7 +90,22 @@ func EncodePhotosFromPaths(paths []string) ([]Photo, error) {
 // base64 data URIs and dates parsed from filenames.
 func encodeFiles(paths []string) ([]Photo, error) {
 	var photos []Photo
+	totalBytes := int64(0)
 	for _, p := range paths {
+		info, err := os.Lstat(p)
+		if err != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		if info.Size() > maxPhotoBytes {
+			return nil, fmt.Errorf("%s exceeds %d bytes", p, maxPhotoBytes)
+		}
+		totalBytes += info.Size()
+		if totalBytes > maxTotalPhotoBytes {
+			return nil, fmt.Errorf("photos exceed %d bytes total", maxTotalPhotoBytes)
+		}
 		data, err := os.ReadFile(p)
 		if err != nil {
 			continue
@@ -120,8 +143,8 @@ func SortPhotosByDate(photos []Photo) {
 // Supports: IMG-20251211-WA0053.jpg (WhatsApp), IMG_20251211_123456.jpg,
 // 20251211_123456.jpg, photo_2025-12-11.jpg, etc.
 var datePatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(\d{4})-(\d{2})-(\d{2})`),     // 2025-12-11
-	regexp.MustCompile(`(\d{4})(\d{2})(\d{2})`),        // 20251211
+	regexp.MustCompile(`(\d{4})-(\d{2})-(\d{2})`), // 2025-12-11
+	regexp.MustCompile(`(\d{4})(\d{2})(\d{2})`),   // 20251211
 }
 
 func parseDateFromFilename(name string) time.Time {

--- a/internal/viz/photos_test.go
+++ b/internal/viz/photos_test.go
@@ -1,6 +1,8 @@
 package viz
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/maxghenis/openmessage/internal/db"
@@ -78,5 +80,32 @@ func TestIsVisualMedia(t *testing.T) {
 				t.Errorf("isVisualMedia(%q) = %v, want %v", tt.mime, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestEncodePhotosFromDirSkipsSymlinkedImages(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "20250101-real.jpg"), []byte("real image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(outside, "secret.jpg")
+	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "20250102-leak.jpg")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	photos, err := EncodePhotosFromDir(dir, 0)
+	if err != nil {
+		t.Fatalf("EncodePhotosFromDir: %v", err)
+	}
+	if len(photos) != 1 {
+		t.Fatalf("got %d photos, want only the real file", len(photos))
+	}
+	if photos[0].Filename != "20250101-real.jpg" {
+		t.Fatalf("encoded filename = %q, want real image", photos[0].Filename)
 	}
 }

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -2045,11 +2045,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		staticHandler.ServeHTTP(w, r)
 	}))
 
-	// Wrap the mux to intercept /mcp/ requests before the mux's catch-all
+	// Wrap the mux to intercept MCP requests before the mux's catch-all.
 	var handler http.Handler = mux
 	if mcpHandler != nil {
 		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/mcp/") {
+			if r.URL.Path == "/mcp" || strings.HasPrefix(r.URL.Path, "/mcp/") {
 				mcpHandler.ServeHTTP(w, r)
 				return
 			}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -37,6 +37,8 @@ var staticFS embed.FS
 // while keeping a runaway POST from exhausting memory.
 const maxUploadBytes = 128 << 20
 
+const maxTranscriptRequestBytes = db.MaxTranscriptBytes + db.MaxTranscriptModelBytes + 4096
+
 // APIHandler creates the HTTP handler with JSON API routes and static file serving.
 // The client may be nil (disconnected state).
 // mcpHandler is an optional http.Handler for the MCP SSE endpoint (mounted at /mcp/).
@@ -1335,12 +1337,18 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "method not allowed", 405)
 			return
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxTranscriptRequestBytes)
 		var req struct {
 			MessageID  string  `json:"message_id"`
 			Transcript *string `json:"transcript"`
 			Model      *string `json:"model,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			var tooLarge *http.MaxBytesError
+			if errors.As(err, &tooLarge) {
+				httpError(w, fmt.Sprintf("transcript request too large (limit %d bytes)", maxTranscriptRequestBytes), http.StatusRequestEntityTooLarge)
+				return
+			}
 			httpError(w, "invalid JSON: "+err.Error(), 400)
 			return
 		}
@@ -1350,6 +1358,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		}
 		if req.Transcript == nil {
 			httpError(w, "transcript required", 400)
+			return
+		}
+		if err := db.ValidateMessageTranscript(*req.Transcript, req.Model); err != nil {
+			httpError(w, err.Error(), http.StatusRequestEntityTooLarge)
 			return
 		}
 		if err := store.SetMessageTranscript(req.MessageID, *req.Transcript, req.Model); err != nil {
@@ -2045,21 +2057,29 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		})
 	}
 
-	// Guard the HTTP API against cross-origin / DNS-rebinding abuse. The server
+	// Guard local control surfaces against cross-origin / DNS-rebinding abuse. The server
 	// binds to 127.0.0.1, but that does NOT stop a malicious web page the user
-	// visits from POSTing to http://127.0.0.1:<port>/api/... (multipart and
-	// body-less POSTs are CORS "simple requests" with no preflight) — which
-	// could drive-by send messages or unpair accounts. Requiring a loopback
-	// Host and (when present) a loopback Origin/Referer closes that vector
-	// without affecting the native app, whose requests are same-origin.
+	// visits from talking to http://127.0.0.1:<port>/api/... or /mcp/... .
+	// Requiring a loopback Host and, when present, a same-origin loopback
+	// Origin/Referer closes that vector without affecting native app requests.
+	return ProtectLocalControl(handler)
+}
+
+// ProtectLocalControl rejects cross-origin browser access to local control
+// surfaces such as /api/* and /mcp/*.
+func ProtectLocalControl(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/") && !isLocalAPIRequest(r) {
+		if isProtectedLocalPath(r.URL.Path) && !isLocalControlRequest(r) {
 			httpError(w, "forbidden: API requests must originate from the local OpenMessage app", http.StatusForbidden)
 			return
 		}
 		setSecurityHeaders(w)
 		handler.ServeHTTP(w, r)
 	})
+}
+
+func isProtectedLocalPath(path string) bool {
+	return strings.HasPrefix(path, "/api/") || path == "/mcp" || strings.HasPrefix(path, "/mcp/")
 }
 
 // setSecurityHeaders adds defense-in-depth headers. The UI relies on
@@ -2096,33 +2116,91 @@ func isLoopbackHost(hostname string) bool {
 	return false
 }
 
-// isLocalAPIRequest validates that an /api/ request originates from the local
-// app rather than a cross-origin web page: the Host must be loopback (defends
-// DNS rebinding), and any Origin/Referer the browser attached must be loopback
-// too (defends drive-by cross-origin POSTs). Same-origin GETs carry no Origin
-// and pass; the native WKWebView is same-origin on 127.0.0.1 and passes.
-func isLocalAPIRequest(r *http.Request) bool {
-	host := r.Host
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		host = h
-	}
-	// An absent Host header is treated as non-local: browsers always send
-	// one, so an empty value only ever comes from a hand-rolled client —
-	// which must not slip past the loopback check by omission.
-	if host == "" || !isLoopbackHost(host) {
+// isLocalControlRequest validates that a protected local request originates
+// from OpenMessage itself rather than a cross-origin browser page: Host must
+// be loopback, and Origin/Referer must be the same local scheme and port.
+func isLocalControlRequest(r *http.Request) bool {
+	reqOrigin, ok := localRequestOrigin(r)
+	if !ok {
 		return false
 	}
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		origin = r.Header.Get("Referer")
 	}
-	if origin != "" {
-		u, err := url.Parse(origin)
-		if err != nil || !isLoopbackHost(u.Hostname()) {
-			return false
-		}
+	if origin == "" {
+		return true
 	}
-	return true
+	headerOrigin, ok := parseLocalOrigin(origin)
+	return ok && headerOrigin == reqOrigin
+}
+
+type localOrigin struct {
+	Scheme string
+	Port   string
+}
+
+func localRequestOrigin(r *http.Request) (localOrigin, bool) {
+	host, port, ok := splitHostPortDefault(r.Host, requestDefaultPort(r))
+	// An absent Host header is treated as non-local: browsers always send
+	// one, so an empty value only ever comes from a hand-rolled client —
+	// which must not slip past the loopback check by omission.
+	if !ok || host == "" || !isLoopbackHost(host) {
+		return localOrigin{}, false
+	}
+	return localOrigin{Scheme: requestScheme(r), Port: port}, true
+}
+
+func parseLocalOrigin(raw string) (localOrigin, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" {
+		return localOrigin{}, false
+	}
+	host, port, ok := splitHostPortDefault(u.Host, defaultPortForScheme(u.Scheme))
+	if !ok || !isLoopbackHost(host) {
+		return localOrigin{}, false
+	}
+	return localOrigin{Scheme: strings.ToLower(u.Scheme), Port: port}, true
+}
+
+func requestScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+func requestDefaultPort(r *http.Request) string {
+	return defaultPortForScheme(requestScheme(r))
+}
+
+func defaultPortForScheme(scheme string) string {
+	if strings.EqualFold(scheme, "https") {
+		return "443"
+	}
+	return "80"
+}
+
+func splitHostPortDefault(hostport, defaultPort string) (string, string, bool) {
+	hostport = strings.TrimSpace(hostport)
+	if hostport == "" {
+		return "", "", false
+	}
+	if host, port, err := net.SplitHostPort(hostport); err == nil {
+		if port == "" {
+			port = defaultPort
+		}
+		return host, port, true
+	}
+	u, err := url.Parse("//" + hostport)
+	if err != nil || u.Hostname() == "" {
+		return "", "", false
+	}
+	port := u.Port()
+	if port == "" {
+		port = defaultPort
+	}
+	return u.Hostname(), port, true
 }
 
 func mergeSearchResults(store *db.Store, msgs []*db.Message, convos []*db.Conversation, limit int) []SearchResult {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -428,6 +428,29 @@ func TestSetTranscriptRequiresTranscriptField(t *testing.T) {
 	}
 }
 
+func TestSetTranscriptRejectsOversizedPayload(t *testing.T) {
+	ts := newTestServer(t)
+
+	tooLong := strings.Repeat("x", db.MaxTranscriptBytes+1)
+	payload, err := json.Marshal(map[string]string{
+		"message_id": "audio-1",
+		"transcript": tooLong,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(ts.server.URL+"/api/transcript", "application/json", strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("got status %d, want 413: %s", resp.StatusCode, body)
+	}
+}
+
 func TestSetTranscriptPreservesModelWhenOmitted(t *testing.T) {
 	ts := newTestServer(t)
 
@@ -2880,16 +2903,99 @@ func TestAPIRejectsCrossOriginRequests(t *testing.T) {
 		t.Fatal("same-origin POST should not be forbidden")
 	}
 
-	// A loopback Origin is allowed.
+	// The exact same loopback Origin is allowed.
 	req3, _ := http.NewRequest("POST", ts.server.URL+"/api/backfill", strings.NewReader("{}"))
-	req3.Header.Set("Origin", "http://127.0.0.1:7007")
+	req3.Header.Set("Origin", ts.server.URL)
 	resp3, err := http.DefaultClient.Do(req3)
 	if err != nil {
 		t.Fatal(err)
 	}
 	resp3.Body.Close()
 	if resp3.StatusCode == http.StatusForbidden {
-		t.Fatal("loopback-origin POST should not be forbidden")
+		t.Fatal("same-origin loopback POST should not be forbidden")
+	}
+
+	// A different loopback port is still cross-origin and must be rejected.
+	req4, _ := http.NewRequest("POST", ts.server.URL+"/api/backfill", strings.NewReader("{}"))
+	req4.Header.Set("Origin", "http://127.0.0.1:1")
+	resp4, err := http.DefaultClient.Do(req4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp4.Body.Close()
+	if resp4.StatusCode != http.StatusForbidden {
+		t.Fatalf("other-loopback-origin POST: got %d, want 403", resp4.StatusCode)
+	}
+}
+
+func TestMCPRouteRejectsCrossOriginRequests(t *testing.T) {
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	mcpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("mcp ok"))
+	})
+	h := APIHandlerWithOptions(store, nil, zerolog.Nop(), mcpHandler, APIOptions{})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/mcp/sse", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-origin MCP: got %d, want 403", resp.StatusCode)
+	}
+
+	req2, _ := http.NewRequest("GET", srv.URL+"/mcp/sse", nil)
+	req2.Header.Set("Origin", srv.URL)
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("same-origin MCP: got %d, want 200", resp2.StatusCode)
+	}
+}
+
+func TestProtectLocalControlRejectsMCPOnlyCrossOriginRequests(t *testing.T) {
+	protected := ProtectLocalControl(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp/sse" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv := httptest.NewServer(protected)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/mcp/sse", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-origin MCP-only route: got %d, want 403", resp.StatusCode)
+	}
+
+	req2, _ := http.NewRequest("GET", srv.URL+"/mcp/sse", nil)
+	req2.Header.Set("Origin", srv.URL)
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("same-origin MCP-only route: got %d, want 200", resp2.StatusCode)
 	}
 }
 
@@ -3188,17 +3294,17 @@ func TestAPIGuardRejectsEmptyHost(t *testing.T) {
 	// the way a hand-rolled client omitting it would reach it.
 	r := httptest.NewRequest(http.MethodGet, "/api/conversations", nil)
 	r.Host = ""
-	if isLocalAPIRequest(r) {
+	if isLocalControlRequest(r) {
 		t.Fatal("request with empty Host must not pass the loopback guard")
 	}
 
 	r.Host = "127.0.0.1:7007"
-	if !isLocalAPIRequest(r) {
+	if !isLocalControlRequest(r) {
 		t.Fatal("loopback Host must pass the guard")
 	}
 
 	r.Host = "evil.example.com"
-	if isLocalAPIRequest(r) {
+	if isLocalControlRequest(r) {
 		t.Fatal("non-loopback Host must not pass the guard")
 	}
 }

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -2964,6 +2964,28 @@ func TestMCPRouteRejectsCrossOriginRequests(t *testing.T) {
 	if resp2.StatusCode != http.StatusOK {
 		t.Fatalf("same-origin MCP: got %d, want 200", resp2.StatusCode)
 	}
+
+	req3, _ := http.NewRequest("POST", srv.URL+"/mcp", nil)
+	req3.Header.Set("Origin", "http://evil.example.com")
+	resp3, err := http.DefaultClient.Do(req3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp3.Body.Close()
+	if resp3.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-origin MCP exact path: got %d, want 403", resp3.StatusCode)
+	}
+
+	req4, _ := http.NewRequest("POST", srv.URL+"/mcp", nil)
+	req4.Header.Set("Origin", srv.URL)
+	resp4, err := http.DefaultClient.Do(req4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp4.Body.Close()
+	if resp4.StatusCode != http.StatusOK {
+		t.Fatalf("same-origin MCP exact path: got %d, want 200", resp4.StatusCode)
+	}
 }
 
 func TestProtectLocalControlRejectsMCPOnlyCrossOriginRequests(t *testing.T) {


### PR DESCRIPTION
## Summary
- guard the MCP/SSE and local API surfaces against cross-origin localhost access
- bound transcript writes across HTTP, MCP, and DB paths
- confine story/viz exports to a private OpenMessage export root by default, with symlink checks and byte caps

## Validation
- git diff --check
- go test ./...
- OPENMESSAGES_E2E_PORT=7011 npm run test:e2e (63 passed)
- final security reviewer re-check found no blocking findings after the symlink fix

Refs #39
Fixes #57
Fixes #58