### PR TITLE
Add bounded content-addressed blob store + attachment index (rebuild Wave 2 / S6)

### DIFF
--- a/internal/storage/blob/store.go
+++ b/internal/storage/blob/store.go
@@ -1,0 +1,400 @@
+// Package blob provides private, content-addressed storage for media blobs.
+package blob
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const (
+	privateDirMode  = 0o700
+	privateFileMode = 0o600
+	copyBufferSize  = 32 * 1024
+)
+
+// BlobRef identifies a blob and records the metadata supplied when it was put.
+type BlobRef struct {
+	Hash string
+	Size int64
+	MIME string
+}
+
+// ErrTooLarge reports that a reader contained more than the configured hard
+// byte cap. Put consumes at most Max+1 bytes before returning this error.
+type ErrTooLarge struct {
+	Max int64
+}
+
+func (e *ErrTooLarge) Error() string {
+	return fmt.Sprintf("blob exceeds maximum size of %d bytes", e.Max)
+}
+
+// BlobStore stores blobs beneath a private root directory. Blob contents are
+// addressed by lowercase SHA-256 hashes and sharded as root/ab/cdef....
+type BlobStore struct {
+	root string
+	mu   sync.RWMutex
+}
+
+// New creates a BlobStore rooted at root. Existing roots are tightened to
+// mode 0700; a symlink or non-directory root is rejected.
+func New(root string) (*BlobStore, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, fmt.Errorf("create blob store: root is empty")
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("create blob store: resolve root: %w", err)
+	}
+	if err := ensurePrivateDir(absRoot); err != nil {
+		return nil, fmt.Errorf("create blob store: %w", err)
+	}
+
+	return &BlobStore{root: absRoot}, nil
+}
+
+// Put streams r into the store while hashing it. It reads no more than max+1
+// bytes, never buffers the complete blob, and atomically deduplicates by hash.
+func (s *BlobStore) Put(ctx context.Context, r io.Reader, declaredMIME string, max int64) (BlobRef, error) {
+	if s == nil {
+		return BlobRef{}, fmt.Errorf("put blob: store is nil")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ctx == nil {
+		return BlobRef{}, fmt.Errorf("put blob: context is nil")
+	}
+	if r == nil {
+		return BlobRef{}, fmt.Errorf("put blob: reader is nil")
+	}
+	if max < 0 {
+		return BlobRef{}, fmt.Errorf("put blob: max must be non-negative")
+	}
+	if err := ctx.Err(); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: %w", err)
+	}
+	if err := ensurePrivateDir(s.root); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(s.root, ".blob-put-*")
+	if err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	stageDir := ""
+	defer func() {
+		_ = tmp.Close()
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+		if stageDir != "" {
+			_ = os.Remove(stageDir)
+		}
+	}()
+
+	if err := tmp.Chmod(privateFileMode); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: set temp file mode: %w", err)
+	}
+
+	hasher := sha256.New()
+	size, err := copyCapped(ctx, io.MultiWriter(tmp, hasher), r, max)
+	if err != nil {
+		var tooLarge *ErrTooLarge
+		if errors.As(err, &tooLarge) {
+			return BlobRef{}, tooLarge
+		}
+		return BlobRef{}, fmt.Errorf("put blob: stream content: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: close temp file: %w", err)
+	}
+
+	hash := hex.EncodeToString(hasher.Sum(nil))
+	ref := BlobRef{Hash: hash, Size: size, MIME: declaredMIME}
+	finalPath, err := s.path(ref)
+	if err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: derive final path: %w", err)
+	}
+	shardDir := filepath.Dir(finalPath)
+	if err := ensurePrivateDir(shardDir); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: create hash shard: %w", err)
+	}
+	// Make creation of the shard durable before publishing an entry within it.
+	if err := syncDir(s.root); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: sync root directory: %w", err)
+	}
+
+	stageDir, err = os.MkdirTemp(shardDir, ".blob-stage-*")
+	if err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: create staging directory: %w", err)
+	}
+	if err := os.Chmod(stageDir, privateDirMode); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: set staging directory mode: %w", err)
+	}
+	stagePath := filepath.Join(stageDir, "blob")
+	if err := os.Rename(tmpPath, stagePath); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: stage temp file: %w", err)
+	}
+	tmpPath = stagePath
+
+	// Link publishes without replacing an existing inode. Concurrent puts of
+	// identical bytes therefore converge on one final file, including across
+	// different BlobStore instances using the same root.
+	for {
+		linkErr := os.Link(stagePath, finalPath)
+		switch {
+		case linkErr == nil:
+		case errors.Is(linkErr, fs.ErrExist):
+			if err := validateExistingBlob(finalPath, size); err != nil {
+				// A Delete through another BlobStore may remove the entry
+				// between Link's EEXIST result and validation. Retry publication
+				// only for that precise race; preserve all other stat errors.
+				if errors.Is(err, fs.ErrNotExist) {
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						return BlobRef{}, fmt.Errorf("put blob: %w", ctxErr)
+					}
+					continue
+				}
+				return BlobRef{}, fmt.Errorf("put blob: validate deduplicated blob: %w", err)
+			}
+		default:
+			return BlobRef{}, fmt.Errorf("put blob: publish blob: %w", linkErr)
+		}
+		break
+	}
+
+	if err := os.Remove(stagePath); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: remove staged file: %w", err)
+	}
+	tmpPath = ""
+	if err := os.Remove(stageDir); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: remove staging directory: %w", err)
+	}
+	stageDir = ""
+	if err := syncDir(shardDir); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: sync hash shard: %w", err)
+	}
+	// The staging rename removed the original temp entry from root. Sync both
+	// sides of that cross-directory rename before reporting a durable Put.
+	if err := syncDir(s.root); err != nil {
+		return BlobRef{}, fmt.Errorf("put blob: sync root directory after publish: %w", err)
+	}
+
+	return ref, nil
+}
+
+// Open opens the regular file identified by ref for reading.
+func (s *BlobStore) Open(ref BlobRef) (io.ReadCloser, error) {
+	if s == nil {
+		return nil, fmt.Errorf("open blob: store is nil")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	path, err := s.path(ref)
+	if err != nil {
+		return nil, fmt.Errorf("open blob: %w", err)
+	}
+	pathInfo, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("open blob: %w", err)
+	}
+	if !pathInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("open blob: hash path is not a regular file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open blob: %w", err)
+	}
+	fileInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("open blob: stat file: %w", err)
+	}
+	if !fileInfo.Mode().IsRegular() || !os.SameFile(pathInfo, fileInfo) {
+		_ = file.Close()
+		return nil, fmt.Errorf("open blob: hash path changed while opening")
+	}
+	return file, nil
+}
+
+// Stat returns file information for the regular file identified by ref.
+func (s *BlobStore) Stat(ref BlobRef) (fs.FileInfo, error) {
+	if s == nil {
+		return nil, fmt.Errorf("stat blob: store is nil")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	path, err := s.path(ref)
+	if err != nil {
+		return nil, fmt.Errorf("stat blob: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat blob: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("stat blob: hash path is not a regular file")
+	}
+	return info, nil
+}
+
+// Delete removes the blob identified by ref.
+func (s *BlobStore) Delete(ref BlobRef) error {
+	if s == nil {
+		return fmt.Errorf("delete blob: store is nil")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	path, err := s.path(ref)
+	if err != nil {
+		return fmt.Errorf("delete blob: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("delete blob: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("delete blob: hash path is not a regular file")
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("delete blob: %w", err)
+	}
+	if err := syncDir(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("delete blob: sync hash shard: %w", err)
+	}
+	return nil
+}
+
+func (s *BlobStore) path(ref BlobRef) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("store is nil")
+	}
+	if err := validateHash(ref.Hash); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.root, ref.Hash[:2], ref.Hash[2:]), nil
+}
+
+func validateHash(hash string) error {
+	if len(hash) != sha256.Size*2 {
+		return fmt.Errorf("invalid blob hash: expected %d lowercase hex characters", sha256.Size*2)
+	}
+	for _, char := range hash {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return fmt.Errorf("invalid blob hash: expected lowercase SHA-256 hex")
+		}
+	}
+	return nil
+}
+
+func ensurePrivateDir(path string) error {
+	if err := os.MkdirAll(path, privateDirMode); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("path is not a private directory")
+	}
+	if err := os.Chmod(path, privateDirMode); err != nil {
+		return fmt.Errorf("set directory mode: %w", err)
+	}
+	return nil
+}
+
+func validateExistingBlob(path string, expectedSize int64) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("hash path is not a regular file")
+	}
+	if info.Mode().Perm() != privateFileMode {
+		return fmt.Errorf("hash path mode is %04o, want %04o", info.Mode().Perm(), privateFileMode)
+	}
+	if info.Size() != expectedSize {
+		return fmt.Errorf("hash path size is %d, want %d", info.Size(), expectedSize)
+	}
+	return nil
+}
+
+func copyCapped(ctx context.Context, dst io.Writer, src io.Reader, max int64) (int64, error) {
+	buffer := make([]byte, copyBufferSize)
+	var written int64
+	emptyReads := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+
+		remaining := max - written
+		readSize := len(buffer)
+		if remaining < int64(readSize) {
+			// remaining is non-negative and smaller than the buffer, so this
+			// conversion cannot overflow. The extra byte detects max+1.
+			readSize = int(remaining) + 1
+		}
+		n, readErr := src.Read(buffer[:readSize])
+		if n < 0 || n > readSize {
+			return written, fmt.Errorf("reader returned invalid byte count %d", n)
+		}
+		if n > 0 {
+			emptyReads = 0
+			if int64(n) > remaining {
+				return written, &ErrTooLarge{Max: max}
+			}
+			writeN, writeErr := dst.Write(buffer[:n])
+			if writeN < 0 || writeN > n {
+				return written, fmt.Errorf("writer returned invalid byte count %d", writeN)
+			}
+			written += int64(writeN)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if writeN != n {
+				return written, io.ErrShortWrite
+			}
+		} else {
+			emptyReads++
+			if emptyReads >= 100 {
+				return written, io.ErrNoProgress
+			}
+		}
+
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return written, nil
+			}
+			return written, readErr
+		}
+	}
+}
+
+func syncDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}

