### PR TITLE
Harden media serving and bound uploads (rebuild Wave 0 / F5)

### DIFF
--- a/internal/tools/send_media_to_conversation.go
+++ b/internal/tools/send_media_to_conversation.go
@@ -62,6 +62,11 @@ func sendMediaToConversationTool() mcp.Tool {
 	)
 }
 
+// maxMediaUploadBytes bounds a single MCP media send. It mirrors the HTTP
+// upload cap so an MCP client cannot read an arbitrarily large local file fully
+// into memory and take the backend down.
+const maxMediaUploadBytes = 128 << 20
+
 func sendMediaToConversationHandler(a *app.App) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
@@ -86,6 +91,13 @@ func sendMediaToConversationHandler(a *app.App) server.ToolHandlerFunc {
 			return errorResult(fmt.Sprintf("conversation %s not found", conversationID)), nil
 		}
 
+		if info, err := os.Stat(filePath); err != nil {
+			return errorResult(fmt.Sprintf("stat file: %v", err)), nil
+		} else if info.IsDir() {
+			return errorResult("file_path must point to a file"), nil
+		} else if info.Size() > maxMediaUploadBytes {
+			return errorResult(fmt.Sprintf("file too large (%d bytes; limit %d MB)", info.Size(), maxMediaUploadBytes>>20)), nil
+		}
 		data, err := os.ReadFile(filePath)
 		if err != nil {
 			return errorResult(fmt.Sprintf("read file: %v", err)), nil

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -34,10 +34,12 @@ import (
 //go:embed static/*
 var staticFS embed.FS
 
-// maxUploadBytes bounds /api/send-media request bodies. 128MB sits above
-// every platform's attachment cap (Signal ~100MB, WhatsApp ~64MB, MMS ~1MB)
-// while keeping a runaway POST from exhausting memory.
-const maxUploadBytes = 128 << 20
+// maxUploadBytes bounds /api/send-media and /api/schedule-media request bodies.
+// 128MB sits above every platform's attachment cap (Signal ~100MB, WhatsApp
+// ~64MB, MMS ~1MB) while keeping a runaway POST from exhausting memory. It is a
+// var (not a const) only so tests can shrink it; it is never mutated in
+// production.
+var maxUploadBytes int64 = 128 << 20
 
 const maxTranscriptRequestBytes = db.MaxTranscriptBytes + db.MaxTranscriptModelBytes + 4096
 
@@ -1353,8 +1355,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "method not allowed", 405)
 			return
 		}
-		if err := r.ParseMultipartForm(25 << 20); err != nil {
-			httpError(w, "invalid multipart form: "+err.Error(), 400)
+		if !parseBoundedMultipartForm(w, r) {
 			return
 		}
 		convID := strings.TrimSpace(r.FormValue("conversation_id"))
@@ -1377,24 +1378,13 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "conversation not found", 400)
 			return
 		}
-		file, header, err := r.FormFile("file")
-		if err != nil {
-			httpError(w, "file is required: "+err.Error(), 400)
-			return
-		}
-		defer file.Close()
-		data, err := io.ReadAll(file)
-		if err != nil {
-			httpError(w, "read file: "+err.Error(), 500)
+		data, filename, mime, ok := readFormFile(w, r, "file")
+		if !ok {
 			return
 		}
 		if len(data) == 0 {
 			httpError(w, "file is empty", 400)
 			return
-		}
-		mime := header.Header.Get("Content-Type")
-		if mime == "" {
-			mime = "application/octet-stream"
 		}
 		sm := &db.ScheduledMessage{
 			ID:             scheduledID(),
@@ -1405,7 +1395,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			Status:         db.ScheduleStatusPending,
 			CreatedAt:      time.Now().UnixMilli(),
 			MediaData:      data,
-			MediaFilename:  header.Filename,
+			MediaFilename:  filename,
 			MediaMime:      mime,
 		}
 		if err := store.CreateScheduledMessage(sm); err != nil {
@@ -1823,19 +1813,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "method not allowed", 405)
 			return
 		}
-		// Cap the whole request body: ParseMultipartForm's argument only
-		// bounds the in-memory portion (the rest spills to disk), and the
-		// attachment is read fully into memory below — without this cap a
-		// single oversized POST can OOM the backend and take every live
-		// sync down with it.
-		r.Body = http.MaxBytesReader(w, r.Body, maxUploadBytes)
-		if err := r.ParseMultipartForm(10 << 20); err != nil {
-			var tooLarge *http.MaxBytesError
-			if errors.As(err, &tooLarge) {
-				httpError(w, fmt.Sprintf("attachment too large (limit %d MB)", maxUploadBytes>>20), http.StatusRequestEntityTooLarge)
-				return
-			}
-			httpError(w, "invalid multipart form: "+err.Error(), 400)
+		if !parseBoundedMultipartForm(w, r) {
 			return
 		}
 
@@ -1852,29 +1830,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return
 		}
 
