### PR TITLE
Add internal/bridge domain types (rebuild Wave 1 / C1)

### DIFF
--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -1,0 +1,154 @@
+package bridge
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestEventPayloadInvariant(t *testing.T) {
+	tests := []struct {
+		name  string
+		event Event
+	}{
+		{
+			name:  "conversation",
+			event: Event{Kind: EventConversation, Conversation: &ConversationEvent{}},
+		},
+		{
+			name:  "message",
+			event: Event{Kind: EventMessage, Message: &MessageEvent{}},
+		},
+		{
+			name:  "message mutation",
+			event: Event{Kind: EventMessageMutation, MessageMutation: &MessageMutationEvent{}},
+		},
+		{
+			name:  "reaction",
+			event: Event{Kind: EventReaction, Reaction: &ReactionEvent{}},
+		},
+		{
+			name:  "receipt",
+			event: Event{Kind: EventReceipt, Receipt: &ReceiptEvent{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !validEvent(tt.event) {
+				t.Fatalf("validEvent(%+v) = false, want true", tt.event)
+			}
+		})
+	}
+
+	invalid := []Event{
+		{Kind: EventMessage},
+		{Kind: EventMessage, Conversation: &ConversationEvent{}},
+		{Kind: EventMessage, Message: &MessageEvent{}, Receipt: &ReceiptEvent{}},
+	}
+	for _, event := range invalid {
+		if validEvent(event) {
+			t.Fatalf("validEvent(%+v) = true, want false", event)
+		}
+	}
+}
+
+func validEvent(event Event) bool {
+	payloadCount := 0
+	for _, present := range []bool{
+		event.Conversation != nil,
+		event.Message != nil,
+		event.MessageMutation != nil,
+		event.Reaction != nil,
+		event.Receipt != nil,
+	} {
+		if present {
+			payloadCount++
+		}
+	}
+
+	if payloadCount != 1 {
+		return false
+	}
+
+	switch event.Kind {
+	case EventConversation:
+		return event.Conversation != nil
+	case EventMessage:
+		return event.Message != nil
+	case EventMessageMutation:
+		return event.MessageMutation != nil
+	case EventReaction:
+		return event.Reaction != nil
+	case EventReceipt:
+		return event.Receipt != nil
+	default:
+		return false
+	}
+}
+
+func TestOpErrorError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  OpError
+		want string
+	}{
+		{
+			name: "with cause",
+			err: OpError{
+				Class:     FailureRateLimited,
+				Operation: "send_text",
+				Cause:     errors.New("server busy"),
+			},
+			want: "send_text: rate_limited: server busy",
+		},
+		{
+			name: "without cause",
+			err: OpError{
+				Class:     FailureUnsupported,
+				Operation: "send_media",
+			},
+			want: "send_media: unsupported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Fatalf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCapabilitySetJSONRoundTrip(t *testing.T) {
+	want := CapabilitySet{
+		StartConversation: true,
+		TextSend:          true,
+		MediaSend:         true,
+		Reactions:         true,
+		ReadReceipts:      true,
+		PairQR:            true,
+		PairPhone:         true,
+		MediaDownload:     true,
+	}
+
+	encoded, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	const wantJSON = `{"start_conversation":true,"text_send":true,"media_send":true,"reactions":true,"read_receipts":true,"pair_qr":true,"pair_phone":true,"media_download":true}`
+	if string(encoded) != wantJSON {
+		t.Fatalf("json.Marshal() = %s, want %s", encoded, wantJSON)
+	}
+
+	var got CapabilitySet
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round trip = %+v, want %+v", got, want)
+	}
+}

