### PR TITLE
Extract testable backend launch/adoption seams + non-interactive smoke (Wave 0 / F2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,5 +142,13 @@ jobs:
       - name: Build Swift package
         run: swift build --package-path macos/OpenMessage
 
+      - name: Build Go backend for Swift smoke
+        run: GOWORK=off go build -o "$RUNNER_TEMP/openmessage" .
+
+      - name: Test Swift package
+        env:
+          OPENMESSAGE_BINARY: ${{ runner.temp }}/openmessage
+        run: swift test --package-path macos/OpenMessage
+
       - name: Package macOS app
         run: bash macos/build.sh

--- a/macos/OpenMessage/Package.swift
+++ b/macos/OpenMessage/Package.swift
@@ -13,5 +13,10 @@ let package = Package(
                 .copy("Assets.xcassets"),
             ]
         ),
+        .testTarget(
+            name: "OpenMessageTests",
+            dependencies: [.target(name: "OpenMessage")],
+            path: "Tests/OpenMessageTests"
+        ),
     ]
 )

--- a/macos/OpenMessage/Sources/BackendLauncherCore.swift
+++ b/macos/OpenMessage/Sources/BackendLauncherCore.swift
@@ -1,0 +1,196 @@
+import Darwin
+import Foundation
+
+/// Pure command-line classification used when deciding whether a process
+/// listening on the configured port belongs to OpenMessage.
+struct BackendCommandMatcher: Sendable {
+    let binaryPath: String
+
+    /// A backend is reusable only when it was launched from the exact helper
+    /// path this app resolved. Keep the substring behavior in sync with the
+    /// pre-seam adoption logic; stronger identity checks belong to a later
+    /// protocol-handshake change.
+    func isReusableBackendCommand(_ command: String) -> Bool {
+        command.contains("\(binaryPath) serve")
+    }
+
+    /// Broader recognition used only to clean up a conflicting OpenMessage
+    /// helper before launching the app's exact helper.
+    func isOpenMessageBackendCommand(_ command: String) -> Bool {
+        let normalized = command.replacingOccurrences(of: "\\", with: "/")
+        if isReusableBackendCommand(normalized) {
+            return true
+        }
+        if normalized.contains("/usr/local/bin/openmessage serve") {
+            return true
+        }
+        return normalized.contains("/OpenMessage")
+            && (
+                normalized.contains(".app/Contents/Resources/openmessage serve")
+                || normalized.contains(".app/Contents/MacOS/openmessage-helper serve")
+            )
+    }
+}
+
+/// Complete, inspectable description of one backend launch.
+struct BackendLaunchConfiguration: Equatable, Sendable {
+    let executableURL: URL
+    let arguments: [String]
+    let environment: [String: String]
+    let currentDirectoryURL: URL
+    let dataDirectoryURL: URL
+    let port: Int
+
+    var baseURL: URL {
+        URL(string: "http://127.0.0.1:\(port)")!
+    }
+
+    /// Configuration used by the native app. `additionalEnvironment` exists so
+    /// isolated package tests can add stricter test-only controls without
+    /// changing or contradicting the canonical environment shipped by
+    /// BackendManager.
+    static func application(
+        executablePath: String,
+        dataDirectory: String,
+        port: Int,
+        homeDirectory: String = NSHomeDirectory(),
+        additionalEnvironment: [String: String] = [:]
+    ) -> BackendLaunchConfiguration {
+        var environment = additionalEnvironment
+        environment.merge([
+            "OPENMESSAGES_PORT": String(port),
+            "OPENMESSAGES_DATA_DIR": dataDirectory,
+            "OPENMESSAGES_LOG_LEVEL": "info",
+            "OPENMESSAGES_APP_SANDBOX": "1",
+            "OPENMESSAGES_MACOS_NOTIFICATIONS": "0",
+            "HOME": homeDirectory,
+            "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
+        ]) { _, canonical in canonical }
+
+        let dataDirectoryURL = URL(fileURLWithPath: dataDirectory, isDirectory: true)
+        return BackendLaunchConfiguration(
+            executableURL: URL(fileURLWithPath: executablePath),
+            arguments: ["serve", "--web"],
+            environment: environment,
+            currentDirectoryURL: dataDirectoryURL,
+            dataDirectoryURL: dataDirectoryURL,
+            port: port
+        )
+    }
+}
+
+/// Injectable process construction boundary. Tests can inspect the immutable
+/// launch configuration or substitute process creation without involving
+/// BackendManager, AppKit, or ObservableObject.
+protocol BackendProcessSpawning {
+    func makeProcess(for configuration: BackendLaunchConfiguration) -> Process
+}
+
+struct FoundationBackendProcessSpawner: BackendProcessSpawning {
+    func makeProcess(for configuration: BackendLaunchConfiguration) -> Process {
+        let process = Process()
+        process.executableURL = configuration.executableURL
+        process.arguments = configuration.arguments
+        process.environment = configuration.environment
+        process.currentDirectoryURL = configuration.currentDirectoryURL
+        return process
+    }
+}
+
+enum BackendTerminationResult {
+    case noProcess
+    case exited(status: Int32, reason: Process.TerminationReason)
+    case timedOut
+}
+
+/// Foundation-only process lifecycle core shared by BackendManager and the
+/// non-interactive package smoke test.
+/// BackendManager and the smoke test serialize process ownership on the main
+/// actor, preventing launch/terminate transitions from racing one another.
+@MainActor
+final class BackendLauncherCore {
+    let configuration: BackendLaunchConfiguration
+    private let processSpawner: any BackendProcessSpawning
+    private(set) var process: Process?
+
+    init(
+        configuration: BackendLaunchConfiguration,
+        processSpawner: any BackendProcessSpawning = FoundationBackendProcessSpawner()
+    ) {
+        self.configuration = configuration
+        self.processSpawner = processSpawner
+    }
+
+    /// Creates a fresh Process for every launch. Callers may attach output and
+    /// termination handlers in `configure` before the process starts.
+    @discardableResult
+    func launch(configure: (Process) -> Void = { _ in }) throws -> Process {
+        if let process, process.isRunning {
+            throw BackendLauncherError.alreadyRunning
+        }
+
+        let process = processSpawner.makeProcess(for: configuration)
+        configure(process)
+        self.process = process
+        do {
+            try process.run()
+            return process
+        } catch {
+            self.process = nil
+            throw error
+        }
+    }
+
+    /// Non-blocking SIGTERM used by BackendManager.stop(), preserving its
+    /// existing UI behavior.
+    func terminate() {
+        guard let process else { return }
+        if process.isRunning {
+            process.terminate()
+        }
+        self.process = nil
+    }
+
+    /// Sends SIGTERM and waits only until the supplied deadline. A timeout does
+    /// not silently force success; callers decide whether a SIGKILL is suitable.
+    func terminateAndWait(timeout: TimeInterval) -> BackendTerminationResult {
+        guard let process else { return .noProcess }
+        if process.isRunning {
+            process.terminate()
+        }
+        return waitForExit(of: process, timeout: timeout)
+    }
+
+    /// Leak protection for a timed-out test or app quit. The returned outcome
+    /// remains explicit so a forced exit can never count as a clean smoke pass.
+    func forceTerminateAndWait(timeout: TimeInterval) -> BackendTerminationResult {
+        guard let process else { return .noProcess }
+        if process.isRunning {
+            _ = Darwin.kill(process.processIdentifier, SIGKILL)
+        }
+        return waitForExit(of: process, timeout: timeout)
+    }
+
+    private func waitForExit(of process: Process, timeout: TimeInterval) -> BackendTerminationResult {
+        let deadline = Date().addingTimeInterval(max(0, timeout))
+        while process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        guard !process.isRunning else { return .timedOut }
+
+        if self.process === process {
+            self.process = nil
+        }
+        return .exited(status: process.terminationStatus, reason: process.terminationReason)
+    }
+
+    deinit {
+        if let process, process.isRunning {
+            process.terminate()
+        }
+    }
+}
+
+enum BackendLauncherError: Error {
+    case alreadyRunning
+}