-		file, header, err := r.FormFile("file")
-		if err != nil {
-			httpError(w, "file is required: "+err.Error(), 400)
+		data, filename, mime, ok := readFormFile(w, r, "file")
+		if !ok {
 			return
 		}
-		defer file.Close()
-
-		data, err := io.ReadAll(file)
-		if err != nil {
-			var tooLarge *http.MaxBytesError
-			if errors.As(err, &tooLarge) {
-				httpError(w, fmt.Sprintf("attachment too large (limit %d MB)", maxUploadBytes>>20), http.StatusRequestEntityTooLarge)
-				return
-			}
-			httpError(w, "read file: "+err.Error(), 500)
-			return
-		}
-
-		mime := header.Header.Get("Content-Type")
-		if mime == "" {
-			mime = "application/octet-stream"
-		}
-		sendMediaBytes(w, convID, data, header.Filename, mime, caption, replyToID, idempotencyKey)
+		sendMediaBytes(w, convID, data, filename, mime, caption, replyToID, idempotencyKey)
 	})
 
 	mux.HandleFunc("/api/media/", func(w http.ResponseWriter, r *http.Request) {
@@ -1905,9 +1865,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			if mimeType == "" {
 				mimeType = msg.MimeType
 			}
-			w.Header().Set("Content-Type", mimeType)
-			w.Header().Set("Cache-Control", "public, max-age=86400")
-			w.Write(data)
+			writeMediaResponse(w, data, "", mimeType)
 			return
 		}
 		if msg.SourcePlatform == "signal" || strings.HasPrefix(msg.MessageID, "signal:") || strings.HasPrefix(msg.MediaID, "signalatt:") {
@@ -1923,9 +1881,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			if mimeType == "" {
 				mimeType = msg.MimeType
 			}
-			w.Header().Set("Content-Type", mimeType)
-			w.Header().Set("Cache-Control", "public, max-age=86400")
-			w.Write(data)
+			writeMediaResponse(w, data, "", mimeType)
 			return
 		}
 		cli := getClient()
@@ -1945,9 +1901,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, googleAPIErrorMessage("download media", err), 502)
 			return
 		}
