### PR TITLE
Gate signal-cli >=0.14.5 and circuit-break the getSender poison loop (Wave 0 / F8)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -196,12 +196,11 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				if !status.Paired || status.Connected || status.Pairing || status.Connecting {
 					continue
 				}
-				// Skip reconnect when the account needs manual re-pairing.
-				// Hammering signal-cli every 5s with a known-bad account
-				// wastes resources and produces noise in the logs. The UI
-				// will show the needs_reauth state so the user knows to
-				// open Platforms and re-pair.
-				if status.NeedsReauth {
+				// Skip terminal states that require manual remediation.
+				// Hammering signal-cli every 5s with a known-bad account or
+				// binary wastes resources and produces noise in the logs. The
+				// status payload tells the UI whether to re-pair or upgrade.
+				if status.NeedsReauth || status.UpgradeRequired {
 					continue
 				}
 				if err := a.StartSignalConnect(); err != nil {

--- a/internal/signallive/characterization_test.go
+++ b/internal/signallive/characterization_test.go
@@ -1,0 +1,614 @@
+package signallive
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+func TestSignalIncomingSourceIDUsesStableSenderTimestampIdentity(t *testing.T) {
+	const (
+		conversationID = "signal:+15551234567"
+		sender         = "+15557654321"
+		timestamp      = int64(1700000000123)
+	)
+
+	base := signalIncomingSourceID(conversationID, sender, timestamp, "before edit")
+	if got := signalIncomingSourceID("  "+conversationID+"  ", "  "+sender+"  ", timestamp, "after edit"); got != base {
+		t.Fatalf("body/whitespace changed stable source ID: got %q, want %q", got, base)
+	}
+
+	changed := []struct {
+		name           string
+		conversationID string
+		sender         string
+		timestamp      int64
+	}{
+		{name: "conversation", conversationID: "signal:+15550000000", sender: sender, timestamp: timestamp},
+		{name: "sender", conversationID: conversationID, sender: "+15550000000", timestamp: timestamp},
+		{name: "timestamp", conversationID: conversationID, sender: sender, timestamp: timestamp + 1},
+	}
+	for _, tc := range changed {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := signalIncomingSourceID(tc.conversationID, tc.sender, tc.timestamp, "before edit"); got == base {
+				t.Fatalf("changing %s did not change source ID %q", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestParseSignalContactsRecordedOutput(t *testing.T) {
+	raw := []byte("INFO  AccountHelper - refreshing contacts\n" +
+		"Number: +15551234567 ACI: d91b5024-f3db-4c82-98f8-2691974d6a9b Name:  Profile name: Michael Thorning Username:  Color:  Blocked: false Message expiration: disabled\n" +
+		"Number: +15559876543 ACI: 9f4b50e3-ebf2-413c-a856-161756a6161a Name: Taylor Profile name: Taylor Username:  Color:  Blocked: false\n" +
+		"Number: +15550000000 Name: missing ACI\n")
+
+	got := parseSignalContacts(raw)
+	want := map[string]string{
+		"d91b5024-f3db-4c82-98f8-2691974d6a9b": "+15551234567",
+		"9f4b50e3-ebf2-413c-a856-161756a6161a": "+15559876543",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parseSignalContacts() = %#v, want %#v", got, want)
+	}
+	for aci, number := range want {
+		if got[aci] != number {
+			t.Fatalf("parseSignalContacts()[%q] = %q, want %q", aci, got[aci], number)
+		}
+	}
+}
+
+func TestSignalEnvelopeAndSentTargetAliases(t *testing.T) {
+	t.Run("envelope source", func(t *testing.T) {
+		cases := []struct {
+			name string
+			env  *signalEnvelope
+			want string
+		}{
+			{name: "nil", want: ""},
+			{name: "source", env: &signalEnvelope{Source: " +15550000001 "}, want: "+15550000001"},
+			{name: "source UUID", env: &signalEnvelope{SourceUUID: "uuid-source"}, want: "uuid-source"},
+			{name: "source service ID", env: &signalEnvelope{SourceServiceID: "service-source"}, want: "service-source"},
+			{name: "source number", env: &signalEnvelope{SourceNumber: "+15550000002"}, want: "+15550000002"},
+			{
+				name: "documented precedence",
+				env: &signalEnvelope{
+					Source:          "legacy-source",
+					SourceUUID:      "uuid-source",
+					SourceServiceID: "service-source",
+					SourceNumber:    "+15550000003",
+				},
+				want: "+15550000003",
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				if got := signalEnvelopeSource(tc.env); got != tc.want {
+					t.Fatalf("signalEnvelopeSource() = %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("sent target", func(t *testing.T) {
+		cases := []struct {
+			name string
+			sent *signalSentMessage
+			want string
+		}{
+			{name: "nil", want: ""},
+			{name: "destination", sent: &signalSentMessage{Destination: " legacy-target "}, want: "legacy-target"},
+			{name: "destination service ID", sent: &signalSentMessage{DestinationServiceID: "service-target"}, want: "service-target"},
+			{name: "destination UUID", sent: &signalSentMessage{DestinationUUID: "uuid-target"}, want: "uuid-target"},
+			{name: "destination E164", sent: &signalSentMessage{DestinationE164: "+15550000004"}, want: "+15550000004"},
+			{name: "destination number", sent: &signalSentMessage{DestinationNumber: "+15550000005"}, want: "+15550000005"},
+			{
+				name: "documented precedence",
+				sent: &signalSentMessage{
+					Destination:          "legacy-target",
+					DestinationServiceID: "service-target",
+					DestinationUUID:      "uuid-target",
+					DestinationE164:      "+15550000006",
+					DestinationNumber:    "+15550000007",
+				},
+				want: "+15550000007",
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				if got := signalSentTarget(tc.sent); got != tc.want {
+					t.Fatalf("signalSentTarget() = %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
+}
+
+func TestSignalQuoteAndMentionNormalization(t *testing.T) {
+	const (
+		conversationID = "signal-group:test-group"
+		timestamp      = int64(1700000000123)
+	)
+
+	t.Run("quotes", func(t *testing.T) {
+		if got := signalQuoteReplyID(conversationID, nil); got != "" {
+			t.Fatalf("nil quote reply ID = %q, want empty", got)
+		}
+		if got := signalQuoteReplyID(conversationID, &signalQuotedMessage{Author: "+15550000001"}); got != "" {
+			t.Fatalf("zero-timestamp quote reply ID = %q, want empty", got)
+		}
+
+		quote := &signalQuotedMessage{
+			Timestamp: timestamp,
+			Author:    "+15550000001",
+			AuthorACI: "quote-author-aci",
+			Text:      "original quote text",
+		}
+		want := "signal:" + signalIncomingSourceID(conversationID, "quote-author-aci", timestamp, "")
+		if got := signalQuoteReplyID(conversationID, quote); got != want {
+			t.Fatalf("ACI quote reply ID = %q, want %q", got, want)
+		}
+		quote.Text = "edited quote text"
+		if got := signalQuoteReplyID(conversationID, quote); got != want {
+			t.Fatalf("quote text changed stable reply ID: got %q, want %q", got, want)
+		}
+
+		fallback := &signalQuotedMessage{Timestamp: timestamp, Author: "+15550000001"}
+		fallbackWant := "signal:" + signalIncomingSourceID(conversationID, "+15550000001", timestamp, "")
+		if got := signalQuoteReplyID(conversationID, fallback); got != fallbackWant {
+			t.Fatalf("author fallback reply ID = %q, want %q", got, fallbackWant)
+		}
+	})
+
+	t.Run("mentions", func(t *testing.T) {
+		const account = "+15551230000"
+		cases := []struct {
+			name     string
+			mentions []signalMention
+			account  string
+			want     bool
+		}{
+			{name: "number", mentions: []signalMention{{Number: account}}, account: account, want: true},
+			{name: "recipient number", mentions: []signalMention{{RecipientNumber: " " + account + " "}}, account: account, want: true},
+			{name: "recipient", mentions: []signalMention{{Recipient: account}}, account: account, want: true},
+			{name: "case-insensitive service ID", mentions: []signalMention{{Recipient: "ACCOUNT-ACI"}}, account: "account-aci", want: true},
+			{name: "different recipient", mentions: []signalMention{{Number: "+15550000000"}}, account: account, want: false},
+			{name: "empty account", mentions: []signalMention{{Number: account}}, account: "", want: false},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				if got := signalMentionsMe(tc.mentions, tc.account); got != tc.want {
+					t.Fatalf("signalMentionsMe() = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	})
+}
+
+func TestSignalReactionNormalizationSupportsNestedAndLegacyTargets(t *testing.T) {
+	cases := []struct {
+		name          string
+		raw           string
+		account       string
+		wantAuthor    string
+		wantTimestamp int64
+	}{
+		{
+			name:          "nested target",
+			raw:           `{"target":{"authorAci":"nested-author-aci","timestamp":1700000000123},"targetAuthor":"legacy-author","targetSentTimestamp":0}`,
+			account:       "+15551230000",
+			wantAuthor:    "nested-author-aci",
+			wantTimestamp: 1700000000123,
+		},
+		{
+			name:          "legacy top-level target",
+			raw:           `{"targetAuthorServiceId":"legacy-author-aci","targetSentTimestamp":1700000000456}`,
+			account:       "+15551230000",
+			wantAuthor:    "legacy-author-aci",
+			wantTimestamp: 1700000000456,
+		},
+		{
+			name:          "top-level timestamp wins",
+			raw:           `{"target":{"author":"nested-author","timestamp":1700000000123},"targetSentTimestamp":1700000000789}`,
+			account:       "+15551230000",
+			wantAuthor:    "nested-author",
+			wantTimestamp: 1700000000789,
+		},
+		{
+			name:       "account author fallback",
+			raw:        `{}`,
+			account:    "+15551230000",
+			wantAuthor: "+15551230000",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var reaction signalReaction
+			if err := json.Unmarshal([]byte(tc.raw), &reaction); err != nil {
+				t.Fatalf("json.Unmarshal(reaction): %v", err)
+			}
+			if got := signalReactionTargetAuthor(&reaction, tc.account); got != tc.wantAuthor {
+				t.Fatalf("signalReactionTargetAuthor() = %q, want %q", got, tc.wantAuthor)
+			}
+			if got := signalReactionTargetTimestamp(&reaction); got != tc.wantTimestamp {
+				t.Fatalf("signalReactionTargetTimestamp() = %d, want %d", got, tc.wantTimestamp)
+			}
+		})
+	}
+
+	if got := signalReactionTargetAuthor(nil, "+15551230000"); got != "" {
+		t.Fatalf("nil reaction target author = %q, want empty", got)
+	}
+	if got := signalReactionTargetTimestamp(nil); got != 0 {
+		t.Fatalf("nil reaction target timestamp = %d, want zero", got)
+	}
+}
+
+func TestSignalUnsupportedContentPlaceholders(t *testing.T) {
+	cases := []struct {
+		name        string
+		attachments []signalAttachment
+		flags       signalUnsupportedContentFlags
+		want        string
+	}{
+		{name: "default", want: signalUnsupportedMessagePlaceholder},
+		{name: "photo", attachments: []signalAttachment{{ContentType: " image/jpeg "}}, want: "[Photo]"},
+		{name: "video", attachments: []signalAttachment{{ContentType: "video/mp4"}}, want: "[Video]"},
+		{name: "audio", attachments: []signalAttachment{{ContentType: "audio/ogg"}}, want: "[Audio]"},
+		{name: "generic attachment", attachments: []signalAttachment{{ContentType: "application/pdf"}}, want: "[Attachment]"},
+		{name: "sticker", flags: signalUnsupportedContentFlags{HasSticker: true}, want: "[Sticker]"},
+		{name: "contact", flags: signalUnsupportedContentFlags{HasContacts: true}, want: "[Contact]"},
+		{name: "payment", flags: signalUnsupportedContentFlags{HasPayment: true}, want: "[Payment]"},
+		{name: "poll", flags: signalUnsupportedContentFlags{HasPollCreate: true}, want: "[Poll]"},
+		{name: "poll vote", flags: signalUnsupportedContentFlags{HasPollVote: true}, want: "[Poll vote]"},
+		{name: "poll closed", flags: signalUnsupportedContentFlags{HasPollTerminate: true}, want: "[Poll closed]"},
+		{name: "remote delete", flags: signalUnsupportedContentFlags{HasRemoteDelete: true}, want: "[Deleted message]"},
+		{name: "pin", flags: signalUnsupportedContentFlags{HasPinMessage: true}, want: "[Pinned message]"},
+		{name: "unpin", flags: signalUnsupportedContentFlags{HasUnpinMessage: true}, want: "[Unpinned message]"},
+		{name: "admin delete", flags: signalUnsupportedContentFlags{HasAdminDelete: true}, want: "[Deleted by admin]"},
+		{name: "group update", flags: signalUnsupportedContentFlags{HasGroupUpdate: true}, want: "[Group updated]"},
+		{name: "story reply", flags: signalUnsupportedContentFlags{HasStoryContext: true}, want: "[Story reply]"},
+		{name: "expiration update", flags: signalUnsupportedContentFlags{IsExpirationUpdate: true}, want: "[Disappearing messages updated]"},
+		{name: "view once", flags: signalUnsupportedContentFlags{ViewOnce: true}, want: "[View-once message]"},
+		{name: "link preview", flags: signalUnsupportedContentFlags{HasPreview: true}, want: "[Link preview]"},
+		{
+			name:        "attachment takes precedence",
+			attachments: []signalAttachment{{ContentType: "image/png"}},
+			flags:       signalUnsupportedContentFlags{HasSticker: true, HasContacts: true, HasPayment: true},
+			want:        "[Photo]",
+		},
+		{
+			name: "flag precedence",
+			flags: signalUnsupportedContentFlags{
+				HasSticker:         true,
+				HasContacts:        true,
+				HasPayment:         true,
+				HasRemoteDelete:    true,
+				IsExpirationUpdate: true,
+				ViewOnce:           true,
+				HasPreview:         true,
+			},
+			want: "[Sticker]",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := signalUnsupportedContentPlaceholder(tc.attachments, tc.flags); got != tc.want {
+				t.Fatalf("signalUnsupportedContentPlaceholder() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("message body takes precedence", func(t *testing.T) {
+		data := &signalDataMessage{
+			Message:     "  visible body  ",
+			Attachments: []signalAttachment{{ContentType: "image/png"}},
+			Sticker:     json.RawMessage(`{"packId":"pack-1"}`),
+		}
+		if got := data.displayBody(); got != "visible body" {
+			t.Fatalf("data displayBody() = %q, want visible body", got)
+		}
+		sent := &signalSentMessage{
+			Message:      "  sent body  ",
+			Attachments:  []signalAttachment{{ContentType: "video/mp4"}},
+			RemoteDelete: json.RawMessage(`{"targetSentTimestamp":1700000000000}`),
+		}
+		if got := sent.displayBody(); got != "sent body" {
+			t.Fatalf("sent displayBody() = %q, want sent body", got)
+		}
+	})
+}
+
+func TestSignalAttachmentReferenceCodecs(t *testing.T) {
+	t.Run("remote round trip", func(t *testing.T) {
+		encoded := encodeSignalAttachmentRef("  attachment-123  ")
+		if encoded != "signalatt:attachment-123" {
+			t.Fatalf("encodeSignalAttachmentRef() = %q", encoded)
+		}
+		decoded, err := decodeSignalAttachmentRef("  " + encoded + "  ")
+		if err != nil {
+			t.Fatalf("decodeSignalAttachmentRef(): %v", err)
+		}
+		if decoded != "attachment-123" {
+			t.Fatalf("decoded remote attachment = %q", decoded)
+		}
+		if got := encodeSignalAttachmentRef("  "); got != "" {
+			t.Fatalf("empty remote attachment encoded as %q", got)
+		}
+	})
+
+	t.Run("local round trip", func(t *testing.T) {
+		const path = "/tmp/OpenMessage attachments/photo one.png"
+		encoded := encodeSignalLocalAttachmentRef("  " + path + "  ")
+		if !strings.HasPrefix(encoded, signalLocalAttachmentPrefix) {
+			t.Fatalf("encodeSignalLocalAttachmentRef() = %q", encoded)
+		}
+		decoded, err := decodeSignalLocalAttachmentRef(encoded)
+		if err != nil {
+			t.Fatalf("decodeSignalLocalAttachmentRef(): %v", err)
+		}
+		if decoded != path {
+			t.Fatalf("decoded local attachment = %q, want %q", decoded, path)
+		}
+		if got := encodeSignalLocalAttachmentRef("  "); got != "" {
+			t.Fatalf("empty local attachment encoded as %q", got)
+		}
+	})
+
+	malformed := []struct {
+		name  string
+		value string
+		local bool
+	}{
+		{name: "remote wrong prefix", value: "other:attachment-123"},
+		{name: "remote empty", value: "signalatt:"},
+		{name: "local wrong prefix", value: "other:abc", local: true},
+		{name: "local empty", value: "signallocal:", local: true},
+		{name: "local invalid base64", value: "signallocal:not*base64", local: true},
+		{name: "local whitespace path", value: "signallocal:ICA", local: true},
+	}
+	for _, tc := range malformed {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			if tc.local {
+				_, err = decodeSignalLocalAttachmentRef(tc.value)
+			} else {
+				_, err = decodeSignalAttachmentRef(tc.value)
+			}
+			if err == nil {
+				t.Fatalf("decoding malformed reference %q unexpectedly succeeded", tc.value)
+			}
+		})
+	}
+}
+
+func TestSanitizeSignalOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{name: "plain whitespace and carriage return", line: "  signal-cli ready\r  ", want: "signal-cli ready"},
+		{name: "ANSI color", line: "\x1b[31mERROR\x1b[0m", want: "ERROR"},
+		{name: "multiple ANSI sequences", line: "\x1b[1mSignal\x1b[0m \x1b[32mready\x1b[0m", want: "Signal ready"},
+		{name: "unterminated ANSI sequence", line: "message\x1b[31", want: "message"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeSignalOutput(tc.line); got != tc.want {
+				t.Fatalf("sanitizeSignalOutput(%q) = %q, want %q", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractSignalLinkURI(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{name: "missing", line: "Waiting for QR code", want: ""},
+		{name: "bare URI", line: "sgnl://linkdevice?uuid=test", want: "sgnl://linkdevice?uuid=test"},
+		{
+			name: "prefixed recorded output",
+			line: "Link device URI: sgnl://linkdevice?uuid=test&pub_key=abc  ",
+			want: "sgnl://linkdevice?uuid=test&pub_key=abc",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractSignalLinkURI(tc.line); got != tc.want {
+				t.Fatalf("extractSignalLinkURI(%q) = %q, want %q", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCleanSignalCommandOutput(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		output string
+		want   string
+	}{
+		{
+			name: "sanitizes filters and deduplicates",
+			err:  errors.New("exit status 1"),
+			output: "\x1b[31mUser +15551230000 is not registered.\x1b[0m\n" +
+				"████ QR block\n" +
+				"User +15551230000 is not registered.\r\n",
+			want: "exit status 1: User +15551230000 is not registered.",
+		},
+		{
+			name:   "deduplicates error echoed on stdout",
+			err:    errors.New("authorization failed"),
+			output: "authorization failed\n",
+			want:   "authorization failed",
+		},
+		{name: "empty", output: "\n████ QR block\n", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cleanSignalCommandOutput(tc.err, []byte(tc.output)); got != tc.want {
+				t.Fatalf("cleanSignalCommandOutput() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsSignalAccountInvalid(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		output string
+		want   bool
+	}{
+		{name: "not registered output", output: "User +15551230000 is not registered.", want: true},
+		{name: "authorization failed output", output: "AUTHORIZATION FAILED", want: true},
+		{name: "invalid account error", err: errors.New("invalid account +15551230000"), want: true},
+		{name: "transient receive failure", err: errors.New("exit status 1"), output: "Connection closed unexpectedly", want: false},
+		{name: "poison envelope", err: errors.New("exit status 1"), output: "IncomingMessageHandler.getSender() content is null", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSignalAccountInvalid(tc.err, []byte(tc.output)); got != tc.want {
+				t.Fatalf("isSignalAccountInvalid() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSignalEnvelopeRecoveryReason(t *testing.T) {
+	group := &signalGroupInfo{GroupID: "group-1"}
+	cases := []struct {
+		name string
+		env  *signalEnvelope
+		want string
+	}{
+		{name: "nil envelope", want: ""},
+		{name: "empty envelope", env: &signalEnvelope{}, want: ""},
+		{
+			name: "missing edit source",
+			env:  &signalEnvelope{EditMessage: &signalEditMessage{DataMessage: &signalDataMessage{}}},
+			want: "missing_edit_message_source",
+		},
+		{
+			name: "edit source present",
+			env: &signalEnvelope{
+				SourceServiceID: "sender-aci",
+				EditMessage:     &signalEditMessage{DataMessage: &signalDataMessage{}},
+			},
+			want: "",
+		},
+		{
+			name: "source-less group edit allowed",
+			env: &signalEnvelope{EditMessage: &signalEditMessage{DataMessage: &signalDataMessage{
+				GroupInfo: group,
+			}}},
+			want: "",
+		},
+		{name: "missing data source", env: &signalEnvelope{DataMessage: &signalDataMessage{}}, want: "missing_data_message_source"},
+		{
+			name: "data source present",
+			env:  &signalEnvelope{SourceNumber: "+15551234567", DataMessage: &signalDataMessage{}},
+			want: "",
+		},
+		{
+			name: "source-less group data allowed",
+			env:  &signalEnvelope{DataMessage: &signalDataMessage{GroupInfo: group}},
+			want: "",
+		},
+		{
+			name: "missing sent target",
+			env:  &signalEnvelope{SyncMessage: &signalSyncMessage{SentMessage: &signalSentMessage{}}},
+			want: "missing_sent_message_target",
+		},
+		{
+			name: "sent target present",
+			env: &signalEnvelope{SyncMessage: &signalSyncMessage{SentMessage: &signalSentMessage{
+				DestinationServiceID: "recipient-aci",
+			}}},
+			want: "",
+		},
+		{
+			name: "target-less group sent message allowed",
+			env: &signalEnvelope{SyncMessage: &signalSyncMessage{SentMessage: &signalSentMessage{
+				GroupInfo: group,
+			}}},
+			want: "",
+		},
+		{
+			name: "target-less group sent edit allowed",
+			env: &signalEnvelope{SyncMessage: &signalSyncMessage{SentMessage: &signalSentMessage{
+				EditMessage: &signalEditMessage{DataMessage: &signalDataMessage{GroupInfo: group}},
+			}}},
+			want: "",
+		},
+		{
+			name: "first missing reason wins",
+			env: &signalEnvelope{
+				EditMessage: &signalEditMessage{DataMessage: &signalDataMessage{}},
+				DataMessage: &signalDataMessage{},
+				SyncMessage: &signalSyncMessage{SentMessage: &signalSentMessage{}},
+			},
+			want: "missing_edit_message_source",
+		},
+		{name: "typing does not require source", env: &signalEnvelope{TypingMessage: &signalTypingMessage{}}, want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := signalEnvelopeRecoveryReason(tc.env); got != tc.want {
+				t.Fatalf("signalEnvelopeRecoveryReason() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProcessReceiveLineAcceptsResultWrappedEnvelope(t *testing.T) {
+	store, err := db.New(filepath.Join(t.TempDir(), "messages.db"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	bridge := &Bridge{
+		store:     store,
+		logger:    zerolog.Nop(),
+		configDir: t.TempDir(),
+	}
+	payload := []byte(`{"result":{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","sourceName":"Taylor","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"wrapped receive result","mentions":[{"recipient":"+15551230000"}]}}}}`)
+
+	resolved, err := bridge.processReceiveLine("+15550000000", payload, true)
+	if err != nil {
+		t.Fatalf("processReceiveLine(): %v", err)
+	}
+	if !resolved {
+		t.Fatal("result-wrapped payload was not resolved")
+	}
+
+	msgs, err := store.GetMessagesByConversation("signal:+15551234567", 10)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversation(): %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Body != "wrapped receive result" || msgs[0].SenderNumber != "+15551234567" {
+		t.Fatalf("unexpected wrapped message: %+v", msgs[0])
+	}
+	if !msgs[0].MentionsMe {
+		t.Fatalf("result account was not used for mention normalization: %+v", msgs[0])
+	}
+	if status := bridge.receiveRecoveryStatus(); status != nil {
+		t.Fatalf("valid result-wrapped payload was quarantined: %+v", status)
+	}
+}

--- a/internal/signallive/client.go
+++ b/internal/signallive/client.go
@@ -32,13 +32,61 @@ const (
 	receiveTimeoutSeconds = 2
 	receiveMaxMessages    = 100
 	receiveFailureLimit   = 3
+	receivePoisonLimit    = 2
 	receiveRecoveryWindow = 30 * time.Second
 	reactionMatchWindow   = 15 * time.Second
 	sendTimeout           = 20 * time.Second
 	syncRequestTimeout    = 10 * time.Second
 	postLinkProbeTimeout  = 5 * time.Second
+	versionProbeTimeout   = 5 * time.Second
 	historySyncQuietAfter = 45 * time.Second
+
+	signalGetSenderPoisonFingerprint = "incoming_message_get_sender_content_null"
 )
+
+var minimumSignalCLIVersion = signalCLIVersion{major: 0, minor: 14, patch: 5}
+
+type signalCLIVersion struct {
+	major int
+	minor int
+	patch int
+}
+
+func parseSignalCLIVersion(output []byte) (signalCLIVersion, bool) {
+	for _, line := range strings.Split(string(output), "\n") {
+		fields := strings.Fields(sanitizeSignalOutput(line))
+		for i := 0; i+1 < len(fields); i++ {
+			if fields[i] != "signal-cli" {
+				continue
+			}
+			parts := strings.Split(fields[i+1], ".")
+			if len(parts) != 3 {
+				continue
+			}
+			major, majorErr := strconv.Atoi(parts[0])
+			minor, minorErr := strconv.Atoi(parts[1])
+			patch, patchErr := strconv.Atoi(parts[2])
+			if majorErr == nil && minorErr == nil && patchErr == nil {
+				return signalCLIVersion{major: major, minor: minor, patch: patch}, true
+			}
+		}
+	}
+	return signalCLIVersion{}, false
+}
+
+func (v signalCLIVersion) less(other signalCLIVersion) bool {
+	if v.major != other.major {
+		return v.major < other.major
+	}
+	if v.minor != other.minor {
+		return v.minor < other.minor
+	}
+	return v.patch < other.patch
+}
+
+func (v signalCLIVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+}
 
 func isSignalIdleReceiveTimeout(err error, timedOut bool, output []byte) bool {
 	if len(bytes.TrimSpace(output)) != 0 {
@@ -50,8 +98,18 @@ func isSignalIdleReceiveTimeout(err error, timedOut bool, output []byte) bool {
 var (
 	now = time.Now
 
-	signalCLILookPath = exec.LookPath
-	signalCLIStat     = os.Stat
+	signalCLILookPath     = exec.LookPath
+	signalCLIStat         = os.Stat
+	probeSignalCLIVersion = func(ctx context.Context) ([]byte, error) {
+		cmd := exec.CommandContext(ctx, signalCLIExecutable(), "--version")
+		tmpDir, cleanupTmp, tmpErr := newSignalRunTmpDir()
+		if tmpErr == nil {
+			cmd.Env = signalCLIEnv(os.Environ(), tmpDir)
+			defer cleanupTmp()
+		}
+		configureSignalCancel(cmd)
+		return cmd.CombinedOutput()
+	}
 
 	runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
 		commandArgs := append([]string{"--config", configDir}, args...)
@@ -118,14 +176,15 @@ type Callbacks struct {
 }
 
 type StatusSnapshot struct {
-	Connected   bool   `json:"connected"`
-	Connecting  bool   `json:"connecting"`
-	Paired      bool   `json:"paired"`
-	Pairing     bool   `json:"pairing"`
-	Account     string `json:"account,omitempty"`
-	LastError   string `json:"last_error,omitempty"`
-	QRAvailable bool   `json:"qr_available"`
-	QRUpdatedAt int64  `json:"qr_updated_at,omitempty"`
+	Connected       bool   `json:"connected"`
+	Connecting      bool   `json:"connecting"`
+	Paired          bool   `json:"paired"`
+	Pairing         bool   `json:"pairing"`
+	Account         string `json:"account,omitempty"`
+	LastError       string `json:"last_error,omitempty"`
+	QRAvailable     bool   `json:"qr_available"`
+	QRUpdatedAt     int64  `json:"qr_updated_at,omitempty"`
+	UpgradeRequired bool   `json:"upgrade_required,omitempty"`
 	// NeedsReauth is set when signal-cli reports that the stored account is
 	// no longer registered / authorized (e.g. user re-registered Signal on a
 	// new phone, or the linked device was unlinked remotely). When true,
@@ -191,6 +250,10 @@ type Bridge struct {
 	// reconnect. While set, the reconnect ticker skips this bridge so we
 	// don't hammer signal-cli with a known-bad account every 5 seconds.
 	needsReauth bool
+	// upgradeRequired is a terminal receive state for an unsupported
+	// signal-cli version or its known poison-envelope crash. Automatic
+	// reconnects stay parked until a manual connect re-runs the version gate.
+	upgradeRequired bool
 
 	pairCancel    context.CancelFunc
 	receiveCancel context.CancelFunc
@@ -414,7 +477,7 @@ func signalCLIExecutable() string {
 
 func (b *Bridge) ConnectIfPaired() error {
 	b.mu.Lock()
-	if b.pairing || b.connecting || b.connected {
+	if b.pairing || b.connecting || b.connected || b.upgradeRequired {
 		b.mu.Unlock()
 		return nil
 	}
@@ -446,6 +509,7 @@ func (b *Bridge) Connect() error {
 		}
 		b.connecting = true
 		b.needsReauth = false
+		b.upgradeRequired = false
 		b.lastError = ""
 		account := b.account
 		b.mu.Unlock()
@@ -462,6 +526,7 @@ func (b *Bridge) Connect() error {
 	b.pairing = true
 	b.connecting = true
 	b.needsReauth = false
+	b.upgradeRequired = false
 	b.lastError = ""
 	b.qr = QRSnapshot{}
 	b.mu.Unlock()
@@ -485,6 +550,7 @@ func (b *Bridge) Unpair() error {
 	b.pairing = false
 	b.account = ""
 	b.needsReauth = false
+	b.upgradeRequired = false
 	b.lastError = ""
 	b.qr = QRSnapshot{}
 	b.historySync = struct {
@@ -506,16 +572,17 @@ func (b *Bridge) Status() StatusSnapshot {
 		account = b.firstStoredAccount()
 	}
 	snapshot := StatusSnapshot{
-		Connected:   b.connected,
-		Connecting:  b.connecting,
-		Paired:      account != "",
-		Pairing:     b.pairing,
-		Account:     account,
-		LastError:   b.lastError,
-		QRAvailable: b.qr.URI != "",
-		QRUpdatedAt: b.qr.UpdatedAt,
-		NeedsReauth: b.needsReauth,
-		HistorySync: b.historySyncSnapshotLocked(),
+		Connected:       b.connected,
+		Connecting:      b.connecting,
+		Paired:          account != "",
+		Pairing:         b.pairing,
+		Account:         account,
+		LastError:       b.lastError,
+		QRAvailable:     b.qr.URI != "",
+		QRUpdatedAt:     b.qr.UpdatedAt,
+		UpgradeRequired: b.upgradeRequired,
+		NeedsReauth:     b.needsReauth,
+		HistorySync:     b.historySyncSnapshotLocked(),
 	}
 	b.mu.RUnlock()
 	snapshot.ReceiveRecovery = b.receiveRecoveryStatus()
@@ -853,6 +920,7 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 		}
 	}()
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	b.mu.Lock()
 	if b.receiveCancel != nil {
 		b.receiveCancel()
@@ -861,6 +929,38 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 	token := b.receiveToken
 	b.receiveCancel = cancel
 	b.mu.Unlock()
+
+	versionCtx, versionCancel := context.WithTimeout(ctx, versionProbeTimeout)
+	versionOutput, versionErr := probeSignalCLIVersion(versionCtx)
+	versionCancel()
+	if ctx.Err() != nil {
+		b.mu.Lock()
+		if b.receiveToken == token {
+			b.receiveCancel = nil
+			b.connected = false
+			b.connecting = false
+		}
+		b.mu.Unlock()
+		return
+	}
+	version, versionDetected := parseSignalCLIVersion(versionOutput)
+	if versionDetected && version.less(minimumSignalCLIVersion) {
+		b.parkUpgradeRequired(token, fmt.Sprintf(
+			"signal-cli %s is below the required minimum %s; upgrade signal-cli to continue receiving messages",
+			version, minimumSignalCLIVersion,
+		))
+		return
+	}
+	if !versionDetected {
+		event := b.logger.Warn()
+		if versionErr != nil {
+			event = event.Err(versionErr)
+		}
+		if output := strings.TrimSpace(string(versionOutput)); output != "" {
+			event = event.Str("output", output)
+		}
+		event.Msg("Unable to detect signal-cli version; continuing receive without version gate")
+	}
 
 	probedAccount, err := b.probeAccount(ctx, account)
 	if err != nil || probedAccount == "" {
@@ -885,6 +985,7 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 	b.connected = true
 	b.connecting = false
 	b.needsReauth = false // successful connect clears any prior re-auth flag
+	b.upgradeRequired = false
 	b.lastError = ""
 	b.mu.Unlock()
 	b.emitStatusChange()
@@ -898,6 +999,8 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 	}
 
 	consecutiveFailures := 0
+	consecutivePoisonFailures := 0
+	lastPoisonFingerprint := ""
 	for {
 		select {
 		case <-ctx.Done():
@@ -928,6 +1031,8 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 		if err != nil {
 			if isSignalIdleReceiveTimeout(err, timedOut, output) {
 				consecutiveFailures = 0
+				consecutivePoisonFailures = 0
+				lastPoisonFingerprint = ""
 				continue
 			}
 			if isSignalAccountInvalid(err, output) {
@@ -949,8 +1054,25 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 				b.emitStatusChange()
 				return
 			}
+			poisonFingerprint := signalReceivePoisonFingerprint(err, output)
+			if poisonFingerprint == "" {
+				consecutivePoisonFailures = 0
+				lastPoisonFingerprint = ""
+			} else if poisonFingerprint == lastPoisonFingerprint {
+				consecutivePoisonFailures++
+			} else {
+				lastPoisonFingerprint = poisonFingerprint
+				consecutivePoisonFailures = 1
+			}
 			consecutiveFailures++
 			receiveErr := commandError("receive Signal messages", err, output)
+			if consecutivePoisonFailures >= receivePoisonLimit {
+				b.parkUpgradeRequired(token, fmt.Sprintf(
+					"signal-cli repeatedly failed in IncomingMessageHandler.getSender() because content is null; upgrade signal-cli to %s or newer",
+					minimumSignalCLIVersion,
+				))
+				return
+			}
 			if consecutiveFailures >= receiveFailureLimit {
 				b.logger.Warn().Err(receiveErr).Int("failures", consecutiveFailures).Msg("Signal receive polling repeatedly failed; forcing reconnect")
 				b.mu.Lock()
@@ -969,6 +1091,8 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 			continue
 		}
 		consecutiveFailures = 0
+		consecutivePoisonFailures = 0
+		lastPoisonFingerprint = ""
 		if len(bytes.TrimSpace(output)) == 0 {
 			continue
 		}
@@ -976,6 +1100,25 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 			b.logger.Debug().Err(err).Msg("Failed to process Signal receive payload")
 		}
 	}
+}
+
+func (b *Bridge) parkUpgradeRequired(token uint64, detail string) {
+	detail = strings.TrimSpace(detail)
+	b.mu.Lock()
+	if b.receiveToken != token {
+		b.mu.Unlock()
+		return
+	}
+	b.receiveCancel = nil
+	b.connected = false
+	b.connecting = false
+	b.needsReauth = false
+	b.upgradeRequired = true
+	b.lastError = detail
+	account := b.account
+	b.mu.Unlock()
+	b.logger.Warn().Str("account", account).Msg(detail)
+	b.emitStatusChange()
 }
 
 // maybeSweepTmp runs the crash-backstop sweeps at most once per
@@ -3155,6 +3298,16 @@ func isSignalAccountInvalid(err error, output []byte) bool {
 	return strings.Contains(text, "not registered") ||
 		strings.Contains(text, "authorization failed") ||
 		strings.Contains(text, "invalid account")
+}
+
+func signalReceivePoisonFingerprint(err error, output []byte) string {
+	text := strings.ToLower(cleanSignalCommandOutput(err, output))
+	text = strings.NewReplacer(`"`, "", `'`, "").Replace(text)
+	if strings.Contains(text, "getsender") &&
+		strings.Contains(text, "content is null") {
+		return signalGetSenderPoisonFingerprint
+	}
+	return ""
 }
 
 func uniqueStrings(items []string) []string {

--- a/internal/signallive/client_test.go
+++ b/internal/signallive/client_test.go
@@ -201,12 +201,17 @@ func TestStartReceiveLoopDropsSignalConnectionAfterRepeatedReceiveFailures(t *te
 	}
 
 	originalRun := runSignalCLI
+	originalVersionProbe := probeSignalCLIVersion
 	defer func() {
 		_ = bridge.Close()
 		bridge.commandMu.Lock()
 		runSignalCLI = originalRun
 		bridge.commandMu.Unlock()
+		probeSignalCLIVersion = originalVersionProbe
 	}()
+	probeSignalCLIVersion = func(context.Context) ([]byte, error) {
+		return []byte("signal-cli 0.14.5"), nil
+	}
 
 	var receiveCalls atomic.Int32
 	runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
@@ -241,12 +246,17 @@ func TestStartReceiveLoopIgnoresIdleReceiveTimeouts(t *testing.T) {
 	}
 
 	originalRun := runSignalCLI
+	originalVersionProbe := probeSignalCLIVersion
 	defer func() {
 		_ = bridge.Close()
 		bridge.commandMu.Lock()
 		runSignalCLI = originalRun
 		bridge.commandMu.Unlock()
+		probeSignalCLIVersion = originalVersionProbe
 	}()
+	probeSignalCLIVersion = func(context.Context) ([]byte, error) {
+		return []byte("signal-cli 0.14.5"), nil
+	}
 
 	var receiveCalls atomic.Int32
 	runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
@@ -1909,13 +1919,18 @@ func TestConnectEmitsSignalQRCodeAndStoresPairedAccount(t *testing.T) {
 
 	originalStartLink := startSignalLink
 	originalRun := runSignalCLI
+	originalVersionProbe := probeSignalCLIVersion
 	defer func() {
 		_ = bridge.Close()
 		bridge.commandMu.Lock()
 		runSignalCLI = originalRun
 		bridge.commandMu.Unlock()
+		probeSignalCLIVersion = originalVersionProbe
 		startSignalLink = originalStartLink
 	}()
+	probeSignalCLIVersion = func(context.Context) ([]byte, error) {
+		return []byte("signal-cli 0.14.5"), nil
+	}
 
 	releaseWait := make(chan struct{})
 	var callsMu sync.Mutex

--- a/internal/signallive/gate_test.go
+++ b/internal/signallive/gate_test.go
@@ -1,0 +1,468 @@
+package signallive
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+const realisticSignalGetSenderPoison = `WARN  IncomingMessageHandler - Failed to handle incoming message
+java.lang.NullPointerException: Cannot invoke "org.asamk.signal.manager.storage.recipients.RecipientId.getSender()" because "content" is null
+	at org.asamk.signal.manager.helper.IncomingMessageHandler.getSender(IncomingMessageHandler.java:412)`
+
+func TestSignalCLIVersionProbeUsesExactCommandAndPrivateTemp(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	stub := filepath.Join(t.TempDir(), "signal-cli-stub")
+	script := "#!/bin/sh\nprintf '%s|%s|%s' \"$1\" \"$TMPDIR\" \"$SIGNAL_CLI_OPTS\"\nmkdir -p \"$TMPDIR/libsignal-test\"\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OPENMESSAGES_SIGNAL_CLI", stub)
+
+	output, err := probeSignalCLIVersion(context.Background())
+	if err != nil {
+		t.Fatalf("probeSignalCLIVersion(): %v (output=%s)", err, output)
+	}
+	parts := strings.SplitN(string(output), "|", 3)
+	if len(parts) != 3 {
+		t.Fatalf("unexpected version probe output: %q", output)
+	}
+	if parts[0] != "--version" {
+		t.Fatalf("signal-cli arguments = %q, want exact --version", parts[0])
+	}
+	tmpDir, opts := parts[1], parts[2]
+	if !strings.HasPrefix(tmpDir, signalTmpRoot()) {
+		t.Fatalf("version probe TMPDIR %q not confined under %q", tmpDir, signalTmpRoot())
+	}
+	if !strings.Contains(opts, "-Djava.io.tmpdir="+tmpDir) {
+		t.Fatalf("version probe SIGNAL_CLI_OPTS %q missing java.io.tmpdir", opts)
+	}
+	if _, err := os.Stat(tmpDir); !os.IsNotExist(err) {
+		t.Fatalf("version probe temp dir %q should be removed, stat err = %v", tmpDir, err)
+	}
+}
+
+func TestParseSignalCLIVersionBoundaryAndMalformedOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		want       signalCLIVersion
+		wantParsed bool
+		wantBelow  bool
+	}{
+		{
+			name:       "below minimum",
+			output:     "signal-cli 0.14.4\n",
+			want:       signalCLIVersion{major: 0, minor: 14, patch: 4},
+			wantParsed: true,
+			wantBelow:  true,
+		},
+		{
+			name:       "minimum",
+			output:     "signal-cli 0.14.5\n",
+			want:       minimumSignalCLIVersion,
+			wantParsed: true,
+		},
+		{
+			name:       "newer minor",
+			output:     "signal-cli 0.15.0\n",
+			want:       signalCLIVersion{major: 0, minor: 15, patch: 0},
+			wantParsed: true,
+		},
+		{
+			name:       "version after diagnostic line",
+			output:     "WARN  startup diagnostic\nsignal-cli 1.0.0\n",
+			want:       signalCLIVersion{major: 1, minor: 0, patch: 0},
+			wantParsed: true,
+		},
+		{name: "missing patch", output: "signal-cli 0.14\n"},
+		{name: "prefixed version", output: "signal-cli v0.14.5\n"},
+		{name: "non-numeric version", output: "signal-cli latest\n"},
+		{name: "unrelated output", output: "command not found\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, parsed := parseSignalCLIVersion([]byte(tc.output))
+			if parsed != tc.wantParsed {
+				t.Fatalf("parseSignalCLIVersion(%q) parsed = %v, want %v (version=%s)", tc.output, parsed, tc.wantParsed, got)
+			}
+			if !parsed {
+				return
+			}
+			if got != tc.want {
+				t.Fatalf("parseSignalCLIVersion(%q) = %s, want %s", tc.output, got, tc.want)
+			}
+			if below := got.less(minimumSignalCLIVersion); below != tc.wantBelow {
+				t.Fatalf("%s less than minimum %s = %v, want %v", got, minimumSignalCLIVersion, below, tc.wantBelow)
+			}
+		})
+	}
+}
+
+func TestSignalCLIVersionGateParksBelowMinimumBeforeAccountOrReceive(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+
+	var versionCalls atomic.Int32
+	var accountCalls atomic.Int32
+	var receiveCalls atomic.Int32
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			versionCalls.Add(1)
+			return []byte("signal-cli 0.14.4\n"), nil
+		},
+		func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			switch {
+			case hasSignalCLIArg(args, "listAccounts"):
+				accountCalls.Add(1)
+				return []byte(`[{"number":"+15551230000"}]`), nil
+			case hasSignalCLIArg(args, "receive"):
+				receiveCalls.Add(1)
+			}
+			return nil, nil
+		},
+	)
+
+	if err := bridge.ConnectIfPaired(); err != nil {
+		t.Fatalf("ConnectIfPaired(): %v", err)
+	}
+	waitForCondition(t, 2*time.Second, func() bool {
+		status := bridge.Status()
+		return status.UpgradeRequired && !status.Connected && !status.Connecting
+	})
+
+	status := bridge.Status()
+	if !strings.Contains(status.LastError, "0.14.4") ||
+		!strings.Contains(status.LastError, minimumSignalCLIVersion.String()) {
+		t.Fatalf("last_error = %q, want detected and minimum versions", status.LastError)
+	}
+	encodedStatus, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("json.Marshal(status): %v", err)
+	}
+	if !bytes.Contains(encodedStatus, []byte(`"upgrade_required":true`)) {
+		t.Fatalf("status JSON = %s, want upgrade_required=true", encodedStatus)
+	}
+	if got := versionCalls.Load(); got != 1 {
+		t.Fatalf("version probe calls = %d, want 1", got)
+	}
+	if got := accountCalls.Load(); got != 0 {
+		t.Fatalf("listAccounts calls = %d, want 0", got)
+	}
+	if got := receiveCalls.Load(); got != 0 {
+		t.Fatalf("receive calls = %d, want 0", got)
+	}
+}
+
+func TestSignalCLIVersionGateAllowsMinimumVersionToReceive(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+
+	var receiveCalls atomic.Int32
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			return []byte("signal-cli 0.14.5\n"), nil
+		},
+		func(ctx context.Context, _ string, args ...string) ([]byte, error) {
+			if hasSignalCLIArg(args, "listAccounts") {
+				return []byte(`[{"number":"+15551230000"}]`), nil
+			}
+			if hasSignalCLIArg(args, "receive") {
+				receiveCalls.Add(1)
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}
+			return []byte("[]"), nil
+		},
+	)
+
+	if err := bridge.ConnectIfPaired(); err != nil {
+		t.Fatalf("ConnectIfPaired(): %v", err)
+	}
+	waitForCondition(t, 2*time.Second, func() bool {
+		return receiveCalls.Load() > 0
+	})
+
+	status := bridge.Status()
+	if !status.Connected || status.Connecting || status.UpgradeRequired {
+		t.Fatalf("0.14.5 status = %+v, want connected without upgrade requirement", status)
+	}
+}
+
+func TestSignalCLIVersionGateFailsOpenWithWarning(t *testing.T) {
+	tests := []struct {
+		name   string
+		output []byte
+		err    error
+	}{
+		{
+			name: "probe error",
+			err:  errors.New("signal-cli version probe failed"),
+		},
+		{
+			name:   "malformed output",
+			output: []byte("signal-cli version unknown\n"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var log bytes.Buffer
+			bridge := &Bridge{
+				account:   "+15551230000",
+				configDir: t.TempDir(),
+				logger:    zerolog.New(&log),
+			}
+
+			var receiveCalls atomic.Int32
+			installSignalGateStubs(t, bridge,
+				func(context.Context) ([]byte, error) {
+					return tc.output, tc.err
+				},
+				func(ctx context.Context, _ string, args ...string) ([]byte, error) {
+					if hasSignalCLIArg(args, "listAccounts") {
+						return []byte(`[{"number":"+15551230000"}]`), nil
+					}
+					if hasSignalCLIArg(args, "receive") {
+						receiveCalls.Add(1)
+						<-ctx.Done()
+						return nil, ctx.Err()
+					}
+					return []byte("[]"), nil
+				},
+			)
+
+			if err := bridge.ConnectIfPaired(); err != nil {
+				t.Fatalf("ConnectIfPaired(): %v", err)
+			}
+			waitForCondition(t, 2*time.Second, func() bool {
+				return receiveCalls.Load() > 0
+			})
+
+			status := bridge.Status()
+			if !status.Connected || status.UpgradeRequired {
+				t.Fatalf("undetectable version status = %+v, want fail-open connection", status)
+			}
+			if !strings.Contains(log.String(), "Unable to detect signal-cli version") ||
+				!strings.Contains(log.String(), "continuing receive without version gate") {
+				t.Fatalf("warning log missing fail-open explanation: %q", log.String())
+			}
+		})
+	}
+}
+
+func TestSignalReceivePoisonFingerprint(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		output string
+		want   string
+	}{
+		{
+			name:   "real signal-cli crash",
+			err:    errors.New("exit status 1"),
+			output: realisticSignalGetSenderPoison,
+			want:   signalGetSenderPoisonFingerprint,
+		},
+		{
+			name:   "fingerprint split across error and output",
+			err:    errors.New("getSender() failed"),
+			output: `java.lang.NullPointerException: "content" is null`,
+			want:   signalGetSenderPoisonFingerprint,
+		},
+		{
+			name:   "getSender without null content",
+			err:    errors.New("exit status 1"),
+			output: "at IncomingMessageHandler.getSender(IncomingMessageHandler.java:412)",
+		},
+		{
+			name:   "null content without getSender",
+			err:    errors.New("exit status 1"),
+			output: `NullPointerException: "content" is null`,
+		},
+		{
+			name:   "unrelated receive failure",
+			err:    context.DeadlineExceeded,
+			output: "Connection closed unexpectedly",
+		},
+		{name: "empty"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := signalReceivePoisonFingerprint(tc.err, []byte(tc.output)); got != tc.want {
+				t.Fatalf("signalReceivePoisonFingerprint() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRepeatedSignalReceivePoisonParksAtThresholdAndCannotAutoRestart(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+
+	var versionCalls atomic.Int32
+	var receiveCalls atomic.Int32
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			versionCalls.Add(1)
+			return []byte("signal-cli 0.14.5\n"), nil
+		},
+		func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			if hasSignalCLIArg(args, "listAccounts") {
+				return []byte(`[{"number":"+15551230000"}]`), nil
+			}
+			if hasSignalCLIArg(args, "receive") {
+				receiveCalls.Add(1)
+				return []byte(realisticSignalGetSenderPoison), errors.New("exit status 1")
+			}
+			return []byte("[]"), nil
+		},
+	)
+
+	if err := bridge.ConnectIfPaired(); err != nil {
+		t.Fatalf("ConnectIfPaired(): %v", err)
+	}
+	waitForCondition(t, 3*time.Second, func() bool {
+		return bridge.Status().UpgradeRequired
+	})
+
+	status := bridge.Status()
+	if status.Connected || status.Connecting {
+		t.Fatalf("poison status = %+v, want parked", status)
+	}
+	if !strings.Contains(status.LastError, "IncomingMessageHandler.getSender()") ||
+		!strings.Contains(status.LastError, "content is null") ||
+		!strings.Contains(status.LastError, minimumSignalCLIVersion.String()) {
+		t.Fatalf("poison last_error = %q, want fingerprint and upgrade instruction", status.LastError)
+	}
+	if got := receiveCalls.Load(); got != int32(receivePoisonLimit) {
+		t.Fatalf("receive calls at park = %d, want exact poison threshold %d", got, receivePoisonLimit)
+	}
+
+	versionBefore := versionCalls.Load()
+	receiveBefore := receiveCalls.Load()
+	if err := bridge.ConnectIfPaired(); err != nil {
+		t.Fatalf("ConnectIfPaired() while parked: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond)
+	if got := versionCalls.Load(); got != versionBefore {
+		t.Fatalf("version probe restarted while parked: calls = %d, want %d", got, versionBefore)
+	}
+	if got := receiveCalls.Load(); got != receiveBefore {
+		t.Fatalf("receive restarted while parked: calls = %d, want %d", got, receiveBefore)
+	}
+	if status := bridge.Status(); !status.UpgradeRequired || status.Connecting || status.Connected {
+		t.Fatalf("status changed after automatic reconnect attempt: %+v", status)
+	}
+}
+
+func TestSignalReceivePoisonConsecutiveCountResetsAfterIdlePoll(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+
+	var receiveCalls atomic.Int32
+	fourthCallStarted := make(chan struct{})
+	releaseFourthCall := make(chan struct{})
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			return []byte("signal-cli 0.14.5\n"), nil
+		},
+		func(ctx context.Context, _ string, args ...string) ([]byte, error) {
+			if hasSignalCLIArg(args, "listAccounts") {
+				return []byte(`[{"number":"+15551230000"}]`), nil
+			}
+			if !hasSignalCLIArg(args, "receive") {
+				return []byte("[]"), nil
+			}
+
+			switch call := receiveCalls.Add(1); call {
+			case 1, 3:
+				return []byte(realisticSignalGetSenderPoison), errors.New("exit status 1")
+			case 2:
+				return nil, context.DeadlineExceeded
+			case 4:
+				close(fourthCallStarted)
+				select {
+				case <-releaseFourthCall:
+					return []byte(realisticSignalGetSenderPoison), errors.New("exit status 1")
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			default:
+				return nil, errors.New("unexpected receive after poison threshold")
+			}
+		},
+	)
+
+	if err := bridge.ConnectIfPaired(); err != nil {
+		t.Fatalf("ConnectIfPaired(): %v", err)
+	}
+	select {
+	case <-fourthCallStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("fourth receive did not start")
+	}
+	if status := bridge.Status(); status.UpgradeRequired {
+		t.Fatalf("single poison after idle interruption parked early: %+v", status)
+	}
+
+	close(releaseFourthCall)
+	waitForCondition(t, 2*time.Second, func() bool {
+		return bridge.Status().UpgradeRequired
+	})
+	if got := receiveCalls.Load(); got != 4 {
+		t.Fatalf("receive calls = %d, want 4 (poison, idle, poison, poison)", got)
+	}
+}
+
+func installSignalGateStubs(
+	t *testing.T,
+	bridge *Bridge,
+	versionProbe func(context.Context) ([]byte, error),
+	cli func(context.Context, string, ...string) ([]byte, error),
+) {
+	t.Helper()
+	originalVersionProbe := probeSignalCLIVersion
+	originalRunSignalCLI := runSignalCLI
+	probeSignalCLIVersion = versionProbe
+	runSignalCLI = cli
+	t.Cleanup(func() {
+		_ = bridge.Close()
+		probeSignalCLIVersion = originalVersionProbe
+		bridge.commandMu.Lock()
+		runSignalCLI = originalRunSignalCLI
+		bridge.commandMu.Unlock()
+	})
+}
+
+func hasSignalCLIArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Wave 0 / F8 — roadmap item #3 (gate signal-cli + circuit-break poison failures). Implemented by Sol (rotated Codex lane), reviewed by Claude. **Runtime-affecting** — deploys after merge. Safe for the live install (your signal-cli is 0.14.5, which the gate passes).

## Why

signal-cli 0.14.1 hit an NPE — `IncomingMessageHandler.getSender()` because `content` is null — on an unparseable envelope, exited without acking, and poison-looped, flapping `connected` every ~6s until it was manually upgraded to 0.14.5. This makes that floor code-enforced instead of tribal knowledge.

## Production (minimal; the receive-loop rewrite is Wave 1 / SD1–SD3)

- **Version gate.** Before receiving, probe `signal-cli --version` (in the confined JVM tmpdir, via an injectable seam). A detected version **< 0.14.5 parks** the bridge in a new `upgrade_required` state with an actionable `last_error` and does **not** start receive or even probe the account. An **undetectable** version **fails open** with a warning — a probe glitch must not kill a working bridge (the poison circuit is the backstop).
- **Poison circuit.** Two consecutive `getSender`/`content is null` receive failures park as `upgrade_required` instead of hitting the 3-failure reconnect, so a poison envelope can no longer respawn signal-cli every few seconds. Idle/success/unrelated errors reset the streak.
- The 5s reconnect watchdog and `ConnectIfPaired` skip `upgrade_required`; a manual **Connect** clears it and re-probes (e.g. after the user upgrades).

## Tests

Version parse boundaries + malformed output; gate parks 0.14.4 with **zero** account/receive calls; 0.14.5 receives; undetectable fails open + warns; poison fingerprint detection; poison parks at the **exact** threshold and cannot auto-restart while parked; an idle poll resets the poison streak. Plus Signal parser/quarantine/`--attachment=` characterization.

`go test -race ./internal/signallive/` + full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
