### PR TITLE
New Message: start button mirrors the picked platform when routes exist

### DIFF
--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -679,6 +679,17 @@ test('starts a new WhatsApp chat with a number from the platform picker', async 
   await expect(page.locator('#new-msg-overlay')).not.toHaveClass(/show/);
 });
 
+test('start button reflects the picked platform when other routes exist', async ({ page }) => {
+  await page.locator('#new-msg-btn').click();
+  await page.locator('#new-msg-phone').fill('+14155551234'); // Sarah Chen: SMS-only
+  // SMS pick opens the existing route.
+  await expect(page.locator('#new-msg-go')).toHaveText(/Open .+ route/);
+  // WhatsApp pick starts a new WhatsApp chat instead of opening the SMS route.
+  await page.locator('.new-msg-platform-chip[data-platform="whatsapp"]').click();
+  await expect(page.locator('#new-msg-go')).toHaveText('Start WhatsApp chat');
+  await expect(page.locator('#new-msg-routes')).toContainText('Existing routes');
+});
+
 test('requires a country code for new WhatsApp and Signal chats', async ({ page }) => {
   await page.locator('#new-msg-btn').click();
   await page.locator('.new-msg-platform-chip[data-platform="signal"]').click();

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -13868,7 +13868,15 @@ body::after {
     $newMsgHelper.textContent = routeLabels.length > 1
       ? `This number already appears on ${routeLabels.join(' and ')}. Choose the route you want to reply from.`
       : `This number already has a ${routeLabels[0]} route.`;
-    $newMsgGo.textContent = replyRoute ? `Open ${platformMeta(displayPlatformForRoute(replyRoute)).label} route` : 'Start SMS conversation';
+    // The button mirrors what startNewConversation will actually do: open the
+    // picked platform's existing route if there is one, otherwise start a new
+    // thread on the picked platform.
+    const platformRoute = newMsgPlatform === 'sms'
+      ? replyRoute
+      : routes.find(route => sourcePlatformOf(route) === newMsgPlatform) || null;
+    $newMsgGo.textContent = platformRoute
+      ? `Open ${platformMeta(displayPlatformForRoute(platformRoute)).label} route`
+      : (newMsgPlatform === 'sms' ? 'Start SMS conversation' : newMessageStartLabel());
     $newMsgRoutes.classList.add('active');
     $newMsgRoutes.innerHTML = `<div class="new-msg-routes-caption">Existing routes</div>`;
     const routeHost = document.createElement('div');


### PR DESCRIPTION
Follow-up to #82. With WhatsApp/Signal picked and only an SMS route existing for the number, the button label came from the SMS-preferred reply route ("Open SMS route") while clicking it (correctly) created a new chat on the picked platform — label/action mismatch, observed live with a real number. The label now resolves through the same platform-aware logic as `startNewConversation`, and an e2e test pins it.

99/99 Playwright tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
