### PR TITLE
Add identity/conversation repositories over the S4 schema (rebuild Wave 2 / S4b)

### DIFF
--- a/internal/storage/sqlite/errors.go
+++ b/internal/storage/sqlite/errors.go
@@ -1,0 +1,27 @@
+package sqlite
+
+import "errors"
+
+var (
+	// ErrNotFound means the requested repository row does not exist.
+	ErrNotFound = errors.New("sqlite repository row not found")
+
+	// ErrConstraintViolation is the common sentinel for a write that cannot
+	// satisfy the SQLite schema constraints.
+	ErrConstraintViolation = errors.New("sqlite constraint violation")
+
+	// ErrDuplicateIdentityLink means an identity already belongs to a person.
+	ErrDuplicateIdentityLink = errors.New("identity is already linked to a person")
+
+	// ErrInvalidConversationParticipant identifies participant rows that cannot
+	// satisfy the conversation/identity ownership constraints.
+	ErrInvalidConversationParticipant = errors.New("invalid conversation participant")
+
+	// ErrCrossAccountParticipant means a participant, identity, and conversation
+	// do not all belong to the same account.
+	ErrCrossAccountParticipant = errors.New("cross-account conversation participant")
+
+	// ErrOrphanParticipantIdentity means a participant references an identity
+	// that does not exist.
+	ErrOrphanParticipantIdentity = errors.New("orphan conversation participant identity")
+)

--- a/internal/storage/sqlite/models.go
+++ b/internal/storage/sqlite/models.go
@@ -1,0 +1,162 @@
+package sqlite
+
+// AccountMode controls whether an account is connected live or imported from
+// an archive.
+type AccountMode string
+
+const (
+	AccountModeLive    AccountMode = "live"
+	AccountModeArchive AccountMode = "archive"
+)
+
+// DeviceKind identifies the relationship of a device to this installation.
+type DeviceKind string
+
+const (
+	DeviceKindLocalInstallation DeviceKind = "local_installation"
+	DeviceKindRemoteEndpoint    DeviceKind = "remote_endpoint"
+)
+
+// DeviceState is the persisted lifecycle state of a device.
+type DeviceState string
+
+const (
+	DeviceStateActive  DeviceState = "active"
+	DeviceStateRevoked DeviceState = "revoked"
+	DeviceStateUnknown DeviceState = "unknown"
+)
+
+// IdentityKind is deliberately open-ended so bridges can introduce identity
+// kinds without a schema migration.
+type IdentityKind string
+
+// IdentityProvenance records how an identity was linked to a person.
+type IdentityProvenance string
+
+const (
+	IdentityProvenanceExplicit    IdentityProvenance = "explicit"
+	IdentityProvenanceAddressBook IdentityProvenance = "address_book"
+	IdentityProvenanceBridgeAlias IdentityProvenance = "bridge_alias"
+	IdentityProvenanceImport      IdentityProvenance = "import"
+	IdentityProvenanceHeuristic   IdentityProvenance = "heuristic"
+)
+
+// ConversationKind is the persisted shape of a conversation.
+type ConversationKind string
+
+const (
+	ConversationKindDirect    ConversationKind = "direct"
+	ConversationKindGroup     ConversationKind = "group"
+	ConversationKindBroadcast ConversationKind = "broadcast"
+	ConversationKindSystem    ConversationKind = "system"
+)
+
+// NotificationMode is the persisted notification policy for a conversation.
+type NotificationMode string
+
+const (
+	NotificationModeAll      NotificationMode = "all"
+	NotificationModeMentions NotificationMode = "mentions"
+	NotificationModeMuted    NotificationMode = "muted"
+)
+
+// ParticipantRole is a participant's role within a conversation.
+type ParticipantRole string
+
+const (
+	ParticipantRoleMember  ParticipantRole = "member"
+	ParticipantRoleAdmin   ParticipantRole = "admin"
+	ParticipantRoleOwner   ParticipantRole = "owner"
+	ParticipantRoleUnknown ParticipantRole = "unknown"
+)
+
+// Account mirrors one row in accounts.
+type Account struct {
+	AccountID       string
+	BridgeKey       string
+	RemoteAccountID *string
+	DisplayName     string
+	Mode            AccountMode
+	Enabled         bool
+	ConfigJSON      string
+	CreatedAtMS     int64
+	UpdatedAtMS     int64
+}
+
+// Device mirrors one row in devices.
+type Device struct {
+	DeviceID       string
+	AccountID      string
+	RemoteDeviceID *string
+	Kind           DeviceKind
+	DisplayName    string
+	State          DeviceState
+	IsCurrent      bool
+	LastSeenAtMS   *int64
+	CreatedAtMS    int64
+	UpdatedAtMS    int64
+}
+
+// Identity mirrors one row in identities.
+type Identity struct {
+	IdentityID     string
+	AccountID      string
+	Kind           IdentityKind
+	CanonicalValue string
+	RawValue       string
+	DisplayName    string
+	IsSelf         bool
+	MetadataJSON   string
+	CreatedAtMS    int64
+	UpdatedAtMS    int64
+}
+
+// Person mirrors one row in people. DisplayName is intentionally not unique.
+type Person struct {
+	PersonID           string
+	DisplayName        string
+	SortName           string
+	MergedIntoPersonID *string
+	CreatedAtMS        int64
+	UpdatedAtMS        int64
+}
+
+// PersonIdentity mirrors one row in person_identities.
+type PersonIdentity struct {
+	IdentityID string
+	PersonID   string
+	Provenance IdentityProvenance
+	Confidence float64
+	IsPrimary  bool
+	LinkedAtMS int64
+}
+
+// Conversation mirrors one row in conversations.
+type Conversation struct {
+	ConversationID       string
+	AccountID            string
+	RemoteConversationID string
+	Kind                 ConversationKind
+	Title                string
+	RemoteRevision       *string
+	NotificationMode     NotificationMode
+	IsFavorite           bool
+	ArchivedAtMS         *int64
+	LastMessageAtMS      int64
+	MetadataJSON         string
+	CreatedAtMS          int64
+	UpdatedAtMS          int64
+}
+
+// ConversationParticipant mirrors one row in conversation_participants.
+// Participants are always represented as typed rows, never as JSON blobs.
+type ConversationParticipant struct {
+	AccountID      string
+	ConversationID string
+	IdentityID     string
+	Role           ParticipantRole
+	DisplayName    string
+	IsActive       bool
+	JoinedAtMS     *int64
+	LeftAtMS       *int64
+}