--- a/internal/storage/blob/store_test.go
+++ b/internal/storage/blob/store_test.go
@@ -1,0 +1,335 @@
+package blob
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestPutAllowsExactLimitAndOpenRoundTrips(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "blobs")
+	store := newTestStore(t, root)
+	content := bytes.Repeat([]byte("openmessage"), 373)
+
+	ref, err := store.Put(context.Background(), bytes.NewReader(content), "image/test", int64(len(content)))
+	if err != nil {
+		t.Fatalf("Put() at exact limit: %v", err)
+	}
+	wantHash := fmt.Sprintf("%x", sha256.Sum256(content))
+	if ref != (BlobRef{Hash: wantHash, Size: int64(len(content)), MIME: "image/test"}) {
+		t.Fatalf("Put() ref = %+v, want hash=%q size=%d MIME=%q", ref, wantHash, len(content), "image/test")
+	}
+
+	reader, err := store.Open(ref)
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		reader.Close()
+		t.Fatalf("Read(): %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("Open() content differs: got %d bytes, want %d", len(got), len(content))
+	}
+
+	info, err := store.Stat(ref)
+	if err != nil {
+		t.Fatalf("Stat(): %v", err)
+	}
+	if info.Size() != int64(len(content)) {
+		t.Fatalf("Stat().Size() = %d, want %d", info.Size(), len(content))
+	}
+	if gotMode := info.Mode().Perm(); gotMode != privateFileMode {
+		t.Fatalf("blob mode = %04o, want %04o", gotMode, privateFileMode)
+	}
+}
+
+func TestPutRejectsLimitPlusOneAndCleansUp(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "blobs")
+	store := newTestStore(t, root)
+	const max = 4096
+	reader := &countingReader{data: bytes.Repeat([]byte{0x7a}, max+1000)}
+
+	_, err := store.Put(context.Background(), reader, "application/octet-stream", max)
+	var tooLarge *ErrTooLarge
+	if !errors.As(err, &tooLarge) {
+		t.Fatalf("Put() error = %v, want *ErrTooLarge", err)
+	}
+	if tooLarge.Max != max {
+		t.Fatalf("ErrTooLarge.Max = %d, want %d", tooLarge.Max, max)
+	}
+	if reader.bytesRead != max+1 {
+		t.Fatalf("Put() read %d bytes, want exactly max+1 (%d)", reader.bytesRead, max+1)
+	}
+	if files := regularFiles(t, root); len(files) != 0 {
+		t.Fatalf("oversize Put() left files: %v", files)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("ReadDir(root): %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("oversize Put() left root entries: %v", entryNames(entries))
+	}
+}
+
+func TestPutClassifiesLimitPlusOneBeforeReaderError(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "blobs")
+	store := newTestStore(t, root)
+	sourceErr := errors.New("source failed")
+	reader := readerFunc(func(p []byte) (int, error) {
+		for i := range p {
+			p[i] = byte(i)
+		}
+		return len(p), sourceErr
+	})
+
+	_, err := store.Put(context.Background(), reader, "", 8)
+	var tooLarge *ErrTooLarge
+	if !errors.As(err, &tooLarge) {
+		t.Fatalf("Put() error = %v, want *ErrTooLarge", err)
+	}
+	if errors.Is(err, sourceErr) {
+		t.Fatalf("Put() returned source error instead of size error: %v", err)
+	}
+	if files := regularFiles(t, root); len(files) != 0 {
+		t.Fatalf("failed Put() left files: %v", files)
+	}
+}
+
+func TestPutDeduplicatesAndUsesPrivateModes(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "blobs")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("Mkdir(root): %v", err)
+	}
+	if err := os.Chmod(root, 0o755); err != nil {
+		t.Fatalf("Chmod(root): %v", err)
+	}
+	store := newTestStore(t, root)
+	content := bytes.Repeat([]byte("deduplicate me"), 128)
+
+	first, err := store.Put(context.Background(), bytes.NewReader(content), "image/png", int64(len(content)))
+	if err != nil {
+		t.Fatalf("first Put(): %v", err)
+	}
+	second, err := store.Put(context.Background(), bytes.NewReader(content), "image/png", int64(len(content)))
+	if err != nil {
+		t.Fatalf("second Put(): %v", err)
+	}
+	if first != second {
+		t.Fatalf("duplicate refs differ: first=%+v second=%+v", first, second)
+	}
+
+	files := regularFiles(t, root)
+	if len(files) != 1 {
+		t.Fatalf("duplicate Put() left %d regular files (%v), want 1", len(files), files)
+	}
+	wantPath := filepath.Join(root, first.Hash[:2], first.Hash[2:])
+	if files[0] != wantPath {
+		t.Fatalf("blob path = %q, want %q", files[0], wantPath)
+	}
+	assertMode(t, root, privateDirMode)
+	assertMode(t, filepath.Dir(wantPath), privateDirMode)
+	assertMode(t, wantPath, privateFileMode)
+}
+
+func TestConcurrentIdenticalPutsAcrossStoresLeaveOneFile(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "blobs")
+	content := bytes.Repeat([]byte("concurrent content"), 1024)
+
+	const puts = 16
+	stores := make([]*BlobStore, puts)
+	for i := range stores {
+		stores[i] = newTestStore(t, root)
+	}
+	refs := make([]BlobRef, puts)
+	errs := make([]error, puts)
+	var wg sync.WaitGroup
+	for i := range puts {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			refs[i], errs[i] = stores[i].Put(
+				context.Background(),
+				bytes.NewReader(content),
+				"video/test",
+				int64(len(content)),
+			)
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Put()[%d]: %v", i, err)
+		}
+		if refs[i] != refs[0] {
+			t.Fatalf("Put()[%d] ref = %+v, want %+v", i, refs[i], refs[0])
+		}
+	}
+	if files := regularFiles(t, root); len(files) != 1 {
+		t.Fatalf("concurrent Put() left %d regular files (%v), want 1", len(files), files)
+	}
+}
+
+func TestOpenRejectsSymlinkAtHashPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "blobs")
+	store := newTestStore(t, root)
+	target := filepath.Join(t.TempDir(), "outside")
+	if err := os.WriteFile(target, []byte("outside the blob root"), privateFileMode); err != nil {
+		t.Fatalf("WriteFile(target): %v", err)
+	}
+
+	hash := strings.Repeat("a", sha256.Size*2)
+	shard := filepath.Join(root, hash[:2])
+	if err := os.MkdirAll(shard, privateDirMode); err != nil {
+		t.Fatalf("MkdirAll(shard): %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(shard, hash[2:])); err != nil {
+		t.Skipf("Symlink() unavailable: %v", err)
+	}
+
+	if _, err := store.Open(BlobRef{Hash: hash}); err == nil {
+		t.Fatal("Open() followed a symlink at the hash path")
+	}
+}
+
+func TestDeleteRemovesBlob(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "blobs")
+	store := newTestStore(t, root)
+	ref, err := store.Put(context.Background(), bytes.NewBufferString("delete me"), "text/plain", 9)
+	if err != nil {
+		t.Fatalf("Put(): %v", err)
+	}
+
+	if err := store.Delete(ref); err != nil {
+		t.Fatalf("Delete(): %v", err)
+	}
+	if _, err := store.Stat(ref); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Stat() after Delete() error = %v, want os.ErrNotExist", err)
+	}
+	if _, err := store.Open(ref); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Open() after Delete() error = %v, want os.ErrNotExist", err)
+	}
+	if files := regularFiles(t, root); len(files) != 0 {
+		t.Fatalf("Delete() left files: %v", files)
+	}
+}
+
+func TestPutEmptyAtZeroLimitAndMaxIntLimit(t *testing.T) {
+	for _, max := range []int64{0, math.MaxInt64} {
+		t.Run(fmt.Sprintf("max=%d", max), func(t *testing.T) {
+			store := newTestStore(t, filepath.Join(t.TempDir(), "blobs"))
+			ref, err := store.Put(context.Background(), bytes.NewReader(nil), "", max)
+			if err != nil {
+				t.Fatalf("Put(empty): %v", err)
+			}
+			if ref.Size != 0 {
+				t.Fatalf("Put(empty).Size = %d, want 0", ref.Size)
+			}
+		})
+	}
+}
+
+func TestBlobOperationsRejectNonCanonicalHash(t *testing.T) {
+	store := newTestStore(t, filepath.Join(t.TempDir(), "blobs"))
+	invalid := []string{
+		"",
+		"../" + string(bytes.Repeat([]byte{'a'}, 61)),
+		string(bytes.Repeat([]byte{'A'}, 64)),
+		string(bytes.Repeat([]byte{'g'}, 64)),
+	}
+	for _, hash := range invalid {
+		ref := BlobRef{Hash: hash}
+		if _, err := store.Open(ref); err == nil {
+			t.Errorf("Open(%q) succeeded", hash)
+		}
+		if _, err := store.Stat(ref); err == nil {
+			t.Errorf("Stat(%q) succeeded", hash)
+		}
+		if err := store.Delete(ref); err == nil {
+			t.Errorf("Delete(%q) succeeded", hash)
+		}
+	}
+}
+
+type countingReader struct {
+	data      []byte
+	bytesRead int
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	r.bytesRead += n
+	return n, nil
+}
+
+type readerFunc func([]byte) (int, error)
+
+func (f readerFunc) Read(p []byte) (int, error) {
+	return f(p)
+}
+
+func newTestStore(t *testing.T, root string) *BlobStore {
+	t.Helper()
+	store, err := New(root)
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+	return store
+}
+
+func regularFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type().IsRegular() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(%q): %v", root, err)
+	}
+	return files
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode(%q) = %04o, want %04o", path, got, want)
+	}
+}
+
+func entryNames(entries []os.DirEntry) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}