-		w.Header().Set("Content-Type", msg.MimeType)
-		w.Header().Set("Cache-Control", "public, max-age=86400")
-		w.Write(data)
+		writeMediaResponse(w, data, "", msg.MimeType)
 	})
 
 	mux.HandleFunc("/api/react", func(w http.ResponseWriter, r *http.Request) {
@@ -3316,6 +3270,147 @@ func httpError(w http.ResponseWriter, msg string, code int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+func normalizeMIME(mimeType string) string {
+	m := strings.ToLower(strings.TrimSpace(mimeType))
+	if i := strings.IndexByte(m, ';'); i >= 0 {
+		m = strings.TrimSpace(m[:i])
+	}
+	return m
+}
+
+// isPassiveInlineMIME reports whether a media type can be rendered inline in a
+// browser with no risk of executing script. SVG and the HTML/XML family are
+// excluded because they can carry <script>; anything not positively recognized
+// is treated as unsafe and downloaded instead.
+func isPassiveInlineMIME(mimeType string) bool {
+	m := normalizeMIME(mimeType)
+	switch {
+	case m == "image/svg+xml":
+		return false
+	case strings.HasPrefix(m, "image/"),
+		strings.HasPrefix(m, "audio/"),
+		strings.HasPrefix(m, "video/"):
+		return true
+	case m == "application/pdf", m == "text/plain":
+		return true
+	default:
+		return false
+	}
+}
+
+// isActiveMIME reports whether a sniffed type could be interpreted as
+// script-bearing markup. It rejects a payload declared as a passive type whose
+// bytes actually sniff as active content (a spoofed image/png that is really
+// HTML).
+func isActiveMIME(mimeType string) bool {
+	switch normalizeMIME(mimeType) {
+	case "text/html", "application/xhtml+xml", "image/svg+xml", "text/xml", "application/xml":
+		return true
+	}
+	return false
+}
+
+// sanitizeMediaFilename strips path components, control characters, and
+// header-breaking characters so a filename can be placed in a quoted
+// Content-Disposition value. Non-ASCII bytes are replaced to keep the header
+// well-formed; the result is never empty.
+func sanitizeMediaFilename(name string) string {
+	name = strings.TrimSpace(name)
+	if i := strings.LastIndexAny(name, "/\\"); i >= 0 {
+		name = name[i+1:]
+	}
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r < 0x20 || r == 0x7f, r == '"' || r == '\\':
+			// drop
+		case r > 0x7f:
+			b.WriteByte('_')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return "attachment"
+	}
+	return out
+}
+
+// writeMediaResponse serves attachment bytes so a sender-controlled file cannot
+// execute script on the API origin. Only a passive allowlist (image/audio/video/
+// pdf/plain text, never SVG) is served inline with its real type; everything
+// else — HTML, SVG, XML, unknown — is forced to an inert octet-stream download.
+// nosniff, a sandbox CSP, and same-origin CORP apply to every media response as
+// defense in depth. This is the single choke point for /api/media/ serving.
+func writeMediaResponse(w http.ResponseWriter, data []byte, filename, declaredMIME string) {
+	resolved := normalizeMIME(declaredMIME)
+	if resolved == "" {
+		resolved = "application/octet-stream"
+	}
+	inline := isPassiveInlineMIME(resolved) && !isActiveMIME(http.DetectContentType(data))
+
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Security-Policy", "sandbox; default-src 'none'")
+	w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
+	w.Header().Set("Cache-Control", "private, max-age=86400")
+
+	safe := sanitizeMediaFilename(filename)
+	if inline {
+		w.Header().Set("Content-Type", resolved)
+		w.Header().Set("Content-Disposition", `inline; filename="`+safe+`"`)
+	} else {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", `attachment; filename="`+safe+`"`)
+	}
+	_, _ = w.Write(data)
+}
+
+// parseBoundedMultipartForm caps the request body before parsing a multipart
+// upload, so an oversized POST cannot exhaust memory/disk/WAL before the
+// attachment size is known (ParseMultipartForm's own argument only bounds the
+// in-memory portion). It writes a 413/400 response and returns false on failure.
+func parseBoundedMultipartForm(w http.ResponseWriter, r *http.Request) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxUploadBytes)
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			httpError(w, fmt.Sprintf("attachment too large (limit %d MB)", maxUploadBytes>>20), http.StatusRequestEntityTooLarge)
+			return false
+		}
+		httpError(w, "invalid multipart form: "+err.Error(), 400)
+		return false
+	}
+	return true
+}
+
+// readFormFile reads a named multipart file fully into memory, enforcing the
+// body cap installed by parseBoundedMultipartForm (which callers must invoke
+// first). It writes an error response and returns ok=false on failure.
+func readFormFile(w http.ResponseWriter, r *http.Request, field string) (data []byte, filename, mime string, ok bool) {
+	file, header, err := r.FormFile(field)
+	if err != nil {
+		httpError(w, "file is required: "+err.Error(), 400)
+		return nil, "", "", false
+	}
+	defer file.Close()
+	data, err = io.ReadAll(file)
+	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			httpError(w, fmt.Sprintf("attachment too large (limit %d MB)", maxUploadBytes>>20), http.StatusRequestEntityTooLarge)
+			return nil, "", "", false
+		}
+		httpError(w, "read file: "+err.Error(), 500)
+		return nil, "", "", false
+	}
+	mime = header.Header.Get("Content-Type")
+	if mime == "" {
+		mime = "application/octet-stream"
+	}
+	return data, header.Filename, mime, true
 }
 
 // normalizeInternationalNumber validates a user-entered number for platforms

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -3933,3 +3933,106 @@ func TestNewConversationPlatformValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestMediaResponseHardening verifies /api/media/ never serves sender-controlled
+// active content (HTML/SVG, or a payload spoofed as an image) in a way that can
+// execute script on the API origin. Passive media stays inline. (F5)
+func TestMediaResponseHardening(t *testing.T) {
+	png := append([]byte("\x89PNG\r\n\x1a\n"), make([]byte, 64)...)
+	html := []byte("<html><body><script>alert(1)</script></body></html>")
+	svg := []byte(`<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`)
+
+	cases := []struct {
+		name       string
+		declared   string
+		body       []byte
+		wantInline bool
+		wantCT     string
+	}{
+		{"html served inert", "text/html", html, false, "application/octet-stream"},
+		{"svg served inert", "image/svg+xml", svg, false, "application/octet-stream"},
+		{"png stays inline", "image/png", png, true, "image/png"},
+		{"html spoofed as png served inert", "image/png", html, false, "application/octet-stream"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, declared := tc.body, tc.declared
+			ts := newTestServerWithOptions(t, APIOptions{
+				DownloadWhatsAppMedia: func(msg *db.Message) ([]byte, string, error) {
+					return body, declared, nil
+				},
+			})
+			if err := ts.store.UpsertConversation(&db.Conversation{ConversationID: "c1", Name: "A", LastMessageTS: 1}); err != nil {
+				t.Fatal(err)
+			}
+			if err := ts.store.UpsertMessage(&db.Message{
+				MessageID: "m1", ConversationID: "c1", MediaID: "wa:ref",
+				SourcePlatform: "whatsapp", MimeType: declared, TimestampMS: 1,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.Get(ts.server.URL + "/api/media/m1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 200 {
+				b, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status %d: %s", resp.StatusCode, b)
+			}
+			if got := resp.Header.Get("Content-Type"); got != tc.wantCT {
+				t.Errorf("Content-Type = %q, want %q", got, tc.wantCT)
+			}
+			wantDisp := "attachment"
+			if tc.wantInline {
+				wantDisp = "inline"
+			}
+			if disp := resp.Header.Get("Content-Disposition"); !strings.HasPrefix(disp, wantDisp) {
+				t.Errorf("Content-Disposition = %q, want prefix %q", disp, wantDisp)
+			}
+			if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+				t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
+			}
+			if got := resp.Header.Get("Content-Security-Policy"); got != "sandbox; default-src 'none'" {
+				t.Errorf("Content-Security-Policy = %q", got)
+			}
+		})
+	}
+}
+
+// TestScheduleMediaRejectsOversizedUpload proves /api/schedule-media now bounds
+// its body before parsing (it previously read the whole file with io.ReadAll and
+// no cap). (F5)
+func TestScheduleMediaRejectsOversizedUpload(t *testing.T) {
+	orig := maxUploadBytes
+	maxUploadBytes = 512
+	defer func() { maxUploadBytes = orig }()
+
+	ts := newTestServer(t)
+	if err := ts.store.UpsertConversation(&db.Conversation{ConversationID: "c1", Name: "A", LastMessageTS: 1}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("conversation_id", "c1")
+	_ = mw.WriteField("send_at", fmt.Sprint(time.Now().Add(time.Hour).UnixMilli()))
+	fw, err := mw.CreateFormFile("file", "big.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write(make([]byte, 4096)); err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(ts.server.URL+"/api/schedule-media", mw.FormDataContentType(), &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status %d, want 413: %s", resp.StatusCode, b)
+	}
+}


