### PR TITLE
Lock Google/libgm transport invariants with characterization tests (Wave 0 / F6)

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -7,7 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/maxghenis/openmessage/internal/client"
 	"github.com/rs/zerolog"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/events"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestNewDemoUsesIsolatedTempDataDir(t *testing.T) {
@@ -291,5 +295,104 @@ func TestHandleGoogleAuthExpiredErrorMarksDisconnected(t *testing.T) {
 func TestIsGoogleAuthExpiredErrorRecognizesFriendlyStatus(t *testing.T) {
 	if !IsGoogleAuthExpiredError(errors.New(googleAuthExpiredStatusMessage)) {
 		t.Fatal("expected friendly auth-expired status to be recognized")
+	}
+}
+
+func newGoogleCallbackTestApp(t *testing.T) *App {
+	t.Helper()
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	if err := client.SaveSession(sessionPath, &client.SessionData{AuthDataJSON: []byte(`{}`)}); err != nil {
+		t.Fatalf("SaveSession(): %v", err)
+	}
+
+	a := &App{SessionPath: sessionPath, Logger: zerolog.Nop()}
+	// There is no exported callback-registration seam. An auth-less session makes
+	// Connect fail before network I/O while exposing the installed callback through
+	// the current public API. This is test setup, not a LoadAndConnect invariant.
+	if err := a.LoadAndConnect(); err == nil {
+		t.Fatal("auth-less callback fixture unexpectedly connected")
+	}
+	if a.GetClient() == nil || a.EventHandler == nil {
+		t.Fatal("current public API did not expose the installed Google callback")
+	}
+	return a
+}
+
+func TestGoogleEventCredentialClassificationAfterLoad(t *testing.T) {
+	// These classifications guard credentials across the Wave 1 supervisor refactor.
+	t.Run("ListenFatalError keeps credentials", func(t *testing.T) {
+		a := newGoogleCallbackTestApp(t)
+		installedClient := a.GetClient()
+		a.Connected.Store(true)
+
+		a.EventHandler.Handle(&events.ListenFatalError{Error: errors.New("temporary token refresh failure")})
+
+		if a.Connected.Load() {
+			t.Fatal("ListenFatalError must end the live connection")
+		}
+		if a.GetClient() != installedClient {
+			t.Fatal("ListenFatalError must keep the installed client for reconnect")
+		}
+		if _, err := os.Stat(a.SessionPath); err != nil {
+			t.Fatalf("ListenFatalError must keep the session file: %v", err)
+		}
+		status := a.GoogleStatus()
+		if !status.Paired || status.NeedsPairing || status.NeedsRepair {
+			t.Fatalf("ListenFatalError status = %+v, want paired transient disconnect", status)
+		}
+	})
+
+	t.Run("GaiaLoggedOut drops credentials and requires pairing", func(t *testing.T) {
+		a := newGoogleCallbackTestApp(t)
+		a.Connected.Store(true)
+
+		a.EventHandler.Handle(&events.GaiaLoggedOut{})
+
+		if a.Connected.Load() {
+			t.Fatal("GaiaLoggedOut must mark Google disconnected")
+		}
+		if a.GetClient() != nil {
+			t.Fatal("GaiaLoggedOut must drop the invalid client")
+		}
+		if _, err := os.Stat(a.SessionPath); !os.IsNotExist(err) {
+			t.Fatalf("GaiaLoggedOut session stat error = %v, want not exist", err)
+		}
+		status := a.GoogleStatus()
+		if status.Paired || !status.NeedsPairing {
+			t.Fatalf("GaiaLoggedOut status = %+v, want pairing required", status)
+		}
+	})
+}
+
+func TestGoogleEventCallbackRecoversPanics(t *testing.T) {
+	a := newGoogleCallbackTestApp(t)
+	a.Connected.Store(true)
+
+	panickingPathReached := false
+	a.EventHandler.OnSessionInvalid = func() {
+		panickingPathReached = true
+		panic("malformed Google event")
+	}
+
+	messageData, err := proto.Marshal(&gmproto.RPCMessageData{
+		Action:          gmproto.ActionType_GET_UPDATES,
+		UnencryptedData: []byte{0x72, 0x00},
+	})
+	if err != nil {
+		t.Fatalf("marshal GaiaLoggedOut fixture: %v", err)
+	}
+
+	// This public libgm receive path reaches the single callback wrapped for Wave 1.
+	a.GetClient().GM.HandleRPCMsg(&gmproto.IncomingRPCMessage{
+		ResponseID:  "panic-containment-fixture",
+		BugleRoute:  gmproto.BugleRoute_DataEvent,
+		MessageData: messageData,
+	})
+
+	if !panickingPathReached {
+		t.Fatal("GaiaLoggedOut fixture did not reach the panicking handler path")
+	}
+	if a.Connected.Load() {
+		t.Fatal("recovered callback panic must mark Google disconnected")
 	}
 }

--- a/internal/app/gm_characterization_test.go
+++ b/internal/app/gm_characterization_test.go
@@ -1,0 +1,252 @@
+package app
+
+import (
+	"testing"
+
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestNewContactNumbersCharacterization(t *testing.T) {
+	tests := []struct {
+		name   string
+		phones []string
+		want   []*gmproto.ContactNumber
+	}{
+		{
+			name:   "nil input",
+			phones: nil,
+			want:   []*gmproto.ContactNumber{},
+		},
+		{
+			name:   "empty input",
+			phones: []string{},
+			want:   []*gmproto.ContactNumber{},
+		},
+		{
+			name:   "numbers are copied verbatim",
+			phones: []string{"+15551234567", " 555 0100 ", ""},
+			want: []*gmproto.ContactNumber{
+				{MysteriousInt: ContactNumberMysteriousInt, Number: "+15551234567", Number2: "+15551234567"},
+				{MysteriousInt: ContactNumberMysteriousInt, Number: " 555 0100 ", Number2: " 555 0100 "},
+				{MysteriousInt: ContactNumberMysteriousInt, Number: "", Number2: ""},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewContactNumbers(tt.phones)
+			if got == nil {
+				t.Fatal("NewContactNumbers returned nil; current protocol shape uses a non-nil slice")
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(NewContactNumbers()) = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range tt.want {
+				if !proto.Equal(got[i], tt.want[i]) {
+					t.Errorf("NewContactNumbers()[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExtractSIMAndParticipantCharacterization(t *testing.T) {
+	participantSIM := &gmproto.SIMPayload{Two: 1, SIMNumber: 1}
+	fallbackSIM := &gmproto.SIMPayload{Two: 2, SIMNumber: 2}
+	secondParticipantSIM := &gmproto.SIMPayload{Two: 3, SIMNumber: 3}
+
+	tests := []struct {
+		name              string
+		conversation      *gmproto.Conversation
+		wantParticipantID string
+		wantSIM           *gmproto.SIMPayload
+	}{
+		{
+			name: "first self participant and its SIM win",
+			conversation: &gmproto.Conversation{
+				Participants: []*gmproto.Participant{
+					{ID: &gmproto.SmallInfo{Number: "+10000000000"}, SimPayload: fallbackSIM},
+					{
+						ID:         &gmproto.SmallInfo{Number: "+15551234567", ParticipantID: "participant-id-is-not-selected"},
+						IsMe:       true,
+						SimPayload: participantSIM,
+					},
+					{
+						ID:         &gmproto.SmallInfo{Number: "+19999999999"},
+						IsMe:       true,
+						SimPayload: secondParticipantSIM,
+					},
+				},
+				SimCard: &gmproto.SIMCard{SIMData: &gmproto.SIMData{SIMPayload: fallbackSIM}},
+			},
+			wantParticipantID: "+15551234567",
+			wantSIM:           participantSIM,
+		},
+		{
+			name: "self participant without SIM uses conversation fallback",
+			conversation: &gmproto.Conversation{
+				Participants: []*gmproto.Participant{{
+					ID:   &gmproto.SmallInfo{Number: "+15557654321"},
+					IsMe: true,
+				}},
+				SimCard: &gmproto.SIMCard{SIMData: &gmproto.SIMData{SIMPayload: fallbackSIM}},
+			},
+			wantParticipantID: "+15557654321",
+			wantSIM:           fallbackSIM,
+		},
+		{
+			name: "conversation fallback works without self participant",
+			conversation: &gmproto.Conversation{
+				Participants: []*gmproto.Participant{{ID: &gmproto.SmallInfo{Number: "+15550001111"}}},
+				SimCard:      &gmproto.SIMCard{SIMData: &gmproto.SIMData{SIMPayload: fallbackSIM}},
+			},
+			wantSIM: fallbackSIM,
+		},
+		{
+			name:         "nil conversation",
+			conversation: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			participantID, sim := ExtractSIMAndParticipant(tt.conversation)
+			if participantID != tt.wantParticipantID {
+				t.Errorf("participantID = %q, want %q", participantID, tt.wantParticipantID)
+			}
+			// The selected libgm payload must be forwarded, not copied or rebuilt.
+			if sim != tt.wantSIM {
+				t.Errorf("SIM payload pointer = %p, want %p", sim, tt.wantSIM)
+			}
+		})
+	}
+}
+
+func TestSendPayloadWithTmpIDShapeCharacterization(t *testing.T) {
+	textSIM := &gmproto.SIMPayload{Two: 1, SIMNumber: 1}
+	mediaSIM := &gmproto.SIMPayload{Two: 2, SIMNumber: 2}
+	media := &gmproto.MediaContent{
+		Format:                 gmproto.MediaFormats_IMAGE_PNG,
+		MediaID:                "media-id",
+		MediaName:              "photo.png",
+		Size:                   12345,
+		Dimensions:             &gmproto.Dimensions{Width: 640, Height: 480},
+		MediaData:              []byte{0x01, 0x02},
+		ThumbnailMediaID:       "thumbnail-id",
+		DecryptionKey:          []byte{0x03, 0x04},
+		ThumbnailDecryptionKey: []byte{0x05, 0x06},
+		MimeType:               "image/png",
+	}
+
+	tests := []struct {
+		name string
+		got  *gmproto.SendMessageRequest
+		want *gmproto.SendMessageRequest
+	}{
+		{
+			name: "text with reply",
+			got:  BuildSendPayloadWithTmpID("conversation-id", "hello", "reply-id", "+15551234567", textSIM, "transport-request-id"),
+			want: &gmproto.SendMessageRequest{
+				ConversationID: "conversation-id",
+				MessagePayload: &gmproto.MessagePayload{
+					TmpID: "transport-request-id",
+					MessageInfo: []*gmproto.MessageInfo{{
+						Data: &gmproto.MessageInfo_MessageContent{
+							MessageContent: &gmproto.MessageContent{Content: "hello"},
+						},
+					}},
+					ConversationID: "conversation-id",
+					ParticipantID:  "+15551234567",
+					TmpID2:         "transport-request-id",
+				},
+				SIMPayload: &gmproto.SIMPayload{Two: 1, SIMNumber: 1},
+				TmpID:      "transport-request-id",
+				Reply:      &gmproto.ReplyPayload{MessageID: "reply-id"},
+			},
+		},
+		{
+			name: "media",
+			got:  BuildSendMediaPayloadWithTmpID("conversation-id", media, "+15557654321", mediaSIM, "media-request-id"),
+			want: &gmproto.SendMessageRequest{
+				ConversationID: "conversation-id",
+				MessagePayload: &gmproto.MessagePayload{
+					TmpID: "media-request-id",
+					MessageInfo: []*gmproto.MessageInfo{{
+						Data: &gmproto.MessageInfo_MediaContent{
+							MediaContent: &gmproto.MediaContent{
+								Format:                 gmproto.MediaFormats_IMAGE_PNG,
+								MediaID:                "media-id",
+								MediaName:              "photo.png",
+								Size:                   12345,
+								Dimensions:             &gmproto.Dimensions{Width: 640, Height: 480},
+								MediaData:              []byte{0x01, 0x02},
+								ThumbnailMediaID:       "thumbnail-id",
+								DecryptionKey:          []byte{0x03, 0x04},
+								ThumbnailDecryptionKey: []byte{0x05, 0x06},
+								MimeType:               "image/png",
+							},
+						},
+					}},
+					ConversationID: "conversation-id",
+					ParticipantID:  "+15557654321",
+					TmpID2:         "media-request-id",
+				},
+				SIMPayload: &gmproto.SIMPayload{Two: 2, SIMNumber: 2},
+				TmpID:      "media-request-id",
+			},
+		},
+	}
+
+	// API tests already lock the three TmpID locations. Full proto equality adds
+	// the remaining wire-shape defaults and complete media metadata for Wave 1.
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !proto.Equal(tt.got, tt.want) {
+				t.Fatalf("payload = %v, want %v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildReactionPayloadEmojiMappingCharacterization(t *testing.T) {
+	sim := &gmproto.SIMPayload{SIMNumber: 2}
+	tests := []struct {
+		emoji string
+		want  gmproto.EmojiType
+	}{
+		{"👍", gmproto.EmojiType_LIKE},
+		{"😍", gmproto.EmojiType_LOVE},
+		{"😂", gmproto.EmojiType_LAUGH},
+		{"😮", gmproto.EmojiType_SURPRISED},
+		{"😥", gmproto.EmojiType_SAD},
+		{"😠", gmproto.EmojiType_ANGRY},
+		{"👎", gmproto.EmojiType_DISLIKE},
+		{"🤔", gmproto.EmojiType_QUESTIONING},
+		{"😢", gmproto.EmojiType_CRYING_FACE},
+		{"😡", gmproto.EmojiType_POUTING_FACE},
+		{"❤", gmproto.EmojiType_RED_HEART},
+		{"❤️", gmproto.EmojiType_RED_HEART},
+		{"🫡", gmproto.EmojiType_CUSTOM},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.emoji, func(t *testing.T) {
+			// The emoji enum is a wire detail guarded ahead of the Wave 1 supervisor refactor.
+			got := BuildReactionPayload("message-id", tt.emoji, "SwItCh", sim)
+			want := &gmproto.SendReactionRequest{
+				MessageID:    "message-id",
+				ReactionData: &gmproto.ReactionData{Unicode: tt.emoji, Type: tt.want},
+				Action:       gmproto.SendReactionRequest_SWITCH,
+				SIMPayload:   &gmproto.SIMPayload{SIMNumber: 2},
+			}
+			if !proto.Equal(got, want) {
+				t.Fatalf("reaction payload = %v, want %v", got, want)
+			}
+			if got.GetSIMPayload() != sim {
+				t.Error("SIM payload must be forwarded without replacement")
+			}
+		})
+	}
+}

--- a/internal/client/events_test.go
+++ b/internal/client/events_test.go
@@ -143,9 +143,39 @@ func TestHandleMessage_BumpsConversationTimestamp(t *testing.T) {
 	}
 }
 
+func TestHandlePingFailed_EndsGenerationAfterThreeConsecutiveFailures(t *testing.T) {
+	var connectionLost, sessionInvalid int
+	handler := &EventHandler{
+		Logger: zerolog.Nop(),
+		OnConnectionLost: func() {
+			connectionLost++
+		},
+		OnSessionInvalid: func() {
+			sessionInvalid++
+		},
+	}
+
+	// libgm supplies the consecutive count; guard the exact threshold before the
+	// Wave 1 supervisor takes ownership of ending a connection generation.
+	for _, errorCount := range []int{1, 2, 3} {
+		handler.Handle(&events.PingFailed{ErrorCount: errorCount})
+		wantConnectionLost := 0
+		if errorCount == 3 {
+			wantConnectionLost = 1
+		}
+		if connectionLost != wantConnectionLost {
+			t.Fatalf("connection-lost callbacks after ErrorCount %d = %d, want %d", errorCount, connectionLost, wantConnectionLost)
+		}
+		if sessionInvalid != 0 {
+			t.Fatalf("session-invalid callbacks after ErrorCount %d = %d, want 0", errorCount, sessionInvalid)
+		}
+	}
+}
+
 func TestHandleRecoveryEvents_TriggerRealtimeGapCallback(t *testing.T) {
 	var reasons []string
 	var phoneResponding []bool
+	var sessionInvalid, connectionLost int
 	handler := &EventHandler{
 		Logger: zerolog.Nop(),
 		OnRealtimeGapRecovered: func(reason string) {
@@ -154,9 +184,23 @@ func TestHandleRecoveryEvents_TriggerRealtimeGapCallback(t *testing.T) {
 		OnPhoneRespondingChange: func(responding bool) {
 			phoneResponding = append(phoneResponding, responding)
 		},
+		OnSessionInvalid: func() {
+			sessionInvalid++
+		},
+		OnConnectionLost: func() {
+			connectionLost++
+		},
 	}
 
 	handler.Handle(&events.PhoneNotResponding{})
+	// Phone reachability is not credential validity. Keep this distinction when
+	// the Wave 1 supervisor assumes connection-lifecycle ownership.
+	if sessionInvalid != 0 {
+		t.Fatalf("session-invalid callbacks after PhoneNotResponding = %d, want 0", sessionInvalid)
+	}
+	if connectionLost != 0 {
+		t.Fatalf("connection-lost callbacks after PhoneNotResponding = %d, want 0", connectionLost)
+	}
 	handler.Handle(&events.ListenRecovered{})
 	handler.Handle(&events.PhoneRespondingAgain{})
 

--- a/internal/client/extract_test.go
+++ b/internal/client/extract_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"reflect"
 	"testing"
 
 	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
@@ -20,39 +21,88 @@ func TestExtractMediaInfo_NoMedia(t *testing.T) {
 	}
 }
 
-func TestExtractMediaInfo_WithImage(t *testing.T) {
-	msg := &gmproto.Message{
-		MessageInfo: []*gmproto.MessageInfo{
-			{
-				ActionMessageID: strPtr("action-1"),
-				Data: &gmproto.MessageInfo_MediaContent{
-					MediaContent: &gmproto.MediaContent{
-						Format:        gmproto.MediaFormats_IMAGE_JPEG,
-						MediaID:       "mid-123",
-						MediaName:     "photo.jpg",
-						Size:          12345,
-						MimeType:      "image/jpeg",
-						DecryptionKey: []byte{0xde, 0xad, 0xbe, 0xef},
-					},
-				},
+func TestExtractMediaInfo_Characterization(t *testing.T) {
+	// Guard the exact media shape and fallbacks before the Wave 1 supervisor refactor.
+	tests := []struct {
+		name  string
+		media *gmproto.MediaContent
+		want  *MediaInfo
+	}{
+		{
+			name: "complete metadata",
+			media: &gmproto.MediaContent{
+				Format:                 gmproto.MediaFormats_IMAGE_JPEG,
+				MediaID:                "mid-123",
+				MediaName:              "photo.jpg",
+				Size:                   12345,
+				MimeType:               "image/jpeg",
+				DecryptionKey:          []byte{0xde, 0xad, 0xbe, 0xef},
+				ThumbnailMediaID:       "thumb-123",
+				ThumbnailDecryptionKey: []byte{0xca, 0xfe},
+				MediaData:              []byte{0x01, 0x02, 0x03},
+			},
+			want: &MediaInfo{
+				MediaID:                "mid-123",
+				MimeType:               "image/jpeg",
+				MediaName:              "photo.jpg",
+				DecryptionKey:          []byte{0xde, 0xad, 0xbe, 0xef},
+				Size:                   12345,
+				ThumbnailMediaID:       "thumb-123",
+				ThumbnailDecryptionKey: []byte{0xca, 0xfe},
+				InlineData:             []byte{0x01, 0x02, 0x03},
+			},
+		},
+		{
+			name: "thumbnail fallback",
+			media: &gmproto.MediaContent{
+				MimeType:               "image/webp",
+				DecryptionKey:          []byte{0xff},
+				ThumbnailMediaID:       "thumb-only",
+				ThumbnailDecryptionKey: []byte{0x10, 0x20},
+			},
+			want: &MediaInfo{
+				MediaID:                "thumb-only",
+				MimeType:               "image/webp",
+				DecryptionKey:          []byte{0x10, 0x20},
+				ThumbnailMediaID:       "thumb-only",
+				ThumbnailDecryptionKey: []byte{0x10, 0x20},
+			},
+		},
+		{
+			name: "image MIME inference",
+			media: &gmproto.MediaContent{
+				Format:  gmproto.MediaFormats_IMAGE_PNG,
+				MediaID: "image-without-mime",
+			},
+			want: &MediaInfo{
+				MediaID:  "image-without-mime",
+				MimeType: "image/jpeg",
+			},
+		},
+		{
+			name: "default MIME inference",
+			media: &gmproto.MediaContent{
+				Format:  gmproto.MediaFormats_VIDEO_MP4,
+				MediaID: "video-without-mime",
+			},
+			want: &MediaInfo{
+				MediaID:  "video-without-mime",
+				MimeType: "application/octet-stream",
 			},
 		},
 	}
-	info := ExtractMediaInfo(msg)
-	if info == nil {
-		t.Fatal("expected media info, got nil")
-	}
-	if info.MediaID != "mid-123" {
-		t.Errorf("expected MediaID 'mid-123', got %q", info.MediaID)
-	}
-	if info.MimeType != "image/jpeg" {
-		t.Errorf("expected MimeType 'image/jpeg', got %q", info.MimeType)
-	}
-	if info.MediaName != "photo.jpg" {
-		t.Errorf("expected MediaName 'photo.jpg', got %q", info.MediaName)
-	}
-	if len(info.DecryptionKey) != 4 {
-		t.Errorf("expected 4-byte key, got %d bytes", len(info.DecryptionKey))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := &gmproto.Message{
+				MessageInfo: []*gmproto.MessageInfo{{
+					Data: &gmproto.MessageInfo_MediaContent{MediaContent: tt.media},
+				}},
+			}
+			if got := ExtractMediaInfo(msg); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ExtractMediaInfo() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -153,6 +203,50 @@ func TestExtractReplyToID_WithReply(t *testing.T) {
 	}
 	if id := ExtractReplyToID(msg); id != "original-msg-123" {
 		t.Errorf("expected 'original-msg-123', got %q", id)
+	}
+}
+
+func TestExtractSenderInfo_Characterization(t *testing.T) {
+	// Guard sender identity precedence and fallbacks before the Wave 1 supervisor refactor.
+	tests := []struct {
+		name        string
+		participant *gmproto.Participant
+		wantName    string
+		wantNumber  string
+	}{
+		{
+			name: "full name and ID number take precedence",
+			participant: &gmproto.Participant{
+				FullName:        "Ada Lovelace",
+				FirstName:       "Ada",
+				ID:              &gmproto.SmallInfo{Number: "+15551234567"},
+				FormattedNumber: "(555) 123-4567",
+			},
+			wantName:   "Ada Lovelace",
+			wantNumber: "+15551234567",
+		},
+		{
+			name: "first name and formatted number fall back",
+			participant: &gmproto.Participant{
+				FirstName:       "Ada",
+				ID:              &gmproto.SmallInfo{},
+				FormattedNumber: "(555) 123-4567",
+			},
+			wantName:   "Ada",
+			wantNumber: "(555) 123-4567",
+		},
+		{
+			name: "nil sender",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotNumber := ExtractSenderInfo(&gmproto.Message{SenderParticipant: tt.participant})
+			if gotName != tt.wantName || gotNumber != tt.wantNumber {
+				t.Fatalf("ExtractSenderInfo() = (%q, %q), want (%q, %q)", gotName, gotNumber, tt.wantName, tt.wantNumber)
+			}
+		})
 	}
 }
 

--- a/internal/googlecookies/googlecookies_test.go
+++ b/internal/googlecookies/googlecookies_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/cipher"
 	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -63,6 +64,25 @@ func encryptCookie(t *testing.T, value, host string, key []byte, withHostHash bo
 	return append([]byte("v10"), out...)
 }
 
+func TestDeriveKeyChromePBKDF2Vectors(t *testing.T) {
+	// Fixed Chrome vectors guard key derivation before Wave 1 changes credential storage.
+	tests := []struct {
+		iterations int
+		want       string
+	}{
+		{iterations: 1, want: "d7d4df19d842591632e8dfb427ab3474"},
+		{iterations: 1003, want: "01ab06dc67d036480129f3e40d53ca5f"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := hex.EncodeToString(DeriveKey([]byte("test-secret"), tt.iterations))
+			if got != tt.want {
+				t.Fatalf("DeriveKey(iterations=%d) = %s, want %s", tt.iterations, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDecryptCookieRoundTrip(t *testing.T) {
 	key := DeriveKey([]byte("test-secret"), 1003)
 	for _, withHash := range []bool{false, true} {
@@ -74,6 +94,21 @@ func TestDecryptCookieRoundTrip(t *testing.T) {
 		if got != "cookie-value-123" {
 			t.Fatalf("DecryptCookie(withHash=%v) = %q, want %q", withHash, got, "cookie-value-123")
 		}
+	}
+}
+
+func TestDecryptCookieV11(t *testing.T) {
+	// Cookie refresh must keep accepting Chrome's v11 envelope through Wave 1.
+	key := DeriveKey([]byte("test-secret"), 1003)
+	encrypted := encryptCookie(t, "cookie-value-123", ".google.com", key, true)
+	copy(encrypted[:3], "v11")
+
+	got, err := DecryptCookie(encrypted, ".google.com", key)
+	if err != nil {
+		t.Fatalf("DecryptCookie(v11): %v", err)
+	}
+	if got != "cookie-value-123" {
+		t.Fatalf("DecryptCookie(v11) = %q, want %q", got, "cookie-value-123")
 	}
 }
 
@@ -133,23 +168,59 @@ func TestUpdateSessionCookiesPreservesOtherFields(t *testing.T) {
 }
 
 func TestLoadChromeCookiesRequiresAllSessionCookies(t *testing.T) {
-	// A profile whose cookie DB has only a subset of the required cookies must
-	// fail loudly rather than write a half-valid session that 401s anyway.
-	dir := t.TempDir()
-	profile := filepath.Join(dir, "Default")
-	if err := os.MkdirAll(filepath.Join(profile, "Network"), 0o700); err != nil {
-		t.Fatalf("mkdir profile: %v", err)
-	}
-	key := DeriveKey([]byte("secret"), 1003)
-	writeCookieDB(t, filepath.Join(profile, "Network", "Cookies"), []dbCookie{
-		{".google.com", "SID", encryptCookie(t, "v", ".google.com", key, false)},
-		// OSID/HSID/SSID/APISID/SAPISID intentionally absent.
-	})
+	// Exact host/name requirements guard Wave 1 from persisting partial credentials.
+	secret := []byte("secret")
+	key := DeriveKey(secret, 1003)
 
-	_, err := LoadChromeCookies(profile, []byte("secret"))
-	if err == nil {
-		t.Fatal("expected error for missing required cookies, got nil")
+	for _, missing := range requiredCookies {
+		missing := missing
+		t.Run("missing "+missing.host+":"+missing.name, func(t *testing.T) {
+			profile := filepath.Join(t.TempDir(), "Default")
+			if err := os.MkdirAll(filepath.Join(profile, "Network"), 0o700); err != nil {
+				t.Fatalf("mkdir profile: %v", err)
+			}
+			rows := make([]dbCookie, 0, len(requiredCookies)-1)
+			for _, req := range requiredCookies {
+				if req == missing {
+					continue
+				}
+				rows = append(rows, dbCookie{req.host, req.name, encryptCookie(t, "val-"+req.name, req.host, key, true)})
+			}
+			writeCookieDB(t, filepath.Join(profile, "Network", "Cookies"), rows)
+
+			_, err := LoadChromeCookies(profile, secret)
+			wantErr := "missing required cookies: " + missing.host + ":" + missing.name
+			if err == nil || err.Error() != wantErr {
+				t.Fatalf("LoadChromeCookies() error = %v, want %q", err, wantErr)
+			}
+		})
 	}
+
+	t.Run("required name on wrong host", func(t *testing.T) {
+		profile := filepath.Join(t.TempDir(), "Default")
+		if err := os.MkdirAll(filepath.Join(profile, "Network"), 0o700); err != nil {
+			t.Fatalf("mkdir profile: %v", err)
+		}
+		rows := make([]dbCookie, 0, len(requiredCookies))
+		for _, req := range requiredCookies {
+			if req.name == "SID" {
+				continue
+			}
+			rows = append(rows, dbCookie{req.host, req.name, encryptCookie(t, "val-"+req.name, req.host, key, true)})
+		}
+		rows = append(rows, dbCookie{
+			host:      "accounts.google.com",
+			name:      "SID",
+			encrypted: encryptCookie(t, "wrong-host", "accounts.google.com", key, true),
+		})
+		writeCookieDB(t, filepath.Join(profile, "Network", "Cookies"), rows)
+
+		_, err := LoadChromeCookies(profile, secret)
+		const wantErr = "missing required cookies: .google.com:SID"
+		if err == nil || err.Error() != wantErr {
+			t.Fatalf("LoadChromeCookies() error = %v, want %q", err, wantErr)
+		}
+	})
 }
 
 func TestLoadChromeCookiesHappyPath(t *testing.T) {
@@ -177,5 +248,31 @@ func TestLoadChromeCookiesHappyPath(t *testing.T) {
 	}
 	if got["OSID"] != "val-OSID" {
 		t.Fatalf("OSID = %q, want %q", got["OSID"], "val-OSID")
+	}
+}
+
+func TestLoadChromeCookiesSelectsLinuxPBKDF2Iterations(t *testing.T) {
+	// Wave 1 credential handling must preserve selection of Chrome's Linux key.
+	profile := filepath.Join(t.TempDir(), "Default")
+	if err := os.MkdirAll(filepath.Join(profile, "Network"), 0o700); err != nil {
+		t.Fatalf("mkdir profile: %v", err)
+	}
+	secret := []byte("secret")
+	key := DeriveKey(secret, 1)
+	rows := make([]dbCookie, 0, len(requiredCookies))
+	for _, req := range requiredCookies {
+		rows = append(rows, dbCookie{req.host, req.name, encryptCookie(t, "linux-"+req.name, req.host, key, true)})
+	}
+	writeCookieDB(t, filepath.Join(profile, "Network", "Cookies"), rows)
+
+	got, err := LoadChromeCookies(profile, secret)
+	if err != nil {
+		t.Fatalf("LoadChromeCookies(): %v", err)
+	}
+	for _, req := range requiredCookies {
+		want := "linux-" + req.name
+		if got[req.name] != want {
+			t.Fatalf("%s = %q, want %q", req.name, got[req.name], want)
+		}
 	}
 }


### PR DESCRIPTION
Wave 0 / F6. Implemented by Sol, reviewed by Claude. **Tests only — no production change, no deploy.**

Pins the current behavior of the failure-hardened Google transport so the Wave 1 per-bridge supervisor (phases C4/C8) can take over connection lifecycle **without silently regressing any of the hard-won invariants** — the zombie-401 handling, the ping-failure threshold, the phone-vs-credentials distinction.

Locked (gaps only; already-covered invariants left as-is):
- **Event classification** — `ListenFatalError` keeps credentials; `GaiaLoggedOut` drops session / re-pairs; **exactly three** consecutive `PingFailed` end the generation (not 1–2); `PhoneNotResponding` is not credential invalidity.
- **Panic containment** — an event marshaled through the real libgm `HandleRPCMsg` path into a panicking callback is recovered; the process survives and Google is marked disconnected. (Removing the `recover()` wrapper would crash this test.)
- **Payload builders** — text/media protobuf shapes, contact numbers, SIM selection/fallback, every reaction emoji mapping.
- **Extraction** — media metadata/MIME fallbacks, sender-identity precedence.
- **Cookie crypto** — `DeriveKey` vectors, v11 decryption, Linux PBKDF2 selection, required-cookie host/name validation.

`go test ./internal/client/ ./internal/app/ ./internal/googlecookies/` green; no production files touched; no bug surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