--- a/internal/storage/sqlite/attachments.go
+++ b/internal/storage/sqlite/attachments.go
@@ -1,0 +1,207 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const attachmentHashQueryBatchSize = 500
+
+// Attachment describes a logical attachment and its content-addressed blob.
+// CreatedAtMS is populated by GetAttachment; RecordAttachment stamps the row
+// using the repository's injected clock.
+type Attachment struct {
+	AttachmentID string
+	BlobHash     string
+	Size         int64
+	MIME         string
+	Filename     string
+	CreatedAtMS  int64
+}
+
+// AttachmentRepository records logical references to content-addressed blobs.
+type AttachmentRepository struct {
+	store *Store
+	now   func() time.Time
+}
+
+// NewAttachmentRepository creates an attachment repository. now is required so
+// tests and callers can control persisted timestamps.
+func NewAttachmentRepository(
+	store *Store,
+	now func() time.Time,
+) (*AttachmentRepository, error) {
+	if store == nil || store.db == nil {
+		return nil, fmt.Errorf("create attachment repository: store is nil")
+	}
+	if now == nil {
+		return nil, fmt.Errorf("create attachment repository: now function is nil")
+	}
+	return &AttachmentRepository{store: store, now: now}, nil
+}
+
+// RecordAttachment records one logical attachment. Multiple attachment IDs may
+// reference the same blob hash.
+func (r *AttachmentRepository) RecordAttachment(
+	ctx context.Context,
+	attachment Attachment,
+) error {
+	if err := validateAttachment(attachment); err != nil {
+		return fmt.Errorf("record attachment: %w", err)
+	}
+	createdAtMS := r.now().UnixMilli()
+	if createdAtMS <= 0 {
+		return fmt.Errorf("record attachment: current Unix time is not positive")
+	}
+
+	if _, err := r.store.db.ExecContext(ctx, `
+		INSERT INTO attachments (
+			attachment_id,
+			blob_hash,
+			size,
+			mime,
+			filename,
+			created_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?)
+	`,
+		attachment.AttachmentID,
+		attachment.BlobHash,
+		attachment.Size,
+		attachment.MIME,
+		attachment.Filename,
+		createdAtMS,
+	); err != nil {
+		return fmt.Errorf("record attachment %q: %w", attachment.AttachmentID, err)
+	}
+	return nil
+}
+
+// GetAttachment returns the attachment with attachmentID. A missing row wraps
+// database/sql.ErrNoRows so callers can use errors.Is.
+func (r *AttachmentRepository) GetAttachment(
+	ctx context.Context,
+	attachmentID string,
+) (Attachment, error) {
+	if strings.TrimSpace(attachmentID) == "" {
+		return Attachment{}, fmt.Errorf("get attachment: attachment ID is empty")
+	}
+
+	var attachment Attachment
+	if err := r.store.db.QueryRowContext(ctx, `
+		SELECT attachment_id, blob_hash, size, mime, filename, created_at_ms
+		FROM attachments
+		WHERE attachment_id = ?
+	`, attachmentID).Scan(
+		&attachment.AttachmentID,
+		&attachment.BlobHash,
+		&attachment.Size,
+		&attachment.MIME,
+		&attachment.Filename,
+		&attachment.CreatedAtMS,
+	); err != nil {
+		return Attachment{}, fmt.Errorf("get attachment %q: %w", attachmentID, err)
+	}
+	return attachment, nil
+}
+
+// ListUnreferencedBlobHashes returns the valid candidate hashes not referenced
+// by an attachment. It preserves first-seen candidate order and removes
+// duplicate candidates. Candidates are supplied by the blob store because this
+// repository intentionally does not duplicate the filesystem inventory.
+func (r *AttachmentRepository) ListUnreferencedBlobHashes(
+	ctx context.Context,
+	candidates []string,
+) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("list unreferenced blob hashes: %w", err)
+	}
+
+	unique := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if err := validateBlobHash(candidate); err != nil {
+			return nil, fmt.Errorf("list unreferenced blob hashes: %w", err)
+		}
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		unique = append(unique, candidate)
+	}
+	if len(unique) == 0 {
+		return nil, nil
+	}
+
+	referenced := make(map[string]struct{}, len(unique))
+	for start := 0; start < len(unique); start += attachmentHashQueryBatchSize {
+		end := min(start+attachmentHashQueryBatchSize, len(unique))
+		batch := unique[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
+		arguments := make([]any, len(batch))
+		for i, hash := range batch {
+			arguments[i] = hash
+		}
+
+		rows, err := r.store.db.QueryContext(ctx, `
+			SELECT DISTINCT blob_hash
+			FROM attachments
+			WHERE blob_hash IN (`+placeholders+`)
+		`, arguments...)
+		if err != nil {
+			return nil, fmt.Errorf("list referenced blob hashes: %w", err)
+		}
+		for rows.Next() {
+			var hash string
+			if err := rows.Scan(&hash); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scan referenced blob hash: %w", err)
+			}
+			referenced[hash] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("iterate referenced blob hashes: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("close referenced blob hashes: %w", err)
+		}
+	}
+
+	unreferenced := make([]string, 0, len(unique)-len(referenced))
+	for _, candidate := range unique {
+		if _, exists := referenced[candidate]; !exists {
+			unreferenced = append(unreferenced, candidate)
+		}
+	}
+	return unreferenced, nil
+}
+
+func validateAttachment(attachment Attachment) error {
+	if strings.TrimSpace(attachment.AttachmentID) == "" {
+		return fmt.Errorf("attachment ID is empty")
+	}
+	if err := validateBlobHash(attachment.BlobHash); err != nil {
+		return err
+	}
+	if attachment.Size < 0 {
+		return fmt.Errorf("attachment size is negative")
+	}
+	if strings.TrimSpace(attachment.MIME) == "" {
+		return fmt.Errorf("attachment MIME type is empty")
+	}
+	return nil
+}
+
+func validateBlobHash(hash string) error {
+	if len(hash) != 64 {
+		return fmt.Errorf("blob hash %q has length %d, want 64", hash, len(hash))
+	}
+	for _, value := range []byte(hash) {
+		if (value < '0' || value > '9') && (value < 'a' || value > 'f') {
+			return fmt.Errorf("blob hash %q is not lowercase hexadecimal SHA-256", hash)
+		}
+	}
+	return nil
+}