### PR DESCRIPTION
First PR of the staged re-architecture Sol (gpt-5.6-sol, ultra) designed from its own audit. This is **Wave 0 / F5** — the only finding a stranger can trigger by texting you, so it goes first.

## The bug

`/api/media/` served attachment bytes with the sender-controlled MIME type and **no `Content-Disposition`**, and the UI opens generic attachments in a new tab. A contact could send a `text/html` or SVG attachment that, once opened, ran inline script on `127.0.0.1:7007` — reading message history and calling send/unpair/backfill. The CSP allowed `'unsafe-inline'` and didn't stop top-level navigation. Separately, `/api/schedule-media` read the whole upload with `io.ReadAll` and **no size cap** (only `/api/send-media` was bounded), and the MCP media tool did an unbounded `os.ReadFile`.

## The fix

- **One media choke point.** All three `/api/media/` write points (WhatsApp / Signal / Google) go through `writeMediaResponse`: inline only a passive allowlist (`image/*` except SVG, `audio/*`, `video/*`, `application/pdf`, `text/plain`); everything else — HTML, SVG, XML, unknown, or a payload declared passive but sniffing active — is forced to an inert `application/octet-stream` attachment. Every media response now sets `Content-Disposition`, `Content-Security-Policy: sandbox; default-src 'none'`, `X-Content-Type-Options: nosniff`, and `Cross-Origin-Resource-Policy: same-origin`.
- **Bounded uploads.** Both multipart paths share `parseBoundedMultipartForm` / `readFormFile`, which install `MaxBytesReader` before parsing and return 413 past the limit. `schedule-media` was previously unbounded.
- **MCP cap.** The send-media tool stats and rejects files over the limit before reading.

## Testing

- New adversarial tests: html / svg / spoofed-png served inert, real png stays inline, oversize `schedule-media` → 413.
- `go test ./...` green; Playwright **99/99** green.

Note: implemented by Claude (Fable) rather than Sol because Codex hit its usage limit mid-run; Sol will review or drive subsequent Wave 0 PRs once its limit resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
