### PR TITLE
Fix dead "Pair in inbox" button: export overlay global + reliable native delivery

### DIFF
--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -100,6 +100,18 @@ test.beforeEach(async ({ page, request }) => {
   await page.goto('/');
 });
 
+test('native bridge global window.openWhatsAppOverlay opens the platforms overlay', async ({ page }) => {
+  // The macOS wrapper's "Pair in inbox" / menu-bar alert buttons call this via
+  // evaluateJavaScript. The app script is an IIFE, so the function must be
+  // explicitly exported on window — a missing export fails silently in the
+  // native app (the button "does nothing"), which is exactly what this guards.
+  await expect
+    .poll(async () => page.evaluate(() => typeof window.openWhatsAppOverlay))
+    .toBe('function');
+  await page.evaluate(() => window.openWhatsAppOverlay());
+  await expect(page.locator('#wa-overlay.show h2')).toHaveText('Platforms');
+});
+
 test('loads the seeded conversation list and thread view', async ({ page }) => {
   await expect(page.locator('#connection-banner.disconnected')).toHaveCount(0);
   await expect

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -13600,6 +13600,13 @@ body::after {
     showThreadFeedback('Back online. Queued messages will send when their route is connected.');
   });
 
+  // Native macOS app bridge. The Swift wrapper opens the Platforms overlay via
+  // evaluateJavaScript from Settings ("Pair in inbox") and the menu-bar alert.
+  // Everything in this file lives inside an IIFE, so the function must be
+  // exported explicitly — without this the native call's typeof guard sees
+  // undefined and silently does nothing.
+  window.openWhatsAppOverlay = openWhatsAppOverlay;
+
   if (navigator.webdriver) {
     window.__openMessageTestHooks = {
       updateLoadedMessage(messageID, patch = {}) {

--- a/macos/OpenMessage/Sources/ContentView.swift
+++ b/macos/OpenMessage/Sources/ContentView.swift
@@ -180,29 +180,17 @@ struct WebViewContainer: NSViewRepresentable {
 
     final class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
         static let handlerName = "openmessageNotifications"
-        private static let openPlatformsScript = "if (typeof openWhatsAppOverlay === 'function') { openWhatsAppOverlay().catch(err => console.error('Failed to open platforms from native settings:', err)); }"
 
         var backend: BackendManager
         var notifications: NotificationManager
         var contacts: ContactsManager
         weak var webView: WKWebView?
-        private var shouldOpenPlatformsAfterLoad = false
 
         init(backend: BackendManager, notifications: NotificationManager, contacts: ContactsManager) {
             self.backend = backend
             self.notifications = notifications
             self.contacts = contacts
             super.init()
-            NotificationCenter.default.addObserver(
-                self,
-                selector: #selector(handleOpenPlatformsNotification),
-                name: .openPlatformsRequested,
-                object: nil
-            )
-        }
-
-        deinit {
-            NotificationCenter.default.removeObserver(self)
         }
 
         func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
@@ -250,14 +238,12 @@ struct WebViewContainer: NSViewRepresentable {
             decisionHandler(.allow)
         }
 
+        @MainActor
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            guard shouldOpenPlatformsAfterLoad else { return }
-            shouldOpenPlatformsAfterLoad = false
-            openPlatforms()
-        }
-
-        @objc private func handleOpenPlatformsNotification() {
-            openPlatforms()
+            // Deliver any Platforms-overlay request that arrived while no
+            // interactive page existed (window closed, pairing screen, or
+            // mid-load) — the bridge holds the pending flag.
+            WebViewBridge.shared.webViewDidFinishLoad()
         }
 
         private func resolve<T: Encodable>(requestID: String, payload: T) {
@@ -301,17 +287,5 @@ struct WebViewContainer: NSViewRepresentable {
             webView.evaluateJavaScript("window.__openMessageResolveNativeNotifications(\(requestJSON), null);")
         }
 
-        private func openPlatforms() {
-            NSApp.activate(ignoringOtherApps: true)
-            guard let webView else {
-                shouldOpenPlatformsAfterLoad = true
-                return
-            }
-            if webView.isLoading {
-                shouldOpenPlatformsAfterLoad = true
-                return
-            }
-            webView.evaluateJavaScript(Self.openPlatformsScript)
-        }
     }
 }

--- a/macos/OpenMessage/Sources/MenuBarView.swift
+++ b/macos/OpenMessage/Sources/MenuBarView.swift
@@ -25,8 +25,7 @@ struct MenuBarView: View {
                 Divider()
                 Button {
                     openWindow(id: "main")
-                    NSApp.activate(ignoringOtherApps: true)
-                    NotificationCenter.default.post(name: .openPlatformsRequested, object: nil)
+                    WebViewBridge.shared.requestOpenPlatforms()
                 } label: {
                     HStack(alignment: .top, spacing: 8) {
                         Image(systemName: "exclamationmark.triangle.fill")

--- a/macos/OpenMessage/Sources/OpenMessageApp.swift
+++ b/macos/OpenMessage/Sources/OpenMessageApp.swift
@@ -40,9 +40,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @unchecked Sendable {
     }
 }
 
-extension Notification.Name {
-    static let openPlatformsRequested = Notification.Name("OpenMessageOpenPlatformsRequested")
-}
 
 @MainActor
 private final class SettingsViewModel: ObservableObject {
@@ -564,8 +561,10 @@ private struct AppSettingsView: View {
 
     private func openPlatformsInMainWindow() {
         openMainWindow()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            NotificationCenter.default.post(name: .openPlatformsRequested, object: nil)
-        }
+        // Direct call, not a NotificationCenter post: if the main window was
+        // closed there is no coordinator alive to observe a notification, and
+        // a fixed delay races window creation. The bridge remembers the
+        // request and delivers it once the web view finishes loading.
+        WebViewBridge.shared.requestOpenPlatforms()
     }
 }

--- a/macos/OpenMessage/Sources/WebViewBridge.swift
+++ b/macos/OpenMessage/Sources/WebViewBridge.swift
@@ -1,17 +1,34 @@
+import AppKit
 import Foundation
 import WebKit
 
-/// Lets non-view components (notifications) talk to the app's single
-/// WKWebView: open a conversation on banner tap, and read which
-/// conversation is on screen for foreground suppression. Both directions
-/// ride on contracts the web UI already maintains — it keeps the active
-/// conversation synced into `?conversation=` and restores it from the same
-/// query parameter on load — so no extra JS globals are needed.
+/// Lets non-view components (notifications, Settings, the menu bar) talk to
+/// the app's single WKWebView: open a conversation on banner tap, read which
+/// conversation is on screen for foreground suppression, and open the
+/// Platforms overlay. Both directions ride on contracts the web UI already
+/// maintains — it keeps the active conversation synced into `?conversation=`
+/// and restores it from the same query parameter on load, and it exports
+/// `window.openWhatsAppOverlay` for the platforms flow.
 @MainActor
 final class WebViewBridge {
     static let shared = WebViewBridge()
 
     weak var webView: WKWebView?
+
+    /// Set when the Platforms overlay was requested before the web UI could
+    /// take it (main window closed so no web view exists yet, backend still
+    /// on the pairing screen, or the page mid-load); consumed on the next
+    /// successful page load. A plain NotificationCenter post can't cover
+    /// those cases — there is no observer alive to hear it.
+    private var pendingOpenPlatforms = false
+
+    /// The web UI exports this as a real window global (the app script is an
+    /// IIFE, so un-exported functions are invisible to evaluateJavaScript).
+    private static let openPlatformsScript = """
+    if (typeof window.openWhatsAppOverlay === 'function') { \
+    window.openWhatsAppOverlay().catch(err => console.error('Failed to open platforms from native UI:', err)); \
+    } else { console.error('Native bridge: window.openWhatsAppOverlay is not exported'); }
+    """
 
     /// Navigates the UI to a conversation via the existing deep-link path.
     func openConversation(_ conversationID: String) {
@@ -29,5 +46,35 @@ final class WebViewBridge {
         let result = try? await webView.evaluateJavaScript(js)
         guard let id = result as? String, !id.isEmpty else { return nil }
         return id
+    }
+
+    /// Opens the Platforms overlay in the web UI, bringing the main window
+    /// forward. Safe to call while the window is closed or the page is still
+    /// loading — the request is remembered and fires after the next load.
+    /// Callers that can create the main window (a scene with
+    /// `@Environment(\.openWindow)`) should call `openWindow(id: "main")`
+    /// first so a closed window is materialized.
+    func requestOpenPlatforms() {
+        NSApp.activate(ignoringOtherApps: true)
+        guard let webView else {
+            pendingOpenPlatforms = true
+            return
+        }
+        webView.window?.makeKeyAndOrderFront(nil)
+        guard !webView.isLoading else {
+            pendingOpenPlatforms = true
+            return
+        }
+        webView.evaluateJavaScript(Self.openPlatformsScript)
+    }
+
+    /// Called by the web view's navigation delegate after each successful
+    /// load; delivers a platforms request that arrived while no interactive
+    /// page existed.
+    func webViewDidFinishLoad() {
+        guard pendingOpenPlatforms else { return }
+        pendingOpenPlatforms = false
+        webView?.window?.makeKeyAndOrderFront(nil)
+        webView?.evaluateJavaScript(Self.openPlatformsScript)
     }
 }


### PR DESCRIPTION
## Problem

Clicking **Pair in inbox** (Settings → Platforms → WhatsApp/Signal), **Reconnect in inbox**, or the menu-bar re-pair alert did nothing. Both halves of the native→web handoff were broken, each silently:

1. **The JS target was never a global.** The web UI script is one big IIFE; `openWhatsAppOverlay` is scoped inside it. The native call
   ```js
   if (typeof openWhatsAppOverlay === 'function') { openWhatsAppOverlay() }
   ```
   evaluated in the page's global scope, saw `undefined`, and did nothing — the guard made the failure invisible. Broken since the buttons shipped in #68.

2. **Delivery raced window creation.** The Settings button posted `.openPlatformsRequested` after a fixed 0.2 s; the only observer lived in the WKWebView coordinator, which **doesn't exist while the main window is closed** — the notification fired into the void. (The app lives in the menu bar with the window often closed, so this was the common case.)

## Fix

- **Web:** export `window.openWhatsAppOverlay = openWhatsAppOverlay` (with a comment explaining why the export must exist).
- **Native:** move the open-platforms logic into `WebViewBridge` — an always-alive `@MainActor` singleton that already holds the webView. `requestOpenPlatforms()` activates the app, orders the window front, and either evaluates the script immediately or arms a pending flag consumed by the navigation delegate's `didFinish` (covers: window closed, pairing screen, page mid-load). Settings and menu-bar callers invoke it directly; the NotificationCenter hop, the 0.2 s delay, the coordinator's private flag, and the unused `Notification.Name` are gone. The script now also logs an explicit console error if the export is missing, instead of failing silently.

## Regression coverage

New e2e test drives the exact native contract: asserts `window.openWhatsAppOverlay` is a function and that calling it opens the Platforms overlay. A future IIFE/module refactor that drops the export fails CI instead of silently killing the native buttons.

## Testing

- Full Playwright suite: **88/88 pass** (includes the new test)
- `go build` / `go test ./internal/web/ ./cmd/` green (HTML is go:embed'd)
- `swift build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
