### PR TITLE
Add normalized identity-graph + conversation schema (rebuild Wave 2 / S4)

### DIFF
--- a/internal/storage/sqlite/identity_graph_test.go
+++ b/internal/storage/sqlite/identity_graph_test.go
@@ -1,0 +1,201 @@
+package sqlite
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+const identityGraphTestTimeMS int64 = 1_700_000_000_000
+
+func TestConversationParticipantsEnforceAccountAndIdentity(t *testing.T) {
+	store := openIdentityGraphTestStore(t)
+
+	mustExec(t, store.db, `
+		INSERT INTO accounts (account_id, bridge_key, created_at_ms, updated_at_ms)
+		VALUES
+			('account-a', 'signal', ?, ?),
+			('account-b', 'whatsapp', ?, ?)
+	`,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+	)
+	mustExec(t, store.db, `
+		INSERT INTO identities (
+			identity_id,
+			account_id,
+			kind,
+			canonical_value,
+			raw_value,
+			created_at_ms,
+			updated_at_ms
+		) VALUES
+			('identity-a', 'account-a', 'signal_aci', 'aci-a', 'aci-a', ?, ?),
+			('identity-b', 'account-b', 'e164', '+15550000002', '+1 555 000 0002', ?, ?)
+	`,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+	)
+	mustExec(t, store.db, `
+		INSERT INTO conversations (
+			conversation_id,
+			account_id,
+			remote_conversation_id,
+			kind,
+			created_at_ms,
+			updated_at_ms
+		) VALUES ('conversation-a', 'account-a', 'remote-a', 'direct', ?, ?)
+	`, identityGraphTestTimeMS, identityGraphTestTimeMS)
+
+	// account_id participates in both composite foreign keys, so this valid
+	// same-account participant proves the constraints do not reject every row.
+	mustExec(t, store.db, `
+		INSERT INTO conversation_participants (account_id, conversation_id, identity_id)
+		VALUES ('account-a', 'conversation-a', 'identity-a')
+	`)
+
+	expectExecError(t, store.db, "cross-account participant", `
+		INSERT INTO conversation_participants (account_id, conversation_id, identity_id)
+		VALUES ('account-a', 'conversation-a', 'identity-b')
+	`)
+	expectExecError(t, store.db, "orphan participant identity", `
+		INSERT INTO conversation_participants (account_id, conversation_id, identity_id)
+		VALUES ('account-a', 'conversation-a', 'missing-identity')
+	`)
+}
+
+func TestPersonIdentitiesEnforceForeignKeysAndSingleOwner(t *testing.T) {
+	store := openIdentityGraphTestStore(t)
+
+	mustExec(t, store.db, `
+		INSERT INTO accounts (account_id, bridge_key, created_at_ms, updated_at_ms)
+		VALUES ('account-a', 'signal', ?, ?)
+	`, identityGraphTestTimeMS, identityGraphTestTimeMS)
+	mustExec(t, store.db, `
+		INSERT INTO identities (
+			identity_id,
+			account_id,
+			kind,
+			canonical_value,
+			raw_value,
+			created_at_ms,
+			updated_at_ms
+		) VALUES ('identity-a', 'account-a', 'signal_aci', 'aci-a', 'aci-a', ?, ?)
+	`, identityGraphTestTimeMS, identityGraphTestTimeMS)
+	mustExec(t, store.db, `
+		INSERT INTO people (person_id, display_name, created_at_ms, updated_at_ms)
+		VALUES
+			('person-a', 'Alice', ?, ?),
+			('person-b', 'Alice B', ?, ?)
+	`,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+	)
+
+	expectExecError(t, store.db, "person identity with missing person", `
+		INSERT INTO person_identities (
+			identity_id, person_id, provenance, confidence, linked_at_ms
+		) VALUES ('identity-a', 'missing-person', 'explicit', 1.0, ?)
+	`, identityGraphTestTimeMS)
+	expectExecError(t, store.db, "person identity with missing identity", `
+		INSERT INTO person_identities (
+			identity_id, person_id, provenance, confidence, linked_at_ms
+		) VALUES ('missing-identity', 'person-a', 'explicit', 1.0, ?)
+	`, identityGraphTestTimeMS)
+
+	mustExec(t, store.db, `
+		INSERT INTO person_identities (
+			identity_id, person_id, provenance, confidence, linked_at_ms
+		) VALUES ('identity-a', 'person-a', 'explicit', 1.0, ?)
+	`, identityGraphTestTimeMS)
+	expectExecError(t, store.db, "identity linked to a second person", `
+		INSERT INTO person_identities (
+			identity_id, person_id, provenance, confidence, linked_at_ms
+		) VALUES ('identity-a', 'person-b', 'explicit', 1.0, ?)
+	`, identityGraphTestTimeMS)
+}
+
+func TestPeopleDoNotAutoMergeMatchingDisplayNames(t *testing.T) {
+	store := openIdentityGraphTestStore(t)
+
+	mustExec(t, store.db, `
+		INSERT INTO people (person_id, display_name, created_at_ms, updated_at_ms)
+		VALUES
+			('person-a', 'Shared Display Name', ?, ?),
+			('person-b', 'Shared Display Name', ?, ?)
+	`,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+		identityGraphTestTimeMS,
+	)
+
+	var count int
+	if err := store.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM people
+		WHERE display_name = 'Shared Display Name'
+		  AND merged_into_person_id IS NULL
+	`).Scan(&count); err != nil {
+		t.Fatalf("count unmerged people with matching display names: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("unmerged people with matching display names = %d, want 2", count)
+	}
+}
+
+func openIdentityGraphTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+
+	if len(embeddedMigrations) != 2 {
+		t.Fatalf("embedded migrations = %d, want 2", len(embeddedMigrations))
+	}
+	assertPragmaInt(t, store.db, "user_version", 2)
+	ledger := readLedgerRow(t, store.db, 2)
+	if ledger.name != "identity_graph" {
+		t.Fatalf("migration 0002 name = %q, want identity_graph", ledger.name)
+	}
+	if ledger.checksum != embeddedMigrations[1].checksumSHA256 {
+		t.Fatalf(
+			"migration 0002 checksum = %q, want %q",
+			ledger.checksum,
+			embeddedMigrations[1].checksumSHA256,
+		)
+	}
+	return store
+}
+
+func mustExec(t *testing.T, db *sql.DB, statement string, arguments ...any) {
+	t.Helper()
+	if _, err := db.Exec(statement, arguments...); err != nil {
+		t.Fatalf("execute fixture SQL: %v", err)
+	}
+}
+
+func expectExecError(
+	t *testing.T,
+	db *sql.DB,
+	operation string,
+	statement string,
+	arguments ...any,
+) {
+	t.Helper()
+	if _, err := db.Exec(statement, arguments...); err == nil {
+		t.Fatalf("%s succeeded, want constraint error", operation)
+	}
+}

--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -39,8 +39,12 @@ type appliedMigration struct {
 //go:embed migrations/0001_storage_shell.sql
 var migration0001SQL string
 
+//go:embed migrations/0002_identity_graph.sql
+var migration0002SQL string
+
 var embeddedMigrations = []migration{
 	newMigration(1, "storage_shell", migration0001SQL, newStorageShellArguments),
+	newMigration(2, "identity_graph", migration0002SQL, nil),
 }
 
 func newMigration(

--- a/internal/storage/sqlite/migrations/0002_identity_graph.sql
+++ b/internal/storage/sqlite/migrations/0002_identity_graph.sql
@@ -1,0 +1,159 @@
+CREATE TABLE accounts (
+    account_id        TEXT PRIMARY KEY CHECK (trim(account_id) <> ''),
+    bridge_key        TEXT NOT NULL CHECK (trim(bridge_key) <> ''),
+    remote_account_id TEXT CHECK (
+        remote_account_id IS NULL OR trim(remote_account_id) <> ''
+    ),
+    display_name      TEXT NOT NULL DEFAULT '',
+    mode              TEXT NOT NULL DEFAULT 'live'
+                      CHECK (mode IN ('live', 'archive')),
+    enabled           INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+    config_json       TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(config_json)),
+    created_at_ms     INTEGER NOT NULL CHECK (created_at_ms > 0),
+    updated_at_ms     INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
+) STRICT;
+
+CREATE UNIQUE INDEX accounts_remote_uq
+    ON accounts(bridge_key, remote_account_id)
+    WHERE remote_account_id IS NOT NULL;
+
+CREATE TABLE devices (
+    device_id         TEXT PRIMARY KEY CHECK (trim(device_id) <> ''),
+    account_id        TEXT NOT NULL,
+    remote_device_id  TEXT CHECK (
+        remote_device_id IS NULL OR trim(remote_device_id) <> ''
+    ),
+    kind              TEXT NOT NULL
+                      CHECK (kind IN ('local_installation', 'remote_endpoint')),
+    display_name      TEXT NOT NULL DEFAULT '',
+    state             TEXT NOT NULL DEFAULT 'active'
+                      CHECK (state IN ('active', 'revoked', 'unknown')),
+    is_current        INTEGER NOT NULL DEFAULT 0 CHECK (is_current IN (0, 1)),
+    last_seen_at_ms   INTEGER CHECK (
+        last_seen_at_ms IS NULL OR last_seen_at_ms >= 0
+    ),
+    created_at_ms     INTEGER NOT NULL CHECK (created_at_ms > 0),
+    updated_at_ms     INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    FOREIGN KEY (account_id)
+        REFERENCES accounts(account_id) ON DELETE CASCADE,
+    UNIQUE (account_id, device_id)
+) STRICT;
+
+CREATE UNIQUE INDEX devices_remote_uq
+    ON devices(account_id, remote_device_id)
+    WHERE remote_device_id IS NOT NULL;
+
+CREATE UNIQUE INDEX devices_current_local_uq
+    ON devices(account_id)
+    WHERE kind = 'local_installation' AND is_current = 1;
+
+CREATE TABLE identities (
+    identity_id       TEXT PRIMARY KEY CHECK (trim(identity_id) <> ''),
+    account_id        TEXT NOT NULL,
+    kind              TEXT NOT NULL CHECK (trim(kind) <> ''),
+    canonical_value   TEXT NOT NULL CHECK (trim(canonical_value) <> ''),
+    raw_value         TEXT NOT NULL CHECK (trim(raw_value) <> ''),
+    display_name      TEXT NOT NULL DEFAULT '',
+    is_self           INTEGER NOT NULL DEFAULT 0 CHECK (is_self IN (0, 1)),
+    metadata_json     TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(metadata_json)),
+    created_at_ms     INTEGER NOT NULL CHECK (created_at_ms > 0),
+    updated_at_ms     INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    FOREIGN KEY (account_id)
+        REFERENCES accounts(account_id) ON DELETE CASCADE,
+    UNIQUE (account_id, kind, canonical_value),
+    UNIQUE (account_id, identity_id)
+) STRICT;
+
+CREATE INDEX identities_value_idx
+    ON identities(kind, canonical_value);
+
+-- People and their identity links are created explicitly. Display names are
+-- deliberately non-unique and never cause identities or people to be merged.
+CREATE TABLE people (
+    person_id             TEXT PRIMARY KEY CHECK (trim(person_id) <> ''),
+    display_name          TEXT NOT NULL DEFAULT '',
+    sort_name             TEXT NOT NULL DEFAULT '',
+    merged_into_person_id TEXT,
+    created_at_ms         INTEGER NOT NULL CHECK (created_at_ms > 0),
+    updated_at_ms         INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    FOREIGN KEY (merged_into_person_id)
+        REFERENCES people(person_id) ON DELETE RESTRICT,
+    CHECK (
+        merged_into_person_id IS NULL OR merged_into_person_id <> person_id
+    )
+) STRICT;
+
+CREATE TABLE person_identities (
+    identity_id       TEXT PRIMARY KEY,
+    person_id         TEXT NOT NULL,
+    provenance        TEXT NOT NULL CHECK (
+        provenance IN (
+            'explicit', 'address_book', 'bridge_alias', 'import', 'heuristic'
+        )
+    ),
+    confidence        REAL NOT NULL CHECK (confidence BETWEEN 0.0 AND 1.0),
+    is_primary        INTEGER NOT NULL DEFAULT 0 CHECK (is_primary IN (0, 1)),
+    linked_at_ms      INTEGER NOT NULL CHECK (linked_at_ms > 0),
+    FOREIGN KEY (identity_id)
+        REFERENCES identities(identity_id) ON DELETE CASCADE,
+    FOREIGN KEY (person_id)
+        REFERENCES people(person_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE INDEX person_identities_person_idx
+    ON person_identities(person_id);
+
+CREATE UNIQUE INDEX person_primary_identity_uq
+    ON person_identities(person_id)
+    WHERE is_primary = 1;
+
+CREATE TABLE conversations (
+    conversation_id        TEXT PRIMARY KEY CHECK (trim(conversation_id) <> ''),
+    account_id             TEXT NOT NULL,
+    remote_conversation_id TEXT NOT NULL CHECK (trim(remote_conversation_id) <> ''),
+    kind                   TEXT NOT NULL
+                           CHECK (kind IN ('direct', 'group', 'broadcast', 'system')),
+    title                  TEXT NOT NULL DEFAULT '',
+    remote_revision        TEXT,
+    notification_mode      TEXT NOT NULL DEFAULT 'all'
+                           CHECK (notification_mode IN ('all', 'mentions', 'muted')),
+    is_favorite            INTEGER NOT NULL DEFAULT 0 CHECK (is_favorite IN (0, 1)),
+    archived_at_ms         INTEGER CHECK (
+        archived_at_ms IS NULL OR archived_at_ms >= 0
+    ),
+    last_message_at_ms     INTEGER NOT NULL DEFAULT 0
+                           CHECK (last_message_at_ms >= 0),
+    metadata_json          TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(metadata_json)),
+    created_at_ms          INTEGER NOT NULL CHECK (created_at_ms > 0),
+    updated_at_ms          INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    FOREIGN KEY (account_id)
+        REFERENCES accounts(account_id) ON DELETE CASCADE,
+    UNIQUE (account_id, remote_conversation_id),
+    UNIQUE (account_id, conversation_id)
+) STRICT;
+
+CREATE INDEX conversations_recency_idx
+    ON conversations(archived_at_ms, last_message_at_ms DESC, conversation_id);
+
+-- account_id is intentionally repeated here. These two composite foreign keys
+-- require each participant's conversation and identity to share that account,
+-- so both cross-account participants and orphan identities fail declaratively.
+CREATE TABLE conversation_participants (
+    account_id        TEXT NOT NULL,
+    conversation_id   TEXT NOT NULL,
+    identity_id       TEXT NOT NULL,
+    role              TEXT NOT NULL DEFAULT 'member'
+                      CHECK (role IN ('member', 'admin', 'owner', 'unknown')),
+    display_name      TEXT NOT NULL DEFAULT '',
+    is_active         INTEGER NOT NULL DEFAULT 1 CHECK (is_active IN (0, 1)),
+    joined_at_ms      INTEGER CHECK (joined_at_ms IS NULL OR joined_at_ms >= 0),
+    left_at_ms        INTEGER CHECK (left_at_ms IS NULL OR left_at_ms >= 0),
+    PRIMARY KEY (conversation_id, identity_id),
+    FOREIGN KEY (account_id, conversation_id)
+        REFERENCES conversations(account_id, conversation_id) ON DELETE CASCADE,
+    FOREIGN KEY (account_id, identity_id)
+        REFERENCES identities(account_id, identity_id) ON DELETE RESTRICT
+) STRICT;
+
+CREATE INDEX conversation_participants_identity_idx
+    ON conversation_participants(identity_id, conversation_id);

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -71,7 +71,17 @@ func TestOpenInitializesBlankDatabase(t *testing.T) {
 	if err := rows.Close(); err != nil {
 		t.Fatalf("close user table rows: %v", err)
 	}
-	wantTables := []string{"schema_migrations", "store_metadata"}
+	wantTables := []string{
+		"accounts",
+		"conversation_participants",
+		"conversations",
+		"devices",
+		"identities",
+		"people",
+		"person_identities",
+		"schema_migrations",
+		"store_metadata",
+	}
 	if !slices.Equal(tables, wantTables) {
 		t.Fatalf("user tables = %v, want %v", tables, wantTables)
 	}
@@ -90,7 +100,7 @@ func TestOpenInitializesBlankDatabase(t *testing.T) {
 		}
 	}
 
-	ledger := readLedgerRow(t, store.db)
+	ledger := readLedgerRow(t, store.db, 1)
 	if ledger.version != 1 {
 		t.Errorf("ledger version = %d, want 1", ledger.version)
 	}
@@ -137,7 +147,8 @@ func TestOpenInitializesBlankDatabase(t *testing.T) {
 		t.Errorf("store created_at_ms = %d, want > 0", createdAtMS)
 	}
 
-	assertPragmaInt(t, store.db, "user_version", 1)
+	assertRowCount(t, store.db, "schema_migrations", len(embeddedMigrations))
+	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	assertPragmaInt(t, store.db, "application_id", applicationID)
 	assertPragmaInt(t, store.db, "foreign_keys", 1)
 	assertPragmaInt(t, store.db, "busy_timeout", busyTimeoutMS)
@@ -162,7 +173,7 @@ func TestOpenReopenIsIdempotent(t *testing.T) {
 		_ = first.Close()
 		t.Fatalf("first StoreInstanceID(): %v", err)
 	}
-	firstLedger := readLedgerRow(t, first.db)
+	firstLedger := readLedgerRows(t, first.db)
 	if err := first.Close(); err != nil {
 		t.Fatalf("first Close(): %v", err)
 	}
@@ -183,14 +194,14 @@ func TestOpenReopenIsIdempotent(t *testing.T) {
 	if secondID != firstID {
 		t.Errorf("instance ID changed on reopen: first %q, second %q", firstID, secondID)
 	}
-	secondLedger := readLedgerRow(t, second.db)
-	if secondLedger != firstLedger {
+	secondLedger := readLedgerRows(t, second.db)
+	if !slices.Equal(secondLedger, firstLedger) {
 		t.Errorf("migration ledger changed on reopen:\nfirst:  %+v\nsecond: %+v", firstLedger, secondLedger)
 	}
 
-	assertRowCount(t, second.db, "schema_migrations", 1)
+	assertRowCount(t, second.db, "schema_migrations", len(embeddedMigrations))
 	assertRowCount(t, second.db, "store_metadata", 1)
-	assertPragmaInt(t, second.db, "user_version", 1)
+	assertPragmaInt(t, second.db, "user_version", len(embeddedMigrations))
 }
 
 func TestOpenRejectsAppliedMigrationChecksumMismatch(t *testing.T) {
@@ -303,7 +314,7 @@ func TestConcurrentOpenInitializesOnce(t *testing.T) {
 	if finalID != instanceID {
 		t.Errorf("final instance ID = %q, concurrent ID = %q", finalID, instanceID)
 	}
-	assertRowCount(t, store.db, "schema_migrations", 1)
+	assertRowCount(t, store.db, "schema_migrations", len(embeddedMigrations))
 	assertRowCount(t, store.db, "store_metadata", 1)
 }
 
@@ -320,7 +331,7 @@ func TestFailedMigrationRollsBackDDLAndLedger(t *testing.T) {
 	})
 
 	testMigrations := append([]migration(nil), embeddedMigrations...)
-	testMigrations = append(testMigrations, newMigration(2, "broken", `
+	testMigrations = append(testMigrations, newMigration(len(testMigrations)+1, "broken", `
 		CREATE TABLE migration_should_rollback (id INTEGER) STRICT;
 		THIS IS NOT VALID SQL;
 	`, nil))
@@ -341,17 +352,18 @@ func TestFailedMigrationRollsBackDDLAndLedger(t *testing.T) {
 	if tableExists {
 		t.Error("failed migration left partial DDL behind")
 	}
-	assertRowCount(t, store.db, "schema_migrations", 1)
-	assertPragmaInt(t, store.db, "user_version", 1)
+	assertRowCount(t, store.db, "schema_migrations", len(embeddedMigrations))
+	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 }
 
-func readLedgerRow(t *testing.T, db *sql.DB) ledgerRow {
+func readLedgerRow(t *testing.T, db *sql.DB, version int) ledgerRow {
 	t.Helper()
 	var row ledgerRow
 	if err := db.QueryRow(`
 		SELECT version, name, checksum_sha256, applied_at_ms, app_version, execution_ms
 		FROM schema_migrations
-	`).Scan(
+		WHERE version = ?
+	`, version).Scan(
 		&row.version,
 		&row.name,
 		&row.checksum,
@@ -362,6 +374,39 @@ func readLedgerRow(t *testing.T, db *sql.DB) ledgerRow {
 		t.Fatalf("read migration ledger row: %v", err)
 	}
 	return row
+}
+
+func readLedgerRows(t *testing.T, db *sql.DB) []ledgerRow {
+	t.Helper()
+	rows, err := db.Query(`
+		SELECT version, name, checksum_sha256, applied_at_ms, app_version, execution_ms
+		FROM schema_migrations
+		ORDER BY version
+	`)
+	if err != nil {
+		t.Fatalf("read migration ledger: %v", err)
+	}
+	defer rows.Close()
+
+	var ledger []ledgerRow
+	for rows.Next() {
+		var row ledgerRow
+		if err := rows.Scan(
+			&row.version,
+			&row.name,
+			&row.checksum,
+			&row.appliedAtMS,
+			&row.appVersion,
+			&row.executionMS,
+		); err != nil {
+			t.Fatalf("scan migration ledger row: %v", err)
+		}
+		ledger = append(ledger, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate migration ledger: %v", err)
+	}
+	return ledger
 }
 
 func assertRowCount(t *testing.T, db *sql.DB, table string, want int) {


### PR DESCRIPTION
Wave 2 / S4 — the durable cross-platform identity graph (the load-bearing data-model decision, per plan §2.4). Implemented by Sol, reviewed by Claude. Additive DDL + constraint tests (repositories are S4b); no deploy.

Replaces today's JSON-blob participants + never-populated `unified_contacts` (review finding #10). Migration 0002, all STRICT / Unix-ms / real FKs / open-ended `kind` columns:

- **accounts / devices** — one row per connected local account + linked devices.
- **identities** — account-scoped canonical handles, `UNIQUE(account_id, kind, canonical_value)`, raw value retained.
- **people / person_identities** — people created **explicitly** (no display-name uniqueness, **no auto-merge**); `person_identities.identity_id` is PK so an identity links to at most one person, with provenance + confidence for explicit merge/split; `people.merged_into_person_id` supports explicit merges.
- **conversations** — account-scoped, `UNIQUE(account_id, remote_conversation_id)` + a recency index (finding #16).
- **conversation_participants** — two composite FKs to `conversations(account_id, conversation_id)` and `identities(account_id, identity_id)` over a **shared `account_id`**, so a cross-account participant or orphan identity fails **declaratively** (no trigger).

`go test -race` green — cross-account participant, orphan identity, duplicate identity→person link rejected; two same-name people coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
