### PR TITLE
Guard the gmessages fork against silent upstream drift and regression (Wave 0 / F6b)

### DIFF
--- a/.github/workflows/gmessages-fork-drift.yml
+++ b/.github/workflows/gmessages-fork-drift.yml
@@ -1,0 +1,122 @@
+name: GMessages Fork Drift
+
+on:
+  schedule:
+    - cron: "17 10 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  UPSTREAM_REPOSITORY: mautrix/gmessages
+  UPSTREAM_BRANCH: main
+  UPSTREAM_BASE: 3433cc07d5ea9522309adad3a8c92ed5b08dc11d
+  AUTH_REFRESH_RETRY_COMMIT: 0b54a8fe65207f81d353ffe63f4d2549c2eb7976
+  FORK_REPOSITORY: MaxGhenis/gmessages
+  FORK_MODULE: github.com/MaxGhenis/gmessages
+  FORK_BRANCH: main
+  FORK_VERSION: v0.2602.1-0.20260703132304-0e43542dfa0e
+  FORK_COMMIT: 0e43542dfa0e0b97e410f185a5842e8740106099
+  EXPECTED_PATCH_COUNT: "1"
+
+jobs:
+  drift:
+    name: Compare pinned fork with upstream
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the recorded contract
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Match the recorded contract to go.mod
+        run: |
+          set -euo pipefail
+          expected="replace go.mau.fi/mautrix-gmessages => ${FORK_MODULE} ${FORK_VERSION}"
+          if ! grep -Fqx "${expected}" go.mod; then
+            echo "::error::go.mod must contain the recorded gmessages fork pin: ${expected}"
+            exit 1
+          fi
+          if [ "${FORK_VERSION##*-}" != "${FORK_COMMIT:0:12}" ]; then
+            echo "::error::Recorded fork version ${FORK_VERSION} does not identify ${FORK_COMMIT}."
+            exit 1
+          fi
+
+      - name: Record and verify fork topology
+        run: |
+          set -euo pipefail
+
+          git init --quiet gmessages
+          cd gmessages
+          git remote add upstream "https://github.com/${UPSTREAM_REPOSITORY}.git"
+          git remote add fork "https://github.com/${FORK_REPOSITORY}.git"
+          git fetch --quiet --no-tags upstream \
+            "+refs/heads/${UPSTREAM_BRANCH}:refs/remotes/upstream/${UPSTREAM_BRANCH}"
+          git fetch --quiet --no-tags fork \
+            "+refs/heads/${FORK_BRANCH}:refs/remotes/fork/${FORK_BRANCH}"
+
+          upstream_ref="refs/remotes/upstream/${UPSTREAM_BRANCH}"
+          for commit in "${UPSTREAM_BASE}" "${AUTH_REFRESH_RETRY_COMMIT}" "${FORK_COMMIT}"; do
+            if ! git cat-file -e "${commit}^{commit}"; then
+              echo "::error::Required gmessages contract commit ${commit} is not reachable from the fetched branches."
+              exit 1
+            fi
+          done
+
+          if ! git merge-base --is-ancestor "${AUTH_REFRESH_RETRY_COMMIT}" "${UPSTREAM_BASE}"; then
+            echo "::error::Recorded upstream base ${UPSTREAM_BASE} does not contain the required auth-refresh retry ${AUTH_REFRESH_RETRY_COMMIT}."
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "${UPSTREAM_BASE}" "${FORK_COMMIT}"; then
+            echo "::error::Pinned fork ${FORK_REPOSITORY}@${FORK_COMMIT} is not based on recorded upstream ${UPSTREAM_BASE}."
+            exit 1
+          fi
+
+          fork_parents="$(git show --no-patch --format='%P' "${FORK_COMMIT}")"
+          if [ "${fork_parents}" != "${UPSTREAM_BASE}" ]; then
+            echo "::error::Pinned fork ${FORK_REPOSITORY}@${FORK_COMMIT} has parent(s) ${fork_parents}, not the single recorded base ${UPSTREAM_BASE}."
+            exit 1
+          fi
+
+          actual_base="$(git merge-base "${FORK_COMMIT}" "${upstream_ref}")"
+          if [ "${actual_base}" != "${UPSTREAM_BASE}" ]; then
+            echo "::error::Pinned fork ${FORK_REPOSITORY}@${FORK_COMMIT} has merge base ${actual_base}, not recorded base ${UPSTREAM_BASE}."
+            exit 1
+          fi
+
+          patch_count="$(git rev-list --count "${UPSTREAM_BASE}..${FORK_COMMIT}")"
+          if [ "${patch_count}" -ne "${EXPECTED_PATCH_COUNT}" ]; then
+            echo "::error::Pinned fork ${FORK_REPOSITORY}@${FORK_COMMIT} carries ${patch_count} commits over ${UPSTREAM_BASE}; expected ${EXPECTED_PATCH_COUNT}."
+            exit 1
+          fi
+
+          upstream_head="$(git rev-parse "${upstream_ref}")"
+          upstream_ahead="$(git rev-list --count "${UPSTREAM_BASE}..${upstream_ref}")"
+          patch_set="$(git log --reverse --format='%H %s' "${UPSTREAM_BASE}..${FORK_COMMIT}")"
+
+          {
+            echo "## gmessages fork contract"
+            echo
+            echo "| Item | Commit |"
+            echo "| --- | --- |"
+            echo "| Fork pin | ${FORK_VERSION} ([\`${FORK_COMMIT}\`](https://github.com/${FORK_REPOSITORY}/commit/${FORK_COMMIT})) |"
+            echo "| Upstream base | [\`${UPSTREAM_BASE}\`](https://github.com/${UPSTREAM_REPOSITORY}/commit/${UPSTREAM_BASE}) |"
+            echo "| Required auth-refresh retry | [\`${AUTH_REFRESH_RETRY_COMMIT}\`](https://github.com/${UPSTREAM_REPOSITORY}/commit/${AUTH_REFRESH_RETRY_COMMIT}) |"
+            echo "| Current upstream head | [\`${upstream_head}\`](https://github.com/${UPSTREAM_REPOSITORY}/commit/${upstream_head}) |"
+            echo
+            echo "### Carried patch set (${patch_count})"
+            echo '```text'
+            echo "${patch_set}"
+            echo '```'
+            echo
+            echo "Upstream commits after the recorded base: **${upstream_ahead}**"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [ "${upstream_ahead}" -ne 0 ]; then
+            git log --oneline "${UPSTREAM_BASE}..${upstream_ref}"
+            echo "::error title=gmessages fork is behind upstream::${FORK_REPOSITORY}@${FORK_COMMIT} is based on ${UPSTREAM_BASE}, but ${UPSTREAM_REPOSITORY}/${UPSTREAM_BRANCH}@${upstream_head} is ${upstream_ahead} commit(s) ahead. Rebase the carried patch and update the pin and recorded contract."
+            exit 1
+          fi
+
+          echo "${FORK_REPOSITORY}@${FORK_COMMIT} is one carried patch on current upstream base ${UPSTREAM_BASE}."

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -125,12 +125,28 @@ is hardened-runtime only) so the backend can read Chrome's cookie DB and the
 `Chrome Safe Storage` keychain item. First keychain read may prompt once;
 Always Allow persists it.
 
