### PR TITLE
CI: build the real SwiftPM app, not the stale xcodeproj (rebuild Wave 0 / F1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,12 +132,8 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Build macOS app
-        run: |
-          xcodebuild \
-            -project OpenMessage/OpenMessage.xcodeproj \
-            -scheme OpenMessage \
-            -configuration Debug \
-            -destination 'platform=macOS' \
-            CODE_SIGNING_ALLOWED=NO \
-            build
+      - name: Build Swift package
+        run: swift build --package-path macos/OpenMessage
+
+      - name: Package macOS app
+        run: bash macos/build.sh


### PR DESCRIPTION
Wave 0 / F1. Implemented by Sol, reviewed/verified by Claude. CI-only — no runtime change, no deploy.

## The bug (review finding #18)

The `macos-build` job ran `xcodebuild -project OpenMessage/OpenMessage.xcodeproj` — a **stale duplicate** tree. The shipped app is the SwiftPM package at `macos/OpenMessage` (built by `macos/build.sh`). So every green "macOS App Build" check validated code that is never released, and missed breakage in the real sources — which is exactly why F4's `BackendManager.swift` change sailed through that check untested (I had to `swift build` it locally).

## The fix

- Replace the `xcodebuild` step with `swift build --package-path macos/OpenMessage`.
- Add `bash macos/build.sh` so CI also packages the exact release tree (Go universal binary → Swift `.app` → DMG).
- The job no longer references the root `OpenMessage/` tree (which F3 deletes next).

`build.sh` ad-hoc signs when `DEVELOPER_ID` is unset, and the binary is pure-Go (`modernc` sqlite, `CGO_ENABLED=0`), so it packages on a stock `macos-latest` runner with no cert and no C cross-toolchain.

## Verification

- Locally: `swift build --package-path macos/OpenMessage` ✅ and `env -u DEVELOPER_ID bash macos/build.sh` ✅ (produced the DMG) — this mirrors exactly what CI now does. `actionlint` clean.
- **This PR's own `macos-build` run is the real proof** — it now exercises the SwiftPM build + full packaging on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
