### PR TITLE
Default serve to web-only; make HTTP MCP opt-in (rebuild Wave 0 / F4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ The CLI accepts either a JSON cookie object or a full `curl` command for `messag
 ./openmessage serve
 ```
 
-This starts:
-- **Web UI** at [http://127.0.0.1:7007](http://127.0.0.1:7007)
-- **MCP Streamable HTTP endpoint** at `http://127.0.0.1:7007/mcp`
-- **MCP SSE endpoint** at `http://127.0.0.1:7007/mcp/sse`
+This starts the **Web UI** at [http://127.0.0.1:7007](http://127.0.0.1:7007). A bare `serve` is web-only.
 
-When `serve` is launched by an MCP client over pipes, it also serves MCP on stdio automatically.
+MCP transports require an explicit opt-in:
+
+- `./openmessage serve --mcp-sse` starts MCP Streamable HTTP and SSE without the web UI.
+- `./openmessage serve --web --mcp-sse` starts the web UI and both HTTP MCP endpoints.
+- `./openmessage serve --mcp-stdio` starts MCP over stdio for pipe-based clients.
 
 ### 3a. Optional: link WhatsApp or Signal
 
@@ -90,7 +91,7 @@ Add to `~/.mcp.json`:
   "mcpServers": {
     "openmessage": {
       "command": "/path/to/openmessage",
-      "args": ["serve"]
+      "args": ["serve", "--mcp-stdio"]
     }
   }
 }
@@ -98,7 +99,7 @@ Add to `~/.mcp.json`:
 
 Restart Claude Code. The MCP tools appear automatically.
 
-If a client connects to an already-running OpenMessage server instead of launching the binary, point it at:
+To let a client connect over HTTP, start OpenMessage with `--mcp-sse` (or `--web --mcp-sse` to keep the web UI), then point it at:
 
 - Streamable HTTP: `http://127.0.0.1:7007/mcp`
 - SSE: `http://127.0.0.1:7007/mcp/sse`
@@ -252,7 +253,7 @@ If you launch OpenMessage from the macOS app, launchd, systemd, or another super
 - Scheduled messages live in SQLite, are claimed atomically by the background scheduler, and retry when the target platform is temporarily disconnected
 - The web composer stores pending browser-side sends in local storage/IndexedDB and attaches idempotency keys to prevent duplicate delivery during retry
 - MCP tool handlers read from SQLite for queries and route sends through the same local runtime
-- MCP HTTP transport supports both Streamable HTTP at `/mcp` and SSE at `/mcp/sse`; stdio remains available when launched by an MCP client
+- MCP HTTP transport supports both Streamable HTTP at `/mcp` and SSE at `/mcp/sse` when enabled with `--mcp-sse`; stdio is available with `--mcp-stdio`
 - GIF and link-preview proxies validate remote URLs, cap downloads, and keep provider fetches inside the local backend
 - Auth tokens auto-refresh and persist to `session.json`; expired Google cookies can be refreshed by an optional script or surfaced as a guided re-pair flow
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -549,10 +549,7 @@ func RunDemo(logger zerolog.Logger) error {
 }
 
 func parseServeOptions(args []string) (serveOptions, error) {
-	opts := serveOptions{
-		web:    true,
-		mcpSSE: true,
-	}
+	opts := serveOptions{web: true}
 	transportFlagsSeen := false
 	enableExplicitTransportMode := func() {
 		if transportFlagsSeen {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -208,7 +208,7 @@ func TestGoogleStatusNeedsCookieRefreshUsesExplicitAuthExpiredFlag(t *testing.T)
 }
 
 func TestParseServeOptions(t *testing.T) {
-	t.Run("defaults to normal serve", func(t *testing.T) {
+	t.Run("defaults to web only", func(t *testing.T) {
 		opts, err := parseServeOptions(nil)
 		if err != nil {
 			t.Fatalf("parseServeOptions(): %v", err)
@@ -216,8 +216,28 @@ func TestParseServeOptions(t *testing.T) {
 		if opts.demo {
 			t.Fatal("expected demo=false by default")
 		}
-		if !opts.web || !opts.mcpSSE || opts.mcpStdio {
+		if !opts.web || opts.mcpSSE || opts.mcpStdio {
 			t.Fatalf("unexpected default serve options: %+v", opts)
+		}
+	})
+
+	t.Run("MCP SSE flag enables MCP SSE only", func(t *testing.T) {
+		opts, err := parseServeOptions([]string{"--mcp-sse"})
+		if err != nil {
+			t.Fatalf("parseServeOptions(): %v", err)
+		}
+		if opts.web || !opts.mcpSSE || opts.mcpStdio {
+			t.Fatalf("unexpected serve options: %+v", opts)
+		}
+	})
+
+	t.Run("web and MCP SSE can be enabled together", func(t *testing.T) {
+		opts, err := parseServeOptions([]string{"--web", "--mcp-sse"})
+		if err != nil {
+			t.Fatalf("parseServeOptions(): %v", err)
+		}
+		if !opts.web || !opts.mcpSSE || opts.mcpStdio {
+			t.Fatalf("unexpected serve options: %+v", opts)
 		}
 	})
 

--- a/macos/OpenMessage/Sources/BackendManager.swift
+++ b/macos/OpenMessage/Sources/BackendManager.swift
@@ -164,7 +164,7 @@ final class BackendManager: ObservableObject {
         let path = binaryPath
         let dir = dataDir
         proc.executableURL = URL(fileURLWithPath: path)
-        proc.arguments = ["serve"]
+        proc.arguments = ["serve", "--web"]
         proc.currentDirectoryURL = URL(fileURLWithPath: dir, isDirectory: true)
         proc.environment = [
             "OPENMESSAGES_PORT": String(port),


### PR DESCRIPTION
Wave 0 / F4 of the staged re-architecture — the #2 security fix in Sol's roadmap after F5. Implemented by Sol (gpt-5.6-sol), reviewed/verified by Claude.

## The bug (review finding #7)

The macOS app launches a bare `serve`, which defaulted to `{web: true, mcpSSE: true}` — so every shipped install exposed the unauthenticated **MCP SSE/HTTP** surface on `127.0.0.1:7007` alongside the UI. A local process (or a model with local network access) could drive the full MCP tool set. The Host/Origin guard blocks hostile web pages but is not authentication.

## The fix

- `parseServeOptions` now defaults to **web-only**. MCP SSE/HTTP requires an explicit `--mcp-sse`; stdio requires `--mcp-stdio`. Every existing flag, the first-flag reset, and the "at least one transport" guard are unchanged. So bare `serve` → web only; `serve --mcp-sse` → MCP only; `serve --web --mcp-sse` → both.
- The app launches `serve --web` explicitly (the three `contains`-based backend-adoption checks still match).
- Docs corrected. Note: the old `~/.mcp.json` example passed a bare `serve`, which never actually served stdio — there is no auto-pipe detection, `mcpStdio` is only set by the flag — so it now correctly passes `--mcp-stdio`.

## Testing

- New `parseServeOptions` cases: default is web-only; `--mcp-sse` is MCP-only; `--web --mcp-sse` is both.
- Verified live: bare `serve --demo` returns **200** for `/` and **404** for `/mcp` and `/mcp/sse`.
- `go test ./cmd/ ./internal/web/` green; `swift build` green. This is runtime-affecting, so it deploys to the live app on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