--- a/internal/storage/sqlite/attachments_test.go
+++ b/internal/storage/sqlite/attachments_test.go
@@ -1,0 +1,260 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+const attachmentTestTimeMS int64 = 1_700_000_123_456
+
+func TestAttachmentsMigrationAndRepositoryRoundTrip(t *testing.T) {
+	store, repository := openAttachmentTestRepository(t)
+
+	var tableExists bool
+	if err := store.db.QueryRow(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM sqlite_schema
+			WHERE type = 'table' AND name = 'attachments'
+		)
+	`).Scan(&tableExists); err != nil {
+		t.Fatalf("inspect attachments table: %v", err)
+	}
+	if !tableExists {
+		t.Fatal("attachments table does not exist")
+	}
+	var strict int
+	if err := store.db.QueryRow(`
+		SELECT strict
+		FROM pragma_table_list
+		WHERE schema = 'main' AND name = 'attachments'
+	`).Scan(&strict); err != nil {
+		t.Fatalf("read attachments STRICT flag: %v", err)
+	}
+	if strict != 1 {
+		t.Fatalf("attachments strict = %d, want 1", strict)
+	}
+
+	want := Attachment{
+		AttachmentID: "attachment-1",
+		BlobHash:     strings.Repeat("ab", 32),
+		Size:         42,
+		MIME:         "image/png",
+		Filename:     "photo.png",
+		CreatedAtMS:  attachmentTestTimeMS,
+	}
+	if err := repository.RecordAttachment(context.Background(), want); err != nil {
+		t.Fatalf("RecordAttachment(): %v", err)
+	}
+	got, err := repository.GetAttachment(context.Background(), want.AttachmentID)
+	if err != nil {
+		t.Fatalf("GetAttachment(): %v", err)
+	}
+	if got != want {
+		t.Fatalf("GetAttachment() = %+v, want %+v", got, want)
+	}
+}
+
+func TestAttachmentRepositoryListsUnreferencedCandidates(t *testing.T) {
+	_, repository := openAttachmentTestRepository(t)
+	referenced := strings.Repeat("1a", 32)
+	firstUnreferenced := strings.Repeat("2b", 32)
+	secondUnreferenced := strings.Repeat("3c", 32)
+	if err := repository.RecordAttachment(context.Background(), Attachment{
+		AttachmentID: "attachment-1",
+		BlobHash:     referenced,
+		Size:         1,
+		MIME:         "application/octet-stream",
+	}); err != nil {
+		t.Fatalf("RecordAttachment(): %v", err)
+	}
+
+	got, err := repository.ListUnreferencedBlobHashes(context.Background(), []string{
+		firstUnreferenced,
+		referenced,
+		secondUnreferenced,
+		firstUnreferenced,
+	})
+	if err != nil {
+		t.Fatalf("ListUnreferencedBlobHashes(): %v", err)
+	}
+	want := []string{firstUnreferenced, secondUnreferenced}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ListUnreferencedBlobHashes() = %v, want %v", got, want)
+	}
+}
+
+func TestAttachmentRepositoryMissingRowPreservesSentinel(t *testing.T) {
+	_, repository := openAttachmentTestRepository(t)
+
+	_, err := repository.GetAttachment(context.Background(), "missing")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetAttachment() error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestAttachmentsTableEnforcesBlobMetadataConstraints(t *testing.T) {
+	store, _ := openAttachmentTestRepository(t)
+	validHash := strings.Repeat("ab", 32)
+
+	tests := []struct {
+		name         string
+		attachmentID string
+		blobHash     string
+		size         int64
+		mime         string
+		createdAtMS  int64
+	}{
+		{
+			name:         "blank attachment ID",
+			attachmentID: " ",
+			blobHash:     validHash,
+			mime:         "image/png",
+			createdAtMS:  attachmentTestTimeMS,
+		},
+		{
+			name:         "uppercase blob hash",
+			attachmentID: "attachment-uppercase",
+			blobHash:     strings.Repeat("AB", 32),
+			mime:         "image/png",
+			createdAtMS:  attachmentTestTimeMS,
+		},
+		{
+			name:         "short blob hash",
+			attachmentID: "attachment-short",
+			blobHash:     "ab",
+			mime:         "image/png",
+			createdAtMS:  attachmentTestTimeMS,
+		},
+		{
+			name:         "negative size",
+			attachmentID: "attachment-size",
+			blobHash:     validHash,
+			size:         -1,
+			mime:         "image/png",
+			createdAtMS:  attachmentTestTimeMS,
+		},
+		{
+			name:         "blank MIME",
+			attachmentID: "attachment-mime",
+			blobHash:     validHash,
+			mime:         " ",
+			createdAtMS:  attachmentTestTimeMS,
+		},
+		{
+			name:         "nonpositive timestamp",
+			attachmentID: "attachment-time",
+			blobHash:     validHash,
+			mime:         "image/png",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expectExecError(t, store.db, test.name, `
+				INSERT INTO attachments (
+					attachment_id, blob_hash, size, mime, created_at_ms
+				) VALUES (?, ?, ?, ?, ?)
+			`,
+				test.attachmentID,
+				test.blobHash,
+				test.size,
+				test.mime,
+				test.createdAtMS,
+			)
+		})
+	}
+	assertRowCount(t, store.db, "attachments", 0)
+}
+
+func TestAttachmentRepositoryRejectsInvalidInputBeforeWrite(t *testing.T) {
+	store, repository := openAttachmentTestRepository(t)
+
+	tests := []struct {
+		name       string
+		attachment Attachment
+	}{
+		{
+			name: "empty attachment ID",
+			attachment: Attachment{
+				BlobHash: strings.Repeat("ab", 32),
+				MIME:     "image/png",
+			},
+		},
+		{
+			name: "invalid hash",
+			attachment: Attachment{
+				AttachmentID: "attachment-1",
+				BlobHash:     strings.Repeat("AB", 32),
+				MIME:         "image/png",
+			},
+		},
+		{
+			name: "negative size",
+			attachment: Attachment{
+				AttachmentID: "attachment-1",
+				BlobHash:     strings.Repeat("ab", 32),
+				Size:         -1,
+				MIME:         "image/png",
+			},
+		},
+		{
+			name: "empty MIME",
+			attachment: Attachment{
+				AttachmentID: "attachment-1",
+				BlobHash:     strings.Repeat("ab", 32),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := repository.RecordAttachment(context.Background(), test.attachment); err == nil {
+				t.Fatal("RecordAttachment() succeeded, want validation error")
+			}
+		})
+	}
+	assertRowCount(t, store.db, "attachments", 0)
+}
+
+func openAttachmentTestRepository(t *testing.T) (*Store, *AttachmentRepository) {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+
+	if len(embeddedMigrations) != 3 {
+		t.Fatalf("embedded migrations = %d, want 3", len(embeddedMigrations))
+	}
+	assertPragmaInt(t, store.db, "user_version", 3)
+	ledger := readLedgerRow(t, store.db, 3)
+	if ledger.name != "attachments" {
+		t.Fatalf("migration 0003 name = %q, want attachments", ledger.name)
+	}
+	if ledger.checksum != embeddedMigrations[2].checksumSHA256 {
+		t.Fatalf(
+			"migration 0003 checksum = %q, want %q",
+			ledger.checksum,
+			embeddedMigrations[2].checksumSHA256,
+		)
+	}
+
+	repository, err := NewAttachmentRepository(
+		store,
+		func() time.Time { return time.UnixMilli(attachmentTestTimeMS) },
+	)
+	if err != nil {
+		t.Fatalf("NewAttachmentRepository(): %v", err)
+	}
+	return store, repository
+}

--- a/internal/storage/sqlite/identity_graph_test.go
+++ b/internal/storage/sqlite/identity_graph_test.go
@@ -162,10 +162,10 @@ func openIdentityGraphTestStore(t *testing.T) *Store {
 		}
 	})
 
-	if len(embeddedMigrations) != 2 {
-		t.Fatalf("embedded migrations = %d, want 2", len(embeddedMigrations))
+	if len(embeddedMigrations) != 3 {
+		t.Fatalf("embedded migrations = %d, want 3", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 2)
+	assertPragmaInt(t, store.db, "user_version", 3)
 	ledger := readLedgerRow(t, store.db, 2)
 	if ledger.name != "identity_graph" {
 		t.Fatalf("migration 0002 name = %q, want identity_graph", ledger.name)

--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -42,9 +42,13 @@ var migration0001SQL string
 //go:embed migrations/0002_identity_graph.sql
 var migration0002SQL string
 
+//go:embed migrations/0003_attachments.sql
+var migration0003SQL string
+
 var embeddedMigrations = []migration{
 	newMigration(1, "storage_shell", migration0001SQL, newStorageShellArguments),
 	newMigration(2, "identity_graph", migration0002SQL, nil),
+	newMigration(3, "attachments", migration0003SQL, nil),
 }
 
 func newMigration(

--- a/internal/storage/sqlite/migrations/0003_attachments.sql
+++ b/internal/storage/sqlite/migrations/0003_attachments.sql
@@ -1,0 +1,14 @@
+CREATE TABLE attachments (
+    attachment_id    TEXT PRIMARY KEY CHECK (trim(attachment_id) <> ''),
+    blob_hash        TEXT NOT NULL CHECK (
+        length(blob_hash) = 64
+        AND blob_hash = lower(blob_hash)
+        AND blob_hash NOT GLOB '*[^0-9a-f]*'
+    ),
+    size             INTEGER NOT NULL CHECK (size >= 0),
+    mime             TEXT NOT NULL CHECK (trim(mime) <> ''),
+    filename         TEXT NOT NULL DEFAULT '',
+    created_at_ms    INTEGER NOT NULL CHECK (created_at_ms > 0)
+) STRICT;
+
+CREATE INDEX attachments_blob_hash_idx ON attachments(blob_hash);

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -73,6 +73,7 @@ func TestOpenInitializesBlankDatabase(t *testing.T) {
 	}
 	wantTables := []string{
 		"accounts",
+		"attachments",
 		"conversation_participants",
 		"conversations",
 		"devices",


### PR DESCRIPTION
Wave 2 / S6. Implemented by Sol, reviewed by Claude. Additive; no deploy.

Media storage that replaces stuffing large BLOBs into SQLite/WAL (review findings #8/#14).

- **`internal/storage/blob`** — content-addressed store in a private `0700` dir. `Put` streams through a fixed 32 KiB buffer, hashing SHA-256 and enforcing a hard cap (reads at most `max+1` → typed `*ErrTooLarge`; **never buffers the whole blob**). Final path is sharded `ab/<rest>` at `0600`; fsync temp → rename to staging → **atomic no-replace hard-link** so identical bytes converge on **one** file (dedup) even across concurrent puts. Failure/oversize paths clean up temp+staging; canonical-hash + inode checks block path-traversal and symlink opens. `Open`/`Stat`/`Delete` round it out.
- **Migration 0003** adds a STRICT `attachments` table (`blob_hash` constrained to 64-char lowercase hex) in the checksummed ordered list + an `AttachmentRepository` (`RecordAttachment`/`GetAttachment`/`ListUnreferencedBlobHashes` for GC), injected clock.

`go test -race -count=5` green; the only edits to existing tests are migration-count bumps (2→3). Blob package has **no internal deps**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
