### PR TITLE
Improve Google repair and native re-pair flows

### DIFF
--- a/OpenMessage/OpenMessage/ContentView.swift
+++ b/OpenMessage/OpenMessage/ContentView.swift
@@ -109,6 +109,7 @@ struct WebViewContainer: NSViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.setValue(false, forKey: "drawsBackground") // Transparent during load
         context.coordinator.webView = webView
+        WebViewBridge.shared.webView = webView
         webView.navigationDelegate = context.coordinator
         webView.load(URLRequest(url: url))
         return webView

--- a/OpenMessage/OpenMessage/NotificationManager.swift
+++ b/OpenMessage/OpenMessage/NotificationManager.swift
@@ -134,13 +134,38 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
 
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        let conversationID = notification.request.content.userInfo["conversationID"] as? String ?? ""
+        // Suppress the banner and sound when the user is literally looking
+        // at this conversation. On uncertainty, show the banner; silently
+        // dropping a notification is the worse failure.
+        if !conversationID.isEmpty {
+            let appActive = await MainActor.run { NSApp.isActive }
+            if appActive {
+                let active = await WebViewBridge.shared.activeConversationID()
+                if active == conversationID {
+                    return [.list]
+                }
+            }
+        }
         if #available(macOS 11.0, *) {
-            completionHandler([.banner, .list, .sound, .badge])
+            return [.banner, .list, .sound, .badge]
         } else {
-            completionHandler([.alert, .sound, .badge])
+            return [.alert, .sound, .badge]
+        }
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let conversationID = response.notification.request.content.userInfo["conversationID"] as? String ?? ""
+        await MainActor.run {
+            NSApp.activate(ignoringOtherApps: true)
+            if !conversationID.isEmpty {
+                WebViewBridge.shared.openConversation(conversationID)
+            }
         }
     }
 