--- a/internal/bridge/types.go
+++ b/internal/bridge/types.go
@@ -1,0 +1,189 @@
+package bridge
+
+import (
+	"fmt"
+	"time"
+)
+
+type Platform string
+
+type Generation uint64
+
+type RawIngressRecord struct {
+	AccountID    string
+	Generation   Generation
+	DedupeKey    string // stable remote event/envelope ID when available
+	Codec        string // e.g. google.protobuf, whatsapp.event, signal.jsonrpc
+	CodecVersion uint32
+	ReceivedAt   time.Time
+	Payload      []byte // untouched serializable transport frame/event
+}
+
+type IdentityRef struct {
+	Kind      string
+	Canonical string
+	Raw       string
+	Name      string
+	IsSelf    bool
+}
+
+type Participant struct {
+	Identity IdentityRef
+	Role     string
+	Active   bool
+}
+
+type Attachment struct {
+	RemoteID  string
+	RemoteRef []byte
+	Filename  string
+	MIME      string
+	Size      int64
+}
+
+type ConversationEvent struct {
+	RemoteConversationID string
+	Kind                 string
+	Title                string
+	Participants         []Participant
+	RemoteRevision       string
+}
+
+type MessageEvent struct {
+	RemoteConversationID string
+	RemoteMessageID      string
+	ClientRequestID      string // self-echo/outbox correlation
+	Sender               IdentityRef
+	Direction            string
+	Body                 string
+	Attachments          []Attachment
+	ReplyToRemoteID      string
+	OccurredAt           time.Time
+}
+
+type MessageMutationEvent struct {
+	RemoteConversationID string
+	RemoteMessageID      string
+	Kind                 string // edit or delete
+	Body                 string
+	OccurredAt           time.Time
+}
+
+type ReactionAction string
+
+const (
+	ReactionAdd    ReactionAction = "add"
+	ReactionRemove ReactionAction = "remove"
+	ReactionSwitch ReactionAction = "switch"
+)
+
+type ReactionEvent struct {
+	RemoteConversationID  string
+	TargetRemoteMessageID string
+	Actor                 IdentityRef
+	Emoji                 string
+	Action                ReactionAction
+	OccurredAt            time.Time
+}
+
+type ReceiptEvent struct {
+	RemoteConversationID string
+	RemoteMessageIDs     []string
+	Actor                IdentityRef
+	Status               string // delivered or read
+	OccurredAt           time.Time
+}
+
+type TypingEvent struct {
+	RemoteConversationID string
+	Actor                IdentityRef
+	Typing               bool
+	ExpiresAt            time.Time
+}
+
+type EventKind string
+
+const (
+	EventConversation    EventKind = "conversation"
+	EventMessage         EventKind = "message"
+	EventMessageMutation EventKind = "message_mutation"
+	EventReaction        EventKind = "reaction"
+	EventReceipt         EventKind = "receipt"
+)
+
+// Event is the closed normalized durable projection contract: exactly one
+// payload matching Kind must be non-nil. No transport or db type can cross it.
+type Event struct {
+	AccountID       string
+	SourceInboxID   string
+	Kind            EventKind
+	Conversation    *ConversationEvent
+	Message         *MessageEvent
+	MessageMutation *MessageMutationEvent
+	Reaction        *ReactionEvent
+	Receipt         *ReceiptEvent
+}
+
+type EphemeralEvent struct {
+	AccountID  string
+	Generation Generation
+	Typing     *TypingEvent
+}
+
+type FailureClass string
+
+const (
+	FailureTransient          FailureClass = "transient"
+	FailureRateLimited        FailureClass = "rate_limited"
+	FailureCredentialsExpired FailureClass = "credentials_expired"
+	FailureReauthRequired     FailureClass = "reauth_required"
+	FailureUpgradeRequired    FailureClass = "upgrade_required"
+	FailureMisconfigured      FailureClass = "misconfigured"
+	FailureUnsupported        FailureClass = "unsupported"
+)
+
+type DispatchCertainty string
+
+const (
+	DispatchNotCalled DispatchCertainty = "not_dispatched"
+	DispatchUncertain DispatchCertainty = "uncertain"
+)
+
+type OpError struct {
+	Class       FailureClass
+	Operation   string
+	RetryAt     time.Time
+	Fingerprint string
+	Dispatch    DispatchCertainty
+	Cause       error
+}
+
+func (e OpError) Error() string {
+	if e.Cause == nil {
+		return fmt.Sprintf("%s: %s", e.Operation, e.Class)
+	}
+
+	return fmt.Sprintf("%s: %s: %v", e.Operation, e.Class, e.Cause)
+}
+
+type Capability string
+
+const (
+	CapabilityStartConversation Capability = "start_conversation"
+	CapabilityTextSend          Capability = "text_send"
+	CapabilityMediaSend         Capability = "media_send"
+	CapabilityReactions         Capability = "reactions"
+	CapabilityReadReceipts      Capability = "read_receipts"
+	CapabilityMediaDownload     Capability = "media_download"
+)
+
+type CapabilitySet struct {
+	StartConversation bool `json:"start_conversation"`
+	TextSend          bool `json:"text_send"`
+	MediaSend         bool `json:"media_send"`
+	Reactions         bool `json:"reactions"`
+	ReadReceipts      bool `json:"read_receipts"`
+	PairQR            bool `json:"pair_qr"`
+	PairPhone         bool `json:"pair_phone"`
+	MediaDownload     bool `json:"media_download"`
+}


### PR DESCRIPTION
Wave 1 / C1 — the pure type foundation the per-bridge supervisor, registry, and message service (C2–C8, Wave 2) all build on. Implemented by Sol, reviewed by Claude. Additive-only: a new `internal/bridge` package that nothing imports yet, so zero behavior change.

Defines, per plan §2.2/§2.3:
- **IDs**: `Platform`, `Generation`.
- **Ingress**: `RawIngressRecord` (raw transport frame + dedupe key + generation).
- **Value types**: `IdentityRef`, `Participant`, `Attachment`.
- **Normalized events**: `Conversation/Message/MessageMutation/Reaction/Receipt/Typing` payloads + the closed `Event` projection (exactly one payload matching `Kind`) and `EphemeralEvent`.
- **Failure classification**: `FailureClass`, `DispatchCertainty`, `OpError`.
- **Capability metadata**: `Capability` consts, `CapabilitySet`.

Imports only `fmt`/`time` — **no `internal/*` dependency** (the C1 exit criterion), verified. Tests cover the one-payload-per-Kind invariant, `OpError.Error()`, and `CapabilitySet` JSON round-trip. `go vet` + `go test ./internal/bridge/` green; whole repo still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
