### PR TITLE
[codex] Queue disconnected sends and render file attachments

### DIFF
--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -829,6 +829,247 @@ test('keeps existing thread nodes mounted after sending', async ({ page }) => {
   await expectStableThreadNodeStillMounted(page);
 });
 
+test('queues a text message while Google Messages is disconnected', async ({ page }) => {
+  const outbound = `Queued outbound ${Date.now()}`;
+  let sendRequests = 0;
+
+  await page.route('**/api/status', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      connected: false,
+      google: { connected: false, paired: true, needs_pairing: false, needs_repair: false },
+      whatsapp: { connected: true, paired: true },
+      signal: { connected: true, paired: true },
+    }),
+  }));
+  page.on('request', req => {
+    if (req.method() === 'POST' && /\/api\/send(\?|$)/.test(req.url())) {
+      sendRequests += 1;
+    }
+  });
+
+  await page.reload();
+  await openConversation(page, 'Sarah Chen');
+  await page.locator('#compose-input').fill(outbound);
+  await page.locator('#send-btn').click();
+
+  await expect(page.locator('#compose-input')).toHaveValue('');
+  const latestMessage = page.locator('#messages-area .msg').last();
+  await expect(latestMessage).toContainText(outbound);
+  await expect(latestMessage.locator('.msg-status.status-sending')).toBeVisible();
+  await expect(page.locator('#thread-feedback')).toContainText('Message queued.');
+  expect(sendRequests).toBe(0);
+});
+
+test('keeps a transient Google send failure queued until reconnect', async ({ page }) => {
+  const outbound = `Reconnect queued ${Date.now()}`;
+  let sendRequests = 0;
+  let statusPayload = {
+    connected: true,
+    google: { connected: true, paired: true, needs_pairing: false, needs_repair: false },
+    whatsapp: { connected: true, paired: true },
+    signal: { connected: true, paired: true },
+    backfill: { running: false },
+  };
+
+  await page.route('**/api/status', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(statusPayload),
+  }));
+  await page.route('**/api/send', route => {
+    sendRequests += 1;
+    if (sendRequests === 1) {
+      return route.fulfill({
+        status: 502,
+        contentType: 'text/plain',
+        body: 'Google Messages is offline. Check your internet connection, then try again.',
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'SUCCESS', success: true }),
+    });
+  });
+
+  await page.reload();
+  await page.waitForFunction(() => window.__openMessageTestHooks?.applyAppStatus);
+  await openConversation(page, 'Sarah Chen');
+  await page.locator('#compose-input').fill(outbound);
+  await page.locator('#send-btn').click();
+
+  await expect.poll(() => sendRequests).toBe(1);
+  const latestMessage = page.locator('#messages-area .msg').last();
+  await expect(latestMessage).toContainText(outbound);
+  await expect(latestMessage.locator('.msg-status.status-sending')).toBeVisible();
+  await expect(latestMessage.locator('.msg-status.status-failed')).toHaveCount(0);
+  await page.waitForTimeout(700);
+  expect(sendRequests).toBe(1);
+
+  statusPayload = {
+    connected: false,
+    google: { connected: false, paired: true, needs_pairing: false, needs_repair: false },
+    whatsapp: { connected: true, paired: true },
+    signal: { connected: true, paired: true },
+    backfill: { running: false },
+  };
+  await page.evaluate(status => window.__openMessageTestHooks.applyAppStatus(status), statusPayload);
+  await page.waitForTimeout(150);
+  expect(sendRequests).toBe(1);
+
+  statusPayload = {
+    connected: true,
+    google: { connected: true, paired: true, needs_pairing: false, needs_repair: false },
+    whatsapp: { connected: true, paired: true },
+    signal: { connected: true, paired: true },
+    backfill: { running: false },
+  };
+  await page.evaluate(status => window.__openMessageTestHooks.applyAppStatus(status), statusPayload);
+
+  await expect.poll(() => sendRequests).toBe(2);
+  await expect
+    .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem('openmessage.pendingSends.v1') || '[]').length))
+    .toBe(0);
+});
+
+test('queues a text message while Google Messages needs repair', async ({ page }) => {
+  const outbound = `Queued repair ${Date.now()}`;
+  let sendRequests = 0;
+
+  await page.route('**/api/status', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      connected: true,
+      google: { connected: true, paired: true, needs_pairing: false, needs_repair: true },
+      whatsapp: { connected: true, paired: true },
+      signal: { connected: true, paired: true },
+    }),
+  }));
+  page.on('request', req => {
+    if (req.method() === 'POST' && /\/api\/send(\?|$)/.test(req.url())) {
+      sendRequests += 1;
+    }
+  });
+
+  await page.reload();
+  await openConversation(page, 'Sarah Chen');
+  await page.locator('#compose-input').fill(outbound);
+  await page.locator('#send-btn').click();
+
+  await expect(page.locator('#compose-input')).toHaveValue('');
+  const latestMessage = page.locator('#messages-area .msg').last();
+  await expect(latestMessage).toContainText(outbound);
+  await expect(latestMessage.locator('.msg-status.status-sending')).toBeVisible();
+  await expect(page.locator('#thread-feedback')).toContainText('Message queued. Re-pair Google Messages to send it.');
+  expect(sendRequests).toBe(0);
+});
+
+test('queues an attachment while Google Messages needs repair', async ({ page }) => {
+  let sendMediaRequests = 0;
+
+  await page.route('**/api/status', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      connected: true,
+      google: { connected: true, paired: true, needs_pairing: false, needs_repair: true },
+      whatsapp: { connected: true, paired: true },
+      signal: { connected: true, paired: true },
+    }),
+  }));
+  page.on('request', req => {
+    if (req.method() === 'POST' && /\/api\/send-media(\?|$)/.test(req.url())) {
+      sendMediaRequests += 1;
+    }
+  });
+
+  await page.reload();
+  await openConversation(page, 'Sarah Chen');
+  await page.locator('#file-input').setInputFiles({
+    name: 'queued-repair.png',
+    mimeType: 'image/png',
+    buffer: Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z9wAAAABJRU5ErkJggg==',
+      'base64',
+    ),
+  });
+
+  await expect(page.locator('#attach-preview')).toHaveClass(/active/);
+  await page.locator('#send-btn').click();
+
+  await expect(page.locator('#attach-preview')).not.toHaveClass(/active/);
+  const latestMessage = page.locator('#messages-area .msg').last();
+  await expect(latestMessage.locator('img[src^="blob:"]')).toBeVisible();
+  await expect(latestMessage.locator('.msg-status.status-sending')).toBeVisible();
+  await expect(page.locator('#thread-feedback')).toContainText('Message queued. Re-pair Google Messages to send it.');
+  expect(sendMediaRequests).toBe(0);
+});
+
+test('preserves text and attachment when the send queue is full', async ({ page }) => {
+  const outbound = `Queue cap draft ${Date.now()}`;
+  let sendRequests = 0;
+  let sendMediaRequests = 0;
+
+  await page.route('**/api/status', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      connected: false,
+      google: { connected: false, paired: true, needs_pairing: false, needs_repair: false },
+      whatsapp: { connected: true, paired: true },
+      signal: { connected: true, paired: true },
+    }),
+  }));
+  page.on('request', req => {
+    if (req.method() === 'POST' && /\/api\/send(\?|$)/.test(req.url())) {
+      sendRequests += 1;
+    }
+    if (req.method() === 'POST' && /\/api\/send-media(\?|$)/.test(req.url())) {
+      sendMediaRequests += 1;
+    }
+  });
+
+  await page.evaluate(() => {
+    const now = Date.now();
+    const queued = Array.from({ length: 49 }, (_, i) => ({
+      id: `tmp_seed_${i}`,
+      conversation_id: `seed-conversation-${i}`,
+      platform: 'sms',
+      type: 'text',
+      body: `seed ${i}`,
+      timestamp_ms: now + i,
+      status: 'pending',
+    }));
+    localStorage.setItem('openmessage.pendingSends.v1', JSON.stringify(queued));
+  });
+  await page.reload();
+  await openConversation(page, 'Sarah Chen');
+  await page.locator('#file-input').setInputFiles({
+    name: 'queue-cap.png',
+    mimeType: 'image/png',
+    buffer: Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z9wAAAABJRU5ErkJggg==',
+      'base64',
+    ),
+  });
+  await page.locator('#compose-input').fill(outbound);
+
+  await page.locator('#send-btn').click();
+
+  await expect(page.locator('#thread-feedback')).toContainText('Too many queued messages.');
+  await expect(page.locator('#compose-input')).toHaveValue(outbound);
+  await expect(page.locator('#attach-preview')).toHaveClass(/active/);
+  await expect(page.locator('#messages-area')).not.toContainText(outbound);
+  await expect
+    .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem('openmessage.pendingSends.v1') || '[]').length))
+    .toBe(49);
+  expect(sendRequests).toBe(0);
+  expect(sendMediaRequests).toBe(0);
+});
+
 test('sends a Signal text message through the compose box', async ({ page }) => {
   const outbound = `Signal outbound ${Date.now()}`;
 
@@ -983,6 +1224,56 @@ test('sends a GIF through the compose picker', async ({ page }) => {
   expect(sendGIFPayload.conversation_id).toContain('signal:');
   expect(sendGIFPayload.url).toBe('https://media.klipy.com/fake/wave.gif');
   expect(sendGIFPayload.caption).toBe(caption);
+});
+
+test('queues a GIF while the selected route is disconnected', async ({ page }) => {
+  let sendGIFRequests = 0;
+  await page.route('**/api/status', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      connected: true,
+      google: { connected: true, paired: true, needs_pairing: false, needs_repair: false },
+      whatsapp: { connected: true, paired: true },
+      signal: { connected: false, paired: true },
+    }),
+  }));
+  await page.route(/\/api\/gifs(?:\/trending)?\?/, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [{
+          title: 'Queued wave',
+          preview_url: 'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=',
+          url: 'https://media.klipy.com/fake/queued-wave.gif',
+          mime_type: 'image/gif',
+          width: 1,
+          height: 1,
+        }],
+      }),
+    });
+  });
+  page.on('request', req => {
+    if (req.method() === 'POST' && /\/api\/send-gif(\?|$)/.test(req.url())) {
+      sendGIFRequests += 1;
+    }
+  });
+
+  await page.reload();
+  await openConversation(page, 'Taylor Price');
+  await expect(page.locator('#chat-header-source')).toContainText('Signal');
+  await page.locator('#compose-input').fill('Queued GIF caption');
+  await page.locator('#compose-gif-btn').click();
+  await expect(page.locator('#compose-gif-panel.show')).toBeVisible();
+  await page.locator('#compose-gif-panel .gif-tile').first().click();
+
+  await expect(page.locator('#compose-input')).toHaveValue('');
+  const latestMessage = page.locator('#messages-area .msg').last();
+  await expect(latestMessage.locator('img[src^="data:image/gif"]')).toBeVisible();
+  await expect(latestMessage.locator('.msg-status.status-sending')).toBeVisible();
+  await expect(page.locator('#thread-feedback')).toContainText('Message queued.');
+  expect(sendGIFRequests).toBe(0);
 });
 
 test('debounces GIF search while typing', async ({ page }) => {
@@ -1264,6 +1555,33 @@ test('sends a WhatsApp image attachment through the compose box', async ({ page 
   await expect(latestMessage.locator('.msg-media-loading')).toHaveCount(0);
 });
 
+test('renders a sent PDF attachment as an openable file card', async ({ page }) => {
+  const jordanRow = page.locator('#conversation-list > .convo-item').filter({
+    has: page.locator('.convo-name').getByText('Jordan Rivera', { exact: true }),
+  }).first();
+
+  await jordanRow.click();
+  await expect(page.locator('#chat-header-source .chat-route-tab.active')).toContainText('WhatsApp');
+  await page.locator('#file-input').setInputFiles({
+    name: 'menu.pdf',
+    mimeType: 'application/pdf',
+    buffer: Buffer.from('%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n'),
+  });
+
+  await expect(page.locator('#attach-preview')).toHaveClass(/active/);
+  await page.locator('#send-btn').click();
+
+  await expect(page.locator('#attach-preview')).not.toHaveClass(/active/);
+  const latestMessage = page.locator('#messages-area .msg').last();
+  const preview = latestMessage.locator('iframe.msg-pdf-preview');
+  await expect(preview).toHaveAttribute('data-pdf-src', /\/api\/media\//);
+  await expect(preview).toHaveAttribute('src', /^blob:.*#toolbar=0&navpanes=0&view=FitH$/);
+  const card = latestMessage.locator('.msg-document-preview > .msg-attachment-card').last();
+  await expect(card).toContainText('PDF');
+  await expect(card).toContainText('application/pdf');
+  await expect(card).toHaveAttribute('href', /\/api\/media\//);
+});
+
 test('sends a WhatsApp voice note attachment through the compose box', async ({ page }) => {
   const jordanRow = page.locator('#conversation-list > .convo-item').filter({
     has: page.locator('.convo-name').getByText('Jordan Rivera', { exact: true }),
@@ -1284,7 +1602,7 @@ test('sends a WhatsApp voice note attachment through the compose box', async ({ 
   await expect(page.locator('#messages-area audio[src*="/api/media/"]').last()).toBeVisible();
 });
 
-test('restores compose text when send fails', async ({ page }) => {
+test('shows a failed outgoing bubble when send is rejected', async ({ page }) => {
   const outbound = `Send failure ${Date.now()}`;
 
   await openConversation(page, 'Sarah Chen');
@@ -1298,8 +1616,78 @@ test('restores compose text when send fails', async ({ page }) => {
   await page.locator('#send-btn').click();
 
   await expect(page.locator('#thread-feedback')).toContainText('local persistence failed');
-  await expect(page.locator('#compose-input')).toHaveValue(outbound);
-  await expect(page.locator('#messages-area')).not.toContainText(outbound);
+  await expect(page.locator('#compose-input')).toHaveValue('');
+  const latestMessage = page.locator('#messages-area .msg').last();
+  await expect(latestMessage).toContainText(outbound);
+  await expect(latestMessage.locator('.msg-status.status-failed')).toBeVisible();
+  await expect(latestMessage.locator('.msg-retry-send')).toBeVisible();
+});
+
+test('retries a failed queued message from the bubble', async ({ page }) => {
+  const outbound = `Retry failed send ${Date.now()}`;
+
+  await openConversation(page, 'Sarah Chen');
+  await page.route('**/api/send', route => route.fulfill({
+    status: 500,
+    contentType: 'text/plain',
+    body: 'local persistence failed',
+  }), { times: 1 });
+
+  await page.locator('#compose-input').fill(outbound);
+  await page.locator('#send-btn').click();
+
+  const latestMessage = page.locator('#messages-area .msg').last();
+  await expect(latestMessage).toContainText(outbound);
+  await expect(latestMessage.locator('.msg-status.status-failed')).toBeVisible();
+  await latestMessage.locator('.msg-retry-send').click();
+
+  await expect
+    .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem('openmessage.pendingSends.v1') || '[]').length))
+    .toBe(0);
+  await expect(page.locator('#messages-area .msg').filter({ hasText: outbound })).toHaveCount(1);
+  const retriedMessage = page.locator('#messages-area .msg').filter({ hasText: outbound }).last();
+  await expect(retriedMessage.locator('.msg-status.status-failed')).toHaveCount(0);
+  await expect(retriedMessage.locator('.msg-retry-send')).toHaveCount(0);
+});
+
+test('prunes a stale failed queued bubble when the retry is already sent', async ({ page, request }) => {
+  const outbound = `Recovered retry ${Date.now()}`;
+  const now = Date.now();
+
+  await request.post('/_e2e/messages', {
+    data: {
+      body: outbound,
+      conversation_id: 'conv1',
+      is_from_me: true,
+      sender_name: 'Me',
+      sender_number: '+15551234567',
+      timestamp_ms: now,
+      status: 'OUTGOING_DELIVERED',
+    },
+  });
+  await page.evaluate(({ body, timestamp }) => {
+    localStorage.setItem('openmessage.pendingSends.v1', JSON.stringify([{
+      id: `tmp_stale_${timestamp}`,
+      conversation_id: 'conv1',
+      platform: 'sms',
+      type: 'text',
+      body,
+      timestamp_ms: timestamp - 1000,
+      status: 'failed',
+      last_error: 'local persistence failed',
+    }]));
+  }, { body: outbound, timestamp: now });
+
+  await page.reload();
+  await openConversation(page, 'Sarah Chen');
+
+  await expect(page.locator('#messages-area .msg').filter({ hasText: outbound })).toHaveCount(1);
+  const recoveredMessage = page.locator('#messages-area .msg').filter({ hasText: outbound }).last();
+  await expect(recoveredMessage.locator('.msg-status.status-failed')).toHaveCount(0);
+  await expect(recoveredMessage.locator('.msg-retry-send')).toHaveCount(0);
+  await expect
+    .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem('openmessage.pendingSends.v1') || '[]').length))
+    .toBe(0);
 });
 
 test('refreshes the active thread from SSE invalidations', async ({ page, request }) => {

--- a/internal/app/gm.go
+++ b/internal/app/gm.go
@@ -71,7 +71,20 @@ func ExtractSIMAndParticipant(conv *gmproto.Conversation) (participantID string,
 // the mautrix bridge: MessageInfo array (not MessagePayloadContent), TmpID in 3
 // places, SIMPayload, and ParticipantID.
 func BuildSendPayload(conversationID, message, replyToID, participantID string, sim *gmproto.SIMPayload) *gmproto.SendMessageRequest {
-	tmpID := fmt.Sprintf("tmp_%012d", rand.Int63n(1e12))
+	return BuildSendPayloadWithTmpID(conversationID, message, replyToID, participantID, sim, "")
+}
+
+func newSendTmpID(preferred string) string {
+	if preferred = strings.TrimSpace(preferred); preferred != "" {
+		return preferred
+	}
+	return fmt.Sprintf("tmp_%012d", rand.Int63n(1e12))
+}
+
+// BuildSendPayloadWithTmpID is BuildSendPayload with an optional caller-owned
+// temporary ID. Queued sends use this to make retries idempotent server-side.
+func BuildSendPayloadWithTmpID(conversationID, message, replyToID, participantID string, sim *gmproto.SIMPayload, tmpID string) *gmproto.SendMessageRequest {
+	tmpID = newSendTmpID(tmpID)
 	req := &gmproto.SendMessageRequest{
 		ConversationID: conversationID,
 		MessagePayload: &gmproto.MessagePayload{
@@ -100,7 +113,13 @@ func BuildSendPayload(conversationID, message, replyToID, participantID string, 
 // BuildSendMediaPayload constructs a SendMessageRequest with a MediaContent attachment
 // instead of text. Uses the same MessageInfo array format as BuildSendPayload.
 func BuildSendMediaPayload(conversationID string, media *gmproto.MediaContent, participantID string, sim *gmproto.SIMPayload) *gmproto.SendMessageRequest {
-	tmpID := fmt.Sprintf("tmp_%012d", rand.Int63n(1e12))
+	return BuildSendMediaPayloadWithTmpID(conversationID, media, participantID, sim, "")
+}
+
+// BuildSendMediaPayloadWithTmpID is BuildSendMediaPayload with an optional
+// caller-owned temporary ID for idempotent queued media retries.
+func BuildSendMediaPayloadWithTmpID(conversationID string, media *gmproto.MediaContent, participantID string, sim *gmproto.SIMPayload, tmpID string) *gmproto.SendMessageRequest {
+	tmpID = newSendTmpID(tmpID)
 	return &gmproto.SendMessageRequest{
 		ConversationID: conversationID,
 		MessagePayload: &gmproto.MessagePayload{

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -337,6 +337,15 @@ func (s *Store) migrate() error {
 		body TEXT NOT NULL DEFAULT '',
 		created_at INTEGER NOT NULL DEFAULT 0
 	);
+
+	CREATE TABLE IF NOT EXISTS outgoing_send_keys (
+		idempotency_key TEXT PRIMARY KEY,
+		conversation_id TEXT NOT NULL DEFAULT '',
+		message_id TEXT NOT NULL DEFAULT '',
+		status TEXT NOT NULL DEFAULT '',
+		created_at INTEGER NOT NULL DEFAULT 0,
+		updated_at INTEGER NOT NULL DEFAULT 0
+	);
 	`
 	if _, err := s.db.Exec(schema); err != nil {
 		return err
@@ -379,6 +388,7 @@ func (s *Store) migrate() error {
 
 	// Index for dedup on import
 	s.db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_source ON messages(source_platform, source_id) WHERE source_id != ''`)
+	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_outgoing_send_keys_updated ON outgoing_send_keys(updated_at)`)
 
 	// Index for platform-filtered conversation queries
 	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_conversations_platform ON conversations(source_platform)`)

--- a/internal/db/outgoing_send_keys.go
+++ b/internal/db/outgoing_send_keys.go
@@ -1,0 +1,76 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+)
+
+const (
+	OutgoingSendStatusSending          = "sending"
+	OutgoingSendStatusSent             = "sent"
+	OutgoingSendStatusFailed           = "failed"
+	OutgoingSendStatusLocalStoreFailed = "local_store_failed"
+)
+
+type OutgoingSendKey struct {
+	Key            string
+	ConversationID string
+	MessageID      string
+	Status         string
+	CreatedAtMS    int64
+	UpdatedAtMS    int64
+}
+
+func (s *Store) ClaimOutgoingSendKey(key, conversationID string) (bool, *OutgoingSendKey, error) {
+	now := time.Now().UnixMilli()
+	res, err := s.db.Exec(`
+		INSERT OR IGNORE INTO outgoing_send_keys
+			(idempotency_key, conversation_id, message_id, status, created_at, updated_at)
+		VALUES (?, ?, '', ?, ?, ?)
+	`, key, conversationID, OutgoingSendStatusSending, now, now)
+	if err != nil {
+		return false, nil, err
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows > 0 {
+		return true, &OutgoingSendKey{
+			Key:            key,
+			ConversationID: conversationID,
+			Status:         OutgoingSendStatusSending,
+			CreatedAtMS:    now,
+			UpdatedAtMS:    now,
+		}, nil
+	}
+	existing, err := s.GetOutgoingSendKey(key)
+	return false, existing, err
+}
+
+func (s *Store) GetOutgoingSendKey(key string) (*OutgoingSendKey, error) {
+	row := s.db.QueryRow(`
+		SELECT idempotency_key, conversation_id, message_id, status, created_at, updated_at
+		FROM outgoing_send_keys
+		WHERE idempotency_key = ?
+	`, key)
+	var item OutgoingSendKey
+	if err := row.Scan(&item.Key, &item.ConversationID, &item.MessageID, &item.Status, &item.CreatedAtMS, &item.UpdatedAtMS); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &item, nil
+}
+
+func (s *Store) CompleteOutgoingSendKey(key, messageID, status string) error {
+	_, err := s.db.Exec(`
+		UPDATE outgoing_send_keys
+		SET message_id = ?, status = ?, updated_at = ?
+		WHERE idempotency_key = ?
+	`, messageID, status, time.Now().UnixMilli(), key)
+	return err
+}
+
+func (s *Store) ReleaseOutgoingSendKey(key string) error {
+	_, err := s.db.Exec(`DELETE FROM outgoing_send_keys WHERE idempotency_key = ?`, key)
+	return err
+}

--- a/internal/db/outgoing_send_keys_test.go
+++ b/internal/db/outgoing_send_keys_test.go
@@ -53,3 +53,44 @@ func TestOutgoingSendKeyClaimCompleteRelease(t *testing.T) {
 		t.Fatalf("released key still exists: %#v", item)
 	}
 }
+
+// TestOutgoingSendKeyFailedClaimBlocksResend locks in the invariant the Google
+// ambiguous-send handling relies on: when a send errors ambiguously (the request
+// may have reached the platform), the claim is COMPLETED as failed — and a
+// retry with the same key must still be deduped, never re-granted, or it would
+// re-dispatch and deliver a duplicate. A key that was RELEASED (the send
+// provably did not dispatch, e.g. auth rejection) can be claimed again.
+func TestOutgoingSendKeyFailedClaimBlocksResend(t *testing.T) {
+	store, err := New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if claimed, _, err := store.ClaimOutgoingSendKey("tmp_ambig", "conv1"); err != nil || !claimed {
+		t.Fatalf("first claim: claimed=%v err=%v", claimed, err)
+	}
+	// Ambiguous send error → keep the claim as failed.
+	if err := store.CompleteOutgoingSendKey("tmp_ambig", "", OutgoingSendStatusFailed); err != nil {
+		t.Fatal(err)
+	}
+	claimed, item, err := store.ClaimOutgoingSendKey("tmp_ambig", "conv1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed {
+		t.Fatal("a retained (failed) claim must dedup a retry, not re-grant the claim")
+	}
+	if item == nil || item.Status != OutgoingSendStatusFailed {
+		t.Fatalf("expected retained failed claim, got %#v", item)
+	}
+
+	// A released key (provably-not-dispatched path) can be claimed again so a
+	// post-re-pair retry sends the message exactly once.
+	if err := store.ReleaseOutgoingSendKey("tmp_ambig"); err != nil {
+		t.Fatal(err)
+	}
+	if claimed, _, err := store.ClaimOutgoingSendKey("tmp_ambig", "conv1"); err != nil || !claimed {
+		t.Fatalf("post-release re-claim: claimed=%v err=%v", claimed, err)
+	}
+}

--- a/internal/db/outgoing_send_keys_test.go
+++ b/internal/db/outgoing_send_keys_test.go
@@ -1,0 +1,55 @@
+package db
+
+import "testing"
+
+func TestOutgoingSendKeyClaimCompleteRelease(t *testing.T) {
+	store, err := New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	claimed, item, err := store.ClaimOutgoingSendKey("tmp_key_1", "conv1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !claimed {
+		t.Fatal("first claim was not granted")
+	}
+	if item == nil || item.Status != OutgoingSendStatusSending || item.ConversationID != "conv1" {
+		t.Fatalf("unexpected first claim: %#v", item)
+	}
+
+	claimed, item, err = store.ClaimOutgoingSendKey("tmp_key_1", "conv1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed {
+		t.Fatal("duplicate claim was granted")
+	}
+	if item == nil || item.Status != OutgoingSendStatusSending {
+		t.Fatalf("unexpected duplicate item: %#v", item)
+	}
+
+	if err := store.CompleteOutgoingSendKey("tmp_key_1", "msg1", OutgoingSendStatusSent); err != nil {
+		t.Fatal(err)
+	}
+	item, err = store.GetOutgoingSendKey("tmp_key_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item == nil || item.MessageID != "msg1" || item.Status != OutgoingSendStatusSent {
+		t.Fatalf("unexpected completed item: %#v", item)
+	}
+
+	if err := store.ReleaseOutgoingSendKey("tmp_key_1"); err != nil {
+		t.Fatal(err)
+	}
+	item, err = store.GetOutgoingSendKey("tmp_key_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item != nil {
+		t.Fatalf("released key still exists: %#v", item)
+	}
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -652,10 +652,16 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
-			if !markGoogleAuthExpired(err) {
+			authExpired := markGoogleAuthExpired(err)
+			if !authExpired {
 				recordGoogleSendError(err)
 			}
-			if googleSendErrorCanRetry(err) {
+			// The send POST was already attempted. Only an auth rejection proves the
+			// message was NOT dispatched, so release the claim to let a retry (after
+			// re-pair) send it. Any other error (network/timeout) is ambiguous: the
+			// message may have reached Google, so keep the claim and let a retry hit
+			// the dedup (409) instead of delivering a duplicate text.
+			if authExpired {
 				releaseIdempotentSend(idempotencyKey)
 			} else {
 				completeIdempotentSend(idempotencyKey, payload.TmpID, db.OutgoingSendStatusFailed)
@@ -1642,10 +1648,16 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 		resp, err := cli.GM.SendMessage(payload)
 		if err != nil {
-			if !markGoogleAuthExpired(err) {
+			authExpired := markGoogleAuthExpired(err)
+			if !authExpired {
 				recordGoogleSendError(err)
 			}
-			if googleSendErrorCanRetry(err) {
+			// The send POST was already attempted. Only an auth rejection proves the
+			// message was NOT dispatched, so release the claim to let a retry (after
+			// re-pair) send it. Any other error (network/timeout) is ambiguous: the
+			// message may have reached Google, so keep the claim and let a retry hit
+			// the dedup (409) instead of delivering a duplicate text.
+			if authExpired {
 				releaseIdempotentSend(idempotencyKey)
 			} else {
 				completeIdempotentSend(idempotencyKey, payload.TmpID, db.OutgoingSendStatusFailed)
@@ -3225,17 +3237,6 @@ func googleAPIErrorMessage(action string, err error) string {
 		return "Google Messages is offline. Check your internet connection, then try again."
 	}
 	return action + ": " + err.Error()
-}
-
-func googleSendErrorCanRetry(err error) bool {
-	if err == nil {
-		return false
-	}
-	if app.IsGoogleAuthExpiredError(err) || isGoogleNetworkError(err) {
-		return true
-	}
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "not connected") || strings.Contains(message, "disconnected")
 }
 
 // googleSendRejectedMessage builds the user-facing error for a non-SUCCESS

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -41,6 +41,29 @@ const maxUploadBytes = 128 << 20
 
 const maxTranscriptRequestBytes = db.MaxTranscriptBytes + db.MaxTranscriptModelBytes + 4096
 
+func normalizeSendIdempotencyKey(raw string) (string, error) {
+	key := strings.TrimSpace(raw)
+	if key == "" {
+		return "", nil
+	}
+	if len(key) > 128 {
+		return "", fmt.Errorf("idempotency_key is too long")
+	}
+	for i := 0; i < len(key); i++ {
+		c := key[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			continue
+		}
+		switch c {
+		case '_', '-', '.', ':':
+			continue
+		default:
+			return "", fmt.Errorf("idempotency_key contains unsupported characters")
+		}
+	}
+	return key, nil
+}
+
 // APIHandler creates the HTTP handler with JSON API routes and static file serving.
 // The client may be nil (disconnected state).
 // mcpHandler is an optional http.Handler for the MCP SSE endpoint (mounted at /mcp/).
@@ -372,6 +395,76 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		}
 		return nil
 	}
+	writeIdempotentSendResponse := func(w http.ResponseWriter, item *db.OutgoingSendKey) {
+		w.Header().Set("Content-Type", "application/json")
+		payload := map[string]any{
+			"deduplicated": true,
+			"success":      true,
+			"status":       "SUCCESS",
+		}
+		if item != nil {
+			if item.MessageID != "" {
+				payload["message_id"] = item.MessageID
+			}
+			switch item.Status {
+			case db.OutgoingSendStatusSending:
+				payload["success"] = false
+				payload["status"] = "SENDING"
+				payload["error"] = "message send already in progress for this idempotency key"
+				w.WriteHeader(http.StatusConflict)
+			case db.OutgoingSendStatusFailed:
+				payload["success"] = false
+				payload["status"] = "FAILED"
+				payload["error"] = "message send already failed for this idempotency key"
+				w.WriteHeader(http.StatusConflict)
+			case db.OutgoingSendStatusLocalStoreFailed:
+				payload["status"] = "SENT_LOCAL_STORE_FAILED"
+				w.WriteHeader(http.StatusAccepted)
+			}
+		}
+		writeJSON(w, payload)
+	}
+	claimIdempotentSend := func(w http.ResponseWriter, key, conversationID string) (bool, bool) {
+		if key == "" {
+			return true, true
+		}
+		claimed, existing, err := store.ClaimOutgoingSendKey(key, conversationID)
+		if err != nil {
+			httpError(w, "claim idempotency key: "+err.Error(), 500)
+			return false, false
+		}
+		if !claimed {
+			writeIdempotentSendResponse(w, existing)
+			return false, true
+		}
+		return true, true
+	}
+	completeIdempotentSend := func(key, messageID, status string) {
+		if key == "" {
+			return
+		}
+		if err := store.CompleteOutgoingSendKey(key, messageID, status); err != nil {
+			logger.Warn().Err(err).Str("idempotency_key", key).Msg("Failed to complete idempotent send")
+		}
+	}
+	releaseIdempotentSend := func(key string) {
+		if key == "" {
+			return
+		}
+		if err := store.ReleaseOutgoingSendKey(key); err != nil {
+			logger.Warn().Err(err).Str("idempotency_key", key).Msg("Failed to release idempotent send")
+		}
+	}
+	writeLocalStoreFailedSend := func(w http.ResponseWriter, messageID string, err error) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		writeJSON(w, map[string]any{
+			"message_id": messageID,
+			"status":     "SENT_LOCAL_STORE_FAILED",
+			"success":    true,
+			"warning":    "message sent remotely but failed to update local store: " + err.Error(),
+		})
+	}
 	isWhatsAppConversation := func(conversationID string) bool {
 		if strings.HasPrefix(conversationID, "whatsapp:") {
 			return true
@@ -403,7 +496,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return nil, err
 		}
 		if err := recordOutgoingMessage(msg, deleteDraftID); err != nil {
-			return nil, fmt.Errorf("%w: %v", errWhatsAppLocalStore, err)
+			return msg, fmt.Errorf("%w: %v", errWhatsAppLocalStore, err)
 		}
 		return msg, nil
 	}
@@ -416,7 +509,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return nil, err
 		}
 		if err := recordOutgoingMessage(msg, ""); err != nil {
-			return nil, fmt.Errorf("%w: %v", errWhatsAppLocalStore, err)
+			return msg, fmt.Errorf("%w: %v", errWhatsAppLocalStore, err)
 		}
 		return msg, nil
 	}
@@ -429,7 +522,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return nil, err
 		}
 		if err := recordOutgoingMessage(msg, deleteDraftID); err != nil {
-			return nil, fmt.Errorf("%w: %v", errSignalLocalStore, err)
+			return msg, fmt.Errorf("%w: %v", errSignalLocalStore, err)
 		}
 		return msg, nil
 	}
@@ -442,7 +535,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return nil, err
 		}
 		if err := recordOutgoingMessage(msg, ""); err != nil {
-			return nil, fmt.Errorf("%w: %v", errSignalLocalStore, err)
+			return msg, fmt.Errorf("%w: %v", errSignalLocalStore, err)
 		}
 		return msg, nil
 	}
@@ -455,20 +548,32 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	if fetchLinkPreviewImage == nil {
 		fetchLinkPreviewImage = linkPreviewService.FetchImage
 	}
-	sendMediaBytes := func(w http.ResponseWriter, convID string, data []byte, filename, mimeType, caption, replyToID string) {
+	sendMediaBytes := func(w http.ResponseWriter, convID string, data []byte, filename, mimeType, caption, replyToID, idempotencyKey string) {
+		proceed, handled := claimIdempotentSend(w, idempotencyKey, convID)
+		if !handled || !proceed {
+			return
+		}
 		if isSignalConversation(convID) {
 			msg, err := sendSignalMedia(convID, data, filename, mimeType, caption, replyToID)
 			switch {
 			case errors.Is(err, errSignalMediaUnavailable):
+				releaseIdempotentSend(idempotencyKey)
 				httpError(w, err.Error(), 501)
 				return
 			case errors.Is(err, errSignalLocalStore):
-				httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
+				messageID := ""
+				if msg != nil {
+					messageID = msg.MessageID
+				}
+				completeIdempotentSend(idempotencyKey, messageID, db.OutgoingSendStatusLocalStoreFailed)
+				writeLocalStoreFailedSend(w, messageID, err)
 				return
 			case err != nil:
+				completeIdempotentSend(idempotencyKey, "", db.OutgoingSendStatusFailed)
 				httpError(w, err.Error(), 502)
 				return
 			}
+			completeIdempotentSend(idempotencyKey, msg.MessageID, db.OutgoingSendStatusSent)
 			publishMessages(convID)
 			publishConversations()
 			writeJSON(w, map[string]any{
@@ -482,15 +587,23 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			msg, err := sendWhatsAppMedia(convID, data, filename, mimeType, caption, replyToID)
 			switch {
 			case errors.Is(err, errWhatsAppMediaUnavailable):
+				releaseIdempotentSend(idempotencyKey)
 				httpError(w, err.Error(), 501)
 				return
 			case errors.Is(err, errWhatsAppLocalStore):
-				httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
+				messageID := ""
+				if msg != nil {
+					messageID = msg.MessageID
+				}
+				completeIdempotentSend(idempotencyKey, messageID, db.OutgoingSendStatusLocalStoreFailed)
+				writeLocalStoreFailedSend(w, messageID, err)
 				return
 			case err != nil:
+				completeIdempotentSend(idempotencyKey, "", db.OutgoingSendStatusFailed)
 				httpError(w, err.Error(), 502)
 				return
 			}
+			completeIdempotentSend(idempotencyKey, msg.MessageID, db.OutgoingSendStatusSent)
 			publishMessages(convID)
 			publishConversations()
 			writeJSON(w, map[string]any{
@@ -502,6 +615,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		}
 		cli := getClient()
 		if cli == nil {
+			releaseIdempotentSend(idempotencyKey)
 			httpError(w, app.ErrNotConnected, 503)
 			return
 		}
@@ -511,6 +625,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			if !markGoogleAuthExpired(err) {
 				recordGoogleSendError(err)
 			}
+			releaseIdempotentSend(idempotencyKey)
 			httpError(w, googleAPIErrorMessage("upload media", err), 502)
 			return
 		}
@@ -520,12 +635,13 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			if !markGoogleAuthExpired(err) {
 				recordGoogleSendError(err)
 			}
+			releaseIdempotentSend(idempotencyKey)
 			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
 			return
 		}
 
 		myParticipantID, simPayload := app.ExtractSIMAndParticipant(conv)
-		payload := app.BuildSendMediaPayload(convID, media, myParticipantID, simPayload)
+		payload := app.BuildSendMediaPayloadWithTmpID(convID, media, myParticipantID, simPayload, idempotencyKey)
 
 		logger.Info().
 			Str("conv_id", convID).
@@ -538,6 +654,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		if err != nil {
 			if !markGoogleAuthExpired(err) {
 				recordGoogleSendError(err)
+			}
+			if googleSendErrorCanRetry(err) {
+				releaseIdempotentSend(idempotencyKey)
+			} else {
+				completeIdempotentSend(idempotencyKey, payload.TmpID, db.OutgoingSendStatusFailed)
 			}
 			httpError(w, googleAPIErrorMessage("send message", err), 502)
 			return
@@ -561,6 +682,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			if googlePhoneResponding() {
 				recordGoogleSend(false)
 			}
+			completeIdempotentSend(idempotencyKey, payload.TmpID, db.OutgoingSendStatusFailed)
 			httpError(w, googleSendRejectedMessage(resp.GetStatus().String(), googlePhoneResponding()), 502)
 			return
 		}
@@ -577,9 +699,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			MimeType:       media.MimeType,
 			DecryptionKey:  hex.EncodeToString(media.DecryptionKey),
 		}, ""); err != nil {
-			httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
+			completeIdempotentSend(idempotencyKey, payload.TmpID, db.OutgoingSendStatusLocalStoreFailed)
+			writeLocalStoreFailedSend(w, payload.TmpID, err)
 			return
 		}
+		completeIdempotentSend(idempotencyKey, payload.TmpID, db.OutgoingSendStatusSent)
 		publishMessages(convID)
 		publishConversations()
 		writeJSON(w, map[string]any{
@@ -604,6 +728,9 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("X-Accel-Buffering", "no")
 
+		subID, ch := opts.Events.Subscribe()
+		defer opts.Events.Unsubscribe(subID)
+
 		connected := currentConnected()
 		if err := writeSSEEvent(w, StreamEvent{
 			Type:      EventTypeStatus,
@@ -612,9 +739,6 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return
 		}
 		flusher.Flush()
-
-		subID, ch := opts.Events.Subscribe()
-		defer opts.Events.Unsubscribe(subID)
 
 		heartbeat := opts.EventHeartbeat
 		if heartbeat <= 0 {
@@ -1410,6 +1534,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			ConversationID string `json:"conversation_id"`
 			Message        string `json:"message"`
 			ReplyToID      string `json:"reply_to_id,omitempty"`
+			IdempotencyKey string `json:"idempotency_key,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			httpError(w, "invalid JSON: "+err.Error(), 400)
@@ -1419,19 +1544,36 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "conversation_id and message are required", 400)
 			return
 		}
+		idempotencyKey, err := normalizeSendIdempotencyKey(req.IdempotencyKey)
+		if err != nil {
+			httpError(w, err.Error(), 400)
+			return
+		}
+		proceed, handled := claimIdempotentSend(w, idempotencyKey, req.ConversationID)
+		if !handled || !proceed {
+			return
+		}
 		if isWhatsAppConversation(req.ConversationID) {
 			msg, err := sendWhatsAppText(req.ConversationID, req.Message, req.ReplyToID, "")
 			switch {
 			case errors.Is(err, errWhatsAppTextUnavailable):
+				releaseIdempotentSend(idempotencyKey)
 				httpError(w, err.Error(), 501)
 				return
 			case errors.Is(err, errWhatsAppLocalStore):
-				httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
+				messageID := ""
+				if msg != nil {
+					messageID = msg.MessageID
+				}
+				completeIdempotentSend(idempotencyKey, messageID, db.OutgoingSendStatusLocalStoreFailed)
+				writeLocalStoreFailedSend(w, messageID, err)
 				return
 			case err != nil:
+				completeIdempotentSend(idempotencyKey, "", db.OutgoingSendStatusFailed)
 				httpError(w, err.Error(), 502)
 				return
 			}
+			completeIdempotentSend(idempotencyKey, msg.MessageID, db.OutgoingSendStatusSent)
 			publishMessages(req.ConversationID)
 			publishConversations()
 			writeJSON(w, map[string]any{
@@ -1445,15 +1587,23 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			msg, err := sendSignalText(req.ConversationID, req.Message, req.ReplyToID, "")
 			switch {
 			case errors.Is(err, errSignalTextUnavailable):
+				releaseIdempotentSend(idempotencyKey)
 				httpError(w, err.Error(), 501)
 				return
 			case errors.Is(err, errSignalLocalStore):
-				httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
+				messageID := ""
+				if msg != nil {
+					messageID = msg.MessageID
+				}
+				completeIdempotentSend(idempotencyKey, messageID, db.OutgoingSendStatusLocalStoreFailed)
+				writeLocalStoreFailedSend(w, messageID, err)
 				return
 			case err != nil:
+				completeIdempotentSend(idempotencyKey, "", db.OutgoingSendStatusFailed)
 				httpError(w, err.Error(), 502)
 				return
 			}
+			completeIdempotentSend(idempotencyKey, msg.MessageID, db.OutgoingSendStatusSent)
 			publishMessages(req.ConversationID)
 			publishConversations()
 			writeJSON(w, map[string]any{
@@ -1465,6 +1615,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		}
 		cli := getClient()
 		if cli == nil {
+			releaseIdempotentSend(idempotencyKey)
 			httpError(w, app.ErrNotConnected, 503)
 			return
 		}
@@ -1474,13 +1625,14 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			if !markGoogleAuthExpired(err) {
 				recordGoogleSendError(err)
 			}
+			releaseIdempotentSend(idempotencyKey)
 			httpError(w, googleAPIErrorMessage("get conversation", err), 502)
 			return
 		}
 
 		myParticipantID, simPayload := app.ExtractSIMAndParticipant(conv)
 
-		payload := app.BuildSendPayload(req.ConversationID, req.Message, req.ReplyToID, myParticipantID, simPayload)
+		payload := app.BuildSendPayloadWithTmpID(req.ConversationID, req.Message, req.ReplyToID, myParticipantID, simPayload, idempotencyKey)
 
 		logger.Info().
 			Str("conv_id", req.ConversationID).
@@ -1492,6 +1644,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		if err != nil {
 			if !markGoogleAuthExpired(err) {
 				recordGoogleSendError(err)
+			}
+			if googleSendErrorCanRetry(err) {
+				releaseIdempotentSend(idempotencyKey)
+			} else {
+				completeIdempotentSend(idempotencyKey, payload.TmpID, db.OutgoingSendStatusFailed)
 			}
 			httpError(w, googleAPIErrorMessage("send message", err), 502)
 			return
@@ -1518,6 +1675,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			if googlePhoneResponding() {
 				recordGoogleSend(false)
 			}
+			completeIdempotentSend(idempotencyKey, payload.TmpID, db.OutgoingSendStatusFailed)
 			httpError(w, googleSendRejectedMessage(resp.GetStatus().String(), googlePhoneResponding()), 502)
 			return
 		}
@@ -1533,9 +1691,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			Status:         "OUTGOING_SENDING",
 			ReplyToID:      req.ReplyToID,
 		}, ""); err != nil {
-			httpError(w, "message sent remotely but failed to update local store: "+err.Error(), 500)
+			completeIdempotentSend(idempotencyKey, payload.TmpID, db.OutgoingSendStatusLocalStoreFailed)
+			writeLocalStoreFailedSend(w, payload.TmpID, err)
 			return
 		}
+		completeIdempotentSend(idempotencyKey, payload.TmpID, db.OutgoingSendStatusSent)
 		publishMessages(req.ConversationID)
 		publishConversations()
 		writeJSON(w, map[string]any{
@@ -1621,6 +1781,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			URL            string `json:"url"`
 			Caption        string `json:"caption"`
 			ReplyToID      string `json:"reply_to_id"`
+			IdempotencyKey string `json:"idempotency_key"`
 		}
 		if err := json.NewDecoder(io.LimitReader(r.Body, 64<<10)).Decode(&req); err != nil {
 			httpError(w, "invalid JSON: "+err.Error(), 400)
@@ -1631,12 +1792,17 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "conversation_id is required", 400)
 			return
 		}
+		idempotencyKey, err := normalizeSendIdempotencyKey(req.IdempotencyKey)
+		if err != nil {
+			httpError(w, err.Error(), 400)
+			return
+		}
 		data, filename, mimeType, err := downloadGIFMedia(r.Context(), req.URL, maxGIFSendBytes)
 		if err != nil {
 			httpError(w, err.Error(), 400)
 			return
 		}
-		sendMediaBytes(w, convID, data, filename, mimeType, strings.TrimSpace(req.Caption), strings.TrimSpace(req.ReplyToID))
+		sendMediaBytes(w, convID, data, filename, mimeType, strings.TrimSpace(req.Caption), strings.TrimSpace(req.ReplyToID), idempotencyKey)
 	})
 
 	mux.HandleFunc("/api/send-media", func(w http.ResponseWriter, r *http.Request) {
@@ -1663,6 +1829,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		convID := r.FormValue("conversation_id")
 		caption := strings.TrimSpace(r.FormValue("caption"))
 		replyToID := strings.TrimSpace(r.FormValue("reply_to_id"))
+		idempotencyKey, err := normalizeSendIdempotencyKey(r.FormValue("idempotency_key"))
+		if err != nil {
+			httpError(w, err.Error(), 400)
+			return
+		}
 		if convID == "" {
 			httpError(w, "conversation_id is required", 400)
 			return
@@ -1690,7 +1861,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		if mime == "" {
 			mime = "application/octet-stream"
 		}
-		sendMediaBytes(w, convID, data, header.Filename, mime, caption, replyToID)
+		sendMediaBytes(w, convID, data, header.Filename, mime, caption, replyToID, idempotencyKey)
 	})
 
 	mux.HandleFunc("/api/media/", func(w http.ResponseWriter, r *http.Request) {
@@ -2621,6 +2792,7 @@ func setSecurityHeaders(w http.ResponseWriter) {
 			"img-src 'self' data: blob:; "+
 			"media-src 'self' data: blob:; "+
 			"connect-src 'self'; "+
+			"frame-src 'self' blob:; "+
 			"object-src 'none'; "+
 			"base-uri 'self'; "+
 			"frame-ancestors 'none'")
@@ -3055,6 +3227,17 @@ func googleAPIErrorMessage(action string, err error) string {
 	return action + ": " + err.Error()
 }
 
+func googleSendErrorCanRetry(err error) bool {
+	if err == nil {
+		return false
+	}
+	if app.IsGoogleAuthExpiredError(err) || isGoogleNetworkError(err) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "not connected") || strings.Contains(message, "disconnected")
+}
+
 // googleSendRejectedMessage builds the user-facing error for a non-SUCCESS
 // Google send. UNKNOWN is what a silently-unlinked linked device returns on
 // every send, so the message points at re-pairing rather than leaving the
@@ -3084,6 +3267,8 @@ func isGoogleNetworkError(err error) bool {
 		"tls handshake timeout",
 		"connection refused",
 		"connection reset by peer",
+		"google messages is offline",
+		"not connected to google messages",
 	}
 	for _, needle := range needles {
 		if strings.Contains(message, needle) {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -1887,43 +1887,6 @@ func TestGoogleNetworkErrorIsUserFacing(t *testing.T) {
 	}
 }
 
-func TestGoogleSendErrorCanRetry(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{
-			name: "network",
-			err:  errors.New("Google Messages is offline. Check your internet connection, then try again."),
-			want: true,
-		},
-		{
-			name: "not connected",
-			err:  errors.New("not connected to Google Messages"),
-			want: true,
-		},
-		{
-			name: "auth expired",
-			err:  errors.New("HTTP 401: Request had invalid authentication credentials."),
-			want: true,
-		},
-		{
-			name: "non retryable",
-			err:  errors.New("send message: invalid recipient"),
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := googleSendErrorCanRetry(tt.err); got != tt.want {
-				t.Fatalf("googleSendErrorCanRetry() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestGoogleAuthExpiredErrorIsUserFacing(t *testing.T) {
 	raw := "HTTP 401: 16: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential."
 	got := googleAPIErrorMessage("get conversation", errors.New(raw))

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -1065,6 +1065,66 @@ func TestSendMessageUsesWhatsAppSender(t *testing.T) {
 	}
 }
 
+func TestSendMessageIdempotencySkipsDuplicateWhatsAppSender(t *testing.T) {
+	var calls int
+	ts := newTestServerWithOptions(t, APIOptions{
+		SendWhatsAppText: func(conversationID, body, replyToID string) (*db.Message, error) {
+			calls++
+			return &db.Message{
+				MessageID:      fmt.Sprintf("whatsapp:sent-%d", calls),
+				ConversationID: conversationID,
+				Body:           body,
+				IsFromMe:       true,
+				TimestampMS:    1234,
+				Status:         "OUTGOING_SENDING",
+				SourcePlatform: "whatsapp",
+				SourceID:       fmt.Sprintf("sent-%d", calls),
+			}, nil
+		},
+	})
+
+	if err := ts.store.UpsertConversation(&db.Conversation{
+		ConversationID: "whatsapp:15551234567@s.whatsapp.net",
+		Name:           "Jordan Rivera",
+		SourcePlatform: "whatsapp",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"conversation_id":"whatsapp:15551234567@s.whatsapp.net","message":"hello once","idempotency_key":"tmp_text_once"}`
+	for i := 0; i < 2; i++ {
+		resp, err := http.Post(ts.server.URL+"/api/send", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("attempt %d status = %d, want 200: %s", i+1, resp.StatusCode, string(raw))
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload["message_id"] != "whatsapp:sent-1" {
+			t.Fatalf("attempt %d message_id = %#v, want whatsapp:sent-1", i+1, payload["message_id"])
+		}
+		if i == 1 && payload["deduplicated"] != true {
+			t.Fatalf("second response deduplicated = %#v, want true", payload["deduplicated"])
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("SendWhatsAppText calls = %d, want 1", calls)
+	}
+	msgs, err := ts.store.GetMessagesByConversation("whatsapp:15551234567@s.whatsapp.net", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("stored messages = %d, want 1", len(msgs))
+	}
+}
+
 func TestSendDraftUsesWhatsAppSender(t *testing.T) {
 	var calls int
 	ts := newTestServerWithOptions(t, APIOptions{
@@ -1428,6 +1488,91 @@ func TestSendMediaUsesWhatsAppSender(t *testing.T) {
 	}
 }
 
+func TestSendMediaIdempotencySkipsDuplicateWhatsAppSender(t *testing.T) {
+	var calls int
+	ts := newTestServerWithOptions(t, APIOptions{
+		SendWhatsAppMedia: func(conversationID string, data []byte, filename, mime, caption, replyToID string) (*db.Message, error) {
+			calls++
+			return &db.Message{
+				MessageID:      fmt.Sprintf("whatsapp:media-%d", calls),
+				ConversationID: conversationID,
+				Body:           caption,
+				IsFromMe:       true,
+				TimestampMS:    1234,
+				Status:         "OUTGOING_SENDING",
+				MediaID:        fmt.Sprintf("wa:test-ref-%d", calls),
+				MimeType:       mime,
+				SourcePlatform: "whatsapp",
+				SourceID:       fmt.Sprintf("media-%d", calls),
+			}, nil
+		},
+	})
+
+	if err := ts.store.UpsertConversation(&db.Conversation{
+		ConversationID: "whatsapp:15551234567@s.whatsapp.net",
+		Name:           "Jordan Rivera",
+		SourcePlatform: "whatsapp",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	postMedia := func() map[string]any {
+		t.Helper()
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		if err := writer.WriteField("conversation_id", "whatsapp:15551234567@s.whatsapp.net"); err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.WriteField("caption", "check this once"); err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.WriteField("idempotency_key", "tmp_media_once"); err != nil {
+			t.Fatal(err)
+		}
+		part, err := writer.CreateFormFile("file", "menu.pdf")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := part.Write([]byte("%PDF")); err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatal(err)
+		}
+		req, err := http.NewRequest(http.MethodPost, ts.server.URL+"/api/send-media", &body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200: %s", resp.StatusCode, string(raw))
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		return payload
+	}
+
+	first := postMedia()
+	second := postMedia()
+	if first["message_id"] != "whatsapp:media-1" || second["message_id"] != "whatsapp:media-1" {
+		t.Fatalf("message ids = %#v / %#v, want whatsapp:media-1", first["message_id"], second["message_id"])
+	}
+	if second["deduplicated"] != true {
+		t.Fatalf("second response deduplicated = %#v, want true", second["deduplicated"])
+	}
+	if calls != 1 {
+		t.Fatalf("SendWhatsAppMedia calls = %d, want 1", calls)
+	}
+}
+
 func TestSendMediaUsesSignalSender(t *testing.T) {
 	var gotConversationID, gotFilename, gotMIME, gotCaption, gotReplyToID string
 	var gotData []byte
@@ -1739,6 +1884,43 @@ func TestGoogleNetworkErrorIsUserFacing(t *testing.T) {
 	}
 	if strings.Contains(got, "instantmessaging") || strings.Contains(got, "dial tcp") {
 		t.Fatalf("error leaked transport details: %q", got)
+	}
+}
+
+func TestGoogleSendErrorCanRetry(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "network",
+			err:  errors.New("Google Messages is offline. Check your internet connection, then try again."),
+			want: true,
+		},
+		{
+			name: "not connected",
+			err:  errors.New("not connected to Google Messages"),
+			want: true,
+		},
+		{
+			name: "auth expired",
+			err:  errors.New("HTTP 401: Request had invalid authentication credentials."),
+			want: true,
+		},
+		{
+			name: "non retryable",
+			err:  errors.New("send message: invalid recipient"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := googleSendErrorCanRetry(tt.err); got != tt.want {
+				t.Fatalf("googleSendErrorCanRetry() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -2681,6 +2863,19 @@ func TestBuildSendPayloadNoReply(t *testing.T) {
 	}
 }
 
+func TestBuildSendPayloadWithTmpID(t *testing.T) {
+	payload := app.BuildSendPayloadWithTmpID("conv-1", "Queued text", "", "+15551234567", nil, "tmp_queue_123")
+	if payload.TmpID != "tmp_queue_123" {
+		t.Fatalf("TmpID = %q, want tmp_queue_123", payload.TmpID)
+	}
+	if payload.MessagePayload.TmpID != "tmp_queue_123" {
+		t.Fatalf("MessagePayload.TmpID = %q, want tmp_queue_123", payload.MessagePayload.TmpID)
+	}
+	if payload.MessagePayload.TmpID2 != "tmp_queue_123" {
+		t.Fatalf("MessagePayload.TmpID2 = %q, want tmp_queue_123", payload.MessagePayload.TmpID2)
+	}
+}
+
 func TestBuildSendMediaPayload(t *testing.T) {
 	sim := &gmproto.SIMPayload{SIMNumber: 1}
 	media := &gmproto.MediaContent{
@@ -2742,6 +2937,20 @@ func TestBuildSendMediaPayload(t *testing.T) {
 	}
 	if payload.MessagePayload.ConversationID != "conv-1" {
 		t.Errorf("payload ConversationID = %q", payload.MessagePayload.ConversationID)
+	}
+}
+
+func TestBuildSendMediaPayloadWithTmpID(t *testing.T) {
+	media := &gmproto.MediaContent{
+		MediaID:  "media-abc-123",
+		MimeType: "application/pdf",
+	}
+	payload := app.BuildSendMediaPayloadWithTmpID("conv-1", media, "+15551234567", nil, "tmp_media_123")
+	if payload.TmpID != "tmp_media_123" {
+		t.Fatalf("TmpID = %q, want tmp_media_123", payload.TmpID)
+	}
+	if payload.MessagePayload.TmpID != "tmp_media_123" || payload.MessagePayload.TmpID2 != "tmp_media_123" {
+		t.Fatalf("payload tmp ids = %q/%q, want tmp_media_123", payload.MessagePayload.TmpID, payload.MessagePayload.TmpID2)
 	}
 }
 
@@ -3503,7 +3712,7 @@ func TestSecurityHeadersPresent(t *testing.T) {
 	if csp == "" {
 		t.Fatal("Content-Security-Policy header missing")
 	}
-	for _, directive := range []string{"default-src 'self'", "connect-src 'self'", "frame-ancestors 'none'", "object-src 'none'"} {
+	for _, directive := range []string{"default-src 'self'", "connect-src 'self'", "frame-src 'self' blob:", "frame-ancestors 'none'", "object-src 'none'"} {
 		if !strings.Contains(csp, directive) {
 			t.Errorf("CSP missing %q: %s", directive, csp)
 		}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -1171,6 +1171,22 @@ html, body {
   font-size: 10px;
 }
 
+.msg-retry-send {
+  margin-left: 6px;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0;
+}
+
+.msg-retry-send:hover {
+  text-decoration: underline;
+}
+
 /* ─── Media (images, videos, audio) ─── */
 .msg-media {
   margin: 4px 0;
@@ -1205,6 +1221,92 @@ html, body {
 .msg-media audio {
   width: min(320px, 100%);
   display: block;
+}
+
+.msg-document-preview {
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+}
+
+.msg-document-preview .msg-pdf-preview {
+  display: block;
+  width: min(320px, 68vw);
+  height: 220px;
+  border: 0;
+  background: var(--bg-surface);
+}
+
+.msg-pdf-preview-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: min(320px, 68vw);
+  height: 220px;
+  padding: 16px;
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  text-align: center;
+}
+
+.msg-pdf-preview-error[hidden] { display: none; }
+
+.msg-attachment-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: min(320px, 68vw);
+  padding: 10px 12px;
+  margin: 4px 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.msg.sent .msg-attachment-card { margin-left: auto; }
+
+.msg-attachment-card:hover {
+  border-color: var(--border-accent);
+  background: var(--bg-hover);
+}
+
+.msg-attachment-icon {
+  width: 38px;
+  height: 42px;
+  border-radius: var(--radius-sm);
+  background: var(--accent-dim);
+  color: var(--accent-strong);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+
+.msg-attachment-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.msg-attachment-title,
+.msg-attachment-meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.msg-attachment-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.msg-attachment-meta {
+  margin-top: 2px;
+  color: var(--text-secondary);
+  font-size: 12px;
 }
 
 .msg-audio-label {
@@ -5522,6 +5624,7 @@ body::after {
   const googleAvatarCache = new Map();
   const googleAvatarInflight = new Map();
   const pendingMediaLoaderTimers = new WeakMap();
+  const pdfPreviewObjectURLs = new WeakMap();
 
   // ─── DOM refs ───
   const $convoList = document.getElementById('conversation-list');
@@ -5566,6 +5669,20 @@ body::after {
   const $attachRemove = document.getElementById('attach-remove');
   let pendingFile = null; // { file: File, dataUrl: string }
   let composeSendInFlight = false;
+  const PENDING_SENDS_STORAGE_KEY = 'openmessage.pendingSends.v1';
+  const PENDING_SENDS_DB_NAME = 'openmessage-pending-sends';
+  const PENDING_SENDS_DB_STORE = 'files';
+  const PENDING_SEND_MAX_ITEMS = 50;
+  const PENDING_SEND_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+  const PENDING_SEND_CAPACITY_MESSAGE = 'Too many queued messages. Wait for some to send before adding more.';
+  let pendingSendQueue = [];
+  let pendingSendFlushInProgress = false;
+  let pendingSendFlushTimer = null;
+  let pendingSendsDBPromise = null;
+  let queuedSendPlatformReady = { sms: false, whatsapp: false, signal: false };
+  const pendingSendFiles = new Map();
+  const pendingSendObjectURLs = new Map();
+  const pendingSendPreviewHydrations = new Set();
   const $searchInput = document.getElementById('search-input');
   const $connectionBanner = document.getElementById('connection-banner');
   const $connectionBannerCopy = document.getElementById('connection-banner-copy');
@@ -6395,6 +6512,56 @@ body::after {
     });
   }
 
+  function cleanupPDFPreviewURLs(root) {
+    if (!root || !root.querySelectorAll || !window.URL?.revokeObjectURL) return;
+    root.querySelectorAll('iframe.msg-pdf-preview').forEach(frame => {
+      const objectURL = pdfPreviewObjectURLs.get(frame);
+      if (objectURL) {
+        URL.revokeObjectURL(objectURL);
+        pdfPreviewObjectURLs.delete(frame);
+      }
+    });
+  }
+
+  function markPDFPreviewUnavailable(frame) {
+    if (!frame) return;
+    frame.hidden = true;
+    const fallback = frame.parentElement ? frame.parentElement.querySelector('.msg-pdf-preview-error') : null;
+    if (fallback) fallback.hidden = false;
+  }
+
+  function hydratePDFPreviews(root = document) {
+    if (!root || !root.querySelectorAll) return;
+    root.querySelectorAll('iframe.msg-pdf-preview[data-pdf-src]').forEach(frame => {
+      if (frame.dataset.pdfHydrated === 'true') return;
+      const source = frame.dataset.pdfSrc || '';
+      if (!source || !window.URL?.createObjectURL) {
+        markPDFPreviewUnavailable(frame);
+        return;
+      }
+      frame.dataset.pdfHydrated = 'true';
+      fetch(source)
+        .then(response => {
+          if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+          return response.blob();
+        })
+        .then(blob => {
+          if (!frame.isConnected) return;
+          const staleURL = pdfPreviewObjectURLs.get(frame);
+          if (staleURL && window.URL?.revokeObjectURL) {
+            URL.revokeObjectURL(staleURL);
+          }
+          const objectURL = URL.createObjectURL(blob);
+          pdfPreviewObjectURLs.set(frame, objectURL);
+          frame.src = `${objectURL}#toolbar=0&navpanes=0&view=FitH`;
+        })
+        .catch(err => {
+          console.warn('Failed to hydrate PDF preview:', err);
+          markPDFPreviewUnavailable(frame);
+        });
+    });
+  }
+
   function renderAvatarElement(el, { name = '', numbers = [], whatsAppConversationID = '', avatarSource = '', participantIDs = [], contactIDs = [], platforms = [], text = initials(name) || '?', background = avatarColor(name) } = {}) {
     if (!el) return;
     el.classList.remove('has-photo');
@@ -6445,6 +6612,30 @@ body::after {
       || (platform === 'signal' && signalStatus.connected);
   }
 
+  function conversationCanSendNow(convo) {
+    if (!convo) return false;
+    const platform = sourcePlatformOf(convo);
+    if (platform === 'sms') return googleStatus.connected && !googleStatus.needs_repair;
+    if (platform === 'whatsapp') return whatsAppStatus.connected;
+    if (platform === 'signal') return signalStatus.connected;
+    return false;
+  }
+
+  function conversationCanQueueOutbound(convo) {
+    if (!convo) return false;
+    const platform = sourcePlatformOf(convo);
+    if (platform === 'sms') {
+      return googleStatus.connected || (googleStatus.paired && !googleStatus.needs_pairing);
+    }
+    if (platform === 'whatsapp') {
+      return whatsAppStatus.connected || whatsAppStatus.paired;
+    }
+    if (platform === 'signal') {
+      return signalStatus.connected || signalStatus.paired;
+    }
+    return false;
+  }
+
   function isLeaveableWhatsAppGroup(convo) {
     return !!(convo && convo.IsGroup && sourcePlatformOf(convo) === 'whatsapp');
   }
@@ -6455,6 +6646,21 @@ body::after {
       || (sourcePlatformOf(convo) === 'whatsapp' && whatsAppStatus.connected)
       || (sourcePlatformOf(convo) === 'signal' && signalStatus.connected)
     );
+  }
+
+  function conversationCanQueueMediaOutbound(convo) {
+    if (!convo) return false;
+    const platform = sourcePlatformOf(convo);
+    if (platform === 'sms') {
+      return googleStatus.connected || (googleStatus.paired && !googleStatus.needs_pairing);
+    }
+    if (platform === 'whatsapp') {
+      return whatsAppStatus.connected || whatsAppStatus.paired;
+    }
+    if (platform === 'signal') {
+      return signalStatus.connected || signalStatus.paired;
+    }
+    return false;
   }
 
   function isGenericMediaBody(body) {
@@ -6513,6 +6719,66 @@ body::after {
       .replace(/^_+|_+$/g, '')
       .substring(0, 80) || 'message';
     return `openmessage-forward-${rawID}${extensionForMime(mimeType)}`;
+  }
+
+  function fileSizeLabel(bytes) {
+    const size = Number(bytes || 0);
+    if (!Number.isFinite(size) || size <= 0) return '';
+    if (size < 1024) return `${size} B`;
+    if (size < 1024 * 1024) return `${(size / 1024).toFixed(size < 10 * 1024 ? 1 : 0)} KB`;
+    return `${(size / (1024 * 1024)).toFixed(size < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+  }
+
+  function attachmentTypeLabel(mimeType) {
+    const mime = String(mimeType || '').toLowerCase();
+    if (mime === 'application/pdf') return 'PDF';
+    if (mime.includes('word') || mime.includes('document')) return 'DOC';
+    if (mime.includes('spreadsheet') || mime.includes('excel')) return 'XLS';
+    if (mime.includes('presentation') || mime.includes('powerpoint')) return 'PPT';
+    if (mime.includes('zip') || mime.includes('compressed')) return 'ZIP';
+    if (mime.startsWith('text/')) return 'TXT';
+    return 'FILE';
+  }
+
+  function attachmentTitle(message) {
+    const pendingName = String(message && message._pendingFileName || '').trim();
+    if (pendingName) return pendingName;
+    const mime = String(message && message.MimeType || '').trim();
+    const label = mediaKindLabel(mime);
+    if (mime === 'application/pdf') return 'PDF document';
+    if (label !== 'Attachment') return label;
+    return mime ? `Attachment: ${mime}` : 'Attachment';
+  }
+
+  function attachmentMeta(message) {
+    const parts = [];
+    const mime = String(message && message.MimeType || '').trim();
+    const pendingItem = message && message._pendingSendItem;
+    if (mime) parts.push(mime);
+    const size = pendingItem ? fileSizeLabel(pendingItem.file_size) : '';
+    if (size) parts.push(size);
+    if (message && message._pendingSend) {
+      parts.push(message.Status && String(message.Status).startsWith('OUTGOING_FAILED') ? 'Failed' : 'Sending');
+    }
+    return parts.join(' - ');
+  }
+
+  function renderAttachmentCardHTML(message, href) {
+    const mime = String(message && message.MimeType || '').trim();
+    const title = attachmentTitle(message);
+    const meta = attachmentMeta(message);
+    const icon = attachmentTypeLabel(mime);
+    const body = `
+        <span class="msg-attachment-icon">${escapeHtml(icon)}</span>
+        <span class="msg-attachment-copy">
+          <span class="msg-attachment-title">${escapeHtml(title)}</span>
+          ${meta ? `<span class="msg-attachment-meta">${escapeHtml(meta)}</span>` : ''}
+        </span>
+    `;
+    if (!href) {
+      return `<div class="msg-attachment-card" aria-disabled="true">${body}</div>`;
+    }
+    return `<a class="msg-attachment-card" href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${body}</a>`;
   }
 
   function truncateOneLine(value, max = 96) {
@@ -6649,7 +6915,7 @@ body::after {
         return `
           <button
             type="button"
-            class="chat-route-tab${active ? ' active' : ''}${conversationSupportsOutbound(route) ? '' : ' read-only'}"
+            class="chat-route-tab${active ? ' active' : ''}${conversationCanQueueOutbound(route) ? '' : ' read-only'}"
             data-route-id="${escapeHtml(route.ConversationID)}"
             title="${escapeHtml(routeDisplayLabel(route))}"
             ${active ? 'aria-current="page"' : ''}
@@ -6745,24 +7011,29 @@ body::after {
 
   function routeMetaCopy(convo, routes) {
     const platformLabel = platformMeta(sourcePlatformOf(convo)).label;
-    if (conversationSupportsOutbound(convo)) {
+    if (conversationCanQueueOutbound(convo)) {
+      const connected = conversationCanSendNow(convo);
       const note = sourcePlatformOf(convo) === 'whatsapp'
-        ? `Replies and attachments from this composer stay on the ${platformLabel} route for this person.`
+        ? (connected
+          ? `Replies and attachments from this composer stay on the ${platformLabel} route for this person.`
+          : `Replies and attachments from this composer send when ${platformLabel} reconnects.`)
         : (routes.length > 1
-          ? `Replies from this composer stay on the ${platformLabel} route for this person.`
-          : 'Replies from this composer go to this thread.');
+          ? (connected
+            ? `Replies from this composer stay on the ${platformLabel} route for this person.`
+            : `Replies from this composer send on the ${platformLabel} route when it reconnects.`)
+          : (connected ? 'Replies from this composer go to this thread.' : 'Replies from this composer queue until this route reconnects.'));
       if (routes.length > 1) {
         return {
-          label: `Sending via ${platformLabel}`,
+          label: `${connected ? 'Sending' : 'Queued'} via ${platformLabel}`,
           note,
         };
       }
       return {
-        label: `Sending via ${platformLabel}`,
+        label: `${connected ? 'Sending' : 'Queued'} via ${platformLabel}`,
         note,
       };
     }
-    const sendableSibling = routes.find(route => route.ConversationID !== convo.ConversationID && conversationSupportsOutbound(route));
+    const sendableSibling = routes.find(route => route.ConversationID !== convo.ConversationID && conversationCanQueueOutbound(route));
     if (sendableSibling) {
       return {
         label: `Viewing ${platformLabel} history`,
@@ -6779,13 +7050,13 @@ body::after {
 
   function firstSendableSibling(convo = activeConversation) {
     const routes = linkedRoutesForConversation(convo);
-    return routes.find(route => convo && route.ConversationID !== convo.ConversationID && conversationSupportsOutbound(route)) || null;
+    return routes.find(route => convo && route.ConversationID !== convo.ConversationID && conversationCanQueueOutbound(route)) || null;
   }
 
   function preferredReplyRoute(routes) {
     if (!routes || !routes.length) return null;
-    return routes.find(route => sourcePlatformOf(route) === 'sms' && conversationSupportsOutbound(route))
-      || routes.find(route => conversationSupportsOutbound(route))
+    return routes.find(route => sourcePlatformOf(route) === 'sms' && conversationCanQueueOutbound(route))
+      || routes.find(route => conversationCanQueueOutbound(route))
       || null;
   }
 
@@ -6825,11 +7096,12 @@ body::after {
       const btn = document.createElement('button');
       const routePlatform = sourcePlatformOf(route);
       const isActive = route.ConversationID === activeID;
+      const queueable = conversationCanQueueOutbound(route);
       btn.type = 'button';
       btn.className = 'route-switch-btn'
         + (isActive ? ' active' : '')
-        + (conversationSupportsOutbound(route) ? '' : ' read-only');
-      btn.innerHTML = `${platformBadgeHTML(routePlatform)}<span class="route-switch-btn-meta">${conversationSupportsOutbound(route) ? (isActive ? 'Replies here' : 'Reply route') : 'History'}</span>`;
+        + (queueable ? '' : ' read-only');
+      btn.innerHTML = `${platformBadgeHTML(routePlatform)}<span class="route-switch-btn-meta">${queueable ? (isActive ? 'Replies here' : 'Reply route') : 'History'}</span>`;
       if (isActive) {
         btn.setAttribute('aria-current', 'page');
       }
@@ -7440,37 +7712,38 @@ body::after {
       return;
     }
 
-    const canSend = conversationSupportsOutbound(activeConversation);
-    const canSendMedia = conversationSupportsMediaOutbound(activeConversation);
-    $composeInput.disabled = !canSend;
-    if ($composeEmojiBtn) $composeEmojiBtn.disabled = !canSend;
-    if ($composeGifBtn) $composeGifBtn.disabled = composeSendInFlight || !canSendMedia;
-    $attachBtn.disabled = composeSendInFlight || !canSendMedia;
-    $attachBtn.title = canSendMedia
+    const canCompose = conversationCanQueueOutbound(activeConversation);
+    const canQueueMedia = conversationCanQueueMediaOutbound(activeConversation);
+    $composeInput.disabled = !canCompose;
+    if ($composeEmojiBtn) $composeEmojiBtn.disabled = !canCompose;
+    if ($composeGifBtn) $composeGifBtn.disabled = composeSendInFlight || !canQueueMedia;
+    $attachBtn.disabled = composeSendInFlight || !canQueueMedia;
+    $attachBtn.title = canQueueMedia
       ? 'Attach media'
       : (sourcePlatformOf(activeConversation) === 'whatsapp'
         ? 'Reconnect WhatsApp to send attachments on this route'
         : 'Attachments unavailable on this route');
     if ($composeGifBtn) {
-      $composeGifBtn.title = canSendMedia
+      $composeGifBtn.title = canQueueMedia
         ? 'Search GIFs'
         : (sourcePlatformOf(activeConversation) === 'whatsapp'
           ? 'Reconnect WhatsApp to send GIFs on this route'
           : 'GIFs unavailable on this route');
     }
-    $composeInput.placeholder = canSend ? 'Write a message...' : routeUnavailablePlaceholder(activeConversation);
-    if (!canSendMedia && pendingFile) {
+    $composeInput.placeholder = canCompose ? 'Write a message...' : routeUnavailablePlaceholder(activeConversation);
+    if (!canQueueMedia && pendingFile) {
       clearAttachment();
     }
-    if (!canSend && replyToMsg) {
+    if (!canCompose && replyToMsg) {
       clearReply();
     }
-    if (!canSend) {
+    if (!canCompose) {
       closeComposeEmojiPanel();
     }
-    if (!canSendMedia) {
+    if (!canQueueMedia) {
       closeComposeGifPanel();
     }
+    $composeBar.classList.toggle('is-queueing-route', canCompose && !conversationCanSendNow(activeConversation));
     autoResize();
   }
 
@@ -8081,15 +8354,22 @@ body::after {
 
   function messageContextMenuItems(message) {
     const urls = extractMessageURLs(message && message.Body ? message.Body : '');
+    const failedQueuedSend = message && message._pendingSend && message._pendingSendItem && message._pendingSendItem.status === 'failed';
     return [
+      failedQueuedSend ? {
+        label: 'Retry send',
+        action: 'retry-queued-send',
+      } : null,
+      failedQueuedSend ? { type: 'divider' } : null,
       {
         label: 'Reply',
         action: 'reply-message',
+        disabled: !!(message && message._pendingSend),
       },
       {
         label: 'Forward',
         action: 'forward-message',
-        disabled: !messageHasForwardableContent(message),
+        disabled: !!(message && message._pendingSend) || !messageHasForwardableContent(message),
       },
       {
         label: 'Copy text',
@@ -8463,6 +8743,508 @@ body::after {
     }
   }
 
+  function normalizeQueuedSend(raw) {
+    if (!raw || typeof raw !== 'object') return null;
+    const id = String(raw.id || '').trim();
+    const conversationID = String(raw.conversation_id || '').trim();
+    const type = raw.type === 'media' ? 'media' : (raw.type === 'gif' ? 'gif' : 'text');
+    if (!id || !conversationID) return null;
+    if (type === 'text' && !String(raw.body || '').trim()) return null;
+    if (type === 'media' && !String(raw.file_name || '').trim()) return null;
+    if (type === 'gif' && !String(raw.gif_url || '').trim()) return null;
+    const timestampMS = Number(raw.timestamp_ms || Date.now());
+    const rawStatus = String(raw.status || '').trim();
+    let status = rawStatus === 'failed' ? 'failed' : (rawStatus === 'sending' ? 'failed' : 'pending');
+    let lastError = String(raw.last_error || '');
+    if (rawStatus === 'sending' && !lastError) {
+      lastError = 'Send was interrupted. Check the recipient before sending again.';
+    }
+    if (status === 'pending' && Date.now() - timestampMS > PENDING_SEND_MAX_AGE_MS) {
+      status = 'failed';
+      lastError = 'Message expired before it could send.';
+    }
+    return {
+      id,
+      conversation_id: conversationID,
+      platform: normalizePlatform(raw.platform || 'sms'),
+      type,
+      body: String(raw.body || ''),
+      reply_to_id: String(raw.reply_to_id || ''),
+      file_name: String(raw.file_name || ''),
+      mime_type: String(raw.mime_type || ''),
+      file_size: Number(raw.file_size || 0),
+      gif_url: String(raw.gif_url || ''),
+      preview_url: String(raw.preview_url || ''),
+      timestamp_ms: timestampMS,
+      status,
+      wait_for_reconnect: !!raw.wait_for_reconnect,
+      attempts: Number(raw.attempts || 0),
+      next_attempt_at: Number(raw.next_attempt_at || 0),
+      last_error: lastError,
+    };
+  }
+
+  function loadQueuedSends() {
+    try {
+      const raw = localStorage.getItem(PENDING_SENDS_STORAGE_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      pendingSendQueue = Array.isArray(parsed)
+        ? parsed.map(normalizeQueuedSend).filter(Boolean)
+        : [];
+    } catch (err) {
+      console.warn('Failed to load pending sends:', err);
+      pendingSendQueue = [];
+    }
+  }
+
+  function saveQueuedSends() {
+    try {
+      localStorage.setItem(PENDING_SENDS_STORAGE_KEY, JSON.stringify(pendingSendQueue));
+    } catch (err) {
+      console.warn('Failed to save pending sends:', err);
+    }
+  }
+
+  function pendingSendsDB() {
+    if (pendingSendsDBPromise) return pendingSendsDBPromise;
+    pendingSendsDBPromise = new Promise((resolve, reject) => {
+      if (!window.indexedDB) {
+        reject(new Error('IndexedDB is unavailable'));
+        return;
+      }
+      const req = window.indexedDB.open(PENDING_SENDS_DB_NAME, 1);
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore(PENDING_SENDS_DB_STORE);
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error || new Error('open pending-send storage'));
+      req.onblocked = () => reject(new Error('pending-send storage is blocked'));
+    });
+    return pendingSendsDBPromise;
+  }
+
+  function idbTransactionDone(tx) {
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onabort = () => reject(tx.error || new Error('pending-send storage aborted'));
+      tx.onerror = () => reject(tx.error || new Error('pending-send storage failed'));
+    });
+  }
+
+  function rememberPendingSendObjectURL(id, blob) {
+    if (!id || !blob || pendingSendObjectURLs.has(id) || !window.URL?.createObjectURL) return;
+    try {
+      pendingSendObjectURLs.set(id, URL.createObjectURL(blob));
+    } catch (err) {
+      console.warn('Failed to create pending attachment preview URL:', err);
+    }
+  }
+
+  function forgetPendingSendObjectURL(id) {
+    const url = pendingSendObjectURLs.get(id);
+    if (url && window.URL?.revokeObjectURL) {
+      URL.revokeObjectURL(url);
+    }
+    pendingSendObjectURLs.delete(id);
+  }
+
+  async function storePendingSendFile(id, file) {
+    if (!id || !file) return;
+    pendingSendFiles.set(id, file);
+    rememberPendingSendObjectURL(id, file);
+    try {
+      const db = await pendingSendsDB();
+      const tx = db.transaction(PENDING_SENDS_DB_STORE, 'readwrite');
+      tx.objectStore(PENDING_SENDS_DB_STORE).put(file, id);
+      await idbTransactionDone(tx);
+    } catch (err) {
+      console.warn('Pending attachment will retry only while this page stays open:', err);
+    }
+  }
+
+  async function deletePendingSendFile(id) {
+    pendingSendFiles.delete(id);
+    forgetPendingSendObjectURL(id);
+    try {
+      const db = await pendingSendsDB();
+      const tx = db.transaction(PENDING_SENDS_DB_STORE, 'readwrite');
+      tx.objectStore(PENDING_SENDS_DB_STORE).delete(id);
+      await idbTransactionDone(tx);
+    } catch (err) {
+      console.warn('Failed to delete pending attachment:', err);
+    }
+  }
+
+  async function pendingSendFile(item) {
+    if (pendingSendFiles.has(item.id)) return pendingSendFiles.get(item.id);
+    const db = await pendingSendsDB();
+    const blob = await new Promise((resolve, reject) => {
+      const tx = db.transaction(PENDING_SENDS_DB_STORE, 'readonly');
+      const req = tx.objectStore(PENDING_SENDS_DB_STORE).get(item.id);
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => reject(req.error || new Error('read pending attachment'));
+    });
+    if (!blob) {
+      throw new Error('Attachment data is no longer available.');
+    }
+    rememberPendingSendObjectURL(item.id, blob);
+    if (typeof File === 'function' && !(blob instanceof File)) {
+      const file = new File([blob], item.file_name || 'attachment', { type: item.mime_type || blob.type || 'application/octet-stream' });
+      pendingSendFiles.set(item.id, file);
+      return file;
+    }
+    pendingSendFiles.set(item.id, blob);
+    return blob;
+  }
+
+  function hydrateQueuedAttachmentPreviews() {
+    if (!activeConvoId) return;
+    queuedSendsForConversation(activeConvoId).forEach(item => {
+      if (item.type !== 'media' || pendingSendObjectURLs.has(item.id) || pendingSendPreviewHydrations.has(item.id)) return;
+      pendingSendPreviewHydrations.add(item.id);
+      pendingSendFile(item)
+        .then(file => {
+          rememberPendingSendObjectURL(item.id, file);
+          if (activeConvoId === item.conversation_id) {
+            syncQueuedSendsForActiveConversation();
+          }
+        })
+        .catch(err => console.warn('Failed to hydrate pending attachment preview:', err))
+        .finally(() => pendingSendPreviewHydrations.delete(item.id));
+    });
+  }
+
+  function queuedSendID() {
+    return `tmp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  function queuedSendsForConversation(conversationID) {
+    return pendingSendQueue
+      .filter(item => item.conversation_id === conversationID)
+      .sort((a, b) => a.timestamp_ms - b.timestamp_ms || a.id.localeCompare(b.id));
+  }
+
+  function queuedSendMessage(item) {
+    const failed = item.status === 'failed';
+    const hasMediaPreview = item.type === 'media' || item.type === 'gif';
+    return {
+      MessageID: item.id,
+      ConversationID: item.conversation_id,
+      Body: item.body,
+      TimestampMS: item.timestamp_ms,
+      Status: failed ? `OUTGOING_FAILED:${item.last_error || 'queued send failed'}` : 'OUTGOING_SENDING',
+      IsFromMe: true,
+      MediaID: hasMediaPreview ? `pending:${item.id}` : '',
+      MimeType: item.type === 'gif' ? (item.mime_type || 'image/gif') : (item.type === 'media' ? item.mime_type : ''),
+      ReplyToID: item.reply_to_id,
+      SourcePlatform: item.platform,
+      _pendingSend: true,
+      _pendingSendItem: item,
+      _pendingFileName: item.file_name,
+      _pendingFileURL: item.type === 'gif' ? item.preview_url : (pendingSendObjectURLs.get(item.id) || ''),
+    };
+  }
+
+  function queuedTextConfirmedByMessage(item, message) {
+    if (!item || item.type !== 'text' || item.status !== 'failed' || !message || message._pendingSend) return false;
+    if (!message.IsFromMe) return false;
+    if (String(message.ConversationID || '') !== item.conversation_id) return false;
+    if (normalizePlatform(message.SourcePlatform || item.platform) !== normalizePlatform(item.platform)) return false;
+    if (String(message.ReplyToID || '') !== String(item.reply_to_id || '')) return false;
+    if (String(message.Body || '').trim() !== String(item.body || '').trim()) return false;
+    const queuedAt = Number(item.timestamp_ms || 0);
+    const sentAt = Number(message.TimestampMS || 0);
+    return !queuedAt || !sentAt || sentAt >= queuedAt;
+  }
+
+  function pruneQueuedSendsConfirmedByMessages(messages, conversationID) {
+    const confirmedMessages = (messages || []).filter(message => message && !message._pendingSend && message.IsFromMe);
+    if (!confirmedMessages.length) return;
+    const removed = [];
+    pendingSendQueue = pendingSendQueue.filter(item => {
+      if (!item || item.conversation_id !== conversationID) return true;
+      if (!confirmedMessages.some(message => queuedTextConfirmedByMessage(item, message))) return true;
+      removed.push(item.id);
+      return false;
+    });
+    if (!removed.length) return;
+    saveQueuedSends();
+    removed.forEach(id => {
+      deletePendingSendFile(id).catch(err => console.warn('Failed to delete confirmed queued send attachment:', err));
+    });
+  }
+
+  function mergeQueuedSends(messages, conversationID) {
+    pruneQueuedSendsConfirmedByMessages(messages, conversationID);
+    const base = (messages || []).filter(message => !message._pendingSend);
+    const queued = queuedSendsForConversation(conversationID).map(queuedSendMessage);
+    return mergeMessages(base, queued);
+  }
+
+  function syncQueuedSendsForActiveConversation({stickToBottom = null} = {}) {
+    if (!activeConvoId) return;
+    const shouldStick = stickToBottom === null ? isThreadNearBottom() : !!stickToBottom;
+    loadedMessages = mergeQueuedSends(loadedMessages, activeConvoId);
+    updateLoadedMessageBounds();
+    lastThreadSignature = null;
+    renderLoadedMessages({stickToBottom: shouldStick});
+  }
+
+  function findQueuedSend(id) {
+    return pendingSendQueue.find(item => item.id === id) || null;
+  }
+
+  function updateQueuedSend(id, patch) {
+    const item = findQueuedSend(id);
+    if (!item) return null;
+    Object.assign(item, patch);
+    saveQueuedSends();
+    if (activeConvoId === item.conversation_id) {
+      syncQueuedSendsForActiveConversation({stickToBottom: true});
+    }
+    return item;
+  }
+
+  async function removeQueuedSend(id) {
+    const item = findQueuedSend(id);
+    pendingSendQueue = pendingSendQueue.filter(candidate => candidate.id !== id);
+    saveQueuedSends();
+    await deletePendingSendFile(id);
+    if (item && activeConvoId === item.conversation_id) {
+      loadedMessages = loadedMessages.filter(message => String(message.MessageID || '') !== id);
+      updateLoadedMessageBounds();
+      lastThreadSignature = null;
+      renderLoadedMessages({stickToBottom: true});
+    }
+  }
+
+  async function enqueueQueuedSend(item, file = null) {
+    const normalized = normalizeQueuedSend(item);
+    if (!normalized) throw new Error('Invalid queued message.');
+    if (pendingSendQueue.length >= PENDING_SEND_MAX_ITEMS) {
+      throw new Error(PENDING_SEND_CAPACITY_MESSAGE);
+    }
+    pendingSendQueue.push(normalized);
+    saveQueuedSends();
+    if (file) {
+      await storePendingSendFile(normalized.id, file);
+    }
+    if (activeConvoId === normalized.conversation_id) {
+      syncQueuedSendsForActiveConversation({stickToBottom: true});
+    }
+    scheduleQueuedSendFlush(0);
+    return normalized;
+  }
+
+  function queuedSendCapacityAvailable(additionalItems = 1) {
+    const count = Math.max(0, Number(additionalItems || 0));
+    return pendingSendQueue.length + count <= PENDING_SEND_MAX_ITEMS;
+  }
+
+  function platformReadyForQueuedSend(platform) {
+    if (browserIsOffline()) return false;
+    if (platform === 'sms') return googleStatus.connected && !googleStatus.needs_repair;
+    if (platform === 'whatsapp') return whatsAppStatus.connected;
+    if (platform === 'signal') return signalStatus.connected;
+    return false;
+  }
+
+  function queuedSendCanFlush(item) {
+    return item
+      && item.status === 'pending'
+      && !item.wait_for_reconnect
+      && Number(item.next_attempt_at || 0) <= Date.now()
+      && platformReadyForQueuedSend(item.platform);
+  }
+
+  function resetQueuedSendsWaitingForReconnect(platform) {
+    let changed = false;
+    let activeConversationChanged = false;
+    pendingSendQueue.forEach(item => {
+      if (item.platform !== platform || !item.wait_for_reconnect || item.status !== 'pending') return;
+      item.wait_for_reconnect = false;
+      item.next_attempt_at = 0;
+      changed = true;
+      if (activeConvoId === item.conversation_id) activeConversationChanged = true;
+    });
+    if (!changed) return false;
+    saveQueuedSends();
+    if (activeConversationChanged) {
+      syncQueuedSendsForActiveConversation({stickToBottom: true});
+    }
+    scheduleQueuedSendFlush(0);
+    return true;
+  }
+
+  function updateQueuedSendPlatformReadiness() {
+    const next = {
+      sms: platformReadyForQueuedSend('sms'),
+      whatsapp: platformReadyForQueuedSend('whatsapp'),
+      signal: platformReadyForQueuedSend('signal'),
+    };
+    let changed = false;
+    Object.keys(next).forEach(platform => {
+      if (next[platform] && !queuedSendPlatformReady[platform]) {
+        changed = resetQueuedSendsWaitingForReconnect(platform) || changed;
+      }
+    });
+    queuedSendPlatformReady = next;
+    return changed;
+  }
+
+  function queuedSendWaitingMessage(item) {
+    const label = platformMeta(item.platform).label;
+    if (browserIsOffline()) return 'Message queued. It will send when you are back online.';
+    if (item.platform === 'sms' && googleStatus.needs_repair) {
+      return 'Message queued. Re-pair Google Messages to send it.';
+    }
+    return `Message queued. It will send when ${label} reconnects.`;
+  }
+
+  function queuedSendErrorIsRetryable(err) {
+    const status = Number(err && err.status || 0);
+    if (status === 503 || status === 504 || status === 408 || status === 429) return true;
+    const message = err instanceof Error ? err.message : String(err || '');
+    const lower = message.toLowerCase();
+    return isConnectivityErrorMessage(lower)
+      || lower.includes('not connected')
+      || lower.includes('disconnected')
+      || lower.includes('session expired')
+      || lower.includes('refreshing and reconnecting')
+      || lower.includes('connection refused')
+      || lower.includes('connection reset');
+  }
+
+  async function postQueuedJSON(url, body) {
+    try {
+      const resp = await fetch(API + url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!resp.ok) {
+        const err = new Error(await responseError(resp));
+        err.status = resp.status;
+        throw err;
+      }
+      const text = await resp.text();
+      return text ? JSON.parse(text) : null;
+    } catch (err) {
+      throw err instanceof Error ? err : new Error(String(err || 'Request failed'));
+    }
+  }
+
+  async function sendQueuedItem(item) {
+    if (item.type === 'gif') {
+      await postQueuedJSON('/api/send-gif', {
+        conversation_id: item.conversation_id,
+        url: item.gif_url,
+        caption: item.body || undefined,
+        reply_to_id: item.reply_to_id || undefined,
+        idempotency_key: item.id,
+      });
+      return;
+    }
+    if (item.type === 'media') {
+      const file = await pendingSendFile(item);
+      const form = new FormData();
+      form.append('conversation_id', item.conversation_id);
+      form.append('idempotency_key', item.id);
+      form.append('file', file, item.file_name || file.name || 'attachment');
+      if (item.reply_to_id) form.append('reply_to_id', item.reply_to_id);
+      if (item.body) form.append('caption', item.body);
+      const resp = await fetch(API + '/api/send-media', { method: 'POST', body: form });
+      if (!resp.ok) {
+        const err = new Error(await responseError(resp));
+        err.status = resp.status;
+        throw err;
+      }
+      return;
+    }
+    await postQueuedJSON('/api/send', {
+      conversation_id: item.conversation_id,
+      message: item.body,
+      reply_to_id: item.reply_to_id || undefined,
+      idempotency_key: item.id,
+    });
+  }
+
+  function scheduleQueuedSendFlush(delay = 250) {
+    if (!pendingSendQueue.some(item => item.status === 'pending')) return;
+    clearTimeout(pendingSendFlushTimer);
+    pendingSendFlushTimer = setTimeout(() => {
+      pendingSendFlushTimer = null;
+      flushQueuedSends().catch(err => console.error('Queued send flush failed:', err));
+    }, delay);
+  }
+
+  async function flushQueuedSends() {
+    if (pendingSendFlushInProgress || browserIsOffline()) return;
+    pendingSendFlushInProgress = true;
+    let sentAny = false;
+    try {
+      for (const item of pendingSendQueue.slice()) {
+        if (!queuedSendCanFlush(item)) continue;
+        updateQueuedSend(item.id, { status: 'sending', last_error: '' });
+        try {
+          await sendQueuedItem(item);
+          await removeQueuedSend(item.id);
+          sentAny = true;
+        } catch (err) {
+          const retryable = queuedSendErrorIsRetryable(err);
+          const attempts = Number(item.attempts || 0) + 1;
+          const message = retryable
+            ? queuedSendWaitingMessage(item)
+            : (userFacingErrorMessage(err, 'send') || 'Failed to send message');
+          updateQueuedSend(item.id, {
+            status: retryable ? 'pending' : 'failed',
+            attempts,
+            wait_for_reconnect: retryable,
+            next_attempt_at: 0,
+            last_error: message,
+          });
+          if (!retryable && activeConvoId === item.conversation_id) {
+            showThreadFeedback(message, 'send');
+          }
+        }
+      }
+    } finally {
+      pendingSendFlushInProgress = false;
+    }
+    if (sentAny) {
+      if (activeConvoId && threadSearchMode !== 'centered') {
+        await loadMessages(activeConvoId, {poll: true, forceBottom: true});
+      }
+      await loadConversations();
+    }
+    if (pendingSendQueue.some(item => item.status === 'pending' && item.next_attempt_at > Date.now())) {
+      const nextAttempt = Math.min(...pendingSendQueue
+        .filter(item => item.status === 'pending' && item.next_attempt_at > Date.now())
+        .map(item => item.next_attempt_at));
+      scheduleQueuedSendFlush(Math.max(500, nextAttempt - Date.now()));
+    }
+  }
+
+  async function retryQueuedSend(id) {
+    const item = findQueuedSend(id);
+    if (!item) {
+      showThreadFeedback('Queued message is no longer available.', 'send');
+      return;
+    }
+    const updated = updateQueuedSend(id, {
+      status: 'pending',
+      wait_for_reconnect: false,
+      next_attempt_at: 0,
+      last_error: '',
+    }) || item;
+    if (!queuedSendCanFlush(updated)) {
+      showThreadFeedback(queuedSendWaitingMessage(updated), 'send');
+      return;
+    }
+    showThreadFeedback('Retrying message...', 'send');
+    await flushQueuedSends();
+  }
+
   function clearThreadFeedback() {
     if (threadFeedbackTimer) {
       clearTimeout(threadFeedbackTimer);
@@ -8575,6 +9357,7 @@ body::after {
     });
     Array.from(container.children).forEach(child => {
       if (!desiredSet.has(child)) {
+        cleanupPDFPreviewURLs(child);
         child.remove();
       }
     });
@@ -8960,6 +9743,7 @@ body::after {
 
   function renderThreadPlaceholder(message, modifier = '') {
     if (!$messagesArea) return;
+    cleanupPDFPreviewURLs($messagesArea);
     $messagesArea.innerHTML = '';
     const el = document.createElement('div');
     el.className = 'thread-placeholder' + (modifier ? ` ${modifier}` : '');
@@ -9372,18 +10156,19 @@ body::after {
       const isImage = mimeType.startsWith('image/');
       const isAudio = mimeType.startsWith('audio/');
       const isVideo = mimeType.startsWith('video/');
+      const isPDF = mimeType === 'application/pdf';
       const hasMediaID = !!message.MediaID;
-      const mediaSrc = `/api/media/${encodeURIComponent(message.MessageID)}`;
+      const mediaSrc = message._pendingSend ? (message._pendingFileURL || '') : `/api/media/${encodeURIComponent(message.MessageID)}`;
       const audioLabel = (message.Body === '[Voice note]' || message.Body === '[Audio]' || !message.Body) ? (message.Body === '[Voice note]' ? 'Voice note' : 'Audio message') : '';
       const transcript = message.Transcript || message.transcript || '';
       const transcriptModel = message.TranscriptModel || message.transcript_model || '';
 
-      if (hasMediaID && isImage) {
+      if (hasMediaID && isImage && mediaSrc) {
         html += `<div class="msg-media">`;
         html += `<div class="msg-media-loading" data-msg-id="${escapeHtml(message.MessageID)}" data-kind="image"><div class="spinner"></div><span class="msg-media-loading-text">Fetching image...</span></div>`;
         html += `<img src="${mediaSrc}" alt="Image" loading="lazy" decoding="async" onload="handleMediaLoad(this)" onerror="handleMediaError(this, 'image')" onclick="showFullscreen(this.src,'image')">`;
         html += `</div>`;
-      } else if (hasMediaID && isAudio) {
+      } else if (hasMediaID && isAudio && mediaSrc) {
         html += `<div class="msg-media">`;
         if (audioLabel) {
           html += `<div class="msg-audio-label">${escapeHtml(audioLabel)}</div>`;
@@ -9393,19 +10178,25 @@ body::after {
           html += `<div class="msg-transcript" title="${escapeHtml(transcriptModel || 'auto-transcribed')}">${escapeHtml(transcript)}</div>`;
         }
         html += `</div>`;
-      } else if (hasMediaID && isVideo) {
+      } else if (hasMediaID && isVideo && mediaSrc) {
         html += `<div class="msg-media">`;
         html += `<div class="msg-media-loading" data-msg-id="${escapeHtml(message.MessageID)}" data-kind="video"><div class="spinner"></div><span class="msg-media-loading-text">Fetching video...</span></div>`;
         html += `<video src="${mediaSrc}" preload="none" controls playsinline style="display:none" onloadeddata="this.style.display='block';handleMediaLoad(this)" onerror="handleMediaError(this, 'video')" onclick="event.stopPropagation()"></video>`;
+        html += `</div>`;
+      } else if (hasMediaID && isPDF && mediaSrc) {
+        html += `<div class="msg-media msg-document-preview">`;
+        html += `<iframe class="msg-pdf-preview" data-pdf-src="${escapeHtml(mediaSrc)}" title="PDF preview" loading="lazy"></iframe>`;
+        html += `<div class="msg-pdf-preview-error" hidden>PDF preview unavailable. Open the attachment below.</div>`;
+        html += renderAttachmentCardHTML(message, mediaSrc);
         html += `</div>`;
       } else if (!hasMediaID && (isImage || isAudio || isVideo)) {
         const icon = isImage ? '\uD83D\uDDBC\uFE0F' : (isAudio ? '\uD83C\uDFA4' : '\uD83C\uDFA5');
         const label = isImage ? 'Image' : (isAudio ? 'Audio' : 'Video');
         html += `<div style="padding:12px;background:var(--bg-tertiary, #f0f0f0);border-radius:8px;text-align:center;color:var(--text-muted, #999);font-size:13px">${icon} ${label} from phone</div>`;
       } else if (hasMediaID) {
-        html += `<div style="font-size:13px;color:var(--text-secondary);padding:6px 0">Attachment: ${escapeHtml(message.MimeType || 'file')}</div>`;
+        html += renderAttachmentCardHTML(message, mediaSrc);
       } else {
-        html += `<div style="font-size:13px;color:var(--text-muted);padding:6px 0">Attachment (${escapeHtml(message.MimeType || 'file')})</div>`;
+        html += renderAttachmentCardHTML(message, '');
       }
     }
     const previewURL = message.Body ? extractMessageURLs(message.Body)[0] : '';
@@ -9436,11 +10227,16 @@ body::after {
       } catch(e) {}
     }
 
-    html += `<div class="msg-time">${formatMessageTime(message.TimestampMS)}${message.IsFromMe ? formatStatusIndicator(message.Status) : ''}</div>`;
+    const failedQueuedSend = message._pendingSend && message._pendingSendItem && message._pendingSendItem.status === 'failed';
+    html += `<div class="msg-time">${formatMessageTime(message.TimestampMS)}${message.IsFromMe ? formatStatusIndicator(message.Status) : ''}${failedQueuedSend ? '<button type="button" class="msg-retry-send">Retry</button>' : ''}</div>`;
+    const pendingActionDisabled = message._pendingSend ? 'disabled' : '';
     html += `<div class="msg-actions">`;
-    html += `<button class="action-react" title="React"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg></button>`;
-    html += `<button class="action-reply" title="Reply"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 17 4 12 9 7"/><path d="M20 18v-2a4 4 0 0 0-4-4H4"/></svg></button>`;
-    html += `<button class="action-forward" title="Forward" aria-label="Forward message" ${messageHasForwardableContent(message) ? '' : 'disabled'}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 17 20 12 15 7"/><path d="M4 18v-2a4 4 0 0 1 4-4h12"/><polyline points="13 6 18 1 23 6"/><path d="M11 12h7"/></svg></button>`;
+    if (failedQueuedSend) {
+      html += `<button class="action-retry-send" title="Retry send" aria-label="Retry send"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg></button>`;
+    }
+    html += `<button class="action-react" title="React" ${pendingActionDisabled}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg></button>`;
+    html += `<button class="action-reply" title="Reply" ${pendingActionDisabled}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 17 4 12 9 7"/><path d="M20 18v-2a4 4 0 0 0-4-4H4"/></svg></button>`;
+    html += `<button class="action-forward" title="Forward" aria-label="Forward message" ${!message._pendingSend && messageHasForwardableContent(message) ? '' : 'disabled'}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 17 20 12 15 7"/><path d="M4 18v-2a4 4 0 0 1 4-4h12"/><polyline points="13 6 18 1 23 6"/><path d="M11 12h7"/></svg></button>`;
     html += `</div>`;
 
     const safeMsgId = escapeHtml(message.MessageID);
@@ -9456,6 +10252,15 @@ body::after {
     el.innerHTML = html;
     el.dataset.msgId = message.MessageID;
 
+    el.querySelectorAll('.msg-retry-send, .action-retry-send').forEach(button => {
+      button.addEventListener('click', (e) => {
+        e.stopPropagation();
+        retryQueuedSend(message.MessageID).catch(err => {
+          console.error('Failed to retry queued send:', err);
+          showThreadFeedback(err.message || 'Failed to retry message.', 'send');
+        });
+      });
+    });
     el.querySelector('.action-react').addEventListener('click', (e) => {
       e.stopPropagation();
       document.querySelectorAll('.emoji-picker.show').forEach(p => p.classList.remove('show'));
@@ -9612,6 +10417,8 @@ body::after {
     hydrateLinkPreviews();
     hydrateNativeAvatars($messagesArea);
     hydrateMediaElements($messagesArea);
+    hydratePDFPreviews($messagesArea);
+    hydrateQueuedAttachmentPreviews();
     scheduleMediaLoaderLabels($messagesArea);
     observeThreadContentResize();
     observeThreadViewportResize();
@@ -9654,7 +10461,7 @@ body::after {
         const msgs = await fetchJSON(`/api/conversations/${encodeURIComponent(convoId)}/messages?limit=${MESSAGE_PAGE_SIZE}`);
         msgs.reverse();
         if (threadToken !== activeThreadToken || activeConvoId !== convoId) return;
-        loadedMessages = msgs;
+        loadedMessages = mergeQueuedSends(msgs, convoId);
         const drafts = await fetchDrafts(convoId);
         if (threadToken !== activeThreadToken || activeConvoId !== convoId) return;
         loadedDrafts = drafts;
@@ -9682,7 +10489,7 @@ body::after {
         const latestMsgs = await fetchJSON(`/api/conversations/${encodeURIComponent(convoId)}/messages?limit=${MESSAGE_PAGE_SIZE}`);
         latestMsgs.reverse();
         if (threadToken !== activeThreadToken || activeConvoId !== convoId) return;
-        loadedMessages = mergeMessages(pruneMissingLatestTempMessages(loadedMessages, latestMsgs), latestMsgs);
+        loadedMessages = mergeQueuedSends(mergeMessages(pruneMissingLatestTempMessages(loadedMessages, latestMsgs), latestMsgs), convoId);
         const drafts = await fetchDrafts(convoId);
         if (threadToken !== activeThreadToken || activeConvoId !== convoId) return;
         loadedDrafts = drafts;
@@ -9960,98 +10767,100 @@ body::after {
     if (!activeConversation) {
       return;
     }
-    if (browserIsOffline()) {
-      showThreadFeedback(offlineFeedbackMessage('send'), 'send');
-      return;
-    }
     const sendConvoId = activeConvoId;
     const sendConversation = activeConversation;
-    const canSendText = conversationSupportsOutbound(sendConversation);
-    const canSendMedia = conversationSupportsMediaOutbound(sendConversation);
+    const canQueueText = conversationCanQueueOutbound(sendConversation);
+    const canQueueMedia = conversationCanQueueMediaOutbound(sendConversation);
     const activePlatform = sourcePlatformOf(sendConversation);
-    if ($composeInput.value.trim() && !canSendText) {
+    if ($composeInput.value.trim() && !canQueueText) {
       showThreadFeedback(routeUnavailableMessage('reply', sendConversation));
       return;
     }
-    if (pendingFile && !canSendMedia) {
+    if (pendingFile && !canQueueMedia) {
       showThreadFeedback('Attachments are unavailable on this route right now.');
       return;
     }
     const text = $composeInput.value.trim();
-    const originalText = $composeInput.value;
     const hasMedia = !!pendingFile;
+    const file = pendingFile ? pendingFile.file : null;
+    const replyToID = replyToMsg ? String(replyToMsg.MessageID || '') : '';
     const sendsCaptionedWhatsAppMedia = hasMedia
       && activePlatform === 'whatsapp'
       && !(pendingFile.file?.type || '').startsWith('audio/');
     const sendsCaptionedMedia = sendsCaptionedWhatsAppMedia
       || (hasMedia && activePlatform === 'signal');
     if ((!text && !hasMedia) || !sendConvoId) return;
+    const queuedSendCount = (hasMedia ? 1 : 0) + (text && !sendsCaptionedMedia ? 1 : 0);
+    if (!queuedSendCapacityAvailable(queuedSendCount)) {
+      showThreadFeedback(PENDING_SEND_CAPACITY_MESSAGE, 'send');
+      return;
+    }
 
+    const originalText = $composeInput.value;
+    const originalPendingFile = pendingFile;
+    const originalReplyToMsg = replyToMsg;
+    const queuedItems = [];
     composeSendInFlight = true;
     clearThreadFeedback();
     $composeInput.value = '';
     composeTextByConversation.delete(sendConvoId);
-    $sendBtn.disabled = true;
-    $attachBtn.disabled = true;
-    autoResize();
-
-    // Optimistic UI: show message immediately before server round-trip
-    let optimisticEl = null;
-    if (text && !hasMedia) {
-      optimisticEl = document.createElement('div');
-      optimisticEl.className = 'msg sent';
-      const previewURL = extractMessageURLs(text)[0];
-      optimisticEl.innerHTML = `<div class="msg-body">${linkifyMessageBody(text)}</div>${previewURL ? `<div class="msg-link-preview-shell" data-preview-url="${escapeHtml(previewURL)}"></div>` : ''}<div class="msg-time">${formatMessageTime(Date.now())} <span style="opacity:0.5">&#10003;</span></div>`;
-      $messagesArea.appendChild(optimisticEl);
-      hydrateLinkPreviews();
-      $messagesArea.scrollTop = $messagesArea.scrollHeight;
+    if (hasMedia) {
+      clearAttachment();
     }
+    clearReply();
+    autoResize();
 
     try {
       if (hasMedia) {
-        // Send media via multipart form
-        const form = new FormData();
-        form.append('conversation_id', sendConvoId);
-        form.append('file', pendingFile.file);
-        if ((activePlatform === 'whatsapp' || activePlatform === 'signal') && replyToMsg) {
-          form.append('reply_to_id', replyToMsg.MessageID);
-        }
-        if ((sendsCaptionedWhatsAppMedia || activePlatform === 'signal') && text) {
-          form.append('caption', text);
-        }
-        const resp = await fetch('/api/send-media', { method: 'POST', body: form });
-        if (!resp.ok) throw new Error(await responseError(resp));
-        clearAttachment();
+        const mediaItem = {
+          id: queuedSendID(),
+          conversation_id: sendConvoId,
+          platform: activePlatform,
+          type: 'media',
+          body: sendsCaptionedMedia ? text : '',
+          reply_to_id: (activePlatform === 'whatsapp' || activePlatform === 'signal') ? replyToID : '',
+          file_name: file.name || 'attachment',
+          mime_type: file.type || 'application/octet-stream',
+          file_size: file.size || 0,
+          timestamp_ms: Date.now(),
+          status: 'pending',
+        };
+        queuedItems.push(await enqueueQueuedSend(mediaItem, file));
       }
       if (text && !sendsCaptionedMedia) {
-        const payload = {
+        const textItem = {
+          id: queuedSendID(),
           conversation_id: sendConvoId,
-          message: text,
+          platform: activePlatform,
+          type: 'text',
+          body: text,
+          reply_to_id: replyToID,
+          timestamp_ms: Date.now() + (queuedItems.length ? 1 : 0),
+          status: 'pending',
         };
-        if (replyToMsg) {
-          payload.reply_to_id = replyToMsg.MessageID;
-        }
-        await postJSON('/api/send', payload);
+        queuedItems.push(await enqueueQueuedSend(textItem));
       }
-      clearReply();
-      // Refresh to get the real message from server
-      if (activeConvoId === sendConvoId) {
-        if (threadSearchMode === 'centered') {
-          clearThreadSearchUI();
-          resetLoadedThreadState();
-          await loadMessages(sendConvoId, {reset: true, forceBottom: true});
-        } else {
-          await loadMessages(sendConvoId, {poll: true, forceBottom: true});
-        }
+      const waitingItem = queuedItems.find(item => !queuedSendCanFlush(item));
+      if (waitingItem) {
+        showThreadFeedback(queuedSendWaitingMessage(waitingItem), 'send');
       }
-      await loadConversations();
     } catch (err) {
-      if (optimisticEl) optimisticEl.remove();
-      if (text) {
+      await Promise.all(queuedItems.map(item => removeQueuedSend(item.id).catch(removeErr => {
+        console.warn('Failed to roll back queued send after enqueue failure:', removeErr);
+      })));
+      if (originalText) {
+        rememberComposeText(sendConvoId, originalText);
         if (activeConvoId === sendConvoId) {
           $composeInput.value = originalText;
         }
-        rememberComposeText(sendConvoId, originalText);
+      }
+      if (activeConvoId === sendConvoId) {
+        if (hasMedia && originalPendingFile && originalPendingFile.file) {
+          restoreAttachment(originalPendingFile.file);
+        }
+        if (originalReplyToMsg) {
+          setReply(originalReplyToMsg);
+        }
       }
       showThreadFeedback(err.message || 'Failed to send message', 'send');
       console.error('Failed to send:', err);
@@ -10090,9 +10899,8 @@ body::after {
     $sendBtn.disabled = !activeConversation
       || composeSendInFlight
       || (!hasText && !hasMedia)
-      || browserIsOffline()
-      || (hasText && !conversationSupportsOutbound(activeConversation))
-      || (hasMedia && !conversationSupportsMediaOutbound(activeConversation));
+      || (hasText && !conversationCanQueueOutbound(activeConversation))
+      || (hasMedia && !conversationCanQueueMediaOutbound(activeConversation));
     // Schedule supports text and media attachments.
     if ($scheduleBtn) {
       const canScheduleText = hasText && conversationSupportsOutbound(activeConversation);
@@ -10471,7 +11279,7 @@ body::after {
 
 	  function toggleComposeGifPanel() {
 	    if (!$composeGifPanel || !$composeGifBtn) return;
-	    if (!conversationSupportsMediaOutbound(activeConversation)) {
+	    if (!conversationCanQueueMediaOutbound(activeConversation)) {
 	      showThreadFeedback('GIFs are unavailable on this route right now.');
 	      return;
 	    }
@@ -10658,11 +11466,7 @@ body::after {
 	  async function sendComposeGif(result) {
 	    if (gifSending) return;
 	    if (!activeConversation || !activeConvoId) return;
-	    if (browserIsOffline()) {
-	      showThreadFeedback(offlineFeedbackMessage('send'), 'send');
-	      return;
-	    }
-	    if (!conversationSupportsMediaOutbound(activeConversation)) {
+	    if (!conversationCanQueueMediaOutbound(activeConversation)) {
 	      showThreadFeedback('GIFs are unavailable on this route right now.');
 	      return;
 	    }
@@ -10677,49 +11481,70 @@ body::after {
 	    const text = $composeInput.value.trim();
 	    const originalText = $composeInput.value;
 	    const supportsMediaCaption = activePlatform === 'whatsapp' || activePlatform === 'signal';
+	    const replyToID = replyToMsg ? String(replyToMsg.MessageID || '') : '';
+	    const queuedSendCount = 1 + (text && !supportsMediaCaption ? 1 : 0);
+	    if (!queuedSendCapacityAvailable(queuedSendCount)) {
+	      showThreadFeedback(PENDING_SEND_CAPACITY_MESSAGE, 'send');
+	      return;
+	    }
 
 	    clearThreadFeedback();
 	    gifSending = true;
 	    $composeInput.value = '';
 	    composeTextByConversation.delete(sendConvoId);
+	    clearReply();
 	    autoResize();
+	    const queuedItems = [];
 
 	    try {
-	      const payload = {
+	      const gifItem = {
+	        id: queuedSendID(),
 	        conversation_id: sendConvoId,
-	        url: result.url,
+	        platform: activePlatform,
+	        type: 'gif',
+	        body: supportsMediaCaption ? text : '',
+	        reply_to_id: supportsMediaCaption ? replyToID : '',
+	        gif_url: result.url,
+	        preview_url: result.preview_url,
+	        file_name: result.title || 'GIF',
+	        mime_type: result.mime_type || 'image/gif',
+	        timestamp_ms: Date.now(),
+	        status: 'pending',
 	      };
-	      if (supportsMediaCaption && text) payload.caption = text;
-	      if (supportsMediaCaption && replyToMsg) payload.reply_to_id = replyToMsg.MessageID;
-	      await postJSON('/api/send-gif', payload);
+	      queuedItems.push(await enqueueQueuedSend(gifItem));
 
 	      if (text && !supportsMediaCaption) {
-	        const textPayload = {
+	        const textItem = {
+	          id: queuedSendID(),
 	          conversation_id: sendConvoId,
-	          message: text,
+	          platform: activePlatform,
+	          type: 'text',
+	          body: text,
+	          reply_to_id: replyToID,
+	          timestamp_ms: Date.now() + 1,
+	          status: 'pending',
 	        };
-	        if (replyToMsg) textPayload.reply_to_id = replyToMsg.MessageID;
-	        await postJSON('/api/send', textPayload);
+	        queuedItems.push(await enqueueQueuedSend(textItem));
+	      }
+	      const waitingItem = queuedItems.find(item => !queuedSendCanFlush(item));
+	      if (waitingItem) {
+	        showThreadFeedback(queuedSendWaitingMessage(waitingItem), 'send');
 	      }
 
 	      closeComposeGifPanel();
-	      clearReply();
-	      if (activeConvoId === sendConvoId) {
-	        if (threadSearchMode === 'centered') {
-	          clearThreadSearchUI();
-	          resetLoadedThreadState();
-	          await loadMessages(sendConvoId, {reset: true, forceBottom: true});
-	        } else {
-	          await loadMessages(sendConvoId, {poll: true, forceBottom: true});
-	        }
-	      }
-	      await loadConversations();
 	    } catch (err) {
+	      await Promise.all(queuedItems.map(item => removeQueuedSend(item.id).catch(removeErr => {
+	        console.warn('Failed to roll back queued GIF after enqueue failure:', removeErr);
+	      })));
 	      if (text) {
 	        if (activeConvoId === sendConvoId) {
 	          $composeInput.value = originalText;
 	        }
 	        rememberComposeText(sendConvoId, originalText);
+	      }
+	      if (activeConvoId === sendConvoId && replyToID) {
+	        const replyMessage = loadedMessages.find(m => String(m.MessageID || '') === replyToID);
+	        if (replyMessage) setReply(replyMessage);
 	      }
 	      showThreadFeedback(err.message || 'Failed to send GIF', 'send');
 	      throw err;
@@ -10762,20 +11587,9 @@ body::after {
   }
 
   // ─── Attachments (paste + file picker) ───
-  function setAttachment(file) {
-    if (composeSendInFlight) {
-      $fileInput.value = '';
-      return;
-    }
-    if (!conversationSupportsMediaOutbound(activeConversation)) {
-      showThreadFeedback('Attachments are unavailable on this route right now.');
-      return;
-    }
-    pendingFile = { file };
+  function renderAttachmentPreview(file) {
     $attachName.textContent = file.name || 'Attachment';
     $attachPreview.classList.add('active');
-    autoResize();
-
     if (file.type.startsWith('image/')) {
       const reader = new FileReader();
       reader.onload = e => { $attachThumb.src = e.target.result; $attachThumb.style.display = 'block'; };
@@ -10783,6 +11597,27 @@ body::after {
     } else {
       $attachThumb.style.display = 'none';
     }
+  }
+
+  function setAttachment(file) {
+    if (composeSendInFlight) {
+      $fileInput.value = '';
+      return;
+    }
+    if (!conversationCanQueueMediaOutbound(activeConversation)) {
+      showThreadFeedback('Attachments are unavailable on this route right now.');
+      return;
+    }
+    pendingFile = { file };
+    renderAttachmentPreview(file);
+    autoResize();
+  }
+
+  function restoreAttachment(file) {
+    if (!file) return;
+    pendingFile = { file };
+    renderAttachmentPreview(file);
+    autoResize();
   }
 
   function clearAttachment() {
@@ -10830,7 +11665,7 @@ body::after {
 	    $composeBar.addEventListener('dragover', event => {
 	      if (!dragEventHasFiles(event)) return;
 	      event.preventDefault();
-	      event.dataTransfer.dropEffect = conversationSupportsMediaOutbound(activeConversation) ? 'copy' : 'none';
+	      event.dataTransfer.dropEffect = conversationCanQueueMediaOutbound(activeConversation) ? 'copy' : 'none';
 	    });
 	    $composeBar.addEventListener('dragleave', event => {
 	      if (!dragEventHasFiles(event)) return;
@@ -10849,10 +11684,10 @@ body::after {
 
 	  // File picker button
 	  $attachBtn.addEventListener('click', () => {
-    if (!conversationSupportsMediaOutbound(activeConversation)) {
-      showThreadFeedback('Attachments are unavailable on this route right now.');
-      return;
-    }
+	    if (!conversationCanQueueMediaOutbound(activeConversation)) {
+	      showThreadFeedback('Attachments are unavailable on this route right now.');
+	      return;
+	    }
     $fileInput.click();
   });
   $fileInput.addEventListener('change', () => {
@@ -11051,6 +11886,7 @@ body::after {
     whatsAppStatus = normalizeWhatsAppStatus(appStatus.whatsapp || {});
     signalStatus = normalizeSignalStatus(appStatus.signal || {});
     backfillStatus = normalizeBackfillStatus(appStatus.backfill || {});
+    updateQueuedSendPlatformReadiness();
     // Only re-render when something the always-on UI actually shows changed.
     // The banner and empty state key off whether secondary platforms are
     // PAIRED, not their live connected flag — so a Signal/WhatsApp bridge
@@ -11067,7 +11903,10 @@ body::after {
       browserReportsOnline(), activeConvoId, overlayOpen,
       overlayOpen ? [whatsAppStatus, signalStatus] : null,
     ]);
-    if (sig === lastStatusRenderSig) return;
+    if (sig === lastStatusRenderSig) {
+      scheduleQueuedSendFlush();
+      return;
+    }
     lastStatusRenderSig = sig;
     setConnectionState();
     renderWhatsAppButton();
@@ -11078,6 +11917,7 @@ body::after {
     if (activeConversation) {
       refreshConversationChrome();
     }
+    scheduleQueuedSendFlush();
   }
 
   function showGoogleError(message, context = 'google') {
@@ -12148,6 +12988,10 @@ body::after {
         if (context.type === 'message' && context.message) {
           const message = context.message;
           const urls = extractMessageURLs(message.Body || '');
+          if (action === 'retry-queued-send') {
+            await retryQueuedSend(message.MessageID);
+            return;
+          }
           if (action === 'reply-message') {
             setReplyTo(message);
             return;
@@ -12308,6 +13152,7 @@ body::after {
     if (threadContentResizeObserver) {
       threadContentResizeObserver.disconnect();
     }
+    cleanupPDFPreviewURLs($messagesArea);
     $messagesArea.innerHTML = '';
     clearThreadFeedback();
     refreshConversationChrome();
@@ -12738,7 +13583,7 @@ body::after {
     networkIssueDetected = false;
     setConnectionState();
     autoResize();
-    showThreadFeedback(offlineFeedbackMessage());
+    showThreadFeedback('Offline. New messages will queue until you are back online.');
   });
 
   window.addEventListener('online', () => {
@@ -12751,7 +13596,8 @@ body::after {
     if (activeConvoId) {
       loadMessages(activeConvoId, {poll: true});
     }
-    showThreadFeedback('Back online. You can send messages again.');
+    scheduleQueuedSendFlush(0);
+    showThreadFeedback('Back online. Queued messages will send when their route is connected.');
   });
 
   if (navigator.webdriver) {
@@ -12828,8 +13674,10 @@ body::after {
   });
   startEventStream();
   loadTabs();
+  loadQueuedSends();
   loadConversations();
   checkStatus();
+  scheduleQueuedSendFlush(1000);
 
 })();
 </script>


### PR DESCRIPTION
## Summary

- Queue composer sends client-side when the browser or selected platform route is disconnected, clearing the composer immediately and rendering an outgoing sending bubble.
- Retry queued text and media sends when the relevant route reconnects, with failed sends left visible as failed bubbles instead of restoring text to the input.
- Render PDFs and other non-image attachments as openable attachment cards, with inline PDF preview support where the browser supports it.

## Validation

- `node -e "const fs=require('fs'); const html=fs.readFileSync('internal/web/static/index.html','utf8'); const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)].map(m=>m[1]); for (const s of scripts) new Function(s); console.log('parsed', scripts.length, 'script block(s)');"`
- `git diff --check`
- `go test ./internal/web`
- `go test ./...`
- `npx playwright test e2e/ui.spec.js -g "queues a text|renders a sent PDF|failed outgoing"`
- `npx playwright test` (70 passed)

## Notes

Queued attachment blobs are stored in browser IndexedDB for the same browser profile. If that storage is cleared before reconnect, the queued attachment fails visibly rather than silently disappearing.