### PR TITLE
New Message: start chats on WhatsApp or Signal, not just SMS

### DIFF
--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -657,6 +657,37 @@ test('starts a prefilled new message for members without a direct chat', async (
 
   await expect(page.locator('#new-msg-overlay')).toHaveClass(/show/);
   await expect(page.locator('#new-msg-phone')).toHaveValue('+14155550123');
+  // A WhatsApp group member starts a WhatsApp chat, not SMS.
+  await expect(page.locator('.new-msg-platform-chip[data-platform="whatsapp"]')).toHaveClass(/active/);
+  await expect(page.locator('#new-msg-go')).toHaveText('Start WhatsApp chat');
+});
+
+test('starts a new WhatsApp chat with a number from the platform picker', async ({ page }) => {
+  await page.locator('#new-msg-btn').click();
+  await expect(page.locator('#new-msg-overlay')).toHaveClass(/show/);
+  // The pencil button must open a clean dialog (no event-object prefill).
+  await expect(page.locator('#new-msg-phone')).toHaveValue('');
+  await expect(page.locator('.new-msg-platform-chip[data-platform="sms"]')).toHaveClass(/active/);
+
+  await page.locator('.new-msg-platform-chip[data-platform="whatsapp"]').click();
+  await expect(page.locator('#new-msg-helper')).toContainText('Starts a WhatsApp chat');
+  await page.locator('#new-msg-phone').fill('+1 415 555 9876');
+  await page.locator('#new-msg-go').click();
+
+  await expect(page.locator('#chat-header-name')).toHaveText('+14155559876');
+  await expect(page.locator('#chat-header-source')).toContainText('WhatsApp');
+  await expect(page.locator('#new-msg-overlay')).not.toHaveClass(/show/);
+});
+
+test('requires a country code for new WhatsApp and Signal chats', async ({ page }) => {
+  await page.locator('#new-msg-btn').click();
+  await page.locator('.new-msg-platform-chip[data-platform="signal"]').click();
+  await expect(page.locator('#new-msg-go')).toHaveText('Start Signal chat');
+  await page.locator('#new-msg-phone').fill('4155550123');
+  await page.locator('#new-msg-go').click();
+
+  await expect(page.locator('#new-msg-error')).toContainText('country code');
+  await expect(page.locator('#new-msg-overlay')).toHaveClass(/show/);
 });
 
 test('searches only within the active thread', async ({ page }) => {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -2087,6 +2087,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		}
 		var req struct {
 			PhoneNumber string `json:"phone_number"`
+			Platform    string `json:"platform"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			httpError(w, "invalid JSON: "+err.Error(), 400)
@@ -2096,6 +2097,63 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "phone_number is required", 400)
 			return
 		}
+		platform := strings.ToLower(strings.TrimSpace(req.Platform))
+		if platform == "" {
+			platform = "sms"
+		}
+
+		// WhatsApp and Signal route by explicit identifier (JID / E.164
+		// account), so the thread can be created locally without the platform
+		// being connected; the first send resolves the recipient. SMS goes
+		// through Google Messages, which owns conversation creation.
+		if platform == "whatsapp" || platform == "signal" {
+			number, err := normalizeInternationalNumber(req.PhoneNumber)
+			if err != nil {
+				httpError(w, err.Error(), 400)
+				return
+			}
+			convoID := "signal:" + number
+			if platform == "whatsapp" {
+				convoID = "whatsapp:" + strings.TrimPrefix(number, "+") + "@s.whatsapp.net"
+			}
+			if existing, err := store.GetConversation(convoID); err == nil && existing != nil {
+				writeJSON(w, map[string]any{
+					"conversation_id": existing.ConversationID,
+					"name":            existing.Name,
+				})
+				return
+			}
+			name := contactNameForNumber(store, number)
+			if name == "" {
+				name = number
+			}
+			participants, err := json.Marshal([]map[string]any{{"name": name, "number": number}})
+			if err != nil {
+				httpError(w, "encode participants: "+err.Error(), 500)
+				return
+			}
+			if err := store.UpsertConversation(&db.Conversation{
+				ConversationID: convoID,
+				Name:           name,
+				Participants:   string(participants),
+				LastMessageTS:  time.Now().UnixMilli(),
+				SourcePlatform: platform,
+			}); err != nil {
+				httpError(w, "create conversation: "+err.Error(), 500)
+				return
+			}
+			publishConversations()
+			writeJSON(w, map[string]any{
+				"conversation_id": convoID,
+				"name":            name,
+			})
+			return
+		}
+		if platform != "sms" {
+			httpError(w, "unsupported platform: "+platform, 400)
+			return
+		}
+
 		cli := getClient()
 		if cli == nil {
 			httpError(w, app.ErrNotConnected, 503)
@@ -3258,6 +3316,61 @@ func httpError(w http.ResponseWriter, msg string, code int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+// normalizeInternationalNumber validates a user-entered number for platforms
+// that route by explicit E.164 identifier (WhatsApp JIDs, Signal accounts).
+// Google Messages resolves local formats server-side; WhatsApp and Signal
+// have no such resolution, so the country code must be explicit.
+func normalizeInternationalNumber(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if !strings.HasPrefix(trimmed, "+") {
+		return "", errors.New("include the country code, e.g. +14155551234")
+	}
+	var digits strings.Builder
+	for _, r := range trimmed[1:] {
+		switch {
+		case r >= '0' && r <= '9':
+			digits.WriteRune(r)
+		case r == ' ' || r == '-' || r == '(' || r == ')' || r == '.':
+		default:
+			return "", errors.New("that doesn't look like a phone number")
+		}
+	}
+	number := digits.String()
+	if len(number) < 8 || len(number) > 15 {
+		return "", errors.New("include the country code, e.g. +14155551234")
+	}
+	return "+" + number, nil
+}
+
+// contactNameForNumber resolves a display name for a number from the contacts
+// table, falling back to names seen in conversation participants.
+func contactNameForNumber(store *db.Store, number string) string {
+	digits := strings.TrimPrefix(number, "+")
+	pick := func(contacts []*db.Contact, err error) string {
+		if err != nil {
+			return ""
+		}
+		for _, c := range contacts {
+			if c == nil {
+				continue
+			}
+			name := strings.TrimSpace(c.Name)
+			if name == "" || name == number || name == digits {
+				continue
+			}
+			if _, numErr := normalizeInternationalNumber(name); numErr == nil {
+				continue // a bare number posing as a name is not a name
+			}
+			return name
+		}
+		return ""
+	}
+	if name := pick(store.ListContacts(digits, 5)); name != "" {
+		return name
+	}
+	return pick(store.ListContactsFromConversations(digits, 5))
 }
 
 func googleAPIErrorMessage(action string, err error) string {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -3814,3 +3814,122 @@ func (zeroReader) Read(p []byte) (int, error) {
 	}
 	return len(p), nil
 }
+
+func TestNewConversationWhatsAppPlatform(t *testing.T) {
+	ts := newTestServer(t)
+
+	body := `{"phone_number":"+1 (415) 555-0123","platform":"whatsapp"}`
+	resp, err := http.Post(ts.server.URL+"/api/new-conversation", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var got struct {
+		ConversationID string `json:"conversation_id"`
+		Name           string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ConversationID != "whatsapp:14155550123@s.whatsapp.net" {
+		t.Errorf("conversation_id = %q", got.ConversationID)
+	}
+	if got.Name != "+14155550123" {
+		t.Errorf("name = %q", got.Name)
+	}
+
+	conv, err := ts.store.GetConversation(got.ConversationID)
+	if err != nil || conv == nil {
+		t.Fatalf("conversation not stored: %v", err)
+	}
+	if conv.SourcePlatform != "whatsapp" {
+		t.Errorf("source_platform = %q", conv.SourcePlatform)
+	}
+	if !strings.Contains(conv.Participants, "+14155550123") {
+		t.Errorf("participants = %q", conv.Participants)
+	}
+
+	// Creating the same thread again reuses it rather than resetting it.
+	resp2, err := http.Post(ts.server.URL+"/api/new-conversation", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	var got2 struct {
+		ConversationID string `json:"conversation_id"`
+	}
+	if err := json.NewDecoder(resp2.Body).Decode(&got2); err != nil {
+		t.Fatal(err)
+	}
+	if got2.ConversationID != got.ConversationID {
+		t.Errorf("second call returned %q, want %q", got2.ConversationID, got.ConversationID)
+	}
+}
+
+func TestNewConversationSignalPlatformUsesContactName(t *testing.T) {
+	ts := newTestServer(t)
+	if err := ts.store.UpsertContact(&db.Contact{ContactID: "c-ada", Name: "Ada Lovelace", Number: "+14155550777"}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Post(ts.server.URL+"/api/new-conversation", "application/json",
+		strings.NewReader(`{"phone_number":"+14155550777","platform":"signal"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var got struct {
+		ConversationID string `json:"conversation_id"`
+		Name           string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ConversationID != "signal:+14155550777" {
+		t.Errorf("conversation_id = %q", got.ConversationID)
+	}
+	if got.Name != "Ada Lovelace" {
+		t.Errorf("name = %q", got.Name)
+	}
+}
+
+func TestNewConversationPlatformValidation(t *testing.T) {
+	ts := newTestServer(t)
+
+	cases := []struct {
+		name string
+		body string
+		code int
+		want string
+	}{
+		{"missing country code", `{"phone_number":"4155550123","platform":"whatsapp"}`, 400, "country code"},
+		{"garbage number", `{"phone_number":"+not-a-number","platform":"signal"}`, 400, "phone number"},
+		{"unsupported platform", `{"phone_number":"+14155550123","platform":"telegram"}`, 400, "unsupported platform"},
+		{"sms without google client", `{"phone_number":"4155550123"}`, 503, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := http.Post(ts.server.URL+"/api/new-conversation", "application/json", strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != tc.code {
+				t.Fatalf("expected %d, got %d", tc.code, resp.StatusCode)
+			}
+			if tc.want == "" {
+				return
+			}
+			raw, _ := io.ReadAll(resp.Body)
+			if !strings.Contains(string(raw), tc.want) {
+				t.Errorf("body %q does not mention %q", raw, tc.want)
+			}
+		})
+	}
+}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -286,6 +286,35 @@ html, body {
   border-color: var(--border-accent);
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
+.new-msg-platforms {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.new-msg-platform-chip {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  padding: 5px 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.new-msg-platform-chip:hover:not(.active) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.new-msg-platform-chip.active {
+  background: var(--accent);
+  color: var(--bg-deep);
+  border-color: transparent;
+}
+
 .new-msg-go {
   margin-top: 12px;
   width: 100%;
@@ -5460,6 +5489,11 @@ body::after {
           spellcheck="false"
         >
         <div class="new-msg-suggestions" id="new-msg-suggestions" role="listbox" hidden></div>
+        <div class="new-msg-platforms" id="new-msg-platforms" role="group" aria-label="Start the conversation on">
+          <button type="button" class="new-msg-platform-chip active" data-platform="sms" aria-pressed="true">SMS</button>
+          <button type="button" class="new-msg-platform-chip" data-platform="whatsapp" aria-pressed="false">WhatsApp</button>
+          <button type="button" class="new-msg-platform-chip" data-platform="signal" aria-pressed="false">Signal</button>
+        </div>
         <div class="new-msg-helper" id="new-msg-helper">New conversations start on SMS. If this number already exists on another route, choose it explicitly below.</div>
         <div class="new-msg-routes" id="new-msg-routes"></div>
         <button class="new-msg-go" id="new-msg-go">Start conversation</button>
@@ -7338,8 +7372,11 @@ body::after {
           }
           const number = row.dataset.messageNumber || '';
           if (!number) return;
+          const platform = sourcePlatformOf(activeConversation);
           closeContactPopover();
-          openNewMsg(number);
+          // Start the new chat on the group's own platform (a WhatsApp group
+          // member should get a WhatsApp chat), falling back to SMS.
+          openNewMsg(number, platform === 'whatsapp' || platform === 'signal' ? platform : 'sms');
         };
         row.addEventListener('click', () => { activate().catch(() => {}); });
         row.addEventListener('keydown', (event) => {
@@ -13781,6 +13818,39 @@ body::after {
   });
 
   // ─── New Message ───
+  const $newMsgPlatforms = document.getElementById('new-msg-platforms');
+  let newMsgPlatform = 'sms';
+
+  function newMessageStartLabel() {
+    if (newMsgPlatform === 'whatsapp') return 'Start WhatsApp chat';
+    if (newMsgPlatform === 'signal') return 'Start Signal chat';
+    return 'Start conversation';
+  }
+
+  function newMessagePlatformHelperText() {
+    if (newMsgPlatform === 'whatsapp' || newMsgPlatform === 'signal') {
+      const label = platformMeta(newMsgPlatform).label;
+      const status = newMsgPlatform === 'whatsapp' ? whatsAppStatus : signalStatus;
+      const pairedNote = (status.connected || status.paired)
+        ? ''
+        : ` ${label} is not paired yet — the thread opens now and sending works once it is.`;
+      return `Starts a ${label} chat. Include the country code, e.g. +14155551234.${pairedNote}`;
+    }
+    return 'New conversations start on SMS. If this number already exists on another route, choose it explicitly below.';
+  }
+
+  function setNewMsgPlatform(platform) {
+    newMsgPlatform = platform === 'whatsapp' || platform === 'signal' ? platform : 'sms';
+    if ($newMsgPlatforms) {
+      $newMsgPlatforms.querySelectorAll('.new-msg-platform-chip').forEach(chip => {
+        const active = chip.dataset.platform === newMsgPlatform;
+        chip.classList.toggle('active', active);
+        chip.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+    }
+    updateNewMessageRoutes();
+  }
+
   function updateNewMessageRoutes() {
     const phone = $newMsgPhone.value.trim().replace(/[\s\-()]/g, '');
     const routes = matchingRoutesForPhone(phone);
@@ -13789,8 +13859,8 @@ body::after {
     if (!phone || !routes.length) {
       $newMsgRoutes.classList.remove('active');
       $newMsgRoutes.innerHTML = '';
-      $newMsgHelper.textContent = 'New conversations start on SMS. If this number already exists on another route, choose it explicitly below.';
-      $newMsgGo.textContent = 'Start conversation';
+      $newMsgHelper.textContent = newMessagePlatformHelperText();
+      $newMsgGo.textContent = newMessageStartLabel();
       return;
     }
 
@@ -13809,17 +13879,20 @@ body::after {
     }, '', 1);
   }
 
-  function openNewMsg(prefillNumber = '') {
+  function openNewMsg(prefillNumber = '', platform = 'sms') {
     $newMsgOverlay.classList.add('show');
-    $newMsgPhone.value = String(prefillNumber || '');
+    $newMsgPhone.value = typeof prefillNumber === 'string' ? prefillNumber : '';
     $newMsgError.style.display = 'none';
     $newMsgGo.disabled = false;
-    $newMsgGo.textContent = 'Start conversation';
-    $newMsgHelper.textContent = 'Type a name from your contacts, or paste a phone number.';
     $newMsgRoutes.classList.remove('active');
     $newMsgRoutes.innerHTML = '';
     hideSuggestions();
-    if ($newMsgPhone.value.trim()) updateNewMessageRoutes();
+    // Sets the chip state and refreshes helper text, button label, and the
+    // existing-routes panel for whatever number is prefilled.
+    setNewMsgPlatform(platform);
+    if (!$newMsgPhone.value.trim()) {
+      $newMsgHelper.textContent = 'Type a name from your contacts, or paste a phone number.';
+    }
     setTimeout(() => $newMsgPhone.focus(), 100);
   }
 
@@ -13954,7 +14027,12 @@ body::after {
     }
 
     const phone = raw.replace(/[\s\-()]/g, '');
-    const existingReplyRoute = preferredReplyRoute(matchingRoutesForPhone(phone));
+    // On an explicit WhatsApp/Signal pick, only reuse a same-platform route;
+    // otherwise keep the SMS default of preferring any existing reply route.
+    const matchingRoutes = matchingRoutesForPhone(phone);
+    const existingReplyRoute = newMsgPlatform === 'sms'
+      ? preferredReplyRoute(matchingRoutes)
+      : matchingRoutes.find(route => sourcePlatformOf(route) === newMsgPlatform) || null;
     if (existingReplyRoute) {
       closeNewMsg();
       await revealAndSelectConversation(existingReplyRoute);
@@ -13978,7 +14056,7 @@ body::after {
       const resp = await fetch(API + '/api/new-conversation', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone_number: phone }),
+        body: JSON.stringify({ phone_number: phone, platform: newMsgPlatform }),
         signal: controller.signal,
       });
       if (!resp.ok) {
@@ -14001,17 +14079,25 @@ body::after {
     } catch (err) {
       const isAbort = err && err.name === 'AbortError';
       $newMsgError.textContent = isAbort
-        ? 'Request timed out. Check that Google Messages is paired and try again.'
+        ? (newMsgPlatform === 'sms'
+          ? 'Request timed out. Check that Google Messages is paired and try again.'
+          : 'Request timed out. Try again.')
         : (userFacingErrorMessage(err, 'start-conversation') || 'Failed to start conversation');
       $newMsgError.style.display = 'block';
       $newMsgGo.disabled = false;
-      $newMsgGo.textContent = 'Start conversation';
+      $newMsgGo.textContent = newMessageStartLabel();
     } finally {
       clearTimeout(timeoutId);
     }
   }
 
-  $newMsgBtn.addEventListener('click', openNewMsg);
+  // Wrapped so the click event doesn't land in openNewMsg's prefill param.
+  $newMsgBtn.addEventListener('click', () => openNewMsg());
+  if ($newMsgPlatforms) {
+    $newMsgPlatforms.querySelectorAll('.new-msg-platform-chip').forEach(chip => {
+      chip.addEventListener('click', () => setNewMsgPlatform(chip.dataset.platform));
+    });
+  }
   if ($waClose) $waClose.addEventListener('click', closeWhatsAppOverlay);
   if ($waConnectBtn) $waConnectBtn.addEventListener('click', () => { connectWhatsAppBridge().catch(err => showWhatsAppError(err.message || 'Failed to connect WhatsApp')); });
   if ($waResetBtn) $waResetBtn.addEventListener('click', () => { resetWhatsAppBridge().catch(err => showWhatsAppError(err.message || 'Failed to reset WhatsApp')); });


### PR DESCRIPTION
## What

New conversations were hardcoded to SMS ("New conversations start on SMS"), with no way to text a new number on WhatsApp or Signal. Both platforms route by explicit identifier, so no Google-style conversation-creation call is needed.

- **Platform picker** in the New Message dialog: SMS (default) · WhatsApp · Signal. Helper text explains each, including an honest note when the platform is unpaired (thread opens now, sending works after pairing — the compose bar's existing gating handles the rest).
- **Backend**: `/api/new-conversation` accepts `platform`; WhatsApp threads get `whatsapp:<digits>@s.whatsapp.net`, Signal `signal:+E164`, created locally with participants and named from contacts when known. Country code required (clear 400 otherwise). Existing same-platform routes are reused, not duplicated.
- **Group members panel** (#80 follow-up): message actions preselect the group's platform — clicking an unknown member of a WhatsApp group starts a WhatsApp chat, which is the exact flow that motivated this.
- **Bug fix**: `$newMsgBtn.addEventListener('click', openNewMsg)` passed the click event into the new prefill parameter from #80 — the pencil button would have prefilled "[object PointerEvent]". Wrapped, with an e2e regression test asserting the dialog opens clean.

## Testing

- Go: 3 new tests (WhatsApp creation + idempotent reuse, Signal creation with contact-name resolution, validation matrix incl. country code and unsupported platform).
- Playwright: **98/98 passed** — new tests for the picker flow end-to-end (chip → helper → start → WhatsApp thread opens), country-code validation, clean-dialog regression, and member-action platform preselect.
- Visually verified on the demo server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