+### gmessages fork contract
+
 **Root cause of the repeated deaths (fixed in #73):** the `MaxGhenis/gmessages`
 fork was frozen at its 2026-03-02 base and missed upstream's 2026-05-05
-`libgm/longpoll: retry on network error when refreshing auth token`. Without it
-a single transient network blip during a scheduled token refresh permanently
-killed the session. Keep the fork rebased on upstream. The durable
-architectural fix (move SMS/RCS onto an Android companion) is issue #75.
+[`libgm/longpoll: retry on network error when refreshing auth token`](https://github.com/mautrix/gmessages/commit/0b54a8fe65207f81d353ffe63f4d2549c2eb7976).
+Without it, a single transient network blip during a scheduled token refresh
+permanently killed the session.
+
+The replacement in `go.mod` pins fork commit
+[`0e43542dfa0e`](https://github.com/MaxGhenis/gmessages/commit/0e43542dfa0e0b97e410f185a5842e8740106099).
+It is upstream `mautrix/gmessages` base
+[`3433cc07d5ea`](https://github.com/mautrix/gmessages/commit/3433cc07d5ea9522309adad3a8c92ed5b08dc11d),
+which contains the auth-refresh retry, plus exactly one carried patch:
+`Add ListConversationsWithCursor for paginated conversation listing`. That
+method is required by OpenMessage's backfill and reconciliation paths.
+
+**Keep the fork rebased on upstream.** The weekly
+`gmessages-fork-drift.yml` workflow records the base and patch set and fails as
+soon as upstream `main` advances. When rebasing, replay the single carried
+patch, verify the auth-refresh retry is still present, and update the fork pin
+and recorded SHAs together. The durable architectural fix (move SMS/RCS onto
+an Android companion) is issue #75.
 
 ### Don't over-reconnect
 

--- a/gmessages_fork_contract_test.go
+++ b/gmessages_fork_contract_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	gmessagesModule            = "go.mau.fi/mautrix-gmessages"
+	gmessagesFork              = "github.com/MaxGhenis/gmessages"
+	minimumGMessagesFork       = "v0.2602.1-0.20260703132304-0e43542dfa0e"
+	minimumGMessagesForkTime   = "20260703132304"
+	gmessagesAuthRetryContract = "libgm/longpoll auth-refresh network retry"
+)
+
+var pseudoVersionSuffix = regexp.MustCompile(`[.-]([0-9]{14})-[0-9a-f]{12}$`)
+
+type moduleVersion struct {
+	Path    string
+	Version string
+}
+
+type goModFile struct {
+	Require []moduleVersion
+	Replace []struct {
+		Old moduleVersion
+		New moduleVersion
+	}
+}
+
+func TestGMessagesForkContract(t *testing.T) {
+	cmd := exec.Command("go", "mod", "edit", "-json", "go.mod")
+	cmd.Env = envWithGOWorkOff()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("parse go.mod: %v\n%s", err, output)
+	}
+
+	var mod goModFile
+	if err := json.Unmarshal(output, &mod); err != nil {
+		t.Fatalf("decode go.mod: %v", err)
+	}
+
+	required := false
+	for _, requirement := range mod.Require {
+		if requirement.Path == gmessagesModule {
+			required = true
+			break
+		}
+	}
+	if !required {
+		t.Fatalf("%s must remain required so the fork replacement protects the %s", gmessagesModule, gmessagesAuthRetryContract)
+	}
+
+	var replacements []struct {
+		Old moduleVersion
+		New moduleVersion
+	}
+	for _, replacement := range mod.Replace {
+		if replacement.Old.Path == gmessagesModule {
+			replacements = append(replacements, replacement)
+		}
+	}
+	if len(replacements) != 1 {
+		t.Fatalf("%s must have exactly one fork replacement; found %d", gmessagesModule, len(replacements))
+	}
+
+	replacement := replacements[0]
+	if replacement.Old.Version != "" {
+		t.Fatalf("replacement for %s must be unversioned so future require versions cannot bypass it", gmessagesModule)
+	}
+	if replacement.New.Path != gmessagesFork {
+		t.Fatalf("%s must be replaced by %s to preserve the %s; found %s", gmessagesModule, gmessagesFork, gmessagesAuthRetryContract, replacement.New.Path)
+	}
+
+	match := pseudoVersionSuffix.FindStringSubmatch(replacement.New.Version)
+	if match == nil {
+		t.Fatalf("%s must use a canonical pseudo-version that records its commit time and revision; found %q", gmessagesFork, replacement.New.Version)
+	}
+	pinnedTime, err := time.Parse("20060102150405", match[1])
+	if err != nil {
+		t.Fatalf("parse %s pseudo-version timestamp %q: %v", gmessagesFork, match[1], err)
+	}
+	minimumTime, err := time.Parse("20060102150405", minimumGMessagesForkTime)
+	if err != nil {
+		t.Fatalf("parse test minimum timestamp: %v", err)
+	}
+	if pinnedTime.Before(minimumTime) {
+		t.Fatalf("%s pin %s predates known-good %s and can regress the %s", gmessagesFork, replacement.New.Version, minimumGMessagesFork, gmessagesAuthRetryContract)
+	}
+}
+
+func envWithGOWorkOff() []string {
+	env := os.Environ()
+	for i := 0; i < len(env); {
+		if strings.HasPrefix(env[i], "GOWORK=") {
+			env = append(env[:i], env[i+1:]...)
+			continue
+		}
+		i++
+	}
+	return append(env, "GOWORK=off")
+}


### PR DESCRIPTION
Wave 0 / F6b. Implemented by Sol, reviewed by Claude (salvaged intact after a session teardown killed the wrapper — the artifacts were already complete and coherent). CI-only, no deploy.

The `MaxGhenis/gmessages` fork once froze and missed upstream's `libgm/longpoll: retry on network error when refreshing auth token`, which silently killed the Google session on a transient network blip (#73). This makes that class of failure loud:

- **`gmessages-fork-drift.yml`** (weekly + dispatch, pinned action, read-only): fetches upstream + fork, verifies the fork is **exactly one patch** on the recorded base, that the base **contains the auth-refresh-retry commit**, writes a summary table, and **fails the moment upstream `main` advances** past the recorded base — the signal to rebase.
- **`gmessages_fork_contract_test.go`**: asserts `go.mod` still replaces the module with the fork at an unversioned canonical pseudo-version whose timestamp is **≥ the known-good base** — the pin can't silently regress below the fix.
- **Runbook**: records the base, the auth-refresh-retry commit, the single carried patch (`ListConversationsWithCursor`), and the rebase procedure.

`actionlint` clean; `go vet` + `TestGMessagesForkContract` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