--- a/internal/storage/sqlite/repositories.go
+++ b/internal/storage/sqlite/repositories.go
@@ -1,0 +1,1020 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	moderncsqlite "modernc.org/sqlite"
+)
+
+const (
+	sqliteConstraintCode           = 19
+	sqliteConstraintForeignKeyCode = 787
+	sqliteConstraintPrimaryKeyCode = 1555
+)
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func mapConstraintError(err error) error {
+	if !isSQLiteConstraint(err) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", ErrConstraintViolation, err)
+}
+
+func isSQLiteConstraint(err error) bool {
+	code, ok := sqliteErrorCode(err)
+	return ok && code&0xff == sqliteConstraintCode
+}
+
+func isSQLiteErrorCode(err error, want int) bool {
+	code, ok := sqliteErrorCode(err)
+	return ok && code == want
+}
+
+func sqliteErrorCode(err error) (int, bool) {
+	var sqliteErr *moderncsqlite.Error
+	if !errors.As(err, &sqliteErr) {
+		return 0, false
+	}
+	return sqliteErr.Code(), true
+}
+
+func notFound(entity, id string) error {
+	return fmt.Errorf("%s %q: %w", entity, id, ErrNotFound)
+}
+
+func collectRows[T any](rows *sql.Rows, scan func(rowScanner) (T, error)) ([]T, error) {
+	defer rows.Close()
+
+	items := make([]T, 0)
+	for rows.Next() {
+		item, err := scan(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const accountColumns = `
+	account_id,
+	bridge_key,
+	remote_account_id,
+	display_name,
+	mode,
+	enabled,
+	config_json,
+	created_at_ms,
+	updated_at_ms`
+
+// UpsertAccount inserts an account or updates the row with the same account ID.
+// The original creation timestamp is retained on update.
+func (s *Store) UpsertAccount(account Account) error {
+	_, err := s.db.ExecContext(context.Background(), `
+		INSERT INTO accounts (
+			account_id,
+			bridge_key,
+			remote_account_id,
+			display_name,
+			mode,
+			enabled,
+			config_json,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account_id) DO UPDATE SET
+			bridge_key = excluded.bridge_key,
+			remote_account_id = excluded.remote_account_id,
+			display_name = excluded.display_name,
+			mode = excluded.mode,
+			enabled = excluded.enabled,
+			config_json = excluded.config_json,
+			updated_at_ms = excluded.updated_at_ms
+	`,
+		account.AccountID,
+		account.BridgeKey,
+		account.RemoteAccountID,
+		account.DisplayName,
+		account.Mode,
+		account.Enabled,
+		account.ConfigJSON,
+		account.CreatedAtMS,
+		account.UpdatedAtMS,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert account %q: %w", account.AccountID, mapConstraintError(err))
+	}
+	return nil
+}
+
+// GetAccount returns the account with accountID.
+func (s *Store) GetAccount(accountID string) (Account, error) {
+	account, err := scanAccount(s.db.QueryRowContext(
+		context.Background(),
+		"SELECT "+accountColumns+" FROM accounts WHERE account_id = ?",
+		accountID,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Account{}, notFound("account", accountID)
+	}
+	if err != nil {
+		return Account{}, fmt.Errorf("get account %q: %w", accountID, err)
+	}
+	return account, nil
+}
+
+// ListAccounts returns all accounts in stable ID order.
+func (s *Store) ListAccounts() ([]Account, error) {
+	rows, err := s.db.QueryContext(
+		context.Background(),
+		"SELECT "+accountColumns+" FROM accounts ORDER BY account_id",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+	accounts, err := collectRows(rows, scanAccount)
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+	return accounts, nil
+}
+
+func scanAccount(row rowScanner) (Account, error) {
+	var account Account
+	err := row.Scan(
+		&account.AccountID,
+		&account.BridgeKey,
+		&account.RemoteAccountID,
+		&account.DisplayName,
+		&account.Mode,
+		&account.Enabled,
+		&account.ConfigJSON,
+		&account.CreatedAtMS,
+		&account.UpdatedAtMS,
+	)
+	return account, err
+}
+
+const deviceColumns = `
+	device_id,
+	account_id,
+	remote_device_id,
+	kind,
+	display_name,
+	state,
+	is_current,
+	last_seen_at_ms,
+	created_at_ms,
+	updated_at_ms`
+
+// UpsertDevice inserts a device or updates the row with the same device ID.
+// The original creation timestamp is retained on update.
+func (s *Store) UpsertDevice(device Device) error {
+	_, err := s.db.ExecContext(context.Background(), `
+		INSERT INTO devices (
+			device_id,
+			account_id,
+			remote_device_id,
+			kind,
+			display_name,
+			state,
+			is_current,
+			last_seen_at_ms,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(device_id) DO UPDATE SET
+			account_id = excluded.account_id,
+			remote_device_id = excluded.remote_device_id,
+			kind = excluded.kind,
+			display_name = excluded.display_name,
+			state = excluded.state,
+			is_current = excluded.is_current,
+			last_seen_at_ms = excluded.last_seen_at_ms,
+			updated_at_ms = excluded.updated_at_ms
+	`,
+		device.DeviceID,
+		device.AccountID,
+		device.RemoteDeviceID,
+		device.Kind,
+		device.DisplayName,
+		device.State,
+		device.IsCurrent,
+		device.LastSeenAtMS,
+		device.CreatedAtMS,
+		device.UpdatedAtMS,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert device %q: %w", device.DeviceID, mapConstraintError(err))
+	}
+	return nil
+}
+
+// GetDevice returns the device with deviceID.
+func (s *Store) GetDevice(deviceID string) (Device, error) {
+	device, err := scanDevice(s.db.QueryRowContext(
+		context.Background(),
+		"SELECT "+deviceColumns+" FROM devices WHERE device_id = ?",
+		deviceID,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Device{}, notFound("device", deviceID)
+	}
+	if err != nil {
+		return Device{}, fmt.Errorf("get device %q: %w", deviceID, err)
+	}
+	return device, nil
+}
+
+// ListDevices returns the devices for an account in stable ID order.
+func (s *Store) ListDevices(accountID string) ([]Device, error) {
+	rows, err := s.db.QueryContext(
+		context.Background(),
+		"SELECT "+deviceColumns+" FROM devices WHERE account_id = ? ORDER BY device_id",
+		accountID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list devices for account %q: %w", accountID, err)
+	}
+	devices, err := collectRows(rows, scanDevice)
+	if err != nil {
+		return nil, fmt.Errorf("list devices for account %q: %w", accountID, err)
+	}
+	return devices, nil
+}
+
+func scanDevice(row rowScanner) (Device, error) {
+	var device Device
+	err := row.Scan(
+		&device.DeviceID,
+		&device.AccountID,
+		&device.RemoteDeviceID,
+		&device.Kind,
+		&device.DisplayName,
+		&device.State,
+		&device.IsCurrent,
+		&device.LastSeenAtMS,
+		&device.CreatedAtMS,
+		&device.UpdatedAtMS,
+	)
+	return device, err
+}
+
+const identityColumns = `
+	identity_id,
+	account_id,
+	kind,
+	canonical_value,
+	raw_value,
+	display_name,
+	is_self,
+	metadata_json,
+	created_at_ms,
+	updated_at_ms`
+
+// UpsertIdentity inserts an identity or updates the row with the same account,
+// kind, and canonical value. A natural-key conflict retains the existing
+// identity ID and creation timestamp.
+func (s *Store) UpsertIdentity(identity Identity) error {
+	_, err := s.db.ExecContext(context.Background(), `
+		INSERT INTO identities (
+			identity_id,
+			account_id,
+			kind,
+			canonical_value,
+			raw_value,
+			display_name,
+			is_self,
+			metadata_json,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account_id, kind, canonical_value) DO UPDATE SET
+			raw_value = excluded.raw_value,
+			display_name = excluded.display_name,
+			is_self = excluded.is_self,
+			metadata_json = excluded.metadata_json,
+			updated_at_ms = excluded.updated_at_ms
+	`,
+		identity.IdentityID,
+		identity.AccountID,
+		identity.Kind,
+		identity.CanonicalValue,
+		identity.RawValue,
+		identity.DisplayName,
+		identity.IsSelf,
+		identity.MetadataJSON,
+		identity.CreatedAtMS,
+		identity.UpdatedAtMS,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert identity %q: %w", identity.IdentityID, mapConstraintError(err))
+	}
+	return nil
+}
+
+// GetIdentity returns the identity with identityID.
+func (s *Store) GetIdentity(identityID string) (Identity, error) {
+	identity, err := scanIdentity(s.db.QueryRowContext(
+		context.Background(),
+		"SELECT "+identityColumns+" FROM identities WHERE identity_id = ?",
+		identityID,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Identity{}, notFound("identity", identityID)
+	}
+	if err != nil {
+		return Identity{}, fmt.Errorf("get identity %q: %w", identityID, err)
+	}
+	return identity, nil
+}
+
+// GetIdentityByCanonical returns an identity by its account-scoped natural key.
+func (s *Store) GetIdentityByCanonical(
+	accountID string,
+	kind IdentityKind,
+	canonicalValue string,
+) (Identity, error) {
+	identity, err := scanIdentity(s.db.QueryRowContext(
+		context.Background(),
+		"SELECT "+identityColumns+`
+		 FROM identities
+		 WHERE account_id = ? AND kind = ? AND canonical_value = ?`,
+		accountID,
+		kind,
+		canonicalValue,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Identity{}, fmt.Errorf(
+			"identity for account %q, kind %q, canonical value %q: %w",
+			accountID,
+			kind,
+			canonicalValue,
+			ErrNotFound,
+		)
+	}
+	if err != nil {
+		return Identity{}, fmt.Errorf(
+			"get identity for account %q, kind %q, canonical value %q: %w",
+			accountID,
+			kind,
+			canonicalValue,
+			err,
+		)
+	}
+	return identity, nil
+}
+
+// ListIdentities returns an account's identities in stable ID order.
+func (s *Store) ListIdentities(accountID string) ([]Identity, error) {
+	rows, err := s.db.QueryContext(
+		context.Background(),
+		"SELECT "+identityColumns+" FROM identities WHERE account_id = ? ORDER BY identity_id",
+		accountID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list identities for account %q: %w", accountID, err)
+	}
+	identities, err := collectRows(rows, scanIdentity)
+	if err != nil {
+		return nil, fmt.Errorf("list identities for account %q: %w", accountID, err)
+	}
+	return identities, nil
+}
+
+func scanIdentity(row rowScanner) (Identity, error) {
+	var identity Identity
+	err := row.Scan(
+		&identity.IdentityID,
+		&identity.AccountID,
+		&identity.Kind,
+		&identity.CanonicalValue,
+		&identity.RawValue,
+		&identity.DisplayName,
+		&identity.IsSelf,
+		&identity.MetadataJSON,
+		&identity.CreatedAtMS,
+		&identity.UpdatedAtMS,
+	)
+	return identity, err
+}
+
+const personColumns = `
+	person_id,
+	display_name,
+	sort_name,
+	merged_into_person_id,
+	created_at_ms,
+	updated_at_ms`
+
+// CreatePerson creates a person. Names are not used as a deduplication key.
+func (s *Store) CreatePerson(person Person) error {
+	_, err := s.db.ExecContext(context.Background(), `
+		INSERT INTO people (
+			person_id,
+			display_name,
+			sort_name,
+			merged_into_person_id,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?)
+	`,
+		person.PersonID,
+		person.DisplayName,
+		person.SortName,
+		person.MergedIntoPersonID,
+		person.CreatedAtMS,
+		person.UpdatedAtMS,
+	)
+	if err != nil {
+		return fmt.Errorf("create person %q: %w", person.PersonID, mapConstraintError(err))
+	}
+	return nil
+}
+
+// GetPerson returns the person with personID.
+func (s *Store) GetPerson(personID string) (Person, error) {
+	person, err := scanPerson(s.db.QueryRowContext(
+		context.Background(),
+		"SELECT "+personColumns+" FROM people WHERE person_id = ?",
+		personID,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Person{}, notFound("person", personID)
+	}
+	if err != nil {
+		return Person{}, fmt.Errorf("get person %q: %w", personID, err)
+	}
+	return person, nil
+}
+
+// ListPeople returns all people in stable ID order.
+func (s *Store) ListPeople() ([]Person, error) {
+	rows, err := s.db.QueryContext(
+		context.Background(),
+		"SELECT "+personColumns+" FROM people ORDER BY person_id",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list people: %w", err)
+	}
+	people, err := collectRows(rows, scanPerson)
+	if err != nil {
+		return nil, fmt.Errorf("list people: %w", err)
+	}
+	return people, nil
+}
+
+func scanPerson(row rowScanner) (Person, error) {
+	var person Person
+	err := row.Scan(
+		&person.PersonID,
+		&person.DisplayName,
+		&person.SortName,
+		&person.MergedIntoPersonID,
+		&person.CreatedAtMS,
+		&person.UpdatedAtMS,
+	)
+	return person, err
+}
+
+const personIdentityColumns = `
+	identity_id,
+	person_id,
+	provenance,
+	confidence,
+	is_primary,
+	linked_at_ms`
+
+// LinkIdentityToPerson creates a one-owner identity link.
+func (s *Store) LinkIdentityToPerson(link PersonIdentity) error {
+	_, err := s.db.ExecContext(context.Background(), `
+		INSERT INTO person_identities (
+			identity_id,
+			person_id,
+			provenance,
+			confidence,
+			is_primary,
+			linked_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?)
+	`,
+		link.IdentityID,
+		link.PersonID,
+		link.Provenance,
+		link.Confidence,
+		link.IsPrimary,
+		link.LinkedAtMS,
+	)
+	if err == nil {
+		return nil
+	}
+	if isSQLiteErrorCode(err, sqliteConstraintPrimaryKeyCode) {
+		return fmt.Errorf(
+			"link identity %q to person %q: %w: %w: %w",
+			link.IdentityID,
+			link.PersonID,
+			ErrDuplicateIdentityLink,
+			ErrConstraintViolation,
+			err,
+		)
+	}
+	return fmt.Errorf(
+		"link identity %q to person %q: %w",
+		link.IdentityID,
+		link.PersonID,
+		mapConstraintError(err),
+	)
+}
+
+// GetPersonIdentity returns the link owned by identityID.
+func (s *Store) GetPersonIdentity(identityID string) (PersonIdentity, error) {
+	link, err := scanPersonIdentity(s.db.QueryRowContext(
+		context.Background(),
+		"SELECT "+personIdentityColumns+" FROM person_identities WHERE identity_id = ?",
+		identityID,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return PersonIdentity{}, notFound("person identity link", identityID)
+	}
+	if err != nil {
+		return PersonIdentity{}, fmt.Errorf("get person identity link %q: %w", identityID, err)
+	}
+	return link, nil
+}
+
+// ListPersonIdentities returns a person's links in stable identity ID order.
+func (s *Store) ListPersonIdentities(personID string) ([]PersonIdentity, error) {
+	rows, err := s.db.QueryContext(
+		context.Background(),
+		"SELECT "+personIdentityColumns+`
+		 FROM person_identities
+		 WHERE person_id = ?
+		 ORDER BY identity_id`,
+		personID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list identity links for person %q: %w", personID, err)
+	}
+	links, err := collectRows(rows, scanPersonIdentity)
+	if err != nil {
+		return nil, fmt.Errorf("list identity links for person %q: %w", personID, err)
+	}
+	return links, nil
+}
+
+// GetPersonForIdentity resolves identityID to its linked person.
+func (s *Store) GetPersonForIdentity(identityID string) (Person, error) {
+	person, err := scanPerson(s.db.QueryRowContext(
+		context.Background(),
+		"SELECT "+prefixedPersonColumns("p")+`
+		 FROM person_identities AS pi
+		 JOIN people AS p ON p.person_id = pi.person_id
+		 WHERE pi.identity_id = ?`,
+		identityID,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Person{}, notFound("person for identity", identityID)
+	}
+	if err != nil {
+		return Person{}, fmt.Errorf("get person for identity %q: %w", identityID, err)
+	}
+	return person, nil
+}
+
+func scanPersonIdentity(row rowScanner) (PersonIdentity, error) {
+	var link PersonIdentity
+	err := row.Scan(
+		&link.IdentityID,
+		&link.PersonID,
+		&link.Provenance,
+		&link.Confidence,
+		&link.IsPrimary,
+		&link.LinkedAtMS,
+	)
+	return link, err
+}
+
+func prefixedPersonColumns(alias string) string {
+	return alias + `.person_id,
+	` + alias + `.display_name,
+	` + alias + `.sort_name,
+	` + alias + `.merged_into_person_id,
+	` + alias + `.created_at_ms,
+	` + alias + `.updated_at_ms`
+}
+
+const conversationColumns = `
+	conversation_id,
+	account_id,
+	remote_conversation_id,
+	kind,
+	title,
+	remote_revision,
+	notification_mode,
+	is_favorite,
+	archived_at_ms,
+	last_message_at_ms,
+	metadata_json,
+	created_at_ms,
+	updated_at_ms`
+
+// UpsertConversation inserts a conversation or updates the row with the same
+// account and remote conversation ID. A natural-key conflict retains the
+// existing conversation ID and creation timestamp.
+func (s *Store) UpsertConversation(conversation Conversation) error {
+	_, err := s.db.ExecContext(context.Background(), `
+		INSERT INTO conversations (
+			conversation_id,
+			account_id,
+			remote_conversation_id,
+			kind,
+			title,
+			remote_revision,
+			notification_mode,
+			is_favorite,
+			archived_at_ms,
+			last_message_at_ms,
+			metadata_json,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account_id, remote_conversation_id) DO UPDATE SET
+			kind = excluded.kind,
+			title = excluded.title,
+			remote_revision = excluded.remote_revision,
+			notification_mode = excluded.notification_mode,
+			is_favorite = excluded.is_favorite,
+			archived_at_ms = excluded.archived_at_ms,
+			last_message_at_ms = excluded.last_message_at_ms,
+			metadata_json = excluded.metadata_json,
+			updated_at_ms = excluded.updated_at_ms
+	`,
+		conversation.ConversationID,
+		conversation.AccountID,
+		conversation.RemoteConversationID,
+		conversation.Kind,
+		conversation.Title,
+		conversation.RemoteRevision,
+		conversation.NotificationMode,
+		conversation.IsFavorite,
+		conversation.ArchivedAtMS,
+		conversation.LastMessageAtMS,
+		conversation.MetadataJSON,
+		conversation.CreatedAtMS,
+		conversation.UpdatedAtMS,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"upsert conversation %q: %w",
+			conversation.ConversationID,
+			mapConstraintError(err),
+		)
+	}
+	return nil
+}
+
+// GetConversation returns the conversation with conversationID.
+func (s *Store) GetConversation(conversationID string) (Conversation, error) {
+	conversation, err := scanConversation(s.db.QueryRowContext(
+		context.Background(),
+		"SELECT "+conversationColumns+" FROM conversations WHERE conversation_id = ?",
+		conversationID,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Conversation{}, notFound("conversation", conversationID)
+	}
+	if err != nil {
+		return Conversation{}, fmt.Errorf("get conversation %q: %w", conversationID, err)
+	}
+	return conversation, nil
+}
+
+// GetConversationByRemote returns a conversation by the same account-scoped
+// natural key used by UpsertConversation.
+func (s *Store) GetConversationByRemote(
+	accountID string,
+	remoteConversationID string,
+) (Conversation, error) {
+	conversation, err := scanConversation(s.db.QueryRowContext(
+		context.Background(),
+		"SELECT "+conversationColumns+`
+		 FROM conversations
+		 WHERE account_id = ? AND remote_conversation_id = ?`,
+		accountID,
+		remoteConversationID,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Conversation{}, fmt.Errorf(
+			"conversation for account %q and remote ID %q: %w",
+			accountID,
+			remoteConversationID,
+			ErrNotFound,
+		)
+	}
+	if err != nil {
+		return Conversation{}, fmt.Errorf(
+			"get conversation for account %q and remote ID %q: %w",
+			accountID,
+			remoteConversationID,
+			err,
+		)
+	}
+	return conversation, nil
+}
+
+// ListConversationsByRecency returns an account's conversations from newest to
+// oldest, with conversation ID as a deterministic tie-breaker.
+func (s *Store) ListConversationsByRecency(accountID string) ([]Conversation, error) {
+	rows, err := s.db.QueryContext(
+		context.Background(),
+		"SELECT "+conversationColumns+`
+		 FROM conversations
+		 WHERE account_id = ?
+		 ORDER BY last_message_at_ms DESC, conversation_id`,
+		accountID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list conversations for account %q by recency: %w", accountID, err)
+	}
+	conversations, err := collectRows(rows, scanConversation)
+	if err != nil {
+		return nil, fmt.Errorf("list conversations for account %q by recency: %w", accountID, err)
+	}
+	return conversations, nil
+}
+
+func scanConversation(row rowScanner) (Conversation, error) {
+	var conversation Conversation
+	err := row.Scan(
+		&conversation.ConversationID,
+		&conversation.AccountID,
+		&conversation.RemoteConversationID,
+		&conversation.Kind,
+		&conversation.Title,
+		&conversation.RemoteRevision,
+		&conversation.NotificationMode,
+		&conversation.IsFavorite,
+		&conversation.ArchivedAtMS,
+		&conversation.LastMessageAtMS,
+		&conversation.MetadataJSON,
+		&conversation.CreatedAtMS,
+		&conversation.UpdatedAtMS,
+	)
+	return conversation, err
+}
+
+const participantColumns = `
+	account_id,
+	conversation_id,
+	identity_id,
+	role,
+	display_name,
+	is_active,
+	joined_at_ms,
+	left_at_ms`
+
+// ReplaceConversationParticipants atomically replaces every typed participant
+// row for a conversation. Empty account and conversation IDs in an input row
+// are filled from the target conversation; contradictory IDs are rejected.
+func (s *Store) ReplaceConversationParticipants(
+	conversationID string,
+	participants []ConversationParticipant,
+) error {
+	ctx := context.Background()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("replace participants for conversation %q: begin transaction: %w", conversationID, err)
+	}
+	defer tx.Rollback()
+
+	var conversationAccountID string
+	if err := tx.QueryRowContext(
+		ctx,
+		`SELECT account_id FROM conversations WHERE conversation_id = ?`,
+		conversationID,
+	).Scan(&conversationAccountID); errors.Is(err, sql.ErrNoRows) {
+		return notFound("conversation", conversationID)
+	} else if err != nil {
+		return fmt.Errorf("replace participants for conversation %q: read account: %w", conversationID, err)
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`DELETE FROM conversation_participants WHERE conversation_id = ?`,
+		conversationID,
+	); err != nil {
+		return fmt.Errorf("replace participants for conversation %q: delete existing rows: %w", conversationID, err)
+	}
+
+	for i, participant := range participants {
+		if participant.ConversationID != "" && participant.ConversationID != conversationID {
+			return invalidParticipantError(
+				nil,
+				"participant %d names conversation %q while replacing %q",
+				i,
+				participant.ConversationID,
+				conversationID,
+			)
+		}
+
+		accountID := participant.AccountID
+		if accountID == "" {
+			accountID = conversationAccountID
+		}
+		if accountID != conversationAccountID {
+			return invalidParticipantError(
+				ErrCrossAccountParticipant,
+				"participant %d account %q does not match conversation account %q",
+				i,
+				accountID,
+				conversationAccountID,
+			)
+		}
+
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO conversation_participants (
+				account_id,
+				conversation_id,
+				identity_id,
+				role,
+				display_name,
+				is_active,
+				joined_at_ms,
+				left_at_ms
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`,
+			accountID,
+			conversationID,
+			participant.IdentityID,
+			participant.Role,
+			participant.DisplayName,
+			participant.IsActive,
+			participant.JoinedAtMS,
+			participant.LeftAtMS,
+		); err != nil {
+			if isSQLiteErrorCode(err, sqliteConstraintForeignKeyCode) {
+				specific, classifyErr := classifyParticipantForeignKey(
+					ctx,
+					tx,
+					conversationAccountID,
+					participant.IdentityID,
+				)
+				if classifyErr != nil {
+					return fmt.Errorf(
+						"replace participants for conversation %q: classify participant %d constraint: %w",
+						conversationID,
+						i,
+						classifyErr,
+					)
+				}
+				return invalidParticipantConstraintError(
+					specific,
+					err,
+					"insert participant %d identity %q",
+					i,
+					participant.IdentityID,
+				)
+			}
+			if isSQLiteConstraint(err) {
+				return invalidParticipantConstraintError(
+					nil,
+					err,
+					"insert participant %d identity %q",
+					i,
+					participant.IdentityID,
+				)
+			}
+			return fmt.Errorf(
+				"replace participants for conversation %q: insert participant %d: %w",
+				conversationID,
+				i,
+				err,
+			)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		if isSQLiteErrorCode(err, sqliteConstraintForeignKeyCode) {
+			return fmt.Errorf(
+				"%w: %w: commit participant replacement: %w",
+				ErrInvalidConversationParticipant,
+				ErrConstraintViolation,
+				err,
+			)
+		}
+		return fmt.Errorf("replace participants for conversation %q: commit: %w", conversationID, err)
+	}
+	return nil
+}
+
+// ListParticipants returns typed participant rows in stable identity ID order.
+func (s *Store) ListParticipants(conversationID string) ([]ConversationParticipant, error) {
+	rows, err := s.db.QueryContext(
+		context.Background(),
+		"SELECT "+participantColumns+`
+		 FROM conversation_participants
+		 WHERE conversation_id = ?
+		 ORDER BY identity_id`,
+		conversationID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list participants for conversation %q: %w", conversationID, err)
+	}
+	participants, err := collectRows(rows, scanConversationParticipant)
+	if err != nil {
+		return nil, fmt.Errorf("list participants for conversation %q: %w", conversationID, err)
+	}
+	return participants, nil
+}
+
+func scanConversationParticipant(row rowScanner) (ConversationParticipant, error) {
+	var participant ConversationParticipant
+	err := row.Scan(
+		&participant.AccountID,
+		&participant.ConversationID,
+		&participant.IdentityID,
+		&participant.Role,
+		&participant.DisplayName,
+		&participant.IsActive,
+		&participant.JoinedAtMS,
+		&participant.LeftAtMS,
+	)
+	return participant, err
+}
+
+func classifyParticipantForeignKey(
+	ctx context.Context,
+	tx *sql.Tx,
+	conversationAccountID string,
+	identityID string,
+) (error, error) {
+	var identityAccountID string
+	err := tx.QueryRowContext(
+		ctx,
+		`SELECT account_id FROM identities WHERE identity_id = ?`,
+		identityID,
+	).Scan(&identityAccountID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrOrphanParticipantIdentity, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if identityAccountID != conversationAccountID {
+		return ErrCrossAccountParticipant, nil
+	}
+	return nil, nil
+}
+
+func invalidParticipantConstraintError(
+	specific error,
+	cause error,
+	format string,
+	args ...any,
+) error {
+	detail := fmt.Sprintf(format, args...)
+	if specific == nil {
+		return fmt.Errorf(
+			"%w: %w: %s: %w",
+			ErrInvalidConversationParticipant,
+			ErrConstraintViolation,
+			detail,
+			cause,
+		)
+	}
+	return fmt.Errorf(
+		"%w: %w: %w: %s: %w",
+		ErrInvalidConversationParticipant,
+		ErrConstraintViolation,
+		specific,
+		detail,
+		cause,
+	)
+}
+
+func invalidParticipantError(specific error, format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	if specific == nil {
+		return fmt.Errorf(
+			"%w: %w: %s",
+			ErrInvalidConversationParticipant,
+			ErrConstraintViolation,
+			detail,
+		)
+	}
+	return fmt.Errorf(
+		"%w: %w: %w: %s",
+		ErrInvalidConversationParticipant,
+		ErrConstraintViolation,
+		specific,
+		detail,
+	)
+}

--- a/internal/storage/sqlite/repositories_test.go
+++ b/internal/storage/sqlite/repositories_test.go
@@ -1,0 +1,630 @@
+package sqlite
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+const repositoryTestTimeMS int64 = 1_800_000_000_000
+
+func TestRepositoriesRoundTripRows(t *testing.T) {
+	store := openRepositoryTestStore(t)
+
+	remoteAccountID := "remote-account"
+	account := Account{
+		AccountID:       "account-a",
+		BridgeKey:       "signal",
+		RemoteAccountID: &remoteAccountID,
+		DisplayName:     "Signal archive",
+		Mode:            AccountModeArchive,
+		Enabled:         false,
+		ConfigJSON:      `{"region":"us"}`,
+		CreatedAtMS:     repositoryTestTimeMS,
+		UpdatedAtMS:     repositoryTestTimeMS + 1,
+	}
+	mustRepositoryWrite(t, "UpsertAccount", store.UpsertAccount(account))
+	gotAccount, err := store.GetAccount(account.AccountID)
+	mustRepositoryRead(t, "GetAccount", err)
+	assertRepositoryEqual(t, "account", gotAccount, account)
+	accounts, err := store.ListAccounts()
+	mustRepositoryRead(t, "ListAccounts", err)
+	assertRepositoryEqual(t, "accounts", accounts, []Account{account})
+
+	remoteDeviceID := "remote-device"
+	lastSeenAtMS := repositoryTestTimeMS + 2
+	device := Device{
+		DeviceID:       "device-a",
+		AccountID:      account.AccountID,
+		RemoteDeviceID: &remoteDeviceID,
+		Kind:           DeviceKindRemoteEndpoint,
+		DisplayName:    "Phone",
+		State:          DeviceStateUnknown,
+		IsCurrent:      true,
+		LastSeenAtMS:   &lastSeenAtMS,
+		CreatedAtMS:    repositoryTestTimeMS + 2,
+		UpdatedAtMS:    repositoryTestTimeMS + 3,
+	}
+	mustRepositoryWrite(t, "UpsertDevice", store.UpsertDevice(device))
+	gotDevice, err := store.GetDevice(device.DeviceID)
+	mustRepositoryRead(t, "GetDevice", err)
+	assertRepositoryEqual(t, "device", gotDevice, device)
+	devices, err := store.ListDevices(account.AccountID)
+	mustRepositoryRead(t, "ListDevices", err)
+	assertRepositoryEqual(t, "devices", devices, []Device{device})
+
+	identity := Identity{
+		IdentityID:     "identity-a",
+		AccountID:      account.AccountID,
+		Kind:           IdentityKind("email"),
+		CanonicalValue: "alice@example.com",
+		RawValue:       "Alice <alice@example.com>",
+		DisplayName:    "Alice",
+		IsSelf:         true,
+		MetadataJSON:   `{"verified":true}`,
+		CreatedAtMS:    repositoryTestTimeMS + 4,
+		UpdatedAtMS:    repositoryTestTimeMS + 5,
+	}
+	mustRepositoryWrite(t, "UpsertIdentity", store.UpsertIdentity(identity))
+	gotIdentity, err := store.GetIdentity(identity.IdentityID)
+	mustRepositoryRead(t, "GetIdentity", err)
+	assertRepositoryEqual(t, "identity", gotIdentity, identity)
+	canonicalIdentity, err := store.GetIdentityByCanonical(
+		account.AccountID,
+		identity.Kind,
+		identity.CanonicalValue,
+	)
+	mustRepositoryRead(t, "GetIdentityByCanonical", err)
+	assertRepositoryEqual(t, "canonical identity", canonicalIdentity, identity)
+	identities, err := store.ListIdentities(account.AccountID)
+	mustRepositoryRead(t, "ListIdentities", err)
+	assertRepositoryEqual(t, "identities", identities, []Identity{identity})
+
+	parent := Person{
+		PersonID:    "person-parent",
+		DisplayName: "Parent",
+		SortName:    "Parent",
+		CreatedAtMS: repositoryTestTimeMS + 6,
+		UpdatedAtMS: repositoryTestTimeMS + 6,
+	}
+	mustRepositoryWrite(t, "CreatePerson parent", store.CreatePerson(parent))
+	person := Person{
+		PersonID:           "person-a",
+		DisplayName:        "Alice",
+		SortName:           "Example, Alice",
+		MergedIntoPersonID: stringPointer(parent.PersonID),
+		CreatedAtMS:        repositoryTestTimeMS + 7,
+		UpdatedAtMS:        repositoryTestTimeMS + 8,
+	}
+	mustRepositoryWrite(t, "CreatePerson", store.CreatePerson(person))
+	gotPerson, err := store.GetPerson(person.PersonID)
+	mustRepositoryRead(t, "GetPerson", err)
+	assertRepositoryEqual(t, "person", gotPerson, person)
+	people, err := store.ListPeople()
+	mustRepositoryRead(t, "ListPeople", err)
+	assertRepositoryContains(t, "people", people, person)
+
+	personIdentity := PersonIdentity{
+		IdentityID: identity.IdentityID,
+		PersonID:   person.PersonID,
+		Provenance: IdentityProvenanceAddressBook,
+		Confidence: 0.875,
+		IsPrimary:  true,
+		LinkedAtMS: repositoryTestTimeMS + 9,
+	}
+	mustRepositoryWrite(
+		t,
+		"LinkIdentityToPerson",
+		store.LinkIdentityToPerson(personIdentity),
+	)
+	gotPersonIdentity, err := store.GetPersonIdentity(identity.IdentityID)
+	mustRepositoryRead(t, "GetPersonIdentity", err)
+	assertRepositoryEqual(t, "person identity", gotPersonIdentity, personIdentity)
+	personIdentities, err := store.ListPersonIdentities(person.PersonID)
+	mustRepositoryRead(t, "ListPersonIdentities", err)
+	assertRepositoryEqual(
+		t,
+		"person identities",
+		personIdentities,
+		[]PersonIdentity{personIdentity},
+	)
+	identityPerson, err := store.GetPersonForIdentity(identity.IdentityID)
+	mustRepositoryRead(t, "GetPersonForIdentity", err)
+	assertRepositoryEqual(t, "person for identity", identityPerson, person)
+
+	remoteRevision := "revision-7"
+	archivedAtMS := repositoryTestTimeMS + 10
+	conversation := Conversation{
+		ConversationID:       "conversation-a",
+		AccountID:            account.AccountID,
+		RemoteConversationID: "remote-conversation-a",
+		Kind:                 ConversationKindBroadcast,
+		Title:                "Announcements",
+		RemoteRevision:       &remoteRevision,
+		NotificationMode:     NotificationModeMuted,
+		IsFavorite:           true,
+		ArchivedAtMS:         &archivedAtMS,
+		LastMessageAtMS:      repositoryTestTimeMS + 11,
+		MetadataJSON:         `{"color":"blue"}`,
+		CreatedAtMS:          repositoryTestTimeMS + 10,
+		UpdatedAtMS:          repositoryTestTimeMS + 12,
+	}
+	mustRepositoryWrite(t, "UpsertConversation", store.UpsertConversation(conversation))
+	gotConversation, err := store.GetConversation(conversation.ConversationID)
+	mustRepositoryRead(t, "GetConversation", err)
+	assertRepositoryEqual(t, "conversation", gotConversation, conversation)
+	conversations, err := store.ListConversationsByRecency(account.AccountID)
+	mustRepositoryRead(t, "ListConversationsByRecency", err)
+	assertRepositoryEqual(t, "conversations", conversations, []Conversation{conversation})
+
+	joinedAtMS := repositoryTestTimeMS + 13
+	leftAtMS := repositoryTestTimeMS + 14
+	participant := ConversationParticipant{
+		AccountID:      account.AccountID,
+		ConversationID: conversation.ConversationID,
+		IdentityID:     identity.IdentityID,
+		Role:           ParticipantRoleOwner,
+		DisplayName:    "Alice in announcements",
+		IsActive:       false,
+		JoinedAtMS:     &joinedAtMS,
+		LeftAtMS:       &leftAtMS,
+	}
+	mustRepositoryWrite(
+		t,
+		"ReplaceConversationParticipants",
+		store.ReplaceConversationParticipants(conversation.ConversationID, []ConversationParticipant{participant}),
+	)
+	participants, err := store.ListParticipants(conversation.ConversationID)
+	mustRepositoryRead(t, "ListParticipants", err)
+	assertRepositoryEqual(
+		t,
+		"conversation participants",
+		participants,
+		[]ConversationParticipant{participant},
+	)
+}
+
+func TestUpsertsPreserveIDsAndCreationTimes(t *testing.T) {
+	store := openRepositoryTestStore(t)
+
+	account := Account{
+		AccountID:   "account-a",
+		BridgeKey:   "signal",
+		DisplayName: "Before",
+		Mode:        AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: repositoryTestTimeMS,
+		UpdatedAtMS: repositoryTestTimeMS,
+	}
+	mustRepositoryWrite(t, "initial UpsertAccount", store.UpsertAccount(account))
+	updatedAccount := account
+	updatedAccount.DisplayName = "After"
+	updatedAccount.Mode = AccountModeArchive
+	updatedAccount.CreatedAtMS += 50
+	updatedAccount.UpdatedAtMS += 100
+	mustRepositoryWrite(t, "updated UpsertAccount", store.UpsertAccount(updatedAccount))
+	updatedAccount.CreatedAtMS = account.CreatedAtMS
+	gotAccount, err := store.GetAccount(account.AccountID)
+	mustRepositoryRead(t, "GetAccount", err)
+	assertRepositoryEqual(t, "updated account", gotAccount, updatedAccount)
+
+	device := Device{
+		DeviceID:    "device-a",
+		AccountID:   account.AccountID,
+		Kind:        DeviceKindLocalInstallation,
+		DisplayName: "Before",
+		State:       DeviceStateActive,
+		IsCurrent:   true,
+		CreatedAtMS: repositoryTestTimeMS + 1,
+		UpdatedAtMS: repositoryTestTimeMS + 1,
+	}
+	mustRepositoryWrite(t, "initial UpsertDevice", store.UpsertDevice(device))
+	updatedDevice := device
+	updatedDevice.DisplayName = "After"
+	updatedDevice.State = DeviceStateRevoked
+	updatedDevice.CreatedAtMS += 50
+	updatedDevice.UpdatedAtMS += 100
+	mustRepositoryWrite(t, "updated UpsertDevice", store.UpsertDevice(updatedDevice))
+	updatedDevice.CreatedAtMS = device.CreatedAtMS
+	gotDevice, err := store.GetDevice(device.DeviceID)
+	mustRepositoryRead(t, "GetDevice", err)
+	assertRepositoryEqual(t, "updated device", gotDevice, updatedDevice)
+
+	identity := Identity{
+		IdentityID:     "identity-original",
+		AccountID:      account.AccountID,
+		Kind:           IdentityKind("e164"),
+		CanonicalValue: "+15550000001",
+		RawValue:       "+1 (555) 000-0001",
+		DisplayName:    "Before",
+		MetadataJSON:   `{}`,
+		CreatedAtMS:    repositoryTestTimeMS + 2,
+		UpdatedAtMS:    repositoryTestTimeMS + 2,
+	}
+	mustRepositoryWrite(t, "initial UpsertIdentity", store.UpsertIdentity(identity))
+	updatedIdentity := identity
+	updatedIdentity.IdentityID = "identity-discarded"
+	updatedIdentity.RawValue = "+1 555 000 0001"
+	updatedIdentity.DisplayName = "After"
+	updatedIdentity.MetadataJSON = `{"source":"sync"}`
+	updatedIdentity.CreatedAtMS += 50
+	updatedIdentity.UpdatedAtMS += 100
+	mustRepositoryWrite(t, "deduplicating UpsertIdentity", store.UpsertIdentity(updatedIdentity))
+	updatedIdentity.IdentityID = identity.IdentityID
+	updatedIdentity.CreatedAtMS = identity.CreatedAtMS
+	gotIdentity, err := store.GetIdentityByCanonical(
+		account.AccountID,
+		identity.Kind,
+		identity.CanonicalValue,
+	)
+	mustRepositoryRead(t, "GetIdentityByCanonical", err)
+	assertRepositoryEqual(t, "deduplicated identity", gotIdentity, updatedIdentity)
+	assertRepositoryNotFound(t, "discarded identity ID", func() error {
+		_, err := store.GetIdentity("identity-discarded")
+		return err
+	})
+	identities, err := store.ListIdentities(account.AccountID)
+	mustRepositoryRead(t, "ListIdentities", err)
+	if len(identities) != 1 {
+		t.Fatalf("identities after natural-key upsert = %d, want 1", len(identities))
+	}
+
+	conversation := Conversation{
+		ConversationID:       "conversation-original",
+		AccountID:            account.AccountID,
+		RemoteConversationID: "remote-conversation",
+		Kind:                 ConversationKindDirect,
+		Title:                "Before",
+		NotificationMode:     NotificationModeAll,
+		MetadataJSON:         `{}`,
+		CreatedAtMS:          repositoryTestTimeMS + 3,
+		UpdatedAtMS:          repositoryTestTimeMS + 3,
+	}
+	mustRepositoryWrite(t, "initial UpsertConversation", store.UpsertConversation(conversation))
+	updatedConversation := conversation
+	updatedConversation.ConversationID = "conversation-discarded"
+	updatedConversation.Title = "After"
+	updatedConversation.NotificationMode = NotificationModeMentions
+	updatedConversation.LastMessageAtMS = repositoryTestTimeMS + 200
+	updatedConversation.CreatedAtMS += 50
+	updatedConversation.UpdatedAtMS += 100
+	mustRepositoryWrite(
+		t,
+		"deduplicating UpsertConversation",
+		store.UpsertConversation(updatedConversation),
+	)
+	updatedConversation.ConversationID = conversation.ConversationID
+	updatedConversation.CreatedAtMS = conversation.CreatedAtMS
+	gotConversation, err := store.GetConversation(conversation.ConversationID)
+	mustRepositoryRead(t, "GetConversation", err)
+	assertRepositoryEqual(t, "deduplicated conversation", gotConversation, updatedConversation)
+	remoteConversation, err := store.GetConversationByRemote(
+		conversation.AccountID,
+		conversation.RemoteConversationID,
+	)
+	mustRepositoryRead(t, "GetConversationByRemote", err)
+	assertRepositoryEqual(t, "remote conversation", remoteConversation, updatedConversation)
+	assertRepositoryNotFound(t, "discarded conversation ID", func() error {
+		_, err := store.GetConversation("conversation-discarded")
+		return err
+	})
+	conversations, err := store.ListConversationsByRecency(account.AccountID)
+	mustRepositoryRead(t, "ListConversationsByRecency", err)
+	if len(conversations) != 1 {
+		t.Fatalf("conversations after natural-key upsert = %d, want 1", len(conversations))
+	}
+}
+
+func TestIdentityLinksHaveOneOwnerAndPeopleNamesAreNotUnique(t *testing.T) {
+	store := openRepositoryTestStore(t)
+	account := repositoryTestAccount("account-a")
+	mustRepositoryWrite(t, "UpsertAccount", store.UpsertAccount(account))
+	identity := repositoryTestIdentity("identity-a", account.AccountID, "alice")
+	mustRepositoryWrite(t, "UpsertIdentity", store.UpsertIdentity(identity))
+
+	first := Person{
+		PersonID:    "person-a",
+		DisplayName: "Same Name",
+		SortName:    "Name, Same",
+		CreatedAtMS: repositoryTestTimeMS + 10,
+		UpdatedAtMS: repositoryTestTimeMS + 10,
+	}
+	second := first
+	second.PersonID = "person-b"
+	second.CreatedAtMS++
+	second.UpdatedAtMS++
+	mustRepositoryWrite(t, "CreatePerson first", store.CreatePerson(first))
+	mustRepositoryWrite(t, "CreatePerson second", store.CreatePerson(second))
+	people, err := store.ListPeople()
+	mustRepositoryRead(t, "ListPeople", err)
+	if len(people) != 2 {
+		t.Fatalf("same-name people = %d, want 2", len(people))
+	}
+	assertRepositoryContains(t, "same-name people", people, first)
+	assertRepositoryContains(t, "same-name people", people, second)
+
+	link := PersonIdentity{
+		IdentityID: identity.IdentityID,
+		PersonID:   first.PersonID,
+		Provenance: IdentityProvenanceExplicit,
+		Confidence: 1,
+		IsPrimary:  true,
+		LinkedAtMS: repositoryTestTimeMS + 20,
+	}
+	mustRepositoryWrite(t, "first LinkIdentityToPerson", store.LinkIdentityToPerson(link))
+	secondLink := link
+	secondLink.PersonID = second.PersonID
+	secondLink.LinkedAtMS++
+	err = store.LinkIdentityToPerson(secondLink)
+	if !errors.Is(err, ErrDuplicateIdentityLink) {
+		t.Fatalf("second LinkIdentityToPerson error = %v, want ErrDuplicateIdentityLink", err)
+	}
+	if !errors.Is(err, ErrConstraintViolation) {
+		t.Fatalf("second LinkIdentityToPerson error = %v, want ErrConstraintViolation", err)
+	}
+	gotPerson, err := store.GetPersonForIdentity(identity.IdentityID)
+	mustRepositoryRead(t, "GetPersonForIdentity", err)
+	assertRepositoryEqual(t, "identity owner after rejected relink", gotPerson, first)
+}
+
+func TestListConversationsByRecencyScopesOrdersAndBreaksTies(t *testing.T) {
+	store := openRepositoryTestStore(t)
+	accountA := repositoryTestAccount("account-a")
+	accountB := repositoryTestAccount("account-b")
+	accountB.BridgeKey = "whatsapp"
+	mustRepositoryWrite(t, "UpsertAccount A", store.UpsertAccount(accountA))
+	mustRepositoryWrite(t, "UpsertAccount B", store.UpsertAccount(accountB))
+
+	conversation := func(id, accountID string, recency int64) Conversation {
+		return Conversation{
+			ConversationID:       id,
+			AccountID:            accountID,
+			RemoteConversationID: "remote-" + id,
+			Kind:                 ConversationKindGroup,
+			Title:                id,
+			NotificationMode:     NotificationModeAll,
+			LastMessageAtMS:      recency,
+			MetadataJSON:         `{}`,
+			CreatedAtMS:          repositoryTestTimeMS,
+			UpdatedAtMS:          repositoryTestTimeMS,
+		}
+	}
+	want := []Conversation{
+		conversation("conversation-tie-a", accountA.AccountID, 300),
+		conversation("conversation-tie-b", accountA.AccountID, 300),
+		conversation("conversation-middle", accountA.AccountID, 200),
+		conversation("conversation-old", accountA.AccountID, 100),
+	}
+	for _, item := range []Conversation{want[2], want[1], want[3], want[0]} {
+		mustRepositoryWrite(t, "UpsertConversation", store.UpsertConversation(item))
+	}
+	mustRepositoryWrite(
+		t,
+		"UpsertConversation other account",
+		store.UpsertConversation(conversation("conversation-other", accountB.AccountID, 1_000)),
+	)
+
+	got, err := store.ListConversationsByRecency(accountA.AccountID)
+	mustRepositoryRead(t, "ListConversationsByRecency", err)
+	assertRepositoryEqual(t, "recency ordered conversations", got, want)
+}
+
+func TestReplaceConversationParticipantsRejectsInvalidBatchesAtomically(t *testing.T) {
+	store := openRepositoryTestStore(t)
+	accountA := repositoryTestAccount("account-a")
+	accountB := repositoryTestAccount("account-b")
+	accountB.BridgeKey = "whatsapp"
+	mustRepositoryWrite(t, "UpsertAccount A", store.UpsertAccount(accountA))
+	mustRepositoryWrite(t, "UpsertAccount B", store.UpsertAccount(accountB))
+	priorIdentity := repositoryTestIdentity("identity-prior", accountA.AccountID, "prior")
+	validIdentity := repositoryTestIdentity("identity-valid", accountA.AccountID, "valid")
+	crossAccountIdentity := repositoryTestIdentity("identity-cross", accountB.AccountID, "cross")
+	for _, identity := range []Identity{priorIdentity, validIdentity, crossAccountIdentity} {
+		mustRepositoryWrite(t, "UpsertIdentity", store.UpsertIdentity(identity))
+	}
+	conversation := Conversation{
+		ConversationID:       "conversation-a",
+		AccountID:            accountA.AccountID,
+		RemoteConversationID: "remote-a",
+		Kind:                 ConversationKindDirect,
+		NotificationMode:     NotificationModeAll,
+		MetadataJSON:         `{}`,
+		CreatedAtMS:          repositoryTestTimeMS,
+		UpdatedAtMS:          repositoryTestTimeMS,
+	}
+	mustRepositoryWrite(t, "UpsertConversation", store.UpsertConversation(conversation))
+	prior := ConversationParticipant{
+		AccountID:      accountA.AccountID,
+		ConversationID: conversation.ConversationID,
+		IdentityID:     priorIdentity.IdentityID,
+		Role:           ParticipantRoleAdmin,
+		DisplayName:    "Prior participant",
+		IsActive:       true,
+	}
+	mustRepositoryWrite(
+		t,
+		"initial ReplaceConversationParticipants",
+		store.ReplaceConversationParticipants(conversation.ConversationID, []ConversationParticipant{prior}),
+	)
+	valid := ConversationParticipant{
+		AccountID:      accountA.AccountID,
+		ConversationID: conversation.ConversationID,
+		IdentityID:     validIdentity.IdentityID,
+		Role:           ParticipantRoleMember,
+		DisplayName:    "Valid participant",
+		IsActive:       true,
+	}
+
+	tests := []struct {
+		name string
+		row  ConversationParticipant
+		want error
+	}{
+		{
+			name: "cross account identity",
+			row: ConversationParticipant{
+				AccountID:      accountA.AccountID,
+				ConversationID: conversation.ConversationID,
+				IdentityID:     crossAccountIdentity.IdentityID,
+				Role:           ParticipantRoleMember,
+				IsActive:       true,
+			},
+			want: ErrCrossAccountParticipant,
+		},
+		{
+			name: "orphan identity",
+			row: ConversationParticipant{
+				AccountID:      accountA.AccountID,
+				ConversationID: conversation.ConversationID,
+				IdentityID:     "identity-missing",
+				Role:           ParticipantRoleMember,
+				IsActive:       true,
+			},
+			want: ErrOrphanParticipantIdentity,
+		},
+		{
+			name: "mismatched conversation",
+			row: ConversationParticipant{
+				AccountID:      accountA.AccountID,
+				ConversationID: "conversation-other",
+				IdentityID:     validIdentity.IdentityID,
+				Role:           ParticipantRoleMember,
+				IsActive:       true,
+			},
+			want: ErrInvalidConversationParticipant,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := store.ReplaceConversationParticipants(
+				conversation.ConversationID,
+				[]ConversationParticipant{valid, test.row},
+			)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("ReplaceConversationParticipants error = %v, want %v", err, test.want)
+			}
+			if !errors.Is(err, ErrInvalidConversationParticipant) {
+				t.Fatalf("ReplaceConversationParticipants error = %v, want ErrInvalidConversationParticipant", err)
+			}
+			if !errors.Is(err, ErrConstraintViolation) {
+				t.Fatalf("ReplaceConversationParticipants error = %v, want ErrConstraintViolation", err)
+			}
+			got, err := store.ListParticipants(conversation.ConversationID)
+			mustRepositoryRead(t, "ListParticipants after rejected batch", err)
+			assertRepositoryEqual(
+				t,
+				"participants after rejected batch",
+				got,
+				[]ConversationParticipant{prior},
+			)
+		})
+	}
+
+	mustRepositoryWrite(
+		t,
+		"empty ReplaceConversationParticipants",
+		store.ReplaceConversationParticipants(conversation.ConversationID, nil),
+	)
+	got, err := store.ListParticipants(conversation.ConversationID)
+	mustRepositoryRead(t, "ListParticipants after clear", err)
+	if len(got) != 0 {
+		t.Fatalf("participants after empty replace = %d, want 0", len(got))
+	}
+}
+
+func TestRepositoryErrorsAreTyped(t *testing.T) {
+	store := openRepositoryTestStore(t)
+	assertRepositoryNotFound(t, "missing account", func() error {
+		_, err := store.GetAccount("missing-account")
+		return err
+	})
+
+	invalid := repositoryTestAccount("account-invalid")
+	invalid.Mode = AccountMode("invalid")
+	if err := store.UpsertAccount(invalid); !errors.Is(err, ErrConstraintViolation) {
+		t.Fatalf("UpsertAccount invalid mode error = %v, want ErrConstraintViolation", err)
+	}
+}
+
+func openRepositoryTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+	return store
+}
+
+func repositoryTestAccount(id string) Account {
+	return Account{
+		AccountID:   id,
+		BridgeKey:   "signal",
+		Mode:        AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: repositoryTestTimeMS,
+		UpdatedAtMS: repositoryTestTimeMS,
+	}
+}
+
+func repositoryTestIdentity(id, accountID, canonical string) Identity {
+	return Identity{
+		IdentityID:     id,
+		AccountID:      accountID,
+		Kind:           IdentityKind("test"),
+		CanonicalValue: canonical,
+		RawValue:       canonical,
+		MetadataJSON:   `{}`,
+		CreatedAtMS:    repositoryTestTimeMS,
+		UpdatedAtMS:    repositoryTestTimeMS,
+	}
+}
+
+func assertRepositoryNotFound(t *testing.T, name string, operation func() error) {
+	t.Helper()
+	if err := operation(); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("%s error = %v, want ErrNotFound", name, err)
+	}
+}
+
+func mustRepositoryWrite(t *testing.T, name string, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", name, err)
+	}
+}
+
+func mustRepositoryRead(t *testing.T, name string, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", name, err)
+	}
+}
+
+func assertRepositoryEqual[T any](t *testing.T, name string, got, want T) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s = %#v, want %#v", name, got, want)
+	}
+}
+
+func assertRepositoryContains[T any](t *testing.T, name string, got []T, want T) {
+	t.Helper()
+	for _, item := range got {
+		if reflect.DeepEqual(item, want) {
+			return
+		}
+	}
+	t.Fatalf("%s = %#v, does not contain %#v", name, got, want)
+}
+
+func stringPointer(value string) *string {
+	return &value
+}


### PR DESCRIPTION
Wave 2 / S4b. Implemented by Sol, reviewed by Claude (salvaged intact + green after a session interruption). Additive; no deploy.

Typed Go repositories over the S4 identity graph — **no JSON-blob participant API** (the point of the new schema).

- Structs + typed enum constants for all seven S4 tables.
- Repos on `*Store`: Upsert/Get/List for accounts, devices, identities (dedup on `UNIQUE(account_id,kind,canonical_value)`), `GetIdentityByCanonical`; `CreatePerson`, `LinkIdentityToPerson` (→ `ErrDuplicateIdentityLink` when an identity already has a person), `GetPersonForIdentity`; `UpsertConversation`, `GetConversationByRemote`, `ListConversationsByRecency`; **`ReplaceConversationParticipants` in one transaction** that rejects cross-account / orphan-identity batches (`ErrCrossAccountParticipant` / `ErrOrphanParticipantIdentity`) while leaving prior participants intact.
- SQLite constraint failures map to sentinel errors for callers.

`go test -race` green — round-trips, dedup, one-owner-per-identity, non-unique people names, **atomic invalid-batch rejection**, recency ordering, typed errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