--- a/macos/OpenMessage/Sources/BackendManager.swift
+++ b/macos/OpenMessage/Sources/BackendManager.swift
@@ -27,8 +27,9 @@ final class BackendManager: ObservableObject {
     /// surfaces the per-platform problem so a dead bridge can't silently rot.
     @Published var platformAlert: String?
 
-    private var process: Process?
-    /// PID of a backend we adopted instead of spawning (process == nil). Tracked
+    private var launcher: BackendLauncherCore?
+    private let processSpawner: any BackendProcessSpawning
+    /// PID of a backend we adopted instead of spawning (launcher == nil). Tracked
     /// so stop()/quit can still terminate it — otherwise an orphan adopted on a
     /// later launch would be unkillable by the app.
     private var reusedBackendPID: pid_t?
@@ -50,7 +51,8 @@ final class BackendManager: ObservableObject {
     private var pendingRestartTask: Task<Void, Never>?
     private var healthyResetTask: Task<Void, Never>?
 
-    init() {
+    init(processSpawner: any BackendProcessSpawning = FoundationBackendProcessSpawner()) {
+        self.processSpawner = processSpawner
         // Standard Cmd-Q / app-menu "Quit" terminates via NSApplication without
         // going through the menu-bar button's stop(), which left the spawned
         // `serve` process reparented to launchd, holding the port and DB. Hook
@@ -160,70 +162,60 @@ final class BackendManager: ObservableObject {
         if reuseExistingBackendIfNeeded() {
             return
         }
-        let proc = Process()
         let path = binaryPath
         let dir = dataDir
-        proc.executableURL = URL(fileURLWithPath: path)
-        proc.arguments = ["serve", "--web"]
-        proc.currentDirectoryURL = URL(fileURLWithPath: dir, isDirectory: true)
-        proc.environment = [
-            "OPENMESSAGES_PORT": String(port),
-            "OPENMESSAGES_DATA_DIR": dir,
-            "OPENMESSAGES_LOG_LEVEL": "info",
-            "OPENMESSAGES_APP_SANDBOX": "1",
-            // The native app owns notifications when it wraps the backend:
-            // NotificationManager posts UNUserNotificationCenter banners off the
-            // SSE event stream, with tap-to-open and foreground suppression that
-            // the Go side can't do. Disable the backend's own osascript/
-            // terminal-notifier banners so a single inbound message doesn't fire
-            // two notifications. Bare `openmessage serve` in a terminal (no app,
-            // env var unset) still gets Go-side banners via its default logic.
-            "OPENMESSAGES_MACOS_NOTIFICATIONS": "0",
-            "HOME": NSHomeDirectory(),
-            "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
-        ]
+        let configuration = BackendLaunchConfiguration.application(
+            executablePath: path,
+            dataDirectory: dir,
+            port: port
+        )
+        let launcher = BackendLauncherCore(configuration: configuration, processSpawner: processSpawner)
+        self.launcher = launcher
         logger.info("Launching backend at \(path, privacy: .public) with data dir \(dir, privacy: .public)")
 
         let pipe = Pipe()
-        proc.standardOutput = pipe
-        proc.standardError = pipe
-
-        // Read output for logging. Mark the interpolation as .public so
-        // that diagnostic lines like "WhatsApp message fell through to
-        // [Unsupported message]" (with content_types field) can be read
-        // via `log show --predicate 'subsystem == "com.openmessage.app"'`
-        // without flipping the system-wide private_data flag.
-        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else { return }
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            self?.logger.info("\(trimmed, privacy: .public)")
-        }
-
-        proc.terminationHandler = { [weak self] proc in
-            let manager = self
-            let reason = proc.terminationReason == .uncaughtSignal ? "signal" : "exit"
-            let code = proc.terminationStatus
-            Task { @MainActor in
-                guard let manager else { return }
-                manager.logger.warning("Backend terminated via \(reason, privacy: .public) with code \(code)")
-                guard manager.process === proc else { return }
-                manager.process = nil
-                // Only react to crashes while we believed the backend was up. A
-                // deliberate stop()/quit clears `state` first, so this won't
-                // fight an intentional shutdown.
-                if manager.state == .running || manager.state == .starting {
-                    manager.handleUnexpectedTermination(code: code)
-                }
-            }
-        }
 
         do {
-            try proc.run()
-            process = proc
+            try launcher.launch { [weak self] proc in
+                proc.standardOutput = pipe
+                proc.standardError = pipe
+
+                // Read output for logging. Mark the interpolation as .public so
+                // that diagnostic lines like "WhatsApp message fell through to
+                // [Unsupported message]" (with content_types field) can be read
+                // via `log show --predicate 'subsystem == "com.openmessage.app"'`
+                // without flipping the system-wide private_data flag.
+                pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+                    let data = handle.availableData
+                    guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else { return }
+                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                    self?.logger.info("\(trimmed, privacy: .public)")
+                }
+
+                proc.terminationHandler = { [weak self] proc in
+                    let manager = self
+                    let reason = proc.terminationReason == .uncaughtSignal ? "signal" : "exit"
+                    let code = proc.terminationStatus
+                    Task { @MainActor in
+                        guard let manager else { return }
+                        manager.logger.warning("Backend terminated via \(reason, privacy: .public) with code \(code)")
+                        guard manager.launcher?.process === proc else { return }
+                        manager.launcher = nil
+                        // Only react to crashes while we believed the backend was up. A
+                        // deliberate stop()/quit clears ownership first, so this won't
+                        // fight an intentional shutdown.
+                        if manager.state == .running || manager.state == .starting {
+                            manager.handleUnexpectedTermination(code: code)
+                        }
+                    }
+                }
+            }
             reusedBackendPID = nil
             startHealthCheck()
         } catch {
+            if self.launcher === launcher {
+                self.launcher = nil
+            }
             state = .error("Failed to launch backend: \(error.localizedDescription)")
             logger.error("Launch failed: \(error)")
         }
@@ -234,9 +226,9 @@ final class BackendManager: ObservableObject {
         guard !pids.isEmpty else { return false }
         for pid in pids {
             guard pid > 0 else { continue }
-            guard let command = commandLine(for: pid), isReusableBackendCommand(command) else { continue }
+            guard let command = commandLine(for: pid), commandMatcher.isReusableBackendCommand(command) else { continue }
             logger.info("Reusing existing backend pid \(pid): \(command, privacy: .public)")
-            process = nil
+            launcher = nil
             reusedBackendPID = pid
             startHealthCheck()
             return true
@@ -252,7 +244,7 @@ final class BackendManager: ObservableObject {
         for pid in pids {
             guard pid > 0 else { continue }
             guard let command = commandLine(for: pid) else { continue }
-            guard isOpenMessageBackendCommand(command) else { continue }
+            guard commandMatcher.isOpenMessageBackendCommand(command) else { continue }
 
             logger.warning("Stopping conflicting backend pid \(pid): \(command, privacy: .public)")
             _ = Darwin.kill(pid_t(pid), SIGTERM)
@@ -263,7 +255,7 @@ final class BackendManager: ObservableObject {
             waitForPortRelease()
             for pid in listeningPIDs(on: port) {
                 guard pid > 0 else { continue }
-                guard let command = commandLine(for: pid), isOpenMessageBackendCommand(command) else { continue }
+                guard let command = commandLine(for: pid), commandMatcher.isOpenMessageBackendCommand(command) else { continue }
                 logger.warning("Force stopping lingering backend pid \(pid): \(command, privacy: .public)")
                 _ = Darwin.kill(pid_t(pid), SIGKILL)
             }
@@ -271,23 +263,8 @@ final class BackendManager: ObservableObject {
         }
     }
 
-    private func isReusableBackendCommand(_ command: String) -> Bool {
-        command.contains("\(binaryPath) serve")
-    }
-
-    private func isOpenMessageBackendCommand(_ command: String) -> Bool {
-        let normalized = command.replacingOccurrences(of: "\\", with: "/")
-        if isReusableBackendCommand(normalized) {
-            return true
-        }
-        if normalized.contains("/usr/local/bin/openmessage serve") {
-            return true
-        }
-        return normalized.contains("/OpenMessage")
-            && (
-                normalized.contains(".app/Contents/Resources/openmessage serve")
-                || normalized.contains(".app/Contents/MacOS/openmessage-helper serve")
-            )
+    private var commandMatcher: BackendCommandMatcher {
+        BackendCommandMatcher(binaryPath: binaryPath)
     }
 
     private func waitForPortRelease() {
@@ -360,14 +337,14 @@ final class BackendManager: ObservableObject {
         healthCheckTask = nil
         connectionMonitorTask?.cancel()
         connectionMonitorTask = nil
-        if let process {
-            process.terminate()
+        if let launcher {
+            launcher.terminate()
         } else if let pid = reusedBackendPID {
             // We adopted this backend rather than spawning it, so there's no
             // Process handle — signal it by PID so it can still be stopped.
             _ = Darwin.kill(pid, SIGTERM)
         }
-        process = nil
+        launcher = nil
         reusedBackendPID = nil
         state = .stopped
     }
@@ -379,18 +356,16 @@ final class BackendManager: ObservableObject {
         cancelPendingRestart()
         healthCheckTask?.cancel()
         connectionMonitorTask?.cancel()
-        if let process, process.isRunning {
-            process.terminate()
-            let deadline = Date().addingTimeInterval(2)
-            while process.isRunning && Date() < deadline {
-                Thread.sleep(forTimeInterval: 0.05)
-            }
-            if process.isRunning {
-                _ = Darwin.kill(process.processIdentifier, SIGKILL)
+        if let launcher, launcher.process?.isRunning == true {
+            let result = launcher.terminateAndWait(timeout: 2)
+            if case .timedOut = result {
+                _ = launcher.forceTerminateAndWait(timeout: 0.5)
             }
         } else if let pid = reusedBackendPID {
             _ = Darwin.kill(pid, SIGTERM)
         }
+        launcher = nil
+        reusedBackendPID = nil
     }
 
     // ── Auto-restart plumbing ──
@@ -512,7 +487,7 @@ final class BackendManager: ObservableObject {
 
     /// Whether the backend is genuinely down (vs. briefly unreachable).
     private func backendProcessIsDead() -> Bool {
-        if let process {
+        if let process = launcher?.process {
             return !process.isRunning
         }
         // Adopted backend (no Process handle): dead if nothing is listening.
@@ -699,9 +674,6 @@ final class BackendManager: ObservableObject {
         }
     }
 
-    deinit {
-        process?.terminate()
-    }
 }
 
 /// Sendable holder so the AsyncStream's onTermination closure can reach the

--- a/macos/OpenMessage/Tests/OpenMessageTests/BackendCommandMatcherTests.swift
+++ b/macos/OpenMessage/Tests/OpenMessageTests/BackendCommandMatcherTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import XCTest
+@testable import OpenMessage
+
+final class BackendCommandMatcherTests: XCTestCase {
+    private let rootBinary = "/Users/example/src/openmessage/openmessage"
+
+    func testExactRootTreeHelperIsReusableForServeWeb() {
+        let matcher = BackendCommandMatcher(binaryPath: rootBinary)
+
+        XCTAssertTrue(matcher.isReusableBackendCommand("\(rootBinary) serve --web"))
+        XCTAssertTrue(matcher.isOpenMessageBackendCommand("\(rootBinary) serve --web"))
+        XCTAssertFalse(matcher.isReusableBackendCommand("\(rootBinary) pair"))
+        XCTAssertFalse(matcher.isOpenMessageBackendCommand("\(rootBinary) pair"))
+    }
+
+    func testOnlyTheResolvedHelperPathIsReusable() {
+        let matcher = BackendCommandMatcher(binaryPath: rootBinary)
+
+        XCTAssertFalse(matcher.isReusableBackendCommand("/tmp/openmessage serve --web"))
+        XCTAssertFalse(matcher.isReusableBackendCommand("/usr/local/bin/openmessage serve --web"))
+        XCTAssertTrue(matcher.isOpenMessageBackendCommand("/usr/local/bin/openmessage serve --web"))
+        XCTAssertFalse(matcher.isOpenMessageBackendCommand("/opt/homebrew/bin/openmessage serve --web"))
+    }
+
+    func testResolvedSystemHelperCanBeReused() {
+        let matcher = BackendCommandMatcher(binaryPath: "/usr/local/bin/openmessage")
+
+        XCTAssertTrue(matcher.isReusableBackendCommand("/usr/local/bin/openmessage serve --web"))
+    }
+
+    func testRecognizesPackagedResourceAndMacOSHelpers() {
+        let matcher = BackendCommandMatcher(binaryPath: rootBinary)
+
+        XCTAssertTrue(
+            matcher.isOpenMessageBackendCommand(
+                "/Applications/OpenMessage.app/Contents/Resources/openmessage serve --web"
+            )
+        )
+        XCTAssertTrue(
+            matcher.isOpenMessageBackendCommand(
+                "/Applications/OpenMessage.app/Contents/MacOS/openmessage-helper serve --web"
+            )
+        )
+        XCTAssertTrue(
+            matcher.isOpenMessageBackendCommand(
+                "\\Applications\\OpenMessage.app\\Contents\\Resources\\openmessage serve --web"
+            )
+        )
+    }
+
+    func testRejectsForeignAndNonServeCommands() {
+        let matcher = BackendCommandMatcher(binaryPath: rootBinary)
+
+        let commands = [
+            "/Applications/Other.app/Contents/Resources/openmessage serve --web",
+            "/Applications/Other.app/Contents/MacOS/openmessage-helper serve --web",
+            "/Applications/OpenMessage.app/Contents/Resources/openmessage pair",
+            "/usr/local/bin/openmessage pair",
+            "/bin/sh -c serve --web",
+            "/tmp/not-openmessage serve --web",
+        ]
+
+        for command in commands {
+            XCTAssertFalse(
+                matcher.isOpenMessageBackendCommand(command),
+                "Unexpectedly recognized foreign command: \(command)"
+            )
+        }
+    }
+}

--- a/macos/OpenMessage/Tests/OpenMessageTests/BackendLaunchConfigurationTests.swift
+++ b/macos/OpenMessage/Tests/OpenMessageTests/BackendLaunchConfigurationTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import XCTest
+@testable import OpenMessage
+
+final class BackendLaunchConfigurationTests: XCTestCase {
+    func testApplicationConfigurationPreservesBackendLaunchContract() {
+        let configuration = BackendLaunchConfiguration.application(
+            executablePath: "/Applications/OpenMessage.app/Contents/Resources/openmessage",
+            dataDirectory: "/Users/example/Library/Application Support/OpenMessage",
+            port: 8123,
+            homeDirectory: "/Users/example"
+        )
+
+        XCTAssertEqual(
+            configuration.executableURL.path,
+            "/Applications/OpenMessage.app/Contents/Resources/openmessage"
+        )
+        XCTAssertEqual(configuration.arguments, ["serve", "--web"])
+        XCTAssertEqual(configuration.currentDirectoryURL, configuration.dataDirectoryURL)
+        XCTAssertEqual(
+            configuration.dataDirectoryURL.path,
+            "/Users/example/Library/Application Support/OpenMessage"
+        )
+        XCTAssertEqual(configuration.port, 8123)
+        XCTAssertEqual(configuration.baseURL.absoluteString, "http://127.0.0.1:8123")
+        XCTAssertEqual(
+            configuration.environment,
+            [
+                "OPENMESSAGES_PORT": "8123",
+                "OPENMESSAGES_DATA_DIR": "/Users/example/Library/Application Support/OpenMessage",
+                "OPENMESSAGES_LOG_LEVEL": "info",
+                "OPENMESSAGES_APP_SANDBOX": "1",
+                "OPENMESSAGES_MACOS_NOTIFICATIONS": "0",
+                "HOME": "/Users/example",
+                "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
+            ]
+        )
+    }
+
+    func testAdditionalEnvironmentIsExplicitWithoutOverridingCanonicalFields() {
+        let configuration = BackendLaunchConfiguration.application(
+            executablePath: "/tmp/openmessage",
+            dataDirectory: "/tmp/openmessage-data",
+            port: 9000,
+            homeDirectory: "/tmp/home",
+            additionalEnvironment: [
+                "OPENMESSAGES_HOST": "127.0.0.1",
+                "OPENMESSAGES_PORT": "9999",
+            ]
+        )
+
+        XCTAssertEqual(configuration.environment["OPENMESSAGES_HOST"], "127.0.0.1")
+        XCTAssertEqual(configuration.environment["OPENMESSAGES_PORT"], "9000")
+        XCTAssertEqual(configuration.environment["OPENMESSAGES_LOG_LEVEL"], "info")
+    }
+
+    func testFoundationSpawnerAppliesTheCompleteConfiguration() {
+        let configuration = BackendLaunchConfiguration.application(
+            executablePath: "/tmp/openmessage",
+            dataDirectory: "/tmp/openmessage-data",
+            port: 9001,
+            homeDirectory: "/tmp/home"
+        )
+
+        let process = FoundationBackendProcessSpawner().makeProcess(for: configuration)
+
+        XCTAssertEqual(process.executableURL, configuration.executableURL)
+        XCTAssertEqual(process.arguments, configuration.arguments)
+        XCTAssertEqual(process.environment, configuration.environment)
+        XCTAssertEqual(process.currentDirectoryURL, configuration.currentDirectoryURL)
+    }
+}

--- a/macos/OpenMessage/Tests/OpenMessageTests/BackendLauncherSmokeTests.swift
+++ b/macos/OpenMessage/Tests/OpenMessageTests/BackendLauncherSmokeTests.swift
@@ -1,0 +1,234 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import OpenMessage
+
+@MainActor
+final class BackendLauncherSmokeTests: XCTestCase {
+    func testRealBackendLaunchOneRestartAndCleanQuit() async throws {
+        let fileManager = FileManager.default
+        guard let configuredPath = ProcessInfo.processInfo.environment["OPENMESSAGE_BINARY"],
+              !configuredPath.isEmpty else {
+            throw XCTSkip("OPENMESSAGE_BINARY is not set")
+        }
+
+        let binaryPath = (configuredPath as NSString).standardizingPath
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: binaryPath, isDirectory: &isDirectory),
+              !isDirectory.boolValue,
+              fileManager.isExecutableFile(atPath: binaryPath) else {
+            throw XCTSkip("OPENMESSAGE_BINARY is missing or not executable: \(binaryPath)")
+        }
+
+        let temporaryRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("openmessage-f2-smoke-\(UUID().uuidString)", isDirectory: true)
+        let dataDirectory = temporaryRoot.appendingPathComponent("data", isDirectory: true)
+        try fileManager.createDirectory(at: dataDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: temporaryRoot) }
+
+        let logURL = temporaryRoot.appendingPathComponent("backend.log")
+        guard fileManager.createFile(atPath: logURL.path, contents: nil) else {
+            throw SmokeFailure("Could not create backend log at \(logURL.path)")
+        }
+        let logHandle = try FileHandle(forWritingTo: logURL)
+        defer { try? logHandle.close() }
+
+        let port = try reserveLoopbackPort()
+        let configuration = BackendLaunchConfiguration.application(
+            executablePath: binaryPath,
+            dataDirectory: dataDirectory.path,
+            port: port,
+            homeDirectory: temporaryRoot.path,
+            additionalEnvironment: [
+                "OPENMESSAGES_HOST": "127.0.0.1",
+                "OPENMESSAGES_SIGNAL_TMP_SWEEP": "0",
+                "OPENMESSAGES_STARTUP_BACKFILL": "off",
+                "OPENMESSAGE_TELEMETRY": "0",
+                "OPENMESSAGES_DEMO": "0",
+            ]
+        )
+        let launcher = BackendLauncherCore(configuration: configuration)
+        defer {
+            if launcher.process != nil {
+                _ = launcher.forceTerminateAndWait(timeout: 2)
+            }
+        }
+
+        let configureProcess: (Process) -> Void = { process in
+            process.standardOutput = logHandle
+            process.standardError = logHandle
+        }
+
+        let firstProcess = try launcher.launch(configure: configureProcess)
+        try await waitForTwoHTTP200Responses(
+            at: configuration.baseURL,
+            process: firstProcess,
+            timeout: 12,
+            logHandle: logHandle,
+            logURL: logURL
+        )
+        let firstPID = firstProcess.processIdentifier
+        try requireCleanExit(
+            launcher.terminateAndWait(timeout: 5),
+            phase: "first launch",
+            logHandle: logHandle,
+            logURL: logURL
+        )
+        XCTAssertFalse(firstProcess.isRunning)
+
+        let restartedProcess = try launcher.launch(configure: configureProcess)
+        XCTAssertNotEqual(restartedProcess.processIdentifier, firstPID)
+        try await waitForTwoHTTP200Responses(
+            at: configuration.baseURL,
+            process: restartedProcess,
+            timeout: 12,
+            logHandle: logHandle,
+            logURL: logURL
+        )
+        try requireCleanExit(
+            launcher.terminateAndWait(timeout: 5),
+            phase: "restarted launch",
+            logHandle: logHandle,
+            logURL: logURL
+        )
+        XCTAssertFalse(restartedProcess.isRunning)
+        XCTAssertNil(launcher.process)
+    }
+
+    private func waitForTwoHTTP200Responses(
+        at baseURL: URL,
+        process: Process,
+        timeout: TimeInterval,
+        logHandle: FileHandle,
+        logURL: URL
+    ) async throws {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        sessionConfiguration.urlCache = nil
+        sessionConfiguration.connectionProxyDictionary = [:]
+        sessionConfiguration.timeoutIntervalForRequest = 0.75
+        sessionConfiguration.timeoutIntervalForResource = 1
+        let session = URLSession(configuration: sessionConfiguration)
+        defer { session.invalidateAndCancel() }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        var consecutiveSuccesses = 0
+        var lastFailure = "no response"
+
+        while Date() < deadline {
+            guard process.isRunning else {
+                throw SmokeFailure(
+                    "Backend exited before readiness (status \(process.terminationStatus)).\n"
+                        + backendLog(logHandle: logHandle, logURL: logURL)
+                )
+            }
+
+            var request = URLRequest(url: baseURL)
+            request.httpMethod = "GET"
+            request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+            request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+
+            do {
+                let (_, response) = try await session.data(for: request)
+                if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                    consecutiveSuccesses += 1
+                    if consecutiveSuccesses == 2 {
+                        return
+                    }
+                } else {
+                    consecutiveSuccesses = 0
+                    lastFailure = "HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)"
+                }
+            } catch {
+                consecutiveSuccesses = 0
+                lastFailure = error.localizedDescription
+            }
+
+            try await Task.sleep(for: .milliseconds(100))
+        }
+
+        throw SmokeFailure(
+            "Backend did not answer GET / with 200 within \(timeout)s (last failure: \(lastFailure)).\n"
+                + backendLog(logHandle: logHandle, logURL: logURL)
+        )
+    }
+
+    private func requireCleanExit(
+        _ result: BackendTerminationResult,
+        phase: String,
+        logHandle: FileHandle,
+        logURL: URL
+    ) throws {
+        switch result {
+        case let .exited(status, reason):
+            guard reason == .exit, status == 0 else {
+                throw SmokeFailure(
+                    "Backend \(phase) ended via \(reason) with status \(status), expected clean exit 0.\n"
+                        + backendLog(logHandle: logHandle, logURL: logURL)
+                )
+            }
+        case .timedOut:
+            throw SmokeFailure(
+                "Backend \(phase) did not quit within 5s.\n"
+                    + backendLog(logHandle: logHandle, logURL: logURL)
+            )
+        case .noProcess:
+            throw SmokeFailure("Backend \(phase) lost its Process handle before quit")
+        }
+    }
+
+    private func backendLog(logHandle: FileHandle, logURL: URL) -> String {
+        try? logHandle.synchronize()
+        guard let data = try? Data(contentsOf: logURL), !data.isEmpty else {
+            return "Backend log was empty."
+        }
+        return "Backend log:\n\(String(decoding: data, as: UTF8.self))"
+    }
+
+    private func reserveLoopbackPort() throws -> Int {
+        let descriptor = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else {
+            throw SmokeFailure("socket() failed with errno \(errno)")
+        }
+        defer { Darwin.close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        let bindResult = withUnsafePointer(to: &address) { addressPointer in
+            addressPointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                Darwin.bind(
+                    descriptor,
+                    socketAddress,
+                    socklen_t(MemoryLayout<sockaddr_in>.size)
+                )
+            }
+        }
+        guard bindResult == 0 else {
+            throw SmokeFailure("bind() failed with errno \(errno)")
+        }
+
+        var addressLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &address) { addressPointer in
+            addressPointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                Darwin.getsockname(descriptor, socketAddress, &addressLength)
+            }
+        }
+        guard nameResult == 0 else {
+            throw SmokeFailure("getsockname() failed with errno \(errno)")
+        }
+
+        return Int(UInt16(bigEndian: address.sin_port))
+    }
+}
+
+private struct SmokeFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}


### PR DESCRIPTION
Wave 0 / F2. Implemented by Sol, reviewed + locally verified by Claude. Changes the app's launcher (behavior-preserving), so it deploys after merge.

BackendManager's Go-helper launch and backend-adoption logic had zero test coverage — F1 made CI build the real Swift app, F2 makes it *testable*.

- **New `BackendLauncherCore`**: pure adoption predicates, an inspectable launch configuration (path/args/env/data-dir/port), injectable process spawning (`BackendProcessSpawning`, default `FoundationBackendProcessSpawner`), and a bounded launch/restart/quit lifecycle. `BackendManager` is now a thin adapter; adoption predicates, restart limits, health checks, and pairing behavior are unchanged — a launch-contract unit test pins the exact env/args.
- **SwiftPM test target**: 8 unit tests (adoption for root-tree, `/usr/local/bin`, packaged-helper forms, foreign commands, and the `serve --web` contract) + a **real-helper smoke**: launches the Go binary network-free (fresh temp data/HOME, loopback, telemetry/backfill/notifications/sweep disabled), asserts HTTP 200, restarts once, re-asserts, verifies clean exit.
- **CI**: `macos-build` builds the Go helper and runs `swift test` with `OPENMESSAGE_BINARY`, so the smoke runs on the runner too.

**Local verification (the key bit):** Sol's sandbox blocks loopback binds, so it could only run the 8 unit tests. I built the binary and ran the full suite unrestricted — **all 9 pass, including the smoke** (real launch → 200 → restart → 200 → clean quit, 0.685s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
