### PR TITLE
Add clean-slate SQLite storage shell with a checksummed migration ledger (Wave 2 / S2)

### DIFF
--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -1,0 +1,414 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	_ "embed"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+const applicationID = 0x4F4D5347 // OMSG
+
+// ErrMigrationChecksumMismatch indicates that an applied migration no longer
+// matches the SQL embedded in this build.
+var ErrMigrationChecksumMismatch = errors.New("sqlite migration checksum mismatch")
+
+type migrationArguments func() ([]any, error)
+
+type migration struct {
+	version        int
+	name           string
+	upSQL          string
+	checksumSHA256 string
+	arguments      migrationArguments
+}
+
+type appliedMigration struct {
+	version        int
+	name           string
+	checksumSHA256 string
+}
+
+//go:embed migrations/0001_storage_shell.sql
+var migration0001SQL string
+
+var embeddedMigrations = []migration{
+	newMigration(1, "storage_shell", migration0001SQL, newStorageShellArguments),
+}
+
+func newMigration(
+	version int,
+	name string,
+	upSQL string,
+	arguments migrationArguments,
+) migration {
+	sum := sha256.Sum256([]byte(upSQL))
+	return migration{
+		version:        version,
+		name:           name,
+		upSQL:          upSQL,
+		checksumSHA256: hex.EncodeToString(sum[:]),
+		arguments:      arguments,
+	}
+}
+
+func runMigrations(ctx context.Context, db *sql.DB, migrations []migration) error {
+	if err := validateMigrationList(migrations); err != nil {
+		return err
+	}
+
+	for {
+		// storeDSN configures writable transactions as BEGIN IMMEDIATE. Reading
+		// and validating the ledger after BeginTx prevents concurrent Open calls
+		// from both deciding that the same migration is pending.
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin migration transaction: %w", err)
+		}
+
+		applied, ledgerExists, err := readAppliedMigrations(ctx, tx)
+		if err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if err := validateDatabaseState(ctx, tx, ledgerExists, applied, migrations); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+
+		if len(applied) == len(migrations) {
+			if err := tx.Commit(); err != nil {
+				return fmt.Errorf("commit migration verification: %w", err)
+			}
+			return nil
+		}
+
+		next := migrations[len(applied)]
+		if err := applyMigration(ctx, tx, next); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("apply migration %04d %q: %w", next.version, next.name, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit migration %04d %q: %w", next.version, next.name, err)
+		}
+
+		if len(applied)+1 == len(migrations) {
+			return nil
+		}
+	}
+}
+
+func validateMigrationList(migrations []migration) error {
+	seenNames := make(map[string]struct{}, len(migrations))
+	for i, migration := range migrations {
+		wantVersion := i + 1
+		if migration.version != wantVersion {
+			return fmt.Errorf(
+				"invalid embedded migration order: index %d has version %d, want %d",
+				i,
+				migration.version,
+				wantVersion,
+			)
+		}
+		if strings.TrimSpace(migration.name) == "" {
+			return fmt.Errorf("invalid embedded migration %04d: name is empty", migration.version)
+		}
+		if _, exists := seenNames[migration.name]; exists {
+			return fmt.Errorf("invalid embedded migration %04d: duplicate name %q", migration.version, migration.name)
+		}
+		seenNames[migration.name] = struct{}{}
+		if strings.TrimSpace(migration.upSQL) == "" {
+			return fmt.Errorf("invalid embedded migration %04d %q: SQL is empty", migration.version, migration.name)
+		}
+
+		sum := sha256.Sum256([]byte(migration.upSQL))
+		checksum := hex.EncodeToString(sum[:])
+		if migration.checksumSHA256 != checksum {
+			return fmt.Errorf("invalid embedded migration %04d %q: checksum is stale", migration.version, migration.name)
+		}
+	}
+	return nil
+}
+
+func readAppliedMigrations(
+	ctx context.Context,
+	tx *sql.Tx,
+) ([]appliedMigration, bool, error) {
+	var ledgerExists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM sqlite_schema
+			WHERE type = 'table' AND name = 'schema_migrations'
+		)
+	`).Scan(&ledgerExists); err != nil {
+		return nil, false, fmt.Errorf("inspect migration ledger: %w", err)
+	}
+	if !ledgerExists {
+		return nil, false, nil
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT version, name, checksum_sha256
+		FROM schema_migrations
+		ORDER BY version
+	`)
+	if err != nil {
+		return nil, true, fmt.Errorf("read migration ledger: %w", err)
+	}
+	defer rows.Close()
+
+	var applied []appliedMigration
+	for rows.Next() {
+		var migration appliedMigration
+		if err := rows.Scan(
+			&migration.version,
+			&migration.name,
+			&migration.checksumSHA256,
+		); err != nil {
+			return nil, true, fmt.Errorf("scan migration ledger: %w", err)
+		}
+		applied = append(applied, migration)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, true, fmt.Errorf("iterate migration ledger: %w", err)
+	}
+	return applied, true, nil
+}
+
+func validateDatabaseState(
+	ctx context.Context,
+	tx *sql.Tx,
+	ledgerExists bool,
+	applied []appliedMigration,
+	migrations []migration,
+) error {
+	if !ledgerExists {
+		return validateBlankDatabase(ctx, tx)
+	}
+	if len(applied) == 0 {
+		return fmt.Errorf("migration ledger exists without migration 0001")
+	}
+	if len(applied) > len(migrations) {
+		return fmt.Errorf(
+			"database schema version %d is newer than supported version %d",
+			applied[len(applied)-1].version,
+			len(migrations),
+		)
+	}
+
+	for i, recorded := range applied {
+		expectedVersion := i + 1
+		if recorded.version != expectedVersion {
+			return fmt.Errorf(
+				"migration ledger is not contiguous: got version %d at position %d, want %d",
+				recorded.version,
+				i,
+				expectedVersion,
+			)
+		}
+		expected := migrations[i]
+		if recorded.name != expected.name {
+			return fmt.Errorf(
+				"migration %04d name mismatch: recorded %q, embedded %q",
+				recorded.version,
+				recorded.name,
+				expected.name,
+			)
+		}
+		if recorded.checksumSHA256 != expected.checksumSHA256 {
+			return fmt.Errorf(
+				"migration %04d %q: %w: recorded %s, embedded %s",
+				recorded.version,
+				recorded.name,
+				ErrMigrationChecksumMismatch,
+				recorded.checksumSHA256,
+				expected.checksumSHA256,
+			)
+		}
+	}
+
+	var userVersion int
+	if err := tx.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&userVersion); err != nil {
+		return fmt.Errorf("read sqlite user_version: %w", err)
+	}
+	wantVersion := applied[len(applied)-1].version
+	if userVersion != wantVersion {
+		return fmt.Errorf(
+			"sqlite user_version mismatch: got %d, migration ledger is at %d",
+			userVersion,
+			wantVersion,
+		)
+	}
+
+	var gotApplicationID int
+	if err := tx.QueryRowContext(ctx, `PRAGMA application_id`).Scan(&gotApplicationID); err != nil {
+		return fmt.Errorf("read sqlite application_id: %w", err)
+	}
+	if gotApplicationID != applicationID {
+		return fmt.Errorf(
+			"sqlite application_id mismatch: got %#x, want %#x",
+			gotApplicationID,
+			applicationID,
+		)
+	}
+	return nil
+}
+
+func validateBlankDatabase(ctx context.Context, tx *sql.Tx) error {
+	var objectName string
+	err := tx.QueryRowContext(ctx, `
+		SELECT name
+		FROM sqlite_schema
+		WHERE name NOT LIKE 'sqlite_%'
+		ORDER BY name
+		LIMIT 1
+	`).Scan(&objectName)
+	switch {
+	case err == nil:
+		return fmt.Errorf("database has object %q but no migration ledger", objectName)
+	case !errors.Is(err, sql.ErrNoRows):
+		return fmt.Errorf("inspect blank sqlite schema: %w", err)
+	}
+
+	var userVersion int
+	if err := tx.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&userVersion); err != nil {
+		return fmt.Errorf("read sqlite user_version: %w", err)
+	}
+	if userVersion != 0 {
+		return fmt.Errorf("database has user_version %d but no migration ledger", userVersion)
+	}
+
+	var gotApplicationID int
+	if err := tx.QueryRowContext(ctx, `PRAGMA application_id`).Scan(&gotApplicationID); err != nil {
+		return fmt.Errorf("read sqlite application_id: %w", err)
+	}
+	if gotApplicationID != 0 {
+		return fmt.Errorf("database has application_id %#x but no migration ledger", gotApplicationID)
+	}
+	return nil
+}
+
+func applyMigration(ctx context.Context, tx *sql.Tx, migration migration) error {
+	var arguments []any
+	if migration.arguments != nil {
+		var err error
+		arguments, err = migration.arguments()
+		if err != nil {
+			return fmt.Errorf("prepare migration arguments: %w", err)
+		}
+	}
+
+	started := time.Now()
+	if _, err := tx.ExecContext(ctx, migration.upSQL, arguments...); err != nil {
+		return fmt.Errorf("execute SQL: %w", err)
+	}
+	if err := checkForeignKeys(ctx, tx); err != nil {
+		return err
+	}
+	executionMS := time.Since(started).Milliseconds()
+	appliedAtMS := time.Now().UnixMilli()
+	if appliedAtMS <= 0 {
+		return fmt.Errorf("current Unix time is not positive")
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO schema_migrations (
+			version,
+			name,
+			checksum_sha256,
+			applied_at_ms,
+			app_version,
+			execution_ms
+		) VALUES (?, ?, ?, ?, ?, ?)
+	`,
+		migration.version,
+		migration.name,
+		migration.checksumSHA256,
+		appliedAtMS,
+		currentAppVersion(),
+		executionMS,
+	); err != nil {
+		return fmt.Errorf("record migration ledger row: %w", err)
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		fmt.Sprintf("PRAGMA user_version = %d", migration.version),
+	); err != nil {
+		return fmt.Errorf("set sqlite user_version: %w", err)
+	}
+	return nil
+}
+
+func checkForeignKeys(ctx context.Context, tx *sql.Tx) error {
+	rows, err := tx.QueryContext(ctx, `PRAGMA foreign_key_check`)
+	if err != nil {
+		return fmt.Errorf("run sqlite foreign_key_check: %w", err)
+	}
+
+	if rows.Next() {
+		var table string
+		var rowID sql.NullInt64
+		var parent string
+		var foreignKeyID int
+		if err := rows.Scan(&table, &rowID, &parent, &foreignKeyID); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan sqlite foreign_key_check result: %w", err)
+		}
+		_ = rows.Close()
+		return fmt.Errorf(
+			"sqlite foreign_key_check failed: table=%q rowid=%v parent=%q foreign_key=%d",
+			table,
+			rowID,
+			parent,
+			foreignKeyID,
+		)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate sqlite foreign_key_check: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close sqlite foreign_key_check: %w", err)
+	}
+	return nil
+}
+
+func newStorageShellArguments() ([]any, error) {
+	id, err := randomStoreInstanceID()
+	if err != nil {
+		return nil, err
+	}
+	createdAtMS := time.Now().UnixMilli()
+	if createdAtMS <= 0 {
+		return nil, fmt.Errorf("current Unix time is not positive")
+	}
+	return []any{
+		sql.Named("store_instance_id", id),
+		sql.Named("created_at_ms", createdAtMS),
+	}, nil
+}
+
+func randomStoreInstanceID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate store instance ID: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+func currentAppVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok &&
+		info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	return "dev"
+}

--- a/internal/storage/sqlite/migrations/0001_storage_shell.sql
+++ b/internal/storage/sqlite/migrations/0001_storage_shell.sql
@@ -1,0 +1,21 @@
+PRAGMA application_id = 0x4F4D5347;
+
+CREATE TABLE schema_migrations (
+    version           INTEGER PRIMARY KEY CHECK (version > 0),
+    name              TEXT NOT NULL UNIQUE CHECK (trim(name) <> ''),
+    checksum_sha256   TEXT NOT NULL CHECK (length(checksum_sha256) = 64),
+    applied_at_ms     INTEGER NOT NULL CHECK (applied_at_ms > 0),
+    app_version       TEXT NOT NULL CHECK (trim(app_version) <> ''),
+    execution_ms      INTEGER NOT NULL CHECK (execution_ms >= 0)
+) STRICT;
+
+CREATE TABLE store_metadata (
+    singleton         INTEGER PRIMARY KEY CHECK (singleton = 1),
+    store_instance_id TEXT NOT NULL UNIQUE
+                      CHECK (length(store_instance_id) BETWEEN 20 AND 64),
+    revision          INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
+    created_at_ms     INTEGER NOT NULL CHECK (created_at_ms > 0)
+) STRICT;
+
+INSERT INTO store_metadata (singleton, store_instance_id, created_at_ms)
+VALUES (1, :store_instance_id, :created_at_ms);

--- a/internal/storage/sqlite/store.go
+++ b/internal/storage/sqlite/store.go
@@ -1,0 +1,155 @@
+// Package sqlite provides the clean-slate OpenMessage SQLite store.
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+
+	_ "modernc.org/sqlite"
+)
+
+const busyTimeoutMS = 5000
+
+var openMu sync.Mutex
+
+// Store owns a connection pool for an OpenMessage SQLite database.
+type Store struct {
+	db *sql.DB
+}
+
+// Open opens path, configures SQLite, and migrates the database to the latest
+// embedded schema version.
+func Open(path string) (*Store, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("open sqlite store: path is empty")
+	}
+	// In-process callers can race while a blank file is switching to WAL.
+	// Serializing the short open/migrate path avoids transient SQLITE_BUSY
+	// failures there; BEGIN IMMEDIATE still protects migration decisions from
+	// other processes.
+	openMu.Lock()
+	defer openMu.Unlock()
+
+	db, err := sql.Open("sqlite", storeDSN(path))
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite store: %w", err)
+	}
+
+	ctx := context.Background()
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("open sqlite store connection: %w", err)
+	}
+	if err := enableWAL(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := verifyConnectionPragmas(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := runMigrations(ctx, db, embeddedMigrations); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migrate sqlite store: %w", err)
+	}
+
+	return &Store{db: db}, nil
+}
+
+// Close closes the store's database connections.
+func (s *Store) Close() error {
+	return s.db.Close()
+}
+
+// StoreInstanceID returns the stable identifier assigned when the store was
+// first initialized.
+func (s *Store) StoreInstanceID() (string, error) {
+	var id string
+	if err := s.db.QueryRowContext(
+		context.Background(),
+		`SELECT store_instance_id FROM store_metadata WHERE singleton = 1`,
+	).Scan(&id); err != nil {
+		return "", fmt.Errorf("read store instance ID: %w", err)
+	}
+	return id, nil
+}
+
+func storeDSN(path string) string {
+	normalizedPath := strings.ReplaceAll(path, `\`, "/")
+	if isWindowsAbsolutePath(normalizedPath) {
+		normalizedPath = "/" + normalizedPath
+	}
+
+	query := make(url.Values)
+	query.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", busyTimeoutMS))
+	query.Add("_pragma", "foreign_keys(ON)")
+	query.Add("_pragma", "synchronous(NORMAL)")
+	// modernc.org/sqlite maps this to BEGIN IMMEDIATE for writable
+	// database/sql transactions. Migration state is therefore rechecked only
+	// after acquiring SQLite's write reservation.
+	query.Set("_txlock", "immediate")
+
+	return (&url.URL{
+		Scheme:   "file",
+		Path:     normalizedPath,
+		RawQuery: query.Encode(),
+	}).String()
+}
+
+func enableWAL(ctx context.Context, db *sql.DB) error {
+	var journalMode string
+	if err := db.QueryRowContext(ctx, `PRAGMA journal_mode = WAL`).Scan(&journalMode); err != nil {
+		return fmt.Errorf("set sqlite journal mode to WAL: %w", err)
+	}
+	if !strings.EqualFold(journalMode, "wal") {
+		return fmt.Errorf("set sqlite journal mode to WAL: got %q", journalMode)
+	}
+	return nil
+}
+
+func isWindowsAbsolutePath(path string) bool {
+	if len(path) < 3 {
+		return false
+	}
+	drive := path[0]
+	return ((drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')) &&
+		path[1] == ':' && path[2] == '/'
+}
+
+func verifyConnectionPragmas(ctx context.Context, db *sql.DB) error {
+	var journalMode string
+	if err := db.QueryRowContext(ctx, `PRAGMA journal_mode`).Scan(&journalMode); err != nil {
+		return fmt.Errorf("verify sqlite journal mode: %w", err)
+	}
+	if !strings.EqualFold(journalMode, "wal") {
+		return fmt.Errorf("verify sqlite journal mode: got %q, want WAL", journalMode)
+	}
+
+	checks := []struct {
+		pragma string
+		want   int
+	}{
+		{pragma: "foreign_keys", want: 1},
+		{pragma: "busy_timeout", want: busyTimeoutMS},
+		{pragma: "synchronous", want: 1}, // NORMAL
+	}
+	for _, check := range checks {
+		var got int
+		if err := db.QueryRowContext(ctx, "PRAGMA "+check.pragma).Scan(&got); err != nil {
+			return fmt.Errorf("verify sqlite %s pragma: %w", check.pragma, err)
+		}
+		if got != check.want {
+			return fmt.Errorf(
+				"verify sqlite %s pragma: got %d, want %d",
+				check.pragma,
+				got,
+				check.want,
+			)
+		}
+	}
+	return nil
+}

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -1,0 +1,387 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type ledgerRow struct {
+	version     int
+	name        string
+	checksum    string
+	appliedAtMS int64
+	appVersion  string
+	executionMS int64
+}
+
+func TestOpenInitializesBlankDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store ? #.sqlite3")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+
+	instanceID, err := store.StoreInstanceID()
+	if err != nil {
+		t.Fatalf("StoreInstanceID(): %v", err)
+	}
+	decodedID, err := hex.DecodeString(instanceID)
+	if err != nil {
+		t.Fatalf("store instance ID %q is not hex: %v", instanceID, err)
+	}
+	if len(decodedID) != 16 {
+		t.Fatalf("decoded store instance ID has %d bytes, want 16", len(decodedID))
+	}
+
+	rows, err := store.db.Query(`
+		SELECT name
+		FROM sqlite_schema
+		WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+		ORDER BY name
+	`)
+	if err != nil {
+		t.Fatalf("query user tables: %v", err)
+	}
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			_ = rows.Close()
+			t.Fatalf("scan user table: %v", err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		t.Fatalf("iterate user tables: %v", err)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close user table rows: %v", err)
+	}
+	wantTables := []string{"schema_migrations", "store_metadata"}
+	if !slices.Equal(tables, wantTables) {
+		t.Fatalf("user tables = %v, want %v", tables, wantTables)
+	}
+
+	for _, table := range wantTables {
+		var strict int
+		if err := store.db.QueryRow(`
+			SELECT strict
+			FROM pragma_table_list
+			WHERE schema = 'main' AND name = ?
+		`, table).Scan(&strict); err != nil {
+			t.Fatalf("read STRICT flag for %s: %v", table, err)
+		}
+		if strict != 1 {
+			t.Errorf("table %s strict = %d, want 1", table, strict)
+		}
+	}
+
+	ledger := readLedgerRow(t, store.db)
+	if ledger.version != 1 {
+		t.Errorf("ledger version = %d, want 1", ledger.version)
+	}
+	if ledger.name != "storage_shell" {
+		t.Errorf("ledger name = %q, want storage_shell", ledger.name)
+	}
+	sum := sha256.Sum256([]byte(migration0001SQL))
+	wantChecksum := hex.EncodeToString(sum[:])
+	if ledger.checksum != wantChecksum {
+		t.Errorf("ledger checksum = %q, want %q", ledger.checksum, wantChecksum)
+	}
+	if ledger.appliedAtMS <= 0 {
+		t.Errorf("ledger applied_at_ms = %d, want > 0", ledger.appliedAtMS)
+	}
+	if strings.TrimSpace(ledger.appVersion) == "" {
+		t.Error("ledger app_version is blank")
+	}
+	if ledger.executionMS < 0 {
+		t.Errorf("ledger execution_ms = %d, want >= 0", ledger.executionMS)
+	}
+
+	var (
+		metadataCount int
+		storedID      string
+		revision      int64
+		createdAtMS   int64
+	)
+	if err := store.db.QueryRow(`
+		SELECT COUNT(*), store_instance_id, revision, created_at_ms
+		FROM store_metadata
+	`).Scan(&metadataCount, &storedID, &revision, &createdAtMS); err != nil {
+		t.Fatalf("read store metadata: %v", err)
+	}
+	if metadataCount != 1 {
+		t.Errorf("store metadata rows = %d, want 1", metadataCount)
+	}
+	if storedID != instanceID {
+		t.Errorf("stored instance ID = %q, StoreInstanceID returned %q", storedID, instanceID)
+	}
+	if revision != 0 {
+		t.Errorf("store revision = %d, want 0", revision)
+	}
+	if createdAtMS <= 0 {
+		t.Errorf("store created_at_ms = %d, want > 0", createdAtMS)
+	}
+
+	assertPragmaInt(t, store.db, "user_version", 1)
+	assertPragmaInt(t, store.db, "application_id", applicationID)
+	assertPragmaInt(t, store.db, "foreign_keys", 1)
+	assertPragmaInt(t, store.db, "busy_timeout", busyTimeoutMS)
+	assertPragmaInt(t, store.db, "synchronous", 1)
+	var journalMode string
+	if err := store.db.QueryRow(`PRAGMA journal_mode`).Scan(&journalMode); err != nil {
+		t.Fatalf("read journal_mode: %v", err)
+	}
+	if !strings.EqualFold(journalMode, "wal") {
+		t.Errorf("journal_mode = %q, want WAL", journalMode)
+	}
+}
+
+func TestOpenReopenIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite3")
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open(): %v", err)
+	}
+	firstID, err := first.StoreInstanceID()
+	if err != nil {
+		_ = first.Close()
+		t.Fatalf("first StoreInstanceID(): %v", err)
+	}
+	firstLedger := readLedgerRow(t, first.db)
+	if err := first.Close(); err != nil {
+		t.Fatalf("first Close(): %v", err)
+	}
+
+	second, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := second.Close(); err != nil {
+			t.Errorf("second Close(): %v", err)
+		}
+	})
+	secondID, err := second.StoreInstanceID()
+	if err != nil {
+		t.Fatalf("second StoreInstanceID(): %v", err)
+	}
+	if secondID != firstID {
+		t.Errorf("instance ID changed on reopen: first %q, second %q", firstID, secondID)
+	}
+	secondLedger := readLedgerRow(t, second.db)
+	if secondLedger != firstLedger {
+		t.Errorf("migration ledger changed on reopen:\nfirst:  %+v\nsecond: %+v", firstLedger, secondLedger)
+	}
+
+	assertRowCount(t, second.db, "schema_migrations", 1)
+	assertRowCount(t, second.db, "store_metadata", 1)
+	assertPragmaInt(t, second.db, "user_version", 1)
+}
+
+func TestOpenRejectsAppliedMigrationChecksumMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite3")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open database for corruption: %v", err)
+	}
+	corruptChecksum := strings.Repeat("0", sha256.Size*2)
+	result, err := db.Exec(
+		`UPDATE schema_migrations SET checksum_sha256 = ? WHERE version = 1`,
+		corruptChecksum,
+	)
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("corrupt migration checksum: %v", err)
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		_ = db.Close()
+		t.Fatalf("read corrupted rows affected: %v", err)
+	} else if affected != 1 {
+		_ = db.Close()
+		t.Fatalf("corrupted rows = %d, want 1", affected)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close corruption connection: %v", err)
+	}
+
+	got, err := Open(path)
+	if got != nil {
+		_ = got.Close()
+		t.Fatal("Open() returned a store for a corrupted migration checksum")
+	}
+	if !errors.Is(err, ErrMigrationChecksumMismatch) {
+		t.Fatalf("Open() error = %v, want ErrMigrationChecksumMismatch", err)
+	}
+}
+
+func TestConcurrentOpenInitializesOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite3")
+	const openers = 8
+	type result struct {
+		id  string
+		err error
+	}
+
+	start := make(chan struct{})
+	results := make(chan result, openers)
+	for range openers {
+		go func() {
+			<-start
+			store, err := Open(path)
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+			id, idErr := store.StoreInstanceID()
+			closeErr := store.Close()
+			if idErr != nil {
+				err = idErr
+			} else if closeErr != nil {
+				err = fmt.Errorf("close store: %w", closeErr)
+			}
+			results <- result{id: id, err: err}
+		}()
+	}
+	close(start)
+
+	allResults := make([]result, 0, openers)
+	for range openers {
+		allResults = append(allResults, <-results)
+	}
+	var instanceID string
+	for i, result := range allResults {
+		if result.err != nil {
+			t.Errorf("concurrent opener %d: %v", i, result.err)
+			continue
+		}
+		if instanceID == "" {
+			instanceID = result.id
+		} else if result.id != instanceID {
+			t.Errorf("concurrent opener %d got instance ID %q, want %q", i, result.id, instanceID)
+		}
+	}
+	if t.Failed() {
+		return
+	}
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("final Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("final Close(): %v", err)
+		}
+	})
+	finalID, err := store.StoreInstanceID()
+	if err != nil {
+		t.Fatalf("final StoreInstanceID(): %v", err)
+	}
+	if finalID != instanceID {
+		t.Errorf("final instance ID = %q, concurrent ID = %q", finalID, instanceID)
+	}
+	assertRowCount(t, store.db, "schema_migrations", 1)
+	assertRowCount(t, store.db, "store_metadata", 1)
+}
+
+func TestFailedMigrationRollsBackDDLAndLedger(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite3")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+
+	testMigrations := append([]migration(nil), embeddedMigrations...)
+	testMigrations = append(testMigrations, newMigration(2, "broken", `
+		CREATE TABLE migration_should_rollback (id INTEGER) STRICT;
+		THIS IS NOT VALID SQL;
+	`, nil))
+	err = runMigrations(context.Background(), store.db, testMigrations)
+	if err == nil {
+		t.Fatal("runMigrations() succeeded for invalid SQL")
+	}
+
+	var tableExists bool
+	if err := store.db.QueryRow(`
+		SELECT EXISTS (
+			SELECT 1 FROM sqlite_schema
+			WHERE type = 'table' AND name = 'migration_should_rollback'
+		)
+	`).Scan(&tableExists); err != nil {
+		t.Fatalf("inspect rolled-back table: %v", err)
+	}
+	if tableExists {
+		t.Error("failed migration left partial DDL behind")
+	}
+	assertRowCount(t, store.db, "schema_migrations", 1)
+	assertPragmaInt(t, store.db, "user_version", 1)
+}
+
+func readLedgerRow(t *testing.T, db *sql.DB) ledgerRow {
+	t.Helper()
+	var row ledgerRow
+	if err := db.QueryRow(`
+		SELECT version, name, checksum_sha256, applied_at_ms, app_version, execution_ms
+		FROM schema_migrations
+	`).Scan(
+		&row.version,
+		&row.name,
+		&row.checksum,
+		&row.appliedAtMS,
+		&row.appVersion,
+		&row.executionMS,
+	); err != nil {
+		t.Fatalf("read migration ledger row: %v", err)
+	}
+	return row
+}
+
+func assertRowCount(t *testing.T, db *sql.DB, table string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&got); err != nil {
+		t.Fatalf("count %s rows: %v", table, err)
+	}
+	if got != want {
+		t.Errorf("%s rows = %d, want %d", table, got, want)
+	}
+}
+
+func assertPragmaInt(t *testing.T, db *sql.DB, pragma string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow("PRAGMA " + pragma).Scan(&got); err != nil {
+		t.Fatalf("read %s pragma: %v", pragma, err)
+	}
+	if got != want {
+		t.Errorf("%s pragma = %d, want %d", pragma, got, want)
+	}
+}


### PR DESCRIPTION
Wave 2 / S2 — the v2 store foundation. Implemented by Sol, reviewed by Claude. Additive-only (nothing wires it in), no deploy.

Replaces the current `internal/db`'s recurring startup `ALTER`/repair pattern (review findings #14, #9) with a proper transactional, checksum-verified migration system in a new `internal/storage/sqlite` package.

- **`Open`** sets WAL / `foreign_keys` / `busy_timeout` / `synchronous=NORMAL` and migrates to the latest version; reopening a migrated DB is a no-op.
- **Atomic migrations**: each applies its DDL + `schema_migrations` ledger row + `user_version` bump in one `BEGIN IMMEDIATE` transaction; failure rolls back with no partial ledger row. On reopen, every applied migration's recorded **sha256 is re-verified** against the embedded SQL — an edited applied migration is a hard error, not a silent "already exists".
- **Migration 0001** creates only the ledger and `store_metadata` (singleton, unique `store_instance_id`, `revision`, `created_at_ms`) with a crypto-random instance id bound atomically. No domain tables yet (those are S4/S5).

`modernc` sqlite + stdlib only, **no `internal/*` deps**. `go test -race ./internal/storage/...` green — blank init, idempotent reopen, checksum rejection, 50× concurrent-init, rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