--- a/OpenMessage/OpenMessage/OpenMessageApp.swift
+++ b/OpenMessage/OpenMessage/OpenMessageApp.swift
@@ -51,6 +51,8 @@ private final class SettingsViewModel: ObservableObject {
             let connected: Bool
             let paired: Bool
             let needs_pairing: Bool
+            let needs_repair: Bool?
+            let phone_responding: Bool?
         }
 
         struct BackfillStatus: Decodable {
@@ -254,6 +256,18 @@ private struct AppSettingsView: View {
                         backend.beginGooglePairing()
                     }
                     .buttonStyle(.borderedProminent)
+                } else if googleNeedsRepair {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Google Messages needs to be paired again.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+
+                        Button("Pair again") {
+                            openMainWindow()
+                            backend.beginGooglePairing()
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
                 } else if googleNeedsReconnect {
                     Button("Reconnect") {
                         Task {
@@ -267,6 +281,12 @@ private struct AppSettingsView: View {
                         HStack(spacing: 10) {
                             Button("Open inbox") {
                                 openMainWindow()
+                            }
+                            .buttonStyle(.bordered)
+
+                            Button("Pair again") {
+                                openMainWindow()
+                                backend.beginGooglePairing()
                             }
                             .buttonStyle(.bordered)
 
@@ -423,11 +443,18 @@ private struct AppSettingsView: View {
 
     private var googleNeedsReconnect: Bool {
         guard let google = model.appStatus.google else { return false }
-        return google.paired && !google.connected && !google.needs_pairing
+        return google.paired && !google.connected && !google.needs_pairing && google.needs_repair != true
+    }
+
+    private var googleNeedsRepair: Bool {
+        guard let google = model.appStatus.google else { return false }
+        return google.paired && google.needs_repair == true
     }
 
     private var googleStatusText: String {
         guard let google = model.appStatus.google else { return "Unavailable" }
+        if google.paired && google.needs_repair == true { return "Needs re-pair" }
+        if google.connected && google.phone_responding == false { return "Phone offline" }
         if google.connected { return "Connected" }
         if google.paired && !google.needs_pairing { return "Needs reconnect" }
         return "Needs pairing"

--- a/OpenMessage/OpenMessage/WebViewBridge.swift
+++ b/OpenMessage/OpenMessage/WebViewBridge.swift
@@ -4,9 +4,9 @@ import WebKit
 /// Lets non-view components (notifications) talk to the app's single
 /// WKWebView: open a conversation on banner tap, and read which
 /// conversation is on screen for foreground suppression. Both directions
-/// ride on contracts the web UI already maintains — it keeps the active
+/// ride on contracts the web UI already maintains: it keeps the active
 /// conversation synced into `?conversation=` and restores it from the same
-/// query parameter on load — so no extra JS globals are needed.
+/// query parameter on load, so no extra JS globals are needed.
 @MainActor
 final class WebViewBridge {
     static let shared = WebViewBridge()

--- a/cmd/send_group.go
+++ b/cmd/send_group.go
@@ -30,6 +30,7 @@ func RunSendGroup(logger zerolog.Logger, phones []string, message string) error 
 		Numbers: app.NewContactNumbers(phones),
 	})
 	if err != nil {
+		a.HandleGoogleAuthExpiredError(err)
 		return fmt.Errorf("get/create group conversation: %w", err)
 	}
 
@@ -41,6 +42,7 @@ func RunSendGroup(logger zerolog.Logger, phones []string, message string) error 
 	payload := app.BuildSendPayload(conv.GetConversationID(), message, "", "", nil)
 	_, err = cli.GM.SendMessage(payload)
 	if err != nil {
+		a.HandleGoogleAuthExpiredError(err)
 		return fmt.Errorf("send: %w", err)
 	}
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -227,26 +227,33 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				}
 				lastAttempt = time.Now()
 				g := a.GoogleStatus()
-				// Skip reconnect when sends prove the linked device needs a
-				// manual re-pair. Cookie-expiry 401s clear NeedsRepair and use
-				// the auth-refresh reconnect path below.
-				if !g.Paired || g.Connected || g.NeedsPairing || g.NeedsRepair {
+				hasRefreshScript := strings.TrimSpace(os.Getenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT")) != ""
+				switch planGoogleReconnect(g, hasRefreshScript) {
+				case googleReconnectSkip:
 					return
-				}
-				if googleStatusNeedsCookieRefresh(g) {
-					if strings.TrimSpace(os.Getenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT")) != "" {
-						logger.Info().Msg("Google auth expired - refreshing Chrome cookies before reconnect")
-						ctx, cancel := context.WithTimeout(context.Background(), googleCookieRefreshTimeout)
-						err := refreshGoogleSessionCookies(ctx)
-						cancel()
-						if err != nil {
-							logger.Warn().Err(err).Msg("Google cookie refresh before reconnect failed")
-						} else {
-							logger.Info().Msg("Refreshed Google cookies before reconnect")
-						}
+				case googleReconnectPark:
+					// Dead linked-device session with no way to auto-recover
+					// (no cookie-refresh script). Stop reconnecting so we don't
+					// hammer Google's auth endpoint every cycle; flag it so the
+					// UI prompts a manual re-pair. A successful re-pair clears
+					// the flag and reconnect resumes.
+					a.FlagGoogleNeedsRepair()
+					return
+				case googleReconnectRefresh:
+					// Cookies expired but a refresh script is configured: refresh
+					// then reconnect, even if the session was flagged for repair.
+					logger.Info().Msg("Google auth expired - refreshing Chrome cookies before reconnect")
+					ctx, cancel := context.WithTimeout(context.Background(), googleCookieRefreshTimeout)
+					err := refreshGoogleSessionCookies(ctx)
+					cancel()
+					if err != nil {
+						logger.Warn().Err(err).Msg("Google cookie refresh before reconnect failed")
 					} else {
-						logger.Info().Msg("Google auth expired - reconnecting without cookie refresh script")
+						logger.Info().Msg("Refreshed Google cookies before reconnect")
 					}
+					a.ClearGoogleRepairFlag()
+				case googleReconnectRetry:
+					// Ordinary transient disconnect — just reconnect.
 				}
 				logger.Info().Str("trigger", trigger).Msg("Google Messages disconnected - attempting reconnect")
 				if err := a.ReconnectGoogleMessages(); err != nil {
@@ -630,6 +637,42 @@ const googleCookieRefreshTimeout = 20 * time.Second
 
 func googleStatusNeedsCookieRefresh(g app.GoogleStatusSnapshot) bool {
 	return g.AuthExpired || app.IsGoogleAuthExpiredError(fmt.Errorf("%s", g.LastError))
+}
+
+// googleReconnectAction is the reconnect watchdog's decision for a Google
+// Messages session that is currently disconnected.
+type googleReconnectAction int
+
+const (
+	googleReconnectSkip    googleReconnectAction = iota // connected, unpaired, or awaiting first-time pairing
+	googleReconnectRefresh                              // cookies expired and a refresh script is available
+	googleReconnectPark                                 // dead session, no automated recovery — wait for manual re-pair
+	googleReconnectRetry                                // ordinary transient disconnect
+)
+
+// planGoogleReconnect decides what the reconnect watchdog should do for a
+// disconnected Google Messages session. It is pure so the back-off behaviour
+// can be unit-tested without driving the live loop.
+//
+// Key invariant: a session whose cookies have expired is only retried
+// automatically when a cookie-refresh script is configured. Without one (e.g.
+// the macOS app) a reconnect just 401s again, so we park and let the UI prompt
+// a manual re-pair instead of spinning a reconnect storm against Google's auth
+// endpoint — the failure docs/agent-runbook.md warns about.
+func planGoogleReconnect(g app.GoogleStatusSnapshot, hasRefreshScript bool) googleReconnectAction {
+	if !g.Paired || g.Connected || g.NeedsPairing {
+		return googleReconnectSkip
+	}
+	if googleStatusNeedsCookieRefresh(g) {
+		if hasRefreshScript {
+			return googleReconnectRefresh
+		}
+		return googleReconnectPark
+	}
+	if g.NeedsRepair {
+		return googleReconnectPark
+	}
+	return googleReconnectRetry
 }
 
 var refreshGoogleSessionCookies = func(ctx context.Context) error {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -385,6 +385,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				RecordGoogleSend:      a.RecordGoogleSendOutcome,
 				RecordGoogleSendError: a.RecordGoogleSendError,
 				GooglePhoneResponding: a.GooglePhoneResponding,
+				MarkGoogleAuthExpired: a.HandleGoogleAuthExpiredError,
 				ReconnectGoogle:       a.ReconnectGoogleMessages,
 				Unpair:                a.Unpair,
 				WhatsAppStatus:        func() any { return a.WhatsAppStatus() },

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -367,7 +367,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 
 	googleStatus := func() any {
 		if isDemo {
-			return app.GoogleStatusSnapshot{Connected: true, Paired: true, NeedsPairing: false}
+			return app.GoogleStatusSnapshot{Connected: true, Paired: true, NeedsPairing: false, PhoneResponding: true}
 		}
 		return a.GoogleStatus()
 	}
@@ -377,22 +377,24 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		httpHandler := http.Handler(nil)
 		if opts.web {
 			httpHandler = web.APIHandlerWithOptions(a.Store, nil, logger, mcpHTTPHandler, web.APIOptions{
-				Client:               a.GetClient,
-				Events:               events,
-				IdentityName:         identityName,
-				IsConnected:          isConnected,
-				GoogleStatus:         googleStatus,
-				RecordGoogleSend:     a.RecordGoogleSendOutcome,
-				ReconnectGoogle:      a.ReconnectGoogleMessages,
-				Unpair:               a.Unpair,
-				WhatsAppStatus:       func() any { return a.WhatsAppStatus() },
-				ConnectWhatsApp:      a.StartWhatsAppConnect,
-				UnpairWhatsApp:       a.UnpairWhatsApp,
-				SignalStatus:         func() any { return a.SignalStatus() },
-				ConnectSignal:        a.StartSignalConnect,
-				ReplaySignalRecovery: a.ReplaySignalRecoveryQueue,
-				UnpairSignal:         a.UnpairSignal,
-				LeaveWhatsAppGroup:   a.LeaveWhatsAppGroup,
+				Client:                a.GetClient,
+				Events:                events,
+				IdentityName:          identityName,
+				IsConnected:           isConnected,
+				GoogleStatus:          googleStatus,
+				RecordGoogleSend:      a.RecordGoogleSendOutcome,
+				RecordGoogleSendError: a.RecordGoogleSendError,
+				GooglePhoneResponding: a.GooglePhoneResponding,
+				ReconnectGoogle:       a.ReconnectGoogleMessages,
+				Unpair:                a.Unpair,
+				WhatsAppStatus:        func() any { return a.WhatsAppStatus() },
+				ConnectWhatsApp:       a.StartWhatsAppConnect,
+				UnpairWhatsApp:        a.UnpairWhatsApp,
+				SignalStatus:          func() any { return a.SignalStatus() },
+				ConnectSignal:         a.StartSignalConnect,
+				ReplaySignalRecovery:  a.ReplaySignalRecoveryQueue,
+				UnpairSignal:          a.UnpairSignal,
+				LeaveWhatsAppGroup:    a.LeaveWhatsAppGroup,
 				WhatsAppQRCode: func() (any, error) {
 					return a.WhatsAppQRCode()
 				},

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"runtime"
 	"runtime/debug"
@@ -78,6 +79,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	isDemo := app.DemoMode()
 
 	events := web.NewEventBroker()
+	googleReconnectNow := make(chan struct{}, 1)
 	isConnected := func() bool {
 		if isDemo {
 			return true
@@ -89,8 +91,14 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	}
 	a.OnConversationsChange = events.PublishConversations
 	a.OnMessagesChange = events.PublishMessages
-	a.OnStatusChange = func(bool) {
+	a.OnStatusChange = func(connected bool) {
 		publishOverallStatus()
+		if !connected {
+			select {
+			case googleReconnectNow <- struct{}{}:
+			default:
+			}
+		}
 	}
 	a.OnTypingChange = events.PublishTyping
 	a.OnWhatsAppStatusChange = func() {
@@ -212,18 +220,46 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		go func() {
 			ticker := time.NewTicker(15 * time.Second)
 			defer ticker.Stop()
-			for range ticker.C {
-				g := a.GoogleStatus()
-				// Skip reconnect when the credentials are dead (NeedsRepair):
-				// retrying a 401'd session just spams the log every 15s and
-				// never recovers. The UI shows a "Re-pair" banner instead; a
-				// successful re-pair clears the flag and reconnect resumes.
-				if !g.Paired || g.Connected || g.NeedsPairing || g.NeedsRepair {
-					continue
+			lastAttempt := time.Time{}
+			attemptReconnect := func(trigger string) {
+				if !lastAttempt.IsZero() && time.Since(lastAttempt) < 5*time.Second {
+					return
 				}
-				logger.Info().Msg("Google Messages disconnected — attempting reconnect")
+				lastAttempt = time.Now()
+				g := a.GoogleStatus()
+				// Skip reconnect when sends prove the linked device needs a
+				// manual re-pair. Cookie-expiry 401s clear NeedsRepair and use
+				// the auth-refresh reconnect path below.
+				if !g.Paired || g.Connected || g.NeedsPairing || g.NeedsRepair {
+					return
+				}
+				if app.IsGoogleAuthExpiredError(fmt.Errorf("%s", g.LastError)) {
+					if strings.TrimSpace(os.Getenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT")) != "" {
+						logger.Info().Msg("Google auth expired - refreshing Chrome cookies before reconnect")
+						ctx, cancel := context.WithTimeout(context.Background(), googleCookieRefreshTimeout)
+						err := refreshGoogleSessionCookies(ctx)
+						cancel()
+						if err != nil {
+							logger.Warn().Err(err).Msg("Google cookie refresh before reconnect failed")
+						} else {
+							logger.Info().Msg("Refreshed Google cookies before reconnect")
+						}
+					} else {
+						logger.Info().Msg("Google auth expired - reconnecting without cookie refresh script")
+					}
+				}
+				logger.Info().Str("trigger", trigger).Msg("Google Messages disconnected - attempting reconnect")
 				if err := a.ReconnectGoogleMessages(); err != nil {
+					a.HandleGoogleAuthExpiredError(err)
 					logger.Warn().Err(err).Msg("Google Messages reconnect attempt failed")
+				}
+			}
+			for {
+				select {
+				case <-ticker.C:
+					attemptReconnect("timer")
+				case <-googleReconnectNow:
+					attemptReconnect("status-change")
 				}
 			}
 		}()
@@ -588,6 +624,33 @@ func startupBackfillMode() string {
 	default:
 		return "auto"
 	}
+}
+
+const googleCookieRefreshTimeout = 20 * time.Second
+
+var refreshGoogleSessionCookies = func(ctx context.Context) error {
+	script := strings.TrimSpace(os.Getenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT"))
+	if script == "" {
+		return nil
+	}
+	if _, err := os.Stat(script); err != nil {
+		return fmt.Errorf("refresh script unavailable at %s: %w", script, err)
+	}
+
+	cmd := exec.CommandContext(ctx, script, "--quiet", "--no-backup")
+	cmd.Env = os.Environ()
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return fmt.Errorf("refresh Google cookies timed out after %s", googleCookieRefreshTimeout)
+	}
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail == "" {
+			return fmt.Errorf("refresh Google cookies: %w", err)
+		}
+		return fmt.Errorf("refresh Google cookies: %w: %s", err, detail)
+	}
+	return nil
 }
 
 func macOSNotificationsEnabled(interactive bool) bool {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -233,7 +233,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				if !g.Paired || g.Connected || g.NeedsPairing || g.NeedsRepair {
 					return
 				}
-				if app.IsGoogleAuthExpiredError(fmt.Errorf("%s", g.LastError)) {
+				if googleStatusNeedsCookieRefresh(g) {
 					if strings.TrimSpace(os.Getenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT")) != "" {
 						logger.Info().Msg("Google auth expired - refreshing Chrome cookies before reconnect")
 						ctx, cancel := context.WithTimeout(context.Background(), googleCookieRefreshTimeout)
@@ -627,6 +627,10 @@ func startupBackfillMode() string {
 }
 
 const googleCookieRefreshTimeout = 20 * time.Second
+
+func googleStatusNeedsCookieRefresh(g app.GoogleStatusSnapshot) bool {
+	return g.AuthExpired || app.IsGoogleAuthExpiredError(fmt.Errorf("%s", g.LastError))
+}
 
 var refreshGoogleSessionCookies = func(ctx context.Context) error {
 	script := strings.TrimSpace(os.Getenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT"))

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/maxghenis/openmessage/internal/app"
 )
 
 func TestHTTPServerSurvivesIndependently(t *testing.T) {
@@ -173,6 +175,28 @@ func TestRefreshGoogleSessionCookiesUsesEnvScript(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(args)); got != "--quiet --no-backup" {
 		t.Fatalf("args = %q, want %q", got, "--quiet --no-backup")
+	}
+}
+
+func TestGoogleStatusNeedsCookieRefreshUsesExplicitAuthExpiredFlag(t *testing.T) {
+	status := app.GoogleStatusSnapshot{
+		Paired:      true,
+		AuthExpired: true,
+		LastError:   "Google Messages connection lost; reconnecting...",
+	}
+	if !googleStatusNeedsCookieRefresh(status) {
+		t.Fatal("expected explicit auth-expired flag to trigger cookie refresh")
+	}
+
+	status.AuthExpired = false
+	status.LastError = "Google Messages session cookie expired; refreshing and reconnecting..."
+	if !googleStatusNeedsCookieRefresh(status) {
+		t.Fatal("expected auth-expired last error to trigger cookie refresh")
+	}
+
+	status.LastError = "Google Messages connection lost; reconnecting..."
+	if googleStatusNeedsCookieRefresh(status) {
+		t.Fatal("generic reconnect status should not trigger cookie refresh")
 	}
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -163,7 +163,10 @@ func TestRefreshGoogleSessionCookiesUsesEnvScript(t *testing.T) {
 	t.Setenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT", script)
 	t.Setenv("ARGS_PATH", argsPath)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// Generous deadline: the script is trivial, but a 1s budget flakes under
+	// heavy CI load (fork+exec of /bin/sh can slip past it), surfacing as a
+	// spurious "timed out" failure.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := refreshGoogleSessionCookies(ctx); err != nil {
 		t.Fatalf("refreshGoogleSessionCookies(): %v", err)
@@ -278,5 +281,75 @@ func TestConfigureServeEnvRestoresPreviousValue(t *testing.T) {
 	restore()
 	if got := os.Getenv("OPENMESSAGES_DEMO"); got != "existing" {
 		t.Fatalf("OPENMESSAGES_DEMO=%q, want existing after restore", got)
+	}
+}
+
+func TestPlanGoogleReconnect(t *testing.T) {
+	const authErr = "send message: HTTP 401: Request had invalid authentication credentials"
+	tests := []struct {
+		name      string
+		status    app.GoogleStatusSnapshot
+		hasScript bool
+		want      googleReconnectAction
+	}{
+		{
+			name:   "connected does nothing",
+			status: app.GoogleStatusSnapshot{Paired: true, Connected: true},
+			want:   googleReconnectSkip,
+		},
+		{
+			name:   "unpaired does nothing",
+			status: app.GoogleStatusSnapshot{Paired: false},
+			want:   googleReconnectSkip,
+		},
+		{
+			name:   "awaiting first-time pairing does nothing",
+			status: app.GoogleStatusSnapshot{Paired: true, NeedsPairing: true},
+			want:   googleReconnectSkip,
+		},
+		{
+			name:   "ordinary disconnect retries",
+			status: app.GoogleStatusSnapshot{Paired: true},
+			want:   googleReconnectRetry,
+		},
+		{
+			name:      "auth expired with refresh script refreshes",
+			status:    app.GoogleStatusSnapshot{Paired: true, AuthExpired: true},
+			hasScript: true,
+			want:      googleReconnectRefresh,
+		},
+		{
+			name:   "auth expired without refresh script parks (no storm)",
+			status: app.GoogleStatusSnapshot{Paired: true, AuthExpired: true},
+			want:   googleReconnectPark,
+		},
+		{
+			name:   "auth expired via last-error text without script parks",
+			status: app.GoogleStatusSnapshot{Paired: true, LastError: authErr},
+			want:   googleReconnectPark,
+		},
+		{
+			name:      "dead session flagged for repair still refreshes when a script can recover it",
+			status:    app.GoogleStatusSnapshot{Paired: true, NeedsRepair: true, AuthExpired: true},
+			hasScript: true,
+			want:      googleReconnectRefresh,
+		},
+		{
+			name:   "dead session flagged for repair without script parks (macOS)",
+			status: app.GoogleStatusSnapshot{Paired: true, NeedsRepair: true, AuthExpired: true},
+			want:   googleReconnectPark,
+		},
+		{
+			name:   "zombie session needs repair but not auth-expired parks",
+			status: app.GoogleStatusSnapshot{Paired: true, NeedsRepair: true},
+			want:   googleReconnectPark,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := planGoogleReconnect(tc.status, tc.hasScript); got != tc.want {
+				t.Fatalf("planGoogleReconnect(%+v, hasScript=%v) = %d, want %d", tc.status, tc.hasScript, got, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -136,6 +138,41 @@ func TestIMessageSyncSupported(t *testing.T) {
 	runtimeGOOS = func() string { return "windows" }
 	if iMessageSyncSupported() {
 		t.Fatal("expected iMessage sync to be unsupported on windows")
+	}
+}
+
+func TestRefreshGoogleSessionCookiesSkipsWhenUnconfigured(t *testing.T) {
+	t.Setenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := refreshGoogleSessionCookies(ctx); err != nil {
+		t.Fatalf("refreshGoogleSessionCookies(): %v", err)
+	}
+}
+
+func TestRefreshGoogleSessionCookiesUsesEnvScript(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "refresh.sh")
+	argsPath := filepath.Join(dir, "args")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s' \"$*\" > \"$ARGS_PATH\"\n"), 0o700); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	t.Setenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT", script)
+	t.Setenv("ARGS_PATH", argsPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := refreshGoogleSessionCookies(ctx); err != nil {
+		t.Fatalf("refreshGoogleSessionCookies(): %v", err)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	if got := strings.TrimSpace(string(args)); got != "--quiet --no-backup" {
+		t.Fatalf("args = %q, want %q", got, "--quiet --no-backup")
 	}
 }
 

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -1616,44 +1616,51 @@ test('narrow viewport uses single-pane flow with back button', async ({ page }) 
   await expect(page.locator('.sidebar')).toBeVisible();
 });
 
-test('service worker keeps APIs network-only and serves the shell offline', async ({ page, context }) => {
-  await page.evaluate(async () => {
-    for (const registration of await navigator.serviceWorker.getRegistrations()) {
-      await registration.unregister();
-    }
-    for (const key of await caches.keys()) {
-      await caches.delete(key);
-    }
-    await caches.open('openmessage-static-old-test');
-  });
-
-  await page.goto('/');
-  await page.evaluate(async () => {
-    await navigator.serviceWorker.ready;
-  });
-  await page.reload();
-  await expect
-    .poll(async () => page.evaluate(() => !!navigator.serviceWorker.controller))
-    .toBe(true);
-
-  const cacheKeys = await page.evaluate(async () => caches.keys());
-  expect(cacheKeys).toContain('openmessage-static-v1');
-  expect(cacheKeys).not.toContain('openmessage-static-old-test');
-
-  const apiCached = await page.evaluate(async () => {
-    const response = await fetch('/api/status');
-    if (!response.ok) return 'api-failed';
-    const cache = await caches.open('openmessage-static-v1');
-    return !!(await cache.match('/api/status'));
-  });
-  expect(apiCached).toBe(false);
-
-  await context.setOffline(true);
+test('service worker keeps APIs network-only and serves the shell offline', async ({ browser, baseURL }) => {
+  const context = await browser.newContext({ baseURL, serviceWorkers: 'allow' });
+  const page = await context.newPage();
   try {
-    await page.goto('/offline-shell-check', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('#app')).toBeVisible();
+    await page.goto('/');
+    await page.evaluate(async () => {
+      for (const registration of await navigator.serviceWorker.getRegistrations()) {
+        await registration.unregister();
+      }
+      for (const key of await caches.keys()) {
+        await caches.delete(key);
+      }
+      await caches.open('openmessage-static-old-test');
+    });
+
+    await page.goto('/');
+    await page.evaluate(async () => {
+      await navigator.serviceWorker.ready;
+    });
+    await page.reload();
+    await expect
+      .poll(async () => page.evaluate(() => !!navigator.serviceWorker.controller))
+      .toBe(true);
+
+    const cacheKeys = await page.evaluate(async () => caches.keys());
+    expect(cacheKeys).toContain('openmessage-static-v1');
+    expect(cacheKeys).not.toContain('openmessage-static-old-test');
+
+    const apiCached = await page.evaluate(async () => {
+      const response = await fetch('/api/status');
+      if (!response.ok) return 'api-failed';
+      const cache = await caches.open('openmessage-static-v1');
+      return !!(await cache.match('/api/status'));
+    });
+    expect(apiCached).toBe(false);
+
+    await context.setOffline(true);
+    try {
+      await page.goto('/offline-shell-check', { waitUntil: 'domcontentloaded' });
+      await expect(page.locator('#app')).toBeVisible();
+    } finally {
+      await context.setOffline(false);
+    }
   } finally {
-    await context.setOffline(false);
+    await context.close();
   }
 });
 

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -1716,6 +1716,20 @@ test('a stuck Google session (connected + needs_repair) surfaces a re-pair banne
   await expect(page.locator('#connection-banner')).toBeHidden();
 });
 
+test('a connected Google session with a non-responding phone shows phone guidance', async ({ page }) => {
+  await page.waitForFunction(() => window.__openMessageTestHooks?.applyAppStatus);
+  await page.evaluate(() => window.__openMessageTestHooks.applyAppStatus({
+    connected: true,
+    google: { connected: true, paired: true, needs_pairing: false, needs_repair: false, phone_responding: false },
+    whatsapp: { connected: true, paired: true },
+    signal: { connected: true, paired: true },
+    backfill: { running: false },
+  }));
+  await expect(page.locator('#connection-banner')).toBeVisible();
+  await expect(page.locator('#connection-banner-copy')).toContainText('phone isn’t responding');
+  await expect(page.locator('#connection-banner-action')).toBeHidden();
+});
+
 test('an auth-dead Google session (disconnected + needs_repair) shows Re-pair, not Reconnect', async ({ page }) => {
   await page.waitForFunction(() => window.__openMessageTestHooks?.applyAppStatus);
   // connected=false (the 401 case) but paired + needs_repair.
@@ -1729,6 +1743,11 @@ test('an auth-dead Google session (disconnected + needs_repair) shows Re-pair, n
   await expect(page.locator('#connection-banner')).toBeVisible();
   await expect(page.locator('#connection-banner-action')).toHaveText('Re-pair');
   await expect(page.locator('#connection-banner-copy')).toContainText('unlinked OpenMessage');
+  await page.locator('#connection-banner-action').click();
+  await expect(page.locator('#wa-overlay')).toHaveClass(/show/);
+  await expect(page.locator('#gm-reconnect-btn')).toHaveText('Pair again');
+  await expect(page.locator('#gm-reconnect-btn')).toHaveAttribute('data-mode', 'pair');
+  await page.keyboard.press('Escape');
 
   // A plain disconnected (no needs_repair) still says Reconnect.
   await page.evaluate(() => window.__openMessageTestHooks.applyAppStatus({

--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -226,6 +226,7 @@ test('shows live Signal history import progress after pairing starts', async ({ 
     });
   });
 
+  await page.reload();
   await openPlatforms(page);
 
   await expect(page.locator('#signal-status-pill')).toHaveText('Importing history');

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -154,6 +154,7 @@ type App struct {
 	// the UI can surface a re-pair affordance even while "connected".
 	googleSendFailures        atomic.Int32
 	googleNeedsRepair         atomic.Bool
+	googleAuthExpired         atomic.Bool
 	googlePhoneResponding     atomic.Bool
 	googlePhoneRespondingSeen atomic.Bool
 	tempDataDir               string
@@ -170,6 +171,9 @@ type GoogleStatusSnapshot struct {
 	// offer re-pairing even though Connected is true.
 	NeedsRepair bool   `json:"needs_repair,omitempty"`
 	LastError   string `json:"last_error,omitempty"`
+	// AuthExpired is set when Google rejects the web session cookies. Unlike a
+	// true unpair, a cookie refresh plus reconnect can recover it.
+	AuthExpired bool `json:"auth_expired,omitempty"`
 	// PhoneResponding is false after libgm reports PhoneNotResponding. Before
 	// such an event is observed, unknown is treated as healthy.
 	PhoneResponding bool `json:"phone_responding"`
@@ -492,6 +496,7 @@ func (a *App) LoadAndConnect() error {
 	// A clean connect proves the session is alive; clear any prior stuck/dead
 	// state (also covers the path right after re-pairing).
 	a.ClearGoogleRepairFlag()
+	a.googleAuthExpired.Store(false)
 	a.RecordGooglePhoneResponding(true)
 	a.Connected.Store(true)
 	a.setGoogleLastError("")
@@ -641,6 +646,7 @@ func (a *App) GoogleStatus() GoogleStatusSnapshot {
 		// 401 case (which is disconnected).
 		NeedsRepair:     paired && a.googleNeedsRepair.Load(),
 		LastError:       lastError,
+		AuthExpired:     a.googleAuthExpired.Load(),
 		PhoneResponding: a.GooglePhoneResponding(),
 	}
 }
@@ -660,6 +666,7 @@ func (a *App) AnyConnected() bool {
 
 func (a *App) ReconnectGoogleMessages() error {
 	if a.Connected.Load() && a.GetClient() != nil {
+		a.googleAuthExpired.Store(false)
 		a.setGoogleLastError("")
 		return nil
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -152,11 +152,13 @@ type App struct {
 	// Connected=true while every send comes back UNKNOWN (the phone has
 	// silently unlinked us). Count consecutive non-SUCCESS Google sends so
 	// the UI can surface a re-pair affordance even while "connected".
-	googleSendFailures atomic.Int32
-	googleNeedsRepair  atomic.Bool
-	tempDataDir        string
-	pendingMediaMu     sync.Mutex
-	pendingMedia       map[string]struct{}
+	googleSendFailures        atomic.Int32
+	googleNeedsRepair         atomic.Bool
+	googlePhoneResponding     atomic.Bool
+	googlePhoneRespondingSeen atomic.Bool
+	tempDataDir               string
+	pendingMediaMu            sync.Mutex
+	pendingMedia              map[string]struct{}
 }
 
 type GoogleStatusSnapshot struct {
@@ -168,6 +170,9 @@ type GoogleStatusSnapshot struct {
 	// offer re-pairing even though Connected is true.
 	NeedsRepair bool   `json:"needs_repair,omitempty"`
 	LastError   string `json:"last_error,omitempty"`
+	// PhoneResponding is false after libgm reports PhoneNotResponding. Before
+	// such an event is observed, unknown is treated as healthy.
+	PhoneResponding bool `json:"phone_responding"`
 }
 
 // googleRepairThreshold is how many consecutive failed Google sends (with no
@@ -178,12 +183,29 @@ const googleRepairThreshold = 3
 // unlinked session (Connected=true, every send UNKNOWN) becomes visible. A
 // single success clears the flag.
 func (a *App) RecordGoogleSendOutcome(success bool) {
+	a.RecordGoogleSendOutcomeWithPhone(success, true)
+}
+
+func (a *App) RecordGoogleSendOutcomeWithPhone(success bool, phoneResponding bool) {
 	if success {
+		a.RecordGooglePhoneResponding(true)
 		a.googleSendFailures.Store(0)
 		a.googleNeedsRepair.Store(false)
 		return
 	}
+	if !phoneResponding {
+		return
+	}
 	if a.googleSendFailures.Add(1) >= googleRepairThreshold {
+		a.googleNeedsRepair.Store(true)
+	}
+}
+
+// RecordGoogleSendError handles send failures that happen before Google
+// returns a SendMessageResponse status. Only auth/dead-session failures mark
+// the session for re-pair; transient network errors should remain recoverable.
+func (a *App) RecordGoogleSendError(err error) {
+	if isGoogleAuthInvalid(err) {
 		a.googleNeedsRepair.Store(true)
 	}
 }
@@ -193,6 +215,22 @@ func (a *App) RecordGoogleSendOutcome(success bool) {
 func (a *App) ClearGoogleRepairFlag() {
 	a.googleSendFailures.Store(0)
 	a.googleNeedsRepair.Store(false)
+}
+
+// RecordGooglePhoneResponding tracks whether the paired Android phone is
+// currently answering Google Messages requests. This is distinct from
+// NeedsRepair: a non-responding phone may simply be off or offline.
+func (a *App) RecordGooglePhoneResponding(responding bool) {
+	a.googlePhoneResponding.Store(responding)
+	a.googlePhoneRespondingSeen.Store(true)
+}
+
+// GooglePhoneResponding reports true until libgm explicitly says otherwise.
+func (a *App) GooglePhoneResponding() bool {
+	if !a.GooglePaired() || !a.googlePhoneRespondingSeen.Load() {
+		return true
+	}
+	return a.googlePhoneResponding.Load()
 }
 
 func DefaultDataDir() string {
@@ -391,6 +429,15 @@ func (a *App) LoadAndConnect() error {
 		OnRealtimeGapRecovered: func(reason string) {
 			a.StartRecentReconcile(reason)
 		},
+		OnPhoneRespondingChange: func(responding bool) {
+			a.RecordGooglePhoneResponding(responding)
+			if !responding {
+				a.setGoogleLastError("Your phone isn't responding to OpenMessage right now; make sure it's on and online.")
+			} else {
+				a.clearGoogleLastErrorIf("Your phone isn't responding to OpenMessage right now; make sure it's on and online.")
+			}
+			a.emitStatusChange(a.Connected.Load())
+		},
 		OnConnectionLost: func() {
 			// Transient: keep the session so the reconnect watchdog can
 			// recover without a manual re-pair.
@@ -445,6 +492,7 @@ func (a *App) LoadAndConnect() error {
 	// A clean connect proves the session is alive; clear any prior stuck/dead
 	// state (also covers the path right after re-pairing).
 	a.ClearGoogleRepairFlag()
+	a.RecordGooglePhoneResponding(true)
 	a.Connected.Store(true)
 	a.setGoogleLastError("")
 	a.emitStatusChange(true)
@@ -591,8 +639,9 @@ func (a *App) GoogleStatus() GoogleStatusSnapshot {
 		// or a dead-credentials disconnect (auth 401). Either way the fix is
 		// re-pair, not reconnect; gating on `connected` alone would hide the
 		// 401 case (which is disconnected).
-		NeedsRepair: paired && a.googleNeedsRepair.Load(),
-		LastError:   lastError,
+		NeedsRepair:     paired && a.googleNeedsRepair.Load(),
+		LastError:       lastError,
+		PhoneResponding: a.GooglePhoneResponding(),
 	}
 }
 
@@ -625,6 +674,14 @@ func (a *App) setGoogleLastError(message string) {
 	a.statusMu.Lock()
 	defer a.statusMu.Unlock()
 	a.googleLastError = strings.TrimSpace(message)
+}
+
+func (a *App) clearGoogleLastErrorIf(message string) {
+	a.statusMu.Lock()
+	defer a.statusMu.Unlock()
+	if a.googleLastError == strings.TrimSpace(message) {
+		a.googleLastError = ""
+	}
 }
 
 func (a *App) beginBackfill() bool {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -221,6 +221,17 @@ func (a *App) ClearGoogleRepairFlag() {
 	a.googleNeedsRepair.Store(false)
 }
 
+// FlagGoogleNeedsRepair marks the Google Messages session as needing a manual
+// re-pair (cookies expired and no automated refresh is available), so the
+// reconnect watchdog stops retrying and the UI surfaces a "Re-pair" banner. The
+// status change is emitted only on the false->true transition to avoid
+// re-arming the watchdog in a loop.
+func (a *App) FlagGoogleNeedsRepair() {
+	if a.googleNeedsRepair.CompareAndSwap(false, true) {
+		a.emitStatusChange(a.Connected.Load())
+	}
+}
+
 // RecordGooglePhoneResponding tracks whether the paired Android phone is
 // currently answering Google Messages requests. This is distinct from
 // NeedsRepair: a non-responding phone may simply be off or offline.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -274,8 +274,22 @@ func TestHandleGoogleAuthExpiredErrorMarksDisconnected(t *testing.T) {
 	if got := a.GoogleStatus().LastError; got != googleAuthExpiredStatusMessage {
 		t.Fatalf("last error = %q, want %q", got, googleAuthExpiredStatusMessage)
 	}
+	if !a.GoogleStatus().AuthExpired {
+		t.Fatal("expected auth-expired status flag")
+	}
+
+	a.setGoogleLastError("Google Messages connection lost; reconnecting...")
+	if !a.GoogleStatus().AuthExpired {
+		t.Fatal("auth-expired flag should survive generic reconnect last-error text")
+	}
 
 	if a.HandleGoogleAuthExpiredError(errors.New("temporary failure in name resolution")) {
 		t.Fatal("network errors should not be treated as auth expiry")
+	}
+}
+
+func TestIsGoogleAuthExpiredErrorRecognizesFriendlyStatus(t *testing.T) {
+	if !IsGoogleAuthExpiredError(errors.New(googleAuthExpiredStatusMessage)) {
+		t.Fatal("expected friendly auth-expired status to be recognized")
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -244,3 +244,38 @@ func TestIsGoogleAuthInvalid(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleGoogleAuthExpiredErrorMarksDisconnected(t *testing.T) {
+	a := &App{Logger: zerolog.Nop()}
+	a.Connected.Store(true)
+	a.googleNeedsRepair.Store(true)
+	a.googleSendFailures.Store(googleRepairThreshold)
+	statusEmitted := false
+	a.OnStatusChange = func(connected bool) {
+		statusEmitted = true
+		if connected {
+			t.Fatal("expected disconnected status event")
+		}
+	}
+
+	err := errors.New("send message: HTTP 401: 16: Request had invalid authentication credentials")
+	if !a.HandleGoogleAuthExpiredError(err) {
+		t.Fatal("expected auth-expired error to be handled")
+	}
+	if a.Connected.Load() {
+		t.Fatal("expected Google connection to be marked disconnected")
+	}
+	if !statusEmitted {
+		t.Fatal("expected status change event")
+	}
+	if a.googleNeedsRepair.Load() {
+		t.Fatal("auth expiry should clear repair flag and use reconnect flow")
+	}
+	if got := a.GoogleStatus().LastError; got != googleAuthExpiredStatusMessage {
+		t.Fatalf("last error = %q, want %q", got, googleAuthExpiredStatusMessage)
+	}
+
+	if a.HandleGoogleAuthExpiredError(errors.New("temporary failure in name resolution")) {
+		t.Fatal("network errors should not be treated as auth expiry")
+	}
+}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -268,8 +268,8 @@ func TestHandleGoogleAuthExpiredErrorMarksDisconnected(t *testing.T) {
 	if !statusEmitted {
 		t.Fatal("expected status change event")
 	}
-	if a.googleNeedsRepair.Load() {
-		t.Fatal("auth expiry should clear repair flag and use reconnect flow")
+	if !a.googleNeedsRepair.Load() {
+		t.Fatal("auth expiry must NOT clear an existing repair flag: clearing it defeats the reconnect-watchdog back-off and storms Google's auth endpoint on platforms with no cookie-refresh script (e.g. macOS)")
 	}
 	if got := a.GoogleStatus().LastError; got != googleAuthExpiredStatusMessage {
 		t.Fatalf("last error = %q, want %q", got, googleAuthExpiredStatusMessage)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -137,6 +138,89 @@ func TestGoogleSendOutcomeRepairFlag(t *testing.T) {
 	a.RecordGoogleSendOutcome(false)
 	if a.googleNeedsRepair.Load() {
 		t.Fatal("one failure after a success must not immediately re-flag")
+	}
+}
+
+func TestGooglePhoneRespondingStatus(t *testing.T) {
+	a := &App{}
+	a.SessionPath = filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(a.SessionPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !a.GoogleStatus().PhoneResponding {
+		t.Fatal("unknown phone responding state should default to true")
+	}
+	a.RecordGooglePhoneResponding(false)
+	if a.GoogleStatus().PhoneResponding {
+		t.Fatal("PhoneNotResponding should surface in GoogleStatus")
+	}
+	a.RecordGooglePhoneResponding(true)
+	if !a.GoogleStatus().PhoneResponding {
+		t.Fatal("PhoneRespondingAgain should clear the offline state")
+	}
+}
+
+func TestPhoneOfflineFailuresDoNotMarkGoogleForRepair(t *testing.T) {
+	a := &App{}
+	a.SessionPath = filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(a.SessionPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for range googleRepairThreshold {
+		a.RecordGoogleSendOutcomeWithPhone(false, false)
+	}
+	if a.googleSendFailures.Load() != 0 {
+		t.Fatalf("googleSendFailures = %d, want 0", a.googleSendFailures.Load())
+	}
+	if a.GoogleStatus().NeedsRepair {
+		t.Fatal("phone-offline failures should not mark Google as needing repair")
+	}
+}
+
+func TestSuccessfulGoogleSendMarksPhoneResponding(t *testing.T) {
+	a := &App{}
+	a.SessionPath = filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(a.SessionPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a.RecordGooglePhoneResponding(false)
+	if a.GooglePhoneResponding() {
+		t.Fatal("expected phone responding false after explicit offline event")
+	}
+	a.RecordGoogleSendOutcomeWithPhone(true, false)
+	if !a.GooglePhoneResponding() {
+		t.Fatal("successful send should mark phone responding true")
+	}
+}
+
+func TestGoogleSendRejectedMessageUsesPhoneReachability(t *testing.T) {
+	offline := GoogleSendRejectedMessage("UNKNOWN", false)
+	if !strings.Contains(offline, "phone isn't responding") {
+		t.Fatalf("offline error should mention phone reachability, got %q", offline)
+	}
+	stale := GoogleSendRejectedMessage("UNKNOWN", true)
+	if !strings.Contains(stale, "Pair again") {
+		t.Fatalf("responding-phone error should mention re-pairing, got %q", stale)
+	}
+}
+
+func TestRecordGoogleSendErrorOnlyMarksAuthInvalidForRepair(t *testing.T) {
+	a := &App{}
+	a.SessionPath = filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(a.SessionPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a.RecordGoogleSendError(errors.New("dial tcp: i/o timeout"))
+	if a.GoogleStatus().NeedsRepair {
+		t.Fatal("transient network send errors should not mark needs_repair")
+	}
+
+	a.RecordGoogleSendError(errors.New("send message: HTTP 401: invalid authentication credentials"))
+	if !a.GoogleStatus().NeedsRepair {
+		t.Fatal("auth-invalid send errors should mark needs_repair")
 	}
 }
 

--- a/internal/app/backfill.go
+++ b/internal/app/backfill.go
@@ -40,26 +40,13 @@ func orphanContactDiscoveryEnabled() bool {
 	}
 }
 
-func isGoogleAuthExpiredError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "http 401") ||
-		strings.Contains(msg, "session_cookie_invalid") ||
-		strings.Contains(msg, "invalid authentication credentials")
-}
-
 func (a *App) abortBackfillForGoogleAuthError(err error, phase, detail string) bool {
-	if !isGoogleAuthExpiredError(err) {
+	if !a.HandleGoogleAuthExpiredError(err) {
 		return false
 	}
 	if detail != "" {
 		a.BackfillProgress.addError(detail)
 	}
-	a.Connected.Store(false)
-	a.setGoogleLastError("Google Messages session cookie expired; refreshing and reconnecting…")
-	a.emitStatusChange(false)
 	a.Logger.Warn().Err(err).Str("phase", phase).Msg("Deep backfill aborted because Google auth expired")
 	return true
 }
@@ -81,6 +68,7 @@ func (a *App) Backfill() error {
 
 	resp, err := cli.GM.ListConversations(100, gmproto.ListConversationsRequest_INBOX)
 	if err != nil {
+		a.HandleGoogleAuthExpiredError(err)
 		return fmt.Errorf("list conversations: %w", err)
 	}
 
@@ -95,6 +83,9 @@ func (a *App) Backfill() error {
 
 		msgResp, err := cli.GM.FetchMessages(conv.GetConversationID(), 20, nil)
 		if err != nil {
+			if a.HandleGoogleAuthExpiredError(err) {
+				return fmt.Errorf("fetch messages %s: %w", conv.GetConversationID(), err)
+			}
 			a.Logger.Warn().Err(err).Str("conv_id", conv.GetConversationID()).Msg("Failed to fetch messages")
 			continue
 		}
@@ -419,6 +410,7 @@ func (a *App) BackfillConversationByPhone(phone string) error {
 		Numbers: NewContactNumbers([]string{phone}),
 	})
 	if err != nil {
+		a.HandleGoogleAuthExpiredError(err)
 		return fmt.Errorf("get or create conversation: %w", err)
 	}
 
@@ -460,6 +452,10 @@ func (a *App) reconcileRecentConversations(reason string) {
 
 	resp, err := gm.ListConversationsWithCursor(recentReconcileConversationLimit, gmproto.ListConversationsRequest_INBOX, nil)
 	if err != nil {
+		if a.HandleGoogleAuthExpiredError(err) {
+			a.Logger.Warn().Err(err).Str("reason", reason).Msg("Recent reconcile aborted because Google auth expired")
+			return
+		}
 		a.Logger.Warn().Err(err).Str("reason", reason).Msg("Recent reconcile: list conversations failed")
 		return
 	}
@@ -522,6 +518,9 @@ func (a *App) reconcileRecentConversationMessages(gm GMClient, convID string, cl
 
 		msgResp, err := gm.FetchMessages(convID, recentReconcileMessageLimit, cursor)
 		if err != nil {
+			if a.HandleGoogleAuthExpiredError(err) {
+				return storedAny, true
+			}
 			a.Logger.Warn().Err(err).Str("conv_id", convID).Int("page", page).Msg("Recent reconcile: fetch messages failed")
 			return storedAny, false
 		}
@@ -582,6 +581,9 @@ func (a *App) refreshPendingMediaMessageAttempt(convID, messageID string) (bool,
 		}
 		msgResp, err := gm.FetchMessages(convID, recentReconcileMessageLimit, cursor)
 		if err != nil {
+			if a.HandleGoogleAuthExpiredError(err) {
+				return false, true
+			}
 			a.Logger.Warn().Err(err).Str("conv_id", convID).Str("msg_id", messageID).Msg("Pending media refresh fetch failed")
 			return false, false
 		}

--- a/internal/app/backfill.go
+++ b/internal/app/backfill.go
@@ -40,6 +40,30 @@ func orphanContactDiscoveryEnabled() bool {
 	}
 }
 
+func isGoogleAuthExpiredError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "http 401") ||
+		strings.Contains(msg, "session_cookie_invalid") ||
+		strings.Contains(msg, "invalid authentication credentials")
+}
+
+func (a *App) abortBackfillForGoogleAuthError(err error, phase, detail string) bool {
+	if !isGoogleAuthExpiredError(err) {
+		return false
+	}
+	if detail != "" {
+		a.BackfillProgress.addError(detail)
+	}
+	a.Connected.Store(false)
+	a.setGoogleLastError("Google Messages session cookie expired; refreshing and reconnecting…")
+	a.emitStatusChange(false)
+	a.Logger.Warn().Err(err).Str("phase", phase).Msg("Deep backfill aborted because Google auth expired")
+	return true
+}
+
 // Backfill fetches existing conversations and recent messages from
 // Google Messages and stores them in the local database.
 func (a *App) Backfill() error {
@@ -194,6 +218,9 @@ func (a *App) paginateFolder(gm GMClient, folder gmproto.ListConversationsReques
 		}
 		resp, err := gm.ListConversationsWithCursor(100, folder, cursor)
 		if err != nil {
+			if a.abortBackfillForGoogleAuthError(err, "folders", fmt.Sprintf("list %s: %v", folder.String(), err)) {
+				return found, true
+			}
 			a.Logger.Error().Err(err).Str("folder", folder.String()).Msg("Deep backfill: list conversations failed")
 			a.BackfillProgress.addError(fmt.Sprintf("list %s: %v", folder.String(), err))
 			break
@@ -260,6 +287,9 @@ func (a *App) deepBackfillConversationWithToken(gm GMClient, convID string, clie
 		}
 		resp, err := gm.FetchMessages(convID, 50, cursor)
 		if err != nil {
+			if a.abortBackfillForGoogleAuthError(err, "messages", fmt.Sprintf("fetch messages %s: %v", convID, err)) {
+				return total, true
+			}
 			a.Logger.Warn().Err(err).Str("conv_id", convID).Msg("Deep backfill: fetch messages failed")
 			a.BackfillProgress.addError(fmt.Sprintf("fetch messages %s: %v", convID, err))
 			break
@@ -305,6 +335,9 @@ func (a *App) discoverFromContacts(gm GMClient, seen map[string]bool, clientToke
 	}
 	contactsResp, err := gm.ListContacts()
 	if err != nil {
+		if a.abortBackfillForGoogleAuthError(err, "contacts", fmt.Sprintf("list contacts: %v", err)) {
+			return true
+		}
 		a.Logger.Warn().Err(err).Msg("Deep backfill: list contacts failed")
 		a.BackfillProgress.addError(fmt.Sprintf("list contacts: %v", err))
 		return false
@@ -335,6 +368,9 @@ func (a *App) discoverFromContacts(gm GMClient, seen map[string]bool, clientToke
 			},
 		})
 		if err != nil {
+			if a.abortBackfillForGoogleAuthError(err, "contacts", fmt.Sprintf("get or create conversation %s: %v", phone, err)) {
+				return true
+			}
 			a.Logger.Debug().Err(err).Str("phone", phone).Msg("Deep backfill: GetOrCreateConversation failed for contact")
 			a.BackfillProgress.addError("")
 			continue

--- a/internal/app/backfill_test.go
+++ b/internal/app/backfill_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -922,6 +923,74 @@ func TestStartRecentReconcileReturnsFalseWhenBackfillIsRunning(t *testing.T) {
 
 	if a.StartRecentReconcile("listen_recovered") {
 		t.Fatal("recent reconcile should not start while another backfill is active")
+	}
+}
+
+func TestDeepBackfillAbortsOnFolderAuthExpired(t *testing.T) {
+	mock := &mockGMClient{
+		listConvErrors: map[gmproto.ListConversationsRequest_Folder]error{
+			gmproto.ListConversationsRequest_INBOX: fmt.Errorf("HTTP 401: SESSION_COOKIE_INVALID"),
+		},
+	}
+	a := newTestApp(t, mock)
+	a.Connected.Store(true)
+
+	var statusChanges int
+	a.OnStatusChange = func(connected bool) {
+		statusChanges++
+		if connected {
+			t.Fatal("auth-expired backfill should mark Google disconnected")
+		}
+	}
+
+	a.DeepBackfill()
+
+	if a.Connected.Load() {
+		t.Fatal("Google connection should be marked disconnected")
+	}
+	if statusChanges != 1 {
+		t.Fatalf("status change callbacks = %d, want 1", statusChanges)
+	}
+	if got := a.GoogleStatus().LastError; !strings.Contains(got, "session cookie expired") {
+		t.Fatalf("last error = %q, want session cookie expired message", got)
+	}
+	progress := a.GetBackfillProgress()
+	if progress.Errors != 1 {
+		t.Fatalf("errors = %d, want 1", progress.Errors)
+	}
+	if progress.ConversationsFound != 0 {
+		t.Fatalf("conversations found = %d, want 0", progress.ConversationsFound)
+	}
+}
+
+func TestDeepBackfillAbortsOnMessageAuthExpired(t *testing.T) {
+	mock := &mockGMClient{
+		conversations: map[gmproto.ListConversationsRequest_Folder][][]*gmproto.Conversation{
+			gmproto.ListConversationsRequest_INBOX: {
+				{makeConv("c1", "Alice")},
+			},
+		},
+		fetchMsgErrors: map[string]error{
+			"c1": fmt.Errorf("Request had invalid authentication credentials"),
+		},
+	}
+	a := newTestApp(t, mock)
+	a.Connected.Store(true)
+
+	a.DeepBackfill()
+
+	if a.Connected.Load() {
+		t.Fatal("Google connection should be marked disconnected")
+	}
+	if got := a.GoogleStatus().LastError; !strings.Contains(got, "session cookie expired") {
+		t.Fatalf("last error = %q, want session cookie expired message", got)
+	}
+	progress := a.GetBackfillProgress()
+	if progress.Errors != 1 {
+		t.Fatalf("errors = %d, want 1", progress.Errors)
+	}
+	if progress.MessagesFound != 0 {
+		t.Fatalf("messages found = %d, want 0", progress.MessagesFound)
 	}
 }
 

--- a/internal/app/google_auth.go
+++ b/internal/app/google_auth.go
@@ -1,0 +1,31 @@
+package app
+
+import "strings"
+
+const googleAuthExpiredStatusMessage = "Google Messages session cookie expired; refreshing and reconnecting..."
+
+// IsGoogleAuthExpiredError reports whether a Google Messages API error means
+// the linked-device web cookies/session are no longer accepted by Google.
+func IsGoogleAuthExpiredError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "http 401") ||
+		strings.Contains(msg, "session_cookie_invalid") ||
+		strings.Contains(msg, "invalid authentication credentials")
+}
+
+// HandleGoogleAuthExpiredError marks Google disconnected for auth-expiry
+// errors so external watchdogs can refresh cookies and reconnect.
+func (a *App) HandleGoogleAuthExpiredError(err error) bool {
+	if !IsGoogleAuthExpiredError(err) {
+		return false
+	}
+	a.Connected.Store(false)
+	a.ClearGoogleRepairFlag()
+	a.setGoogleLastError(googleAuthExpiredStatusMessage)
+	a.emitStatusChange(false)
+	a.Logger.Warn().Err(err).Msg("Google auth expired; marking disconnected")
+	return true
+}

--- a/internal/app/google_auth.go
+++ b/internal/app/google_auth.go
@@ -17,14 +17,18 @@ func IsGoogleAuthExpiredError(err error) bool {
 		strings.Contains(msg, "invalid authentication credentials")
 }
 
-// HandleGoogleAuthExpiredError marks Google disconnected for auth-expiry
-// errors so external watchdogs can refresh cookies and reconnect.
+// HandleGoogleAuthExpiredError marks Google disconnected for auth-expiry errors
+// so the reconnect watchdog can refresh cookies and reconnect. It deliberately
+// does NOT clear the needs-repair flag: whether an expired session is
+// recoverable depends on a cookie-refresh script being configured, and that
+// decision lives in the watchdog (see planGoogleReconnect). Clearing it here
+// would defeat the watchdog's back-off and, with no refresh script (e.g. the
+// macOS app), spin a reconnect storm against Google's auth endpoint.
 func (a *App) HandleGoogleAuthExpiredError(err error) bool {
 	if !IsGoogleAuthExpiredError(err) {
 		return false
 	}
 	a.Connected.Store(false)
-	a.ClearGoogleRepairFlag()
 	a.googleAuthExpired.Store(true)
 	a.setGoogleLastError(googleAuthExpiredStatusMessage)
 	a.emitStatusChange(false)

--- a/internal/app/google_auth.go
+++ b/internal/app/google_auth.go
@@ -13,6 +13,7 @@ func IsGoogleAuthExpiredError(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "http 401") ||
 		strings.Contains(msg, "session_cookie_invalid") ||
+		strings.Contains(msg, "session cookie expired") ||
 		strings.Contains(msg, "invalid authentication credentials")
 }
 
@@ -24,6 +25,7 @@ func (a *App) HandleGoogleAuthExpiredError(err error) bool {
 	}
 	a.Connected.Store(false)
 	a.ClearGoogleRepairFlag()
+	a.googleAuthExpired.Store(true)
 	a.setGoogleLastError(googleAuthExpiredStatusMessage)
 	a.emitStatusChange(false)
 	a.Logger.Warn().Err(err).Msg("Google auth expired; marking disconnected")

--- a/internal/app/send.go
+++ b/internal/app/send.go
@@ -50,6 +50,7 @@ func (a *App) SendTextToConversation(conversationID, body string) (*db.Conversat
 	case "sms":
 		gmConv, err := getGoogleConversationForSend(a, conversationID)
 		if err != nil {
+			a.RecordGoogleSendError(err)
 			return conv, nil, fmt.Errorf("get Google conversation: %w", err)
 		}
 		payload, err := buildGoogleTextPayload(gmConv, conversationID, body)
@@ -58,11 +59,14 @@ func (a *App) SendTextToConversation(conversationID, body string) (*db.Conversat
 		}
 		resp, err := sendGoogleTextPayload(a, payload)
 		if err != nil {
+			a.RecordGoogleSendError(err)
 			return conv, nil, fmt.Errorf("send Google message: %w", err)
 		}
 		if resp.GetStatus() != gmproto.SendMessageResponse_SUCCESS {
-			return conv, nil, fmt.Errorf("send Google message: %s", resp.GetStatus().String())
+			a.RecordGoogleSendOutcomeWithPhone(false, a.GooglePhoneResponding())
+			return conv, nil, fmt.Errorf("%s", GoogleSendRejectedMessage(resp.GetStatus().String(), a.GooglePhoneResponding()))
 		}
+		a.RecordGoogleSendOutcome(true)
 		msg := &db.Message{
 			MessageID:      payload.TmpID,
 			ConversationID: conversationID,
@@ -79,6 +83,20 @@ func (a *App) SendTextToConversation(conversationID, body string) (*db.Conversat
 	default:
 		return conv, nil, fmt.Errorf("sending is not supported for platform %s via OpenMessage yet", conv.SourcePlatform)
 	}
+}
+
+// GoogleSendRejectedMessage builds the user-facing error for a non-SUCCESS
+// Google send. UNKNOWN can mean either a temporarily unreachable phone or a
+// stale linked-device session; phone reachability lets us point at the right
+// recovery path.
+func GoogleSendRejectedMessage(status string, phoneResponding bool) string {
+	if !phoneResponding {
+		return "send failed (Google Messages returned " + status + "): your phone isn't responding to OpenMessage right now. " +
+			"Make sure your phone is on and connected to the internet, then try again."
+	}
+	return "send failed (Google Messages returned " + status + "). If this keeps happening your phone has " +
+		"likely unlinked OpenMessage - open Platforms -> Google Messages -> Pair again. " +
+		"Also confirm Messages is set as your phone's default SMS app."
 }
 
 func normalizeConversationPlatform(platform string) string {

--- a/internal/app/send.go
+++ b/internal/app/send.go
@@ -50,7 +50,9 @@ func (a *App) SendTextToConversation(conversationID, body string) (*db.Conversat
 	case "sms":
 		gmConv, err := getGoogleConversationForSend(a, conversationID)
 		if err != nil {
-			a.RecordGoogleSendError(err)
+			if !a.HandleGoogleAuthExpiredError(err) {
+				a.RecordGoogleSendError(err)
+			}
 			return conv, nil, fmt.Errorf("get Google conversation: %w", err)
 		}
 		payload, err := buildGoogleTextPayload(gmConv, conversationID, body)
@@ -59,7 +61,9 @@ func (a *App) SendTextToConversation(conversationID, body string) (*db.Conversat
 		}
 		resp, err := sendGoogleTextPayload(a, payload)
 		if err != nil {
-			a.RecordGoogleSendError(err)
+			if !a.HandleGoogleAuthExpiredError(err) {
+				a.RecordGoogleSendError(err)
+			}
 			return conv, nil, fmt.Errorf("send Google message: %w", err)
 		}
 		if resp.GetStatus() != gmproto.SendMessageResponse_SUCCESS {

--- a/internal/app/send_test.go
+++ b/internal/app/send_test.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -72,6 +75,80 @@ func TestSendTextToConversationSMSPersistsOutgoingMessage(t *testing.T) {
 	}
 	if stored == nil || stored.Body != "hello sms" {
 		t.Fatalf("expected persisted outgoing sms message, got %#v", stored)
+	}
+}
+
+func TestSendTextToConversationSMSRejectedUsesPhoneReachability(t *testing.T) {
+	a := testSendApp(t)
+	a.SessionPath = filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(a.SessionPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a.RecordGooglePhoneResponding(false)
+	if err := a.Store.UpsertConversation(&db.Conversation{
+		ConversationID: "sms-conv-1",
+		Name:           "Taylor",
+		LastMessageTS:  time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+
+	originalGetGoogleConversation := getGoogleConversationForSend
+	originalSendGoogleTextPayload := sendGoogleTextPayload
+	getGoogleConversationForSend = func(_ *App, conversationID string) (*gmproto.Conversation, error) {
+		return &gmproto.Conversation{ConversationID: conversationID}, nil
+	}
+	sendGoogleTextPayload = func(_ *App, payload *gmproto.SendMessageRequest) (*gmproto.SendMessageResponse, error) {
+		return &gmproto.SendMessageResponse{Status: gmproto.SendMessageResponse_UNKNOWN}, nil
+	}
+	t.Cleanup(func() {
+		getGoogleConversationForSend = originalGetGoogleConversation
+		sendGoogleTextPayload = originalSendGoogleTextPayload
+	})
+
+	_, _, err := a.SendTextToConversation("sms-conv-1", "hello sms")
+	if err == nil {
+		t.Fatal("expected send rejection")
+	}
+	if !strings.Contains(err.Error(), "phone isn't responding") {
+		t.Fatalf("expected phone reachability error, got %v", err)
+	}
+	if a.googleSendFailures.Load() != 0 {
+		t.Fatalf("googleSendFailures = %d, want 0", a.googleSendFailures.Load())
+	}
+	if a.GoogleStatus().NeedsRepair {
+		t.Fatal("phone-offline send rejection must not mark Google session for repair")
+	}
+}
+
+func TestSendTextToConversationLookupAuthErrorMarksRepair(t *testing.T) {
+	a := testSendApp(t)
+	a.SessionPath = filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(a.SessionPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Store.UpsertConversation(&db.Conversation{
+		ConversationID: "sms-conv-auth",
+		Name:           "Taylor",
+		LastMessageTS:  time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+
+	originalGetGoogleConversation := getGoogleConversationForSend
+	getGoogleConversationForSend = func(_ *App, conversationID string) (*gmproto.Conversation, error) {
+		return nil, errors.New("HTTP 401: invalid authentication credentials")
+	}
+	t.Cleanup(func() {
+		getGoogleConversationForSend = originalGetGoogleConversation
+	})
+
+	_, _, err := a.SendTextToConversation("sms-conv-auth", "hello sms")
+	if err == nil {
+		t.Fatal("expected lookup error")
+	}
+	if !a.GoogleStatus().NeedsRepair {
+		t.Fatal("auth-invalid lookup error should mark Google session for repair")
 	}
 }
 

--- a/internal/app/send_test.go
+++ b/internal/app/send_test.go
@@ -121,8 +121,9 @@ func TestSendTextToConversationSMSRejectedUsesPhoneReachability(t *testing.T) {
 	}
 }
 
-func TestSendTextToConversationLookupAuthErrorMarksRepair(t *testing.T) {
+func TestSendTextToConversationLookupAuthErrorMarksDisconnected(t *testing.T) {
 	a := testSendApp(t)
+	a.Connected.Store(true)
 	a.SessionPath = filepath.Join(t.TempDir(), "session.json")
 	if err := os.WriteFile(a.SessionPath, []byte("{}"), 0o600); err != nil {
 		t.Fatal(err)
@@ -147,8 +148,14 @@ func TestSendTextToConversationLookupAuthErrorMarksRepair(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected lookup error")
 	}
-	if !a.GoogleStatus().NeedsRepair {
-		t.Fatal("auth-invalid lookup error should mark Google session for repair")
+	if a.Connected.Load() {
+		t.Fatal("auth-invalid lookup error should mark Google disconnected")
+	}
+	if a.GoogleStatus().NeedsRepair {
+		t.Fatal("auth-invalid lookup error should use cookie-refresh reconnect, not repair")
+	}
+	if got := a.GoogleStatus().LastError; got != googleAuthExpiredStatusMessage {
+		t.Fatalf("last error = %q, want %q", got, googleAuthExpiredStatusMessage)
 	}
 }
 
@@ -169,5 +176,37 @@ func TestSendTextToConversationUnsupportedPlatform(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not supported") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendTextToConversationGoogleAuthErrorMarksDisconnected(t *testing.T) {
+	a := testSendApp(t)
+	a.Connected.Store(true)
+	if err := a.Store.UpsertConversation(&db.Conversation{
+		ConversationID: "sms-conv-1",
+		Name:           "Taylor",
+		LastMessageTS:  time.Now().UnixMilli(),
+		SourcePlatform: "sms",
+	}); err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+
+	originalGetGoogleConversation := getGoogleConversationForSend
+	getGoogleConversationForSend = func(_ *App, _ string) (*gmproto.Conversation, error) {
+		return nil, errors.New("get conversation: HTTP 401: 16: Request had invalid authentication credentials")
+	}
+	t.Cleanup(func() {
+		getGoogleConversationForSend = originalGetGoogleConversation
+	})
+
+	_, _, err := a.SendTextToConversation("sms-conv-1", "hello sms")
+	if err == nil {
+		t.Fatal("expected send error")
+	}
+	if a.Connected.Load() {
+		t.Fatal("expected auth error to mark Google disconnected")
+	}
+	if got := a.GoogleStatus().LastError; got != googleAuthExpiredStatusMessage {
+		t.Fatalf("last error = %q, want %q", got, googleAuthExpiredStatusMessage)
 	}
 }

--- a/internal/client/events.go
+++ b/internal/client/events.go
@@ -38,6 +38,7 @@ type EventHandler struct {
 	OnRealtimeGapRecovered   func(string)
 	OnTypingChange           func(conversationID, senderName, senderNumber string, typing bool)
 	OnGoogleAvatarCandidates func([]db.ContactAvatarCandidate)
+	OnPhoneRespondingChange  func(bool)
 }
 
 func (h *EventHandler) Handle(rawEvt any) {
@@ -90,8 +91,14 @@ func (h *EventHandler) Handle(rawEvt any) {
 		}
 	case *events.PhoneNotResponding:
 		h.Logger.Warn().Msg("Phone not responding")
+		if h.OnPhoneRespondingChange != nil {
+			h.OnPhoneRespondingChange(false)
+		}
 	case *events.PhoneRespondingAgain:
 		h.Logger.Info().Msg("Phone responding again")
+		if h.OnPhoneRespondingChange != nil {
+			h.OnPhoneRespondingChange(true)
+		}
 		if h.OnRealtimeGapRecovered != nil {
 			h.OnRealtimeGapRecovered("phone_responding_again")
 		}
@@ -107,6 +114,9 @@ func (h *EventHandler) handleClientReady(evt *events.ClientReady) {
 		Str("session_id", evt.SessionID).
 		Int("conversations", len(evt.Conversations)).
 		Msg("Client ready")
+	if h.OnPhoneRespondingChange != nil {
+		h.OnPhoneRespondingChange(true)
+	}
 
 	for _, conv := range evt.Conversations {
 		h.storeConversation(conv)
@@ -179,6 +189,9 @@ func (h *EventHandler) handleMessage(evt *libgm.WrappedMessage) {
 
 	if !dbMsg.IsFromMe && !evt.IsOld && h.OnIncomingMessage != nil {
 		h.OnIncomingMessage(dbMsg)
+	}
+	if !dbMsg.IsFromMe && !evt.IsOld && h.OnPhoneRespondingChange != nil {
+		h.OnPhoneRespondingChange(true)
 	}
 	if !dbMsg.IsFromMe && !evt.IsOld && h.OnPendingMedia != nil && messageNeedsPendingMediaRefresh(msg, dbMsg) {
 		h.OnPendingMedia(dbMsg.ConversationID, dbMsg.MessageID)

--- a/internal/client/events_test.go
+++ b/internal/client/events_test.go
@@ -145,13 +145,18 @@ func TestHandleMessage_BumpsConversationTimestamp(t *testing.T) {
 
 func TestHandleRecoveryEvents_TriggerRealtimeGapCallback(t *testing.T) {
 	var reasons []string
+	var phoneResponding []bool
 	handler := &EventHandler{
 		Logger: zerolog.Nop(),
 		OnRealtimeGapRecovered: func(reason string) {
 			reasons = append(reasons, reason)
 		},
+		OnPhoneRespondingChange: func(responding bool) {
+			phoneResponding = append(phoneResponding, responding)
+		},
 	}
 
+	handler.Handle(&events.PhoneNotResponding{})
 	handler.Handle(&events.ListenRecovered{})
 	handler.Handle(&events.PhoneRespondingAgain{})
 
@@ -163,6 +168,12 @@ func TestHandleRecoveryEvents_TriggerRealtimeGapCallback(t *testing.T) {
 	}
 	if reasons[1] != "phone_responding_again" {
 		t.Fatalf("second recovery reason = %q, want %q", reasons[1], "phone_responding_again")
+	}
+	if len(phoneResponding) != 2 {
+		t.Fatalf("phone responding callback count = %d, want 2", len(phoneResponding))
+	}
+	if phoneResponding[0] != false || phoneResponding[1] != true {
+		t.Fatalf("phone responding callbacks = %v, want [false true]", phoneResponding)
 	}
 }
 

--- a/internal/tools/get_status.go
+++ b/internal/tools/get_status.go
@@ -53,6 +53,7 @@ func getStatusHandler(a *app.App) server.ToolHandlerFunc {
 		fmt.Fprintf(&sb, "  Connected: %v\n", google.Connected)
 		fmt.Fprintf(&sb, "  Paired: %v\n", google.Paired)
 		fmt.Fprintf(&sb, "  Needs pairing: %v\n", google.NeedsPairing)
+		fmt.Fprintf(&sb, "  Phone responding: %v\n", google.PhoneResponding)
 		if google.LastError != "" {
 			fmt.Fprintf(&sb, "  Last error: %s\n", google.LastError)
 		}

--- a/internal/tools/react_to_message.go
+++ b/internal/tools/react_to_message.go
@@ -85,12 +85,14 @@ func reactToMessageHandler(a *app.App) server.ToolHandlerFunc {
 		case "", "sms":
 			gmConv, err := getGoogleReactionConversation(a, conversationID)
 			if err != nil {
+				a.HandleGoogleAuthExpiredError(err)
 				return errorResult(fmt.Sprintf("get conversation: %v", err)), nil
 			}
 			_, simPayload := app.ExtractSIMAndParticipant(gmConv)
 			payload := app.BuildReactionPayload(messageID, emoji, action, simPayload)
 			resp, err := sendGoogleReaction(a, payload)
 			if err != nil {
+				a.HandleGoogleAuthExpiredError(err)
 				return errorResult(fmt.Sprintf("failed to send reaction: %v", err)), nil
 			}
 			if !resp.GetSuccess() {

--- a/internal/tools/send_group_message.go
+++ b/internal/tools/send_group_message.go
@@ -55,7 +55,9 @@ func sendGroupMessageHandler(a *app.App) server.ToolHandlerFunc {
 			Numbers: app.NewContactNumbers(phones),
 		})
 		if err != nil {
-			a.RecordGoogleSendError(err)
+			if !a.HandleGoogleAuthExpiredError(err) {
+				a.RecordGoogleSendError(err)
+			}
 			return errorResult(fmt.Sprintf("failed to get/create group conversation: %v", err)), nil
 		}
 
@@ -67,7 +69,9 @@ func sendGroupMessageHandler(a *app.App) server.ToolHandlerFunc {
 		payload := app.BuildSendPayload(conv.GetConversationID(), message, "", "", nil)
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
-			a.RecordGoogleSendError(err)
+			if !a.HandleGoogleAuthExpiredError(err) {
+				a.RecordGoogleSendError(err)
+			}
 			return errorResult(fmt.Sprintf("failed to send group message: %v", err)), nil
 		}
 		// Surface a carrier/Google rejection instead of reporting success on a

--- a/internal/tools/send_group_message.go
+++ b/internal/tools/send_group_message.go
@@ -55,6 +55,7 @@ func sendGroupMessageHandler(a *app.App) server.ToolHandlerFunc {
 			Numbers: app.NewContactNumbers(phones),
 		})
 		if err != nil {
+			a.RecordGoogleSendError(err)
 			return errorResult(fmt.Sprintf("failed to get/create group conversation: %v", err)), nil
 		}
 
@@ -66,13 +67,16 @@ func sendGroupMessageHandler(a *app.App) server.ToolHandlerFunc {
 		payload := app.BuildSendPayload(conv.GetConversationID(), message, "", "", nil)
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
+			a.RecordGoogleSendError(err)
 			return errorResult(fmt.Sprintf("failed to send group message: %v", err)), nil
 		}
 		// Surface a carrier/Google rejection instead of reporting success on a
 		// non-SUCCESS status (matches the 1:1 send path).
 		if resp.GetStatus() != gmproto.SendMessageResponse_SUCCESS {
-			return errorResult(fmt.Sprintf("failed to send group message: %s", resp.GetStatus().String())), nil
+			a.RecordGoogleSendOutcomeWithPhone(false, a.GooglePhoneResponding())
+			return errorResult(app.GoogleSendRejectedMessage(resp.GetStatus().String(), a.GooglePhoneResponding())), nil
 		}
+		a.RecordGoogleSendOutcome(true)
 
 		// Persist so the group send appears in local history (like 1:1 sends).
 		if err := a.Store.RecordOutgoingMessage(&db.Message{

--- a/internal/tools/send_media_to_conversation.go
+++ b/internal/tools/send_media_to_conversation.go
@@ -118,21 +118,26 @@ func sendMediaToConversationHandler(a *app.App) server.ToolHandlerFunc {
 		case "", "sms":
 			media, err := uploadGoogleMedia(a, data, filename, mimeType)
 			if err != nil {
+				a.RecordGoogleSendError(err)
 				return errorResult(fmt.Sprintf("upload media: %v", err)), nil
 			}
 			gmConv, err := getGoogleConversation(a, conversationID)
 			if err != nil {
+				a.RecordGoogleSendError(err)
 				return errorResult(fmt.Sprintf("get conversation: %v", err)), nil
 			}
 			myParticipantID, simPayload := app.ExtractSIMAndParticipant(gmConv)
 			payload := app.BuildSendMediaPayload(conversationID, media, myParticipantID, simPayload)
 			resp, err := sendGoogleMediaMessage(a, payload)
 			if err != nil {
+				a.RecordGoogleSendError(err)
 				return errorResult(fmt.Sprintf("failed to send media: %v", err)), nil
 			}
 			if resp.GetStatus() != gmproto.SendMessageResponse_SUCCESS {
-				return errorResult(fmt.Sprintf("failed to send media: %s", resp.GetStatus().String())), nil
+				a.RecordGoogleSendOutcomeWithPhone(false, a.GooglePhoneResponding())
+				return errorResult(app.GoogleSendRejectedMessage(resp.GetStatus().String(), a.GooglePhoneResponding())), nil
 			}
+			a.RecordGoogleSendOutcome(true)
 			now := time.Now().UnixMilli()
 			msg := &db.Message{
 				MessageID:      payload.TmpID,

--- a/internal/tools/send_media_to_conversation.go
+++ b/internal/tools/send_media_to_conversation.go
@@ -118,19 +118,25 @@ func sendMediaToConversationHandler(a *app.App) server.ToolHandlerFunc {
 		case "", "sms":
 			media, err := uploadGoogleMedia(a, data, filename, mimeType)
 			if err != nil {
-				a.RecordGoogleSendError(err)
+				if !a.HandleGoogleAuthExpiredError(err) {
+					a.RecordGoogleSendError(err)
+				}
 				return errorResult(fmt.Sprintf("upload media: %v", err)), nil
 			}
 			gmConv, err := getGoogleConversation(a, conversationID)
 			if err != nil {
-				a.RecordGoogleSendError(err)
+				if !a.HandleGoogleAuthExpiredError(err) {
+					a.RecordGoogleSendError(err)
+				}
 				return errorResult(fmt.Sprintf("get conversation: %v", err)), nil
 			}
 			myParticipantID, simPayload := app.ExtractSIMAndParticipant(gmConv)
 			payload := app.BuildSendMediaPayload(conversationID, media, myParticipantID, simPayload)
 			resp, err := sendGoogleMediaMessage(a, payload)
 			if err != nil {
-				a.RecordGoogleSendError(err)
+				if !a.HandleGoogleAuthExpiredError(err) {
+					a.RecordGoogleSendError(err)
+				}
 				return errorResult(fmt.Sprintf("failed to send media: %v", err)), nil
 			}
 			if resp.GetStatus() != gmproto.SendMessageResponse_SUCCESS {

--- a/internal/tools/send_message.go
+++ b/internal/tools/send_message.go
@@ -131,7 +131,9 @@ func sendMessageHandler(a *app.App) server.ToolHandlerFunc {
 			}
 			conv, err := getOrCreateGoogleConversation(a, recipient)
 			if err != nil {
-				a.RecordGoogleSendError(err)
+				if !a.HandleGoogleAuthExpiredError(err) {
+					a.RecordGoogleSendError(err)
+				}
 				return errorResult(fmt.Sprintf("failed to get/create conversation: %v", err)), nil
 			}
 			if conv == nil {
@@ -144,7 +146,9 @@ func sendMessageHandler(a *app.App) server.ToolHandlerFunc {
 			payload := app.BuildSendPayload(conv.GetConversationID(), message, "", myParticipantID, simPayload)
 			resp, err := sendGoogleTextPayload(a, payload)
 			if err != nil {
-				a.RecordGoogleSendError(err)
+				if !a.HandleGoogleAuthExpiredError(err) {
+					a.RecordGoogleSendError(err)
+				}
 				return errorResult(fmt.Sprintf("failed to send: %v", err)), nil
 			}
 			if resp.GetStatus() != gmproto.SendMessageResponse_SUCCESS {

--- a/internal/tools/send_message.go
+++ b/internal/tools/send_message.go
@@ -131,6 +131,7 @@ func sendMessageHandler(a *app.App) server.ToolHandlerFunc {
 			}
 			conv, err := getOrCreateGoogleConversation(a, recipient)
 			if err != nil {
+				a.RecordGoogleSendError(err)
 				return errorResult(fmt.Sprintf("failed to get/create conversation: %v", err)), nil
 			}
 			if conv == nil {
@@ -143,11 +144,14 @@ func sendMessageHandler(a *app.App) server.ToolHandlerFunc {
 			payload := app.BuildSendPayload(conv.GetConversationID(), message, "", myParticipantID, simPayload)
 			resp, err := sendGoogleTextPayload(a, payload)
 			if err != nil {
+				a.RecordGoogleSendError(err)
 				return errorResult(fmt.Sprintf("failed to send: %v", err)), nil
 			}
 			if resp.GetStatus() != gmproto.SendMessageResponse_SUCCESS {
-				return errorResult(fmt.Sprintf("failed to send: %s", resp.GetStatus().String())), nil
+				a.RecordGoogleSendOutcomeWithPhone(false, a.GooglePhoneResponding())
+				return errorResult(app.GoogleSendRejectedMessage(resp.GetStatus().String(), a.GooglePhoneResponding())), nil
 			}
+			a.RecordGoogleSendOutcome(true)
 			now := time.Now().UnixMilli()
 			if err := a.Store.RecordOutgoingMessage(&db.Message{
 				MessageID:      payload.TmpID,

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -460,6 +461,39 @@ func TestSendMessageSMSPersistsConversationAndOutgoingMessage(t *testing.T) {
 	}
 	if message.Body != "hi sms" {
 		t.Fatalf("unexpected structured message: %#v", message)
+	}
+}
+
+func TestSendMessageLookupAuthErrorMarksRepair(t *testing.T) {
+	a := testApp(t)
+	a.SessionPath = filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(a.SessionPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	originalGetOrCreateGoogleConversation := getOrCreateGoogleConversation
+	getOrCreateGoogleConversation = func(_ *app.App, phone string) (*gmproto.Conversation, error) {
+		return nil, errors.New("HTTP 401: invalid authentication credentials")
+	}
+	t.Cleanup(func() {
+		getOrCreateGoogleConversation = originalGetOrCreateGoogleConversation
+	})
+
+	handler := sendMessageHandler(a)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"phone_number": "+15551230000",
+		"message":      "hi sms",
+	}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result")
+	}
+	if !a.GoogleStatus().NeedsRepair {
+		t.Fatal("auth-invalid lookup error should mark Google session for repair")
 	}
 }
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -464,8 +464,9 @@ func TestSendMessageSMSPersistsConversationAndOutgoingMessage(t *testing.T) {
 	}
 }
 
-func TestSendMessageLookupAuthErrorMarksRepair(t *testing.T) {
+func TestSendMessageLookupAuthErrorMarksDisconnected(t *testing.T) {
 	a := testApp(t)
+	a.Connected.Store(true)
 	a.SessionPath = filepath.Join(t.TempDir(), "session.json")
 	if err := os.WriteFile(a.SessionPath, []byte("{}"), 0o600); err != nil {
 		t.Fatal(err)
@@ -492,8 +493,15 @@ func TestSendMessageLookupAuthErrorMarksRepair(t *testing.T) {
 	if !result.IsError {
 		t.Fatal("expected error result")
 	}
-	if !a.GoogleStatus().NeedsRepair {
-		t.Fatal("auth-invalid lookup error should mark Google session for repair")
+	status := a.GoogleStatus()
+	if status.Connected {
+		t.Fatal("auth-invalid lookup error should mark Google disconnected")
+	}
+	if status.NeedsRepair {
+		t.Fatal("auth-invalid lookup error should use cookie-refresh reconnect, not repair")
+	}
+	if !strings.Contains(status.LastError, "session cookie expired") {
+		t.Fatalf("last error = %q, want session cookie expired message", status.LastError)
 	}
 }
 

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -2703,6 +2703,9 @@ func httpError(w http.ResponseWriter, msg string, code int) {
 }
 
 func googleAPIErrorMessage(action string, err error) string {
+	if app.IsGoogleAuthExpiredError(err) {
+		return "Google Messages session expired; refreshing and reconnecting. Try again in a few seconds."
+	}
 	if isGoogleNetworkError(err) {
 		return "Google Messages is offline. Check your internet connection, then try again."
 	}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -61,6 +61,7 @@ type APIOptions struct {
 	RecordGoogleSend      func(success bool) // tracks Google send outcomes for stuck-session detection
 	RecordGoogleSendError func(error)        // tracks auth/dead-session send errors for needs_repair
 	GooglePhoneResponding func() bool
+	MarkGoogleAuthExpired func(error) bool
 	ReconnectGoogle       func() error
 	Unpair                UnpairFunc
 	WhatsAppStatus        func() any
@@ -170,6 +171,16 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return true
 		}
 		return opts.GooglePhoneResponding()
+	}
+	markGoogleAuthExpired := func(err error) bool {
+		if opts.MarkGoogleAuthExpired == nil {
+			return false
+		}
+		marked := opts.MarkGoogleAuthExpired(err)
+		if marked {
+			publishStatus(currentConnected())
+		}
+		return marked
 	}
 	// Per-platform data-freshness, used to catch "zombie" bridges that report
 	// connected=true while no longer actually syncing (the connection flag
@@ -496,14 +507,18 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		media, err := cli.GM.UploadMedia(data, filename, mimeType)
 		if err != nil {
-			recordGoogleSendError(err)
+			if !markGoogleAuthExpired(err) {
+				recordGoogleSendError(err)
+			}
 			httpError(w, googleAPIErrorMessage("upload media", err), 502)
 			return
 		}
 
 		conv, err := cli.GM.GetConversation(convID)
 		if err != nil {
-			recordGoogleSendError(err)
+			if !markGoogleAuthExpired(err) {
+				recordGoogleSendError(err)
+			}
 			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
 			return
 		}
@@ -520,7 +535,9 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
-			recordGoogleSendError(err)
+			if !markGoogleAuthExpired(err) {
+				recordGoogleSendError(err)
+			}
 			httpError(w, googleAPIErrorMessage("send message", err), 502)
 			return
 		}
@@ -1166,7 +1183,9 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		// Fetch conversation to get SIM and participant info
 		conv, err := cli.GM.GetConversation(req.ConversationID)
 		if err != nil {
-			recordGoogleSendError(err)
+			if !markGoogleAuthExpired(err) {
+				recordGoogleSendError(err)
+			}
 			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
 			return
 		}
@@ -1183,7 +1202,9 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
-			recordGoogleSendError(err)
+			if !markGoogleAuthExpired(err) {
+				recordGoogleSendError(err)
+			}
 			httpError(w, googleAPIErrorMessage("send message", err), 502)
 			return
 		}
@@ -1448,6 +1469,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		}
 		data, err := cli.GM.DownloadMedia(msg.MediaID, key)
 		if err != nil {
+			markGoogleAuthExpired(err)
 			httpError(w, googleAPIErrorMessage("download media", err), 502)
 			return
 		}
@@ -1513,12 +1535,16 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		if req.ConversationID != "" {
 			if conv, err := cli.GM.GetConversation(req.ConversationID); err == nil {
 				_, sim = app.ExtractSIMAndParticipant(conv)
+			} else if markGoogleAuthExpired(err) {
+				httpError(w, googleAPIErrorMessage("get conversation", err), 502)
+				return
 			}
 		}
 
 		payload := app.BuildReactionPayload(req.MessageID, req.Emoji, req.Action, sim)
 		resp, err := cli.GM.SendReaction(payload)
 		if err != nil {
+			markGoogleAuthExpired(err)
 			httpError(w, googleAPIErrorMessage("send reaction", err), 502)
 			return
 		}
@@ -1608,7 +1634,9 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			Numbers: app.NewContactNumbers([]string{req.PhoneNumber}),
 		})
 		if err != nil {
-			recordGoogleSendError(err)
+			if !markGoogleAuthExpired(err) {
+				recordGoogleSendError(err)
+			}
 			httpError(w, googleAPIErrorMessage("failed to get/create conversation", err), 502)
 			return
 		}
@@ -1770,7 +1798,9 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		// Use the same send logic as /api/send
 		conv, err := cli.GM.GetConversation(draft.ConversationID)
 		if err != nil {
-			recordGoogleSendError(err)
+			if !markGoogleAuthExpired(err) {
+				recordGoogleSendError(err)
+			}
 			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
 			return
 		}
@@ -1786,7 +1816,9 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
-			recordGoogleSendError(err)
+			if !markGoogleAuthExpired(err) {
+				recordGoogleSendError(err)
+			}
 			httpError(w, googleAPIErrorMessage("send message", err), 502)
 			return
 		}
@@ -1963,6 +1995,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return
 		}
 		if err := opts.BackfillPhone(req.PhoneNumber); err != nil {
+			markGoogleAuthExpired(err)
 			httpError(w, googleAPIErrorMessage("backfill phone", err), 502)
 			return
 		}
@@ -1989,6 +2022,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return
 		}
 		if err := opts.ReconnectGoogle(); err != nil {
+			markGoogleAuthExpired(err)
 			httpError(w, googleAPIErrorMessage("reconnect google messages", err), 502)
 			return
 		}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -59,6 +59,8 @@ type APIOptions struct {
 	IsConnected           StatusChecker
 	GoogleStatus          func() any
 	RecordGoogleSend      func(success bool) // tracks Google send outcomes for stuck-session detection
+	RecordGoogleSendError func(error)        // tracks auth/dead-session send errors for needs_repair
+	GooglePhoneResponding func() bool
 	ReconnectGoogle       func() error
 	Unpair                UnpairFunc
 	WhatsAppStatus        func() any
@@ -157,6 +159,17 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		if opts.RecordGoogleSend != nil {
 			opts.RecordGoogleSend(success)
 		}
+	}
+	recordGoogleSendError := func(err error) {
+		if opts.RecordGoogleSendError != nil {
+			opts.RecordGoogleSendError(err)
+		}
+	}
+	googlePhoneResponding := func() bool {
+		if opts.GooglePhoneResponding == nil {
+			return true
+		}
+		return opts.GooglePhoneResponding()
 	}
 	// Per-platform data-freshness, used to catch "zombie" bridges that report
 	// connected=true while no longer actually syncing (the connection flag
@@ -483,12 +496,14 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		media, err := cli.GM.UploadMedia(data, filename, mimeType)
 		if err != nil {
+			recordGoogleSendError(err)
 			httpError(w, googleAPIErrorMessage("upload media", err), 502)
 			return
 		}
 
 		conv, err := cli.GM.GetConversation(convID)
 		if err != nil {
+			recordGoogleSendError(err)
 			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
 			return
 		}
@@ -505,6 +520,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
+			recordGoogleSendError(err)
 			httpError(w, googleAPIErrorMessage("send message", err), 502)
 			return
 		}
@@ -524,8 +540,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			}, "")
 			publishMessages(convID)
 			publishConversations()
-			recordGoogleSend(false)
-			httpError(w, googleSendRejectedMessage(resp.GetStatus().String()), 502)
+			if googlePhoneResponding() {
+				recordGoogleSend(false)
+			}
+			httpError(w, googleSendRejectedMessage(resp.GetStatus().String(), googlePhoneResponding()), 502)
 			return
 		}
 		recordGoogleSend(true)
@@ -1148,6 +1166,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		// Fetch conversation to get SIM and participant info
 		conv, err := cli.GM.GetConversation(req.ConversationID)
 		if err != nil {
+			recordGoogleSendError(err)
 			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
 			return
 		}
@@ -1164,6 +1183,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
+			recordGoogleSendError(err)
 			httpError(w, googleAPIErrorMessage("send message", err), 502)
 			return
 		}
@@ -1186,8 +1206,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			}, "")
 			publishMessages(req.ConversationID)
 			publishConversations()
-			recordGoogleSend(false)
-			httpError(w, googleSendRejectedMessage(resp.GetStatus().String()), 502)
+			if googlePhoneResponding() {
+				recordGoogleSend(false)
+			}
+			httpError(w, googleSendRejectedMessage(resp.GetStatus().String(), googlePhoneResponding()), 502)
 			return
 		}
 		recordGoogleSend(true)
@@ -1586,6 +1608,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			Numbers: app.NewContactNumbers([]string{req.PhoneNumber}),
 		})
 		if err != nil {
+			recordGoogleSendError(err)
 			httpError(w, googleAPIErrorMessage("failed to get/create conversation", err), 502)
 			return
 		}
@@ -1747,6 +1770,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		// Use the same send logic as /api/send
 		conv, err := cli.GM.GetConversation(draft.ConversationID)
 		if err != nil {
+			recordGoogleSendError(err)
 			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
 			return
 		}
@@ -1762,6 +1786,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
+			recordGoogleSendError(err)
 			httpError(w, googleAPIErrorMessage("send message", err), 502)
 			return
 		}
@@ -1778,8 +1803,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			}, "")
 			publishMessages(draft.ConversationID)
 			publishConversations()
-			recordGoogleSend(false)
-			httpError(w, googleSendRejectedMessage(resp.GetStatus().String()), 502)
+			if googlePhoneResponding() {
+				recordGoogleSend(false)
+			}
+			httpError(w, googleSendRejectedMessage(resp.GetStatus().String(), googlePhoneResponding()), 502)
 			return
 		}
 		recordGoogleSend(true)
@@ -2652,10 +2679,8 @@ func googleAPIErrorMessage(action string, err error) string {
 // Google send. UNKNOWN is what a silently-unlinked linked device returns on
 // every send, so the message points at re-pairing rather than leaving the
 // user with a bare status code.
-func googleSendRejectedMessage(status string) string {
-	return "send failed (Google Messages returned " + status + "). If this keeps happening your phone has " +
-		"likely unlinked OpenMessage — open Platforms → Google Messages → Pair again. " +
-		"Also confirm Messages is set as your phone's default SMS app."
+func googleSendRejectedMessage(status string, phoneResponding bool) string {
+	return app.GoogleSendRejectedMessage(status, phoneResponding)
 }
 
 func isGoogleNetworkError(err error) bool {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -1742,6 +1742,17 @@ func TestGoogleNetworkErrorIsUserFacing(t *testing.T) {
 	}
 }
 
+func TestGoogleAuthExpiredErrorIsUserFacing(t *testing.T) {
+	raw := "HTTP 401: 16: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential."
+	got := googleAPIErrorMessage("get conversation", errors.New(raw))
+	if got != "Google Messages session expired; refreshing and reconnecting. Try again in a few seconds." {
+		t.Fatalf("error = %q", got)
+	}
+	if strings.Contains(got, "OAuth") || strings.Contains(got, "credential") || strings.Contains(got, "HTTP 401") {
+		t.Fatalf("error leaked auth details: %q", got)
+	}
+}
+
 func TestDiagnosticsEndpointIncludesCountsStatusAndReleaseSnapshot(t *testing.T) {
 	ts := newTestServerWithOptions(t, APIOptions{
 		IdentityName: "Max",

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -10514,6 +10514,7 @@ body::after {
       paired: raw.paired === undefined ? !!raw.connected : !!raw.paired,
       needs_pairing: !!raw.needs_pairing,
       needs_repair: !!raw.needs_repair,
+      phone_responding: raw.phone_responding === undefined ? true : !!raw.phone_responding,
       last_error: raw.last_error || '',
     };
   }
@@ -10539,6 +10540,13 @@ body::after {
       $connectionBannerAction.textContent = 'Re-pair';
       $connectionBannerAction.dataset.action = 'open-platforms';
       $connectionBannerAction.style.display = '';
+      return;
+    }
+    if (googleStatus.connected && !googleStatus.phone_responding) {
+      $connectionBanner.className = 'connection-banner disconnected';
+      $connectionBanner.style.display = 'flex';
+      $connectionBannerCopy.textContent = 'Your phone isn’t responding to OpenMessage right now. Make sure it’s on and online, then try again.';
+      $connectionBannerAction.style.display = 'none';
       return;
     }
     if (googleStatus.connected) {
@@ -10675,6 +10683,7 @@ body::after {
   }
 
   function googleStatusText() {
+    if (googleStatus.connected && !googleStatus.phone_responding) return 'Phone offline';
     if (googleStatus.connected) return 'Connected';
     if (googleStatus.paired && !googleStatus.needs_pairing) return 'Needs reconnect';
     return 'Needs pairing';
@@ -10802,8 +10811,19 @@ body::after {
     } else if (googleStatus.last_error) {
       $gmStatusPill.classList.add('error');
     }
-    if (googleStatus.connected) {
-      $gmHelper.textContent = 'Google Messages live sync is active. New SMS and RCS messages should appear immediately. If new messages stop arriving, pair again to refresh the connection.';
+    if (googleStatus.needs_repair) {
+      $gmHelper.textContent = nativeAppBridge()
+        ? 'Google Messages needs to be paired again. Open the native pairing flow to refresh your Android phone connection.'
+        : 'Google Messages needs to be paired again. Use the button below to copy the pair command, then run it in Terminal.';
+      showGoogleError(googleStatus.last_error);
+      $gmActionsRow.style.display = '';
+      $gmReconnectBtn.disabled = false;
+      $gmReconnectBtn.textContent = 'Pair again';
+      $gmReconnectBtn.dataset.mode = 'pair';
+    } else if (googleStatus.connected) {
+      $gmHelper.textContent = googleStatus.phone_responding
+        ? 'Google Messages live sync is active. New SMS and RCS messages should appear immediately. If new messages stop arriving, pair again to refresh the connection.'
+        : 'Google Messages is connected, but your phone is not responding right now. Keep the phone on and online, then try again.';
       showGoogleError('');
       // Keep a re-pair affordance available even while "connected": the
       // connection flag can stay true after the session has silently gone

--- a/macos/OpenMessage/Sources/OpenMessageApp.swift
+++ b/macos/OpenMessage/Sources/OpenMessageApp.swift
@@ -51,6 +51,8 @@ private final class SettingsViewModel: ObservableObject {
             let connected: Bool
             let paired: Bool
             let needs_pairing: Bool
+            let needs_repair: Bool?
+            let phone_responding: Bool?
         }
 
         struct BackfillStatus: Decodable {
@@ -254,6 +256,18 @@ private struct AppSettingsView: View {
                         backend.beginGooglePairing()
                     }
                     .buttonStyle(.borderedProminent)
+                } else if googleNeedsRepair {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Google Messages needs to be paired again.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+
+                        Button("Pair again") {
+                            openMainWindow()
+                            backend.beginGooglePairing()
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
                 } else if googleNeedsReconnect {
                     Button("Reconnect") {
                         Task {
@@ -267,6 +281,12 @@ private struct AppSettingsView: View {
                         HStack(spacing: 10) {
                             Button("Open inbox") {
                                 openMainWindow()
+                            }
+                            .buttonStyle(.bordered)
+
+                            Button("Pair again") {
+                                openMainWindow()
+                                backend.beginGooglePairing()
                             }
                             .buttonStyle(.bordered)
 
@@ -423,11 +443,18 @@ private struct AppSettingsView: View {
 
     private var googleNeedsReconnect: Bool {
         guard let google = model.appStatus.google else { return false }
-        return google.paired && !google.connected && !google.needs_pairing
+        return google.paired && !google.connected && !google.needs_pairing && google.needs_repair != true
+    }
+
+    private var googleNeedsRepair: Bool {
+        guard let google = model.appStatus.google else { return false }
+        return google.paired && google.needs_repair == true
     }
 
     private var googleStatusText: String {
         guard let google = model.appStatus.google else { return "Unavailable" }
+        if google.paired && google.needs_repair == true { return "Needs re-pair" }
+        if google.connected && google.phone_responding == false { return "Phone offline" }
         if google.connected { return "Connected" }
         if google.paired && !google.needs_pairing { return "Needs reconnect" }
         return "Needs pairing"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -11,6 +11,7 @@ module.exports = defineConfig({
   use: {
     baseURL,
     headless: true,
+    serviceWorkers: 'block',
     trace: 'retain-on-failure',
   },
   webServer: {

--- a/scripts/openmessage-cookie-watchdog.sh
+++ b/scripts/openmessage-cookie-watchdog.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATUS_URL="${OPENMESSAGE_STATUS_URL:-http://127.0.0.1:7007/api/status}"
+SERVICE_NAME="${OPENMESSAGE_SERVICE_NAME:-openmessage.service}"
+REFRESH_SCRIPT="${OPENMESSAGE_COOKIE_REFRESH_SCRIPT:-/home/tim/source/openmessage/scripts/refresh-google-session-cookies-linux.py}"
+FORCE=0
+
+if [[ "${1:-}" == "--force" ]]; then
+  FORCE=1
+fi
+
+status_json=""
+if status_json="$(curl -fsS --max-time 5 "$STATUS_URL" 2>/dev/null)"; then
+  read -r paired connected last_error < <(
+    python3 -c 'import json,sys
+data=json.load(sys.stdin)
+g=data.get("google") or {}
+print(str(bool(g.get("paired"))).lower(), str(bool(g.get("connected"))).lower(), (g.get("last_error") or "").replace("\n", " "))' <<<"$status_json"
+  )
+else
+  paired="false"
+  connected="false"
+  last_error="status endpoint unavailable"
+fi
+
+if [[ "$FORCE" != "1" ]]; then
+  if [[ "$paired" != "true" ]]; then
+    echo "OpenMessage is not paired; cookie watchdog has nothing to refresh."
+    exit 0
+  fi
+  if [[ "$connected" == "true" ]]; then
+    echo "OpenMessage Google connection is healthy."
+    exit 0
+  fi
+fi
+
+echo "Refreshing OpenMessage Google cookies and restarting service. reason=${last_error:-forced}"
+systemctl --user stop "$SERVICE_NAME" || true
+"$REFRESH_SCRIPT" --quiet --no-backup
+systemctl --user start "$SERVICE_NAME"

--- a/scripts/openmessage-cookie-watchdog.sh
+++ b/scripts/openmessage-cookie-watchdog.sh
@@ -6,6 +6,8 @@ SERVICE_NAME="${OPENMESSAGE_SERVICE_NAME:-openmessage.service}"
 REFRESH_SCRIPT="${OPENMESSAGE_COOKIE_REFRESH_SCRIPT:-/home/tim/source/openmessage/scripts/refresh-google-session-cookies-linux.py}"
 FORCE=0
 
+auth_error_pattern="SESSION_COOKIE_INVALID|invalid authentication credentials|HTTP 401"
+
 if [[ "${1:-}" == "--force" ]]; then
   FORCE=1
 fi
@@ -28,6 +30,19 @@ if [[ "$FORCE" != "1" ]]; then
   if [[ "$paired" != "true" ]]; then
     echo "OpenMessage is not paired; cookie watchdog has nothing to refresh."
     exit 0
+  fi
+  if grep -Eiq "$auth_error_pattern" <<<"$last_error"; then
+    connected="false"
+  fi
+  if [[ "$connected" == "true" ]]; then
+    main_pid="$(systemctl --user show "$SERVICE_NAME" -P MainPID 2>/dev/null || true)"
+    if [[ "$main_pid" =~ ^[0-9]+$ ]] && [[ "$main_pid" != "0" ]]; then
+      if journalctl --user "_PID=$main_pid" --since "${OPENMESSAGE_COOKIE_WATCHDOG_LOG_WINDOW:-3 minutes ago}" --no-pager 2>/dev/null | grep -Eiq "$auth_error_pattern"; then
+        echo "Current OpenMessage process logged Google auth expiry; refreshing cookies."
+        connected="false"
+        last_error="recent service log contains Google auth expiry"
+      fi
+    fi
   fi
   if [[ "$connected" == "true" ]]; then
     echo "OpenMessage Google connection is healthy."

--- a/scripts/openmessage-cookie-watchdog.sh
+++ b/scripts/openmessage-cookie-watchdog.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 STATUS_URL="${OPENMESSAGE_STATUS_URL:-http://127.0.0.1:7007/api/status}"
 SERVICE_NAME="${OPENMESSAGE_SERVICE_NAME:-openmessage.service}"
-REFRESH_SCRIPT="${OPENMESSAGE_COOKIE_REFRESH_SCRIPT:-/home/tim/source/openmessage/scripts/refresh-google-session-cookies-linux.py}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REFRESH_SCRIPT="${OPENMESSAGE_COOKIE_REFRESH_SCRIPT:-$SCRIPT_DIR/refresh-google-session-cookies-linux.py}"
 FORCE=0
 
 auth_error_pattern="SESSION_COOKIE_INVALID|invalid authentication credentials|HTTP 401"

--- a/scripts/refresh-google-session-cookies-linux.py
+++ b/scripts/refresh-google-session-cookies-linux.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Refresh OpenMessage Google account cookies from a local Chrome profile.
+
+This is intentionally Linux/KWallet-specific. It updates only
+auth_data.cookies in OpenMessage's session.json and never prints cookie values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+
+REQUIRED_COOKIES = {
+    ("messages.google.com", "OSID"),
+    (".google.com", "SID"),
+    (".google.com", "HSID"),
+    (".google.com", "SSID"),
+    (".google.com", "APISID"),
+    (".google.com", "SAPISID"),
+}
+HOST_PRIORITY = {
+    "messages.google.com": 0,
+    ".google.com": 1,
+    "accounts.google.com": 2,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    home = Path.home()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        default=os.environ.get(
+            "OPENMESSAGE_CHROME_PROFILE",
+            str(home / ".config/google-chrome/Default"),
+        ),
+        help="Chrome profile directory containing Network/Cookies",
+    )
+    parser.add_argument(
+        "--session",
+        default=os.environ.get(
+            "OPENMESSAGE_SESSION_PATH",
+            str(home / ".local/share/openmessage/session.json"),
+        ),
+        help="OpenMessage session.json path",
+    )
+    parser.add_argument(
+        "--wallet",
+        default=os.environ.get("OPENMESSAGE_KWALLET", "kdewallet"),
+        help="KWallet wallet name",
+    )
+    parser.add_argument(
+        "--wallet-folder",
+        default=os.environ.get("OPENMESSAGE_KWALLET_FOLDER", "Chrome Keys"),
+        help="KWallet folder containing Chrome Safe Storage",
+    )
+    parser.add_argument(
+        "--wallet-entry",
+        default=os.environ.get("OPENMESSAGE_KWALLET_ENTRY", "Chrome Safe Storage"),
+        help="KWallet password entry name",
+    )
+    parser.add_argument("--quiet", action="store_true", help="only print errors")
+    parser.add_argument("--no-backup", action="store_true", help="do not write a session backup")
+    return parser.parse_args()
+
+
+def chrome_safe_storage_secret(args: argparse.Namespace) -> bytes:
+    value = subprocess.check_output(
+        [
+            "kwallet-query",
+            "--folder",
+            args.wallet_folder,
+            "--read-password",
+            args.wallet_entry,
+            args.wallet,
+        ],
+        text=False,
+    ).rstrip(b"\n")
+    if not value:
+        raise RuntimeError("Chrome Safe Storage key was empty")
+    return value
+
+
+def derive_key(secret: bytes, iterations: int) -> bytes:
+    return hashlib.pbkdf2_hmac("sha1", secret, b"saltysalt", iterations, 16)
+
+
+def decrypt_cookie(encrypted_value: bytes, host: str, key: bytes) -> str | None:
+    if not encrypted_value:
+        return None
+    encrypted_value = bytes(encrypted_value)
+    if not (encrypted_value.startswith(b"v10") or encrypted_value.startswith(b"v11")):
+        return None
+
+    decryptor = Cipher(
+        algorithms.AES(key),
+        modes.CBC(b" " * 16),
+        backend=default_backend(),
+    ).decryptor()
+    padded = decryptor.update(encrypted_value[3:]) + decryptor.finalize()
+    pad_len = padded[-1]
+    if pad_len < 1 or pad_len > 16:
+        raise ValueError("invalid cookie padding")
+
+    plain = padded[:-pad_len]
+    host_hash = hashlib.sha256(host.encode()).digest()
+    if plain.startswith(host_hash):
+        plain = plain[32:]
+    return plain.decode("utf-8")
+
+
+def load_chrome_cookies(profile: Path, secret: bytes) -> tuple[dict[str, str], int, int, int]:
+    cookie_db = profile / "Network" / "Cookies"
+    if not cookie_db.exists():
+        raise FileNotFoundError(f"Chrome cookie DB not found: {cookie_db}")
+
+    rows = sqlite3.connect(f"file:{cookie_db}?mode=ro&immutable=1", uri=True).execute(
+        """
+        select host_key, name, encrypted_value, value
+        from cookies
+        where host_key in ('.google.com','messages.google.com','accounts.google.com')
+           or host_key like '%.google.com'
+        """
+    ).fetchall()
+
+    best: tuple[tuple[int, int, int], int, dict[str, tuple[str, str]], int, int, set[tuple[str, str]]] | None = None
+    for iterations in (1, 1003):
+        key = derive_key(secret, iterations)
+        values: dict[str, tuple[str, str]] = {}
+        ok = 0
+        failed = 0
+        for host, name, encrypted_value, plain_value in rows:
+            value = plain_value or None
+            if not value and encrypted_value:
+                try:
+                    value = decrypt_cookie(encrypted_value, host, key)
+                except Exception:
+                    failed += 1
+                    continue
+            if value is None:
+                continue
+            ok += 1
+            previous = values.get(name)
+            if previous is None or HOST_PRIORITY.get(host, 10) < HOST_PRIORITY.get(previous[0], 10):
+                values[name] = (host, value)
+
+        present = {
+            (host, name)
+            for name, (host, _value) in values.items()
+            if (host, name) in REQUIRED_COOKIES
+        }
+        score = (len(present), ok, -failed)
+        if best is None or score > best[0]:
+            best = (score, iterations, values, ok, failed, present)
+
+    if best is None:
+        raise RuntimeError("no Google cookies found in Chrome profile")
+
+    _score, iterations, values, ok, failed, present = best
+    missing = sorted(REQUIRED_COOKIES - present)
+    if missing:
+        missing_text = ", ".join(f"{host}:{name}" for host, name in missing)
+        raise RuntimeError(f"missing required cookies: {missing_text}")
+
+    return {name: value for name, (_host, value) in values.items()}, iterations, ok, failed
+
+
+def update_session(session_path: Path, cookies: dict[str, str], backup: bool) -> Path | None:
+    if not session_path.exists():
+        raise FileNotFoundError(f"OpenMessage session not found: {session_path}")
+
+    backup_path = None
+    if backup:
+        backup_path = session_path.with_name(f"session.json.bak-{time.strftime('%Y%m%d-%H%M%S')}")
+        shutil.copy2(session_path, backup_path)
+
+    data = json.loads(session_path.read_text())
+    data.setdefault("auth_data", {})["cookies"] = cookies
+
+    tmp = session_path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data, separators=(",", ":")) + "\n")
+    os.chmod(tmp, 0o600)
+    tmp.replace(session_path)
+    return backup_path
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        secret = chrome_safe_storage_secret(args)
+        cookies, iterations, decrypted, failed = load_chrome_cookies(Path(args.profile), secret)
+        backup_path = update_session(Path(args.session), cookies, backup=not args.no_backup)
+    except Exception as exc:
+        print(f"refresh_google_session_cookies: {exc}", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print("session_cookie_refresh_ok")
+        if backup_path:
+            print(f"backup: {backup_path}")
+        print(f"cookies_written: {len(cookies)}")
+        print(f"decrypt_iterations: {iterations}")
+        print(f"decrypted_cookies: {decrypted}")
+        print(f"decrypt_failures: {failed}")
+        print("required_present: APISID,HSID,OSID,SAPISID,SID,SSID")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- distinguish PhoneNotResponding from stale Google sessions so send errors become actionable
- mark auth/dead-session send failures as needs_repair across web and MCP send paths
- add native Platforms re-pair affordances and preserve conversation IDs in native deep links

## Validation
- git diff --check
- go test ./...
- OPENMESSAGES_E2E_PORT=7012 npm run test:e2e (64 passed)
- final native reviewer re-check found no blocking findings after the Xcode target bridge fix
- xcodebuild/swift unavailable on this Fedora host, so macOS native compilation is left to CI

Fixes #43
Fixes #44
Fixes #60
Fixes #63