### PR TITLE
Add durable inbox + normalized messages with idempotent projection (rebuild Wave 2 / S5)

### DIFF
--- a/internal/storage/sqlite/attachments_test.go
+++ b/internal/storage/sqlite/attachments_test.go
@@ -233,10 +233,10 @@ func openAttachmentTestRepository(t *testing.T) (*Store, *AttachmentRepository) 
 		}
 	})
 
-	if len(embeddedMigrations) != 3 {
-		t.Fatalf("embedded migrations = %d, want 3", len(embeddedMigrations))
+	if len(embeddedMigrations) != 4 {
+		t.Fatalf("embedded migrations = %d, want 4", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 3)
+	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 3)
 	if ledger.name != "attachments" {
 		t.Fatalf("migration 0003 name = %q, want attachments", ledger.name)

--- a/internal/storage/sqlite/errors.go
+++ b/internal/storage/sqlite/errors.go
@@ -24,4 +24,37 @@ var (
 	// ErrOrphanParticipantIdentity means a participant references an identity
 	// that does not exist.
 	ErrOrphanParticipantIdentity = errors.New("orphan conversation participant identity")
+
+	// ErrInvalidInboxRecord identifies an inbox row that cannot satisfy the
+	// durable ingress schema.
+	ErrInvalidInboxRecord = errors.New("invalid inbox record")
+
+	// ErrOrphanInboxAccount means an inbox row references an account that does
+	// not exist.
+	ErrOrphanInboxAccount = errors.New("orphan inbox account")
+
+	// ErrInvalidMessage identifies a normalized message that cannot satisfy the
+	// message schema or its projection relationship to an inbox row.
+	ErrInvalidMessage = errors.New("invalid message")
+
+	// ErrCrossAccountMessage means a message, its inbox record, conversation,
+	// and sender identity do not all belong to the same account.
+	ErrCrossAccountMessage = errors.New("cross-account message")
+
+	// ErrOrphanMessage is the common sentinel for a message that references a
+	// missing inbox row, conversation, or sender identity.
+	ErrOrphanMessage = errors.New("orphan message")
+
+	// ErrOrphanMessageInbox identifies a missing source inbox row.
+	ErrOrphanMessageInbox = errors.New("orphan message inbox")
+
+	// ErrOrphanMessageConversation identifies a missing message conversation.
+	ErrOrphanMessageConversation = errors.New("orphan message conversation")
+
+	// ErrOrphanMessageIdentity identifies a missing sender identity.
+	ErrOrphanMessageIdentity = errors.New("orphan message sender identity")
+
+	// ErrInboxProjectionConflict means an already-processed inbox row was
+	// replayed with different message identity or normalized content.
+	ErrInboxProjectionConflict = errors.New("inbox projection conflict")
 )

--- a/internal/storage/sqlite/identity_graph_test.go
+++ b/internal/storage/sqlite/identity_graph_test.go
@@ -162,10 +162,10 @@ func openIdentityGraphTestStore(t *testing.T) *Store {
 		}
 	})
 
-	if len(embeddedMigrations) != 3 {
-		t.Fatalf("embedded migrations = %d, want 3", len(embeddedMigrations))
+	if len(embeddedMigrations) != 4 {
+		t.Fatalf("embedded migrations = %d, want 4", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 3)
+	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 2)
 	if ledger.name != "identity_graph" {
 		t.Fatalf("migration 0002 name = %q, want identity_graph", ledger.name)

--- a/internal/storage/sqlite/messages.go
+++ b/internal/storage/sqlite/messages.go
@@ -1,0 +1,614 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// MessageDirection is the persisted direction of a normalized message.
+type MessageDirection string
+
+const (
+	MessageDirectionIncoming MessageDirection = "incoming"
+	MessageDirectionOutgoing MessageDirection = "outgoing"
+)
+
+// MessageState is the current normalized state of a message.
+type MessageState string
+
+const (
+	MessageStateActive  MessageState = "active"
+	MessageStateEdited  MessageState = "edited"
+	MessageStateDeleted MessageState = "deleted"
+)
+
+// InboxRecord is one durable, undecoded transport frame. ReceivedAtMS and
+// ProcessedAtMS are populated on reads; AppendInbox stamps ReceivedAtMS with
+// the repository's injected clock and always stores ProcessedAtMS as NULL.
+type InboxRecord struct {
+	InboxID       string
+	AccountID     string
+	Generation    int64
+	DedupeKey     string
+	Codec         string
+	CodecVersion  int64
+	ReceivedAtMS  int64
+	Payload       []byte
+	ProcessedAtMS *int64
+}
+
+// Message is one normalized projected message. CreatedAtMS and UpdatedAtMS are
+// populated on reads; ProjectMessage stamps them with the injected clock.
+type Message struct {
+	MessageID        string
+	ConversationID   string
+	AccountID        string
+	RemoteMessageID  string
+	SenderIdentityID *string
+	Direction        MessageDirection
+	Body             string
+	ReplyToRemoteID  *string
+	State            MessageState
+	OccurredAtMS     int64
+	CreatedAtMS      int64
+	UpdatedAtMS      int64
+}
+
+// MessageProjection couples a normalized message to the durable inbox frame
+// from which it was decoded.
+type MessageProjection struct {
+	InboxID string
+	Message Message
+}
+
+// MessageRepository owns durable inbox ingestion and normalized projection.
+type MessageRepository struct {
+	store *Store
+	now   func() time.Time
+}
+
+// NewMessageRepository creates an inbox/message repository. now is required so
+// all storage-owned timestamps are deterministic in tests.
+func NewMessageRepository(
+	store *Store,
+	now func() time.Time,
+) (*MessageRepository, error) {
+	if store == nil || store.db == nil {
+		return nil, fmt.Errorf("create message repository: store is nil")
+	}
+	if now == nil {
+		return nil, fmt.Errorf("create message repository: now function is nil")
+	}
+	return &MessageRepository{store: store, now: now}, nil
+}
+
+// AppendInbox commits a raw transport frame before decoding. A nonempty
+// account-scoped dedupe key returns the original inbox ID without changing the
+// stored frame.
+func (r *MessageRepository) AppendInbox(
+	ctx context.Context,
+	record InboxRecord,
+) (string, error) {
+	receivedAtMS, err := r.nowMS("append inbox")
+	if err != nil {
+		return "", err
+	}
+
+	result, err := r.store.db.ExecContext(ctx, `
+		INSERT INTO inbox (
+			inbox_id,
+			account_id,
+			generation,
+			dedupe_key,
+			codec,
+			codec_version,
+			received_at_ms,
+			payload
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account_id, dedupe_key) WHERE dedupe_key <> '' DO NOTHING
+	`,
+		record.InboxID,
+		record.AccountID,
+		record.Generation,
+		record.DedupeKey,
+		record.Codec,
+		record.CodecVersion,
+		receivedAtMS,
+		record.Payload,
+	)
+	if err != nil {
+		return "", invalidInboxConstraintError(err, record.InboxID)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return "", fmt.Errorf("append inbox %q: read rows affected: %w", record.InboxID, err)
+	}
+	if affected == 1 {
+		return record.InboxID, nil
+	}
+	if affected != 0 || record.DedupeKey == "" {
+		return "", fmt.Errorf(
+			"append inbox %q: unexpected rows affected: %d",
+			record.InboxID,
+			affected,
+		)
+	}
+
+	var existingID string
+	if err := r.store.db.QueryRowContext(ctx, `
+		SELECT inbox_id
+		FROM inbox
+		WHERE account_id = ? AND dedupe_key = ?
+	`, record.AccountID, record.DedupeKey).Scan(&existingID); err != nil {
+		return "", fmt.Errorf(
+			"append inbox %q: read existing deduplicated row: %w",
+			record.InboxID,
+			err,
+		)
+	}
+	return existingID, nil
+}
+
+// Unprocessed returns durable frames in receipt order. Multiple workers may
+// observe the same row; ProjectMessage provides the idempotent serialization
+// boundary.
+func (r *MessageRepository) Unprocessed(ctx context.Context) ([]InboxRecord, error) {
+	rows, err := r.store.db.QueryContext(ctx, `
+		SELECT `+inboxColumns+`
+		FROM inbox
+		WHERE processed_at_ms IS NULL
+		ORDER BY received_at_ms, inbox_id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list unprocessed inbox records: %w", err)
+	}
+	records, err := collectRows(rows, scanInboxRecord)
+	if err != nil {
+		return nil, fmt.Errorf("list unprocessed inbox records: %w", err)
+	}
+	return records, nil
+}
+
+// GetMessage returns the normalized message with messageID.
+func (r *MessageRepository) GetMessage(
+	ctx context.Context,
+	messageID string,
+) (Message, error) {
+	message, err := scanMessage(r.store.db.QueryRowContext(ctx, `
+		SELECT `+messageColumns+`
+		FROM messages
+		WHERE message_id = ?
+	`, messageID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Message{}, notFound("message", messageID)
+	}
+	if err != nil {
+		return Message{}, fmt.Errorf("get message %q: %w", messageID, err)
+	}
+	return message, nil
+}
+
+// ProjectMessage atomically upserts a normalized message by remote ID and
+// marks its source inbox row processed. A replay of an already-processed inbox
+// row returns without writing either timestamp.
+func (r *MessageRepository) ProjectMessage(
+	ctx context.Context,
+	projection MessageProjection,
+) error {
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("project message %q: begin transaction: %w", projection.Message.MessageID, err)
+	}
+	defer tx.Rollback()
+
+	var (
+		inboxAccountID string
+		receivedAtMS   int64
+		processedAtMS  sql.NullInt64
+	)
+	if err := tx.QueryRowContext(ctx, `
+		SELECT account_id, received_at_ms, processed_at_ms
+		FROM inbox
+		WHERE inbox_id = ?
+	`, projection.InboxID).Scan(
+		&inboxAccountID,
+		&receivedAtMS,
+		&processedAtMS,
+	); errors.Is(err, sql.ErrNoRows) {
+		return invalidMessageError(
+			orphanMessageError(ErrOrphanMessageInbox),
+			"source inbox %q does not exist",
+			projection.InboxID,
+		)
+	} else if err != nil {
+		return fmt.Errorf(
+			"project message %q: read inbox %q: %w",
+			projection.Message.MessageID,
+			projection.InboxID,
+			err,
+		)
+	}
+	if inboxAccountID != projection.Message.AccountID {
+		return invalidMessageError(
+			ErrCrossAccountMessage,
+			"source inbox %q account %q does not match message account %q",
+			projection.InboxID,
+			inboxAccountID,
+			projection.Message.AccountID,
+		)
+	}
+	message := projection.Message
+	if processedAtMS.Valid {
+		existing, err := scanMessage(tx.QueryRowContext(ctx, `
+			SELECT `+messageColumns+`
+			FROM messages
+			WHERE account_id = ?
+			  AND conversation_id = ?
+			  AND remote_message_id = ?
+		`,
+			message.AccountID,
+			message.ConversationID,
+			message.RemoteMessageID,
+		))
+		naturalKeyExists := true
+		if errors.Is(err, sql.ErrNoRows) {
+			naturalKeyExists = false
+		} else if err != nil {
+			return fmt.Errorf(
+				"project message %q: read processed inbox natural key: %w",
+				message.MessageID,
+				err,
+			)
+		}
+		// Execute the same SQLite write inside the transaction that will be
+		// rolled back. This keeps SQLite authoritative for orphan/cross-account
+		// validation even when the source inbox has already been processed.
+		if err := r.upsertMessage(ctx, tx, message, processedAtMS.Int64); err != nil {
+			return err
+		}
+		if !naturalKeyExists || !sameProjectedMessage(existing, message) {
+			return fmt.Errorf(
+				"%w: %w: processed inbox %q does not match message natural key/content (%q, %q, %q)",
+				ErrInvalidMessage,
+				ErrInboxProjectionConflict,
+				projection.InboxID,
+				message.AccountID,
+				message.ConversationID,
+				message.RemoteMessageID,
+			)
+		}
+		return nil
+	}
+
+	nowMS, err := r.nowMS("project message")
+	if err != nil {
+		return err
+	}
+	if err := r.upsertMessage(ctx, tx, message, nowMS); err != nil {
+		return err
+	}
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE inbox
+		SET processed_at_ms = ?
+		WHERE inbox_id = ? AND account_id = ? AND processed_at_ms IS NULL
+	`, nowMS, projection.InboxID, message.AccountID)
+	if err != nil {
+		if isSQLiteConstraint(err) {
+			return invalidMessageConstraintError(
+				nil,
+				err,
+				"mark source inbox %q processed at %d after receipt at %d",
+				projection.InboxID,
+				nowMS,
+				receivedAtMS,
+			)
+		}
+		return fmt.Errorf(
+			"project message %q: mark inbox %q processed: %w",
+			message.MessageID,
+			projection.InboxID,
+			err,
+		)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf(
+			"project message %q: read processed inbox rows affected: %w",
+			message.MessageID,
+			err,
+		)
+	}
+	if affected != 1 {
+		return fmt.Errorf(
+			"project message %q: mark inbox %q processed: affected %d rows, want 1",
+			message.MessageID,
+			projection.InboxID,
+			affected,
+		)
+	}
+
+	if err := tx.Commit(); err != nil {
+		if isSQLiteConstraint(err) {
+			return invalidMessageConstraintError(nil, err, "commit message projection")
+		}
+		return fmt.Errorf("project message %q: commit: %w", message.MessageID, err)
+	}
+	return nil
+}
+
+func (r *MessageRepository) upsertMessage(
+	ctx context.Context,
+	tx *sql.Tx,
+	message Message,
+	nowMS int64,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO messages (
+			message_id,
+			conversation_id,
+			account_id,
+			remote_message_id,
+			sender_identity_id,
+			direction,
+			body,
+			reply_to_remote_id,
+			state,
+			occurred_at_ms,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account_id, conversation_id, remote_message_id) DO UPDATE SET
+			sender_identity_id = excluded.sender_identity_id,
+			direction = excluded.direction,
+			body = excluded.body,
+			reply_to_remote_id = excluded.reply_to_remote_id,
+			state = excluded.state,
+			occurred_at_ms = excluded.occurred_at_ms,
+			updated_at_ms = excluded.updated_at_ms
+		WHERE messages.sender_identity_id IS NOT excluded.sender_identity_id
+		   OR messages.direction IS NOT excluded.direction
+		   OR messages.body IS NOT excluded.body
+		   OR messages.reply_to_remote_id IS NOT excluded.reply_to_remote_id
+		   OR messages.state IS NOT excluded.state
+		   OR messages.occurred_at_ms IS NOT excluded.occurred_at_ms
+	`,
+		message.MessageID,
+		message.ConversationID,
+		message.AccountID,
+		message.RemoteMessageID,
+		message.SenderIdentityID,
+		message.Direction,
+		message.Body,
+		message.ReplyToRemoteID,
+		message.State,
+		message.OccurredAtMS,
+		nowMS,
+		nowMS,
+	); err != nil {
+		return r.mapMessageWriteError(ctx, tx, message, err)
+	}
+	return nil
+}
+
+const inboxColumns = `
+	inbox_id,
+	account_id,
+	generation,
+	dedupe_key,
+	codec,
+	codec_version,
+	received_at_ms,
+	payload,
+	processed_at_ms`
+
+func scanInboxRecord(row rowScanner) (InboxRecord, error) {
+	var record InboxRecord
+	err := row.Scan(
+		&record.InboxID,
+		&record.AccountID,
+		&record.Generation,
+		&record.DedupeKey,
+		&record.Codec,
+		&record.CodecVersion,
+		&record.ReceivedAtMS,
+		&record.Payload,
+		&record.ProcessedAtMS,
+	)
+	return record, err
+}
+
+const messageColumns = `
+	message_id,
+	conversation_id,
+	account_id,
+	remote_message_id,
+	sender_identity_id,
+	direction,
+	body,
+	reply_to_remote_id,
+	state,
+	occurred_at_ms,
+	created_at_ms,
+	updated_at_ms`
+
+func scanMessage(row rowScanner) (Message, error) {
+	var message Message
+	err := row.Scan(
+		&message.MessageID,
+		&message.ConversationID,
+		&message.AccountID,
+		&message.RemoteMessageID,
+		&message.SenderIdentityID,
+		&message.Direction,
+		&message.Body,
+		&message.ReplyToRemoteID,
+		&message.State,
+		&message.OccurredAtMS,
+		&message.CreatedAtMS,
+		&message.UpdatedAtMS,
+	)
+	return message, err
+}
+
+func sameProjectedMessage(existing Message, candidate Message) bool {
+	return optionalStringEqual(existing.SenderIdentityID, candidate.SenderIdentityID) &&
+		existing.Direction == candidate.Direction &&
+		existing.Body == candidate.Body &&
+		optionalStringEqual(existing.ReplyToRemoteID, candidate.ReplyToRemoteID) &&
+		existing.State == candidate.State &&
+		existing.OccurredAtMS == candidate.OccurredAtMS
+}
+
+func optionalStringEqual(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func (r *MessageRepository) nowMS(operation string) (int64, error) {
+	nowMS := r.now().UnixMilli()
+	if nowMS <= 0 {
+		return 0, fmt.Errorf("%s: current Unix time is not positive", operation)
+	}
+	return nowMS, nil
+}
+
+func invalidInboxConstraintError(cause error, inboxID string) error {
+	if !isSQLiteConstraint(cause) {
+		return fmt.Errorf("append inbox %q: %w", inboxID, cause)
+	}
+	if isSQLiteErrorCode(cause, sqliteConstraintForeignKeyCode) {
+		return fmt.Errorf(
+			"%w: %w: %w: append inbox %q: %w",
+			ErrInvalidInboxRecord,
+			ErrConstraintViolation,
+			ErrOrphanInboxAccount,
+			inboxID,
+			cause,
+		)
+	}
+	return fmt.Errorf(
+		"%w: %w: append inbox %q: %w",
+		ErrInvalidInboxRecord,
+		ErrConstraintViolation,
+		inboxID,
+		cause,
+	)
+}
+
+func (r *MessageRepository) mapMessageWriteError(
+	ctx context.Context,
+	tx *sql.Tx,
+	message Message,
+	cause error,
+) error {
+	if !isSQLiteConstraint(cause) {
+		return fmt.Errorf("project message %q: upsert: %w", message.MessageID, cause)
+	}
+	var specific error
+	if isSQLiteErrorCode(cause, sqliteConstraintForeignKeyCode) {
+		var err error
+		specific, err = classifyMessageForeignKey(ctx, tx, message)
+		if err != nil {
+			return fmt.Errorf(
+				"project message %q: classify foreign key constraint: %w",
+				message.MessageID,
+				err,
+			)
+		}
+	}
+	return invalidMessageConstraintError(
+		specific,
+		cause,
+		"upsert message %q",
+		message.MessageID,
+	)
+}
+
+func classifyMessageForeignKey(
+	ctx context.Context,
+	tx *sql.Tx,
+	message Message,
+) (error, error) {
+	var conversationAccountID string
+	err := tx.QueryRowContext(ctx, `
+		SELECT account_id
+		FROM conversations
+		WHERE conversation_id = ?
+	`, message.ConversationID).Scan(&conversationAccountID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return orphanMessageError(ErrOrphanMessageConversation), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if conversationAccountID != message.AccountID {
+		return ErrCrossAccountMessage, nil
+	}
+
+	if message.SenderIdentityID == nil {
+		return nil, nil
+	}
+	var identityAccountID string
+	err = tx.QueryRowContext(ctx, `
+		SELECT account_id
+		FROM identities
+		WHERE identity_id = ?
+	`, *message.SenderIdentityID).Scan(&identityAccountID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return orphanMessageError(ErrOrphanMessageIdentity), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if identityAccountID != message.AccountID {
+		return ErrCrossAccountMessage, nil
+	}
+	return nil, nil
+}
+
+func orphanMessageError(specific error) error {
+	return fmt.Errorf("%w: %w", ErrOrphanMessage, specific)
+}
+
+func invalidMessageConstraintError(
+	specific error,
+	cause error,
+	format string,
+	args ...any,
+) error {
+	detail := fmt.Sprintf(format, args...)
+	if specific == nil {
+		return fmt.Errorf(
+			"%w: %w: %s: %w",
+			ErrInvalidMessage,
+			ErrConstraintViolation,
+			detail,
+			cause,
+		)
+	}
+	return fmt.Errorf(
+		"%w: %w: %w: %s: %w",
+		ErrInvalidMessage,
+		ErrConstraintViolation,
+		specific,
+		detail,
+		cause,
+	)
+}
+
+func invalidMessageError(specific error, format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return fmt.Errorf(
+		"%w: %w: %w: %s",
+		ErrInvalidMessage,
+		ErrConstraintViolation,
+		specific,
+		detail,
+	)
+}

--- a/internal/storage/sqlite/messages_test.go
+++ b/internal/storage/sqlite/messages_test.go
@@ -1,0 +1,724 @@
+package sqlite
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+const messageTestTimeMS int64 = 1_900_000_000_000
+
+func TestInboxAppendIsIdempotentByAccountDedupeKey(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageAccount(t, store, "account-a", "signal")
+	seedMessageAccount(t, store, "account-b", "whatsapp")
+
+	first := messageTestInbox("inbox-original", "account-a", "remote-event-1", []byte("original"))
+	firstID, err := repository.AppendInbox(context.Background(), first)
+	if err != nil {
+		t.Fatalf("AppendInbox(first): %v", err)
+	}
+	if firstID != first.InboxID {
+		t.Fatalf("AppendInbox(first) ID = %q, want %q", firstID, first.InboxID)
+	}
+
+	clock.Set(messageTestTimeMS + 100)
+	duplicate := messageTestInbox("inbox-discarded", "account-a", first.DedupeKey, []byte("replacement"))
+	duplicateID, err := repository.AppendInbox(context.Background(), duplicate)
+	if err != nil {
+		t.Fatalf("AppendInbox(duplicate): %v", err)
+	}
+	if duplicateID != first.InboxID {
+		t.Fatalf("AppendInbox(duplicate) ID = %q, want existing %q", duplicateID, first.InboxID)
+	}
+
+	records, err := repository.Unprocessed(context.Background())
+	if err != nil {
+		t.Fatalf("Unprocessed(): %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("unprocessed inbox records = %d, want 1", len(records))
+	}
+	got := records[0]
+	if got.InboxID != first.InboxID || got.ReceivedAtMS != messageTestTimeMS {
+		t.Fatalf("deduplicated inbox row = %+v, want original ID and timestamp", got)
+	}
+	if !bytes.Equal(got.Payload, first.Payload) {
+		t.Fatalf("deduplicated inbox payload = %q, want %q", got.Payload, first.Payload)
+	}
+	if got.ProcessedAtMS != nil {
+		t.Fatalf("deduplicated inbox processed_at_ms = %v, want nil", got.ProcessedAtMS)
+	}
+
+	accountB := messageTestInbox("inbox-account-b", "account-b", first.DedupeKey, []byte("other account"))
+	if _, err := repository.AppendInbox(context.Background(), accountB); err != nil {
+		t.Fatalf("AppendInbox(same key, other account): %v", err)
+	}
+	for i := range 2 {
+		record := messageTestInbox(fmt.Sprintf("inbox-no-dedupe-%d", i), "account-a", "", []byte{byte(i)})
+		if _, err := repository.AppendInbox(context.Background(), record); err != nil {
+			t.Fatalf("AppendInbox(empty dedupe %d): %v", i, err)
+		}
+	}
+	assertRowCount(t, store.db, "inbox", 4)
+	records, err = repository.Unprocessed(context.Background())
+	if err != nil {
+		t.Fatalf("Unprocessed() ordered records: %v", err)
+	}
+	wantOrder := []string{
+		"inbox-original",
+		"inbox-account-b",
+		"inbox-no-dedupe-0",
+		"inbox-no-dedupe-1",
+	}
+	if len(records) != len(wantOrder) {
+		t.Fatalf("ordered unprocessed records = %d, want %d", len(records), len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if records[i].InboxID != want {
+			t.Fatalf("unprocessed record %d = %q, want %q", i, records[i].InboxID, want)
+		}
+	}
+}
+
+func TestAppendInboxConcurrentDuplicatesReturnOneID(t *testing.T) {
+	store, repository := openMessageTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
+	)
+	seedMessageAccount(t, store, "account-a", "signal")
+
+	const writers = 12
+	start := make(chan struct{})
+	ids := make(chan string, writers)
+	errs := make(chan error, writers)
+	var workers sync.WaitGroup
+	for i := range writers {
+		workers.Add(1)
+		go func(i int) {
+			defer workers.Done()
+			<-start
+			record := messageTestInbox(
+				fmt.Sprintf("inbox-concurrent-%02d", i),
+				"account-a",
+				"one-remote-event",
+				[]byte{byte(i)},
+			)
+			id, err := repository.AppendInbox(context.Background(), record)
+			ids <- id
+			errs <- err
+		}(i)
+	}
+	close(start)
+	workers.Wait()
+	close(ids)
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent AppendInbox(): %v", err)
+		}
+	}
+	var effectiveID string
+	for id := range ids {
+		if effectiveID == "" {
+			effectiveID = id
+		}
+		if id != effectiveID {
+			t.Fatalf("concurrent AppendInbox() ID = %q, want common ID %q", id, effectiveID)
+		}
+	}
+	assertRowCount(t, store.db, "inbox", 1)
+}
+
+func TestAppendInboxMapsSQLiteConstraints(t *testing.T) {
+	store, repository := openMessageTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
+	)
+	record := messageTestInbox("inbox-orphan", "account-missing", "event-orphan", []byte("frame"))
+	_, err := repository.AppendInbox(context.Background(), record)
+	for _, want := range []error{
+		ErrInvalidInboxRecord,
+		ErrConstraintViolation,
+		ErrOrphanInboxAccount,
+	} {
+		if !errors.Is(err, want) {
+			t.Fatalf("AppendInbox(orphan account) error = %v, want %v", err, want)
+		}
+	}
+	assertRowCount(t, store.db, "inbox", 0)
+}
+
+func TestProjectMessageIsIdempotentByRemoteID(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageProjectionGraph(t, store)
+
+	firstInbox := messageTestInbox("inbox-1", "account-a", "event-1", []byte("frame 1"))
+	if _, err := repository.AppendInbox(context.Background(), firstInbox); err != nil {
+		t.Fatalf("AppendInbox(first): %v", err)
+	}
+	message := messageTestMessage("message-original", "conversation-a", "account-a", "remote-message-1", pointer("identity-a"))
+	if err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: firstInbox.InboxID,
+		Message: message,
+	}); err != nil {
+		t.Fatalf("ProjectMessage(first): %v", err)
+	}
+
+	clock.Set(messageTestTimeMS + 1_000)
+	if err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: firstInbox.InboxID,
+		Message: message,
+	}); err != nil {
+		t.Fatalf("ProjectMessage(replay same inbox): %v", err)
+	}
+
+	secondInbox := messageTestInbox("inbox-2", "account-a", "event-2", []byte("frame 2"))
+	if _, err := repository.AppendInbox(context.Background(), secondInbox); err != nil {
+		t.Fatalf("AppendInbox(second): %v", err)
+	}
+	duplicateMessage := message
+	duplicateMessage.MessageID = "message-discarded"
+	if err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: secondInbox.InboxID,
+		Message: duplicateMessage,
+	}); err != nil {
+		t.Fatalf("ProjectMessage(same remote ID): %v", err)
+	}
+
+	assertRowCount(t, store.db, "messages", 1)
+	got, err := repository.GetMessage(context.Background(), message.MessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(): %v", err)
+	}
+	if got.MessageID != message.MessageID {
+		t.Fatalf("projected message ID = %q, want original %q", got.MessageID, message.MessageID)
+	}
+	if got.CreatedAtMS != messageTestTimeMS || got.UpdatedAtMS != messageTestTimeMS {
+		t.Fatalf(
+			"projected timestamps = (%d, %d), want unchanged (%d, %d)",
+			got.CreatedAtMS,
+			got.UpdatedAtMS,
+			messageTestTimeMS,
+			messageTestTimeMS,
+		)
+	}
+	assertInboxProcessedAt(t, store, firstInbox.InboxID, messageTestTimeMS)
+	assertInboxProcessedAt(t, store, secondInbox.InboxID, messageTestTimeMS+1_000)
+
+	clock.Set(messageTestTimeMS + 2_000)
+	thirdInbox := messageTestInbox("inbox-3", "account-a", "event-3", []byte("frame 3"))
+	if _, err := repository.AppendInbox(context.Background(), thirdInbox); err != nil {
+		t.Fatalf("AppendInbox(third): %v", err)
+	}
+	updatedMessage := message
+	updatedMessage.MessageID = "message-second-discarded"
+	updatedMessage.Body = "edited body"
+	updatedMessage.ReplyToRemoteID = pointer("remote-parent")
+	updatedMessage.State = MessageStateEdited
+	updatedMessage.OccurredAtMS++
+	if err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: thirdInbox.InboxID,
+		Message: updatedMessage,
+	}); err != nil {
+		t.Fatalf("ProjectMessage(changed same remote ID): %v", err)
+	}
+	got, err = repository.GetMessage(context.Background(), message.MessageID)
+	if err != nil {
+		t.Fatalf("GetMessage() after changed upsert: %v", err)
+	}
+	if got.MessageID != message.MessageID || got.CreatedAtMS != messageTestTimeMS {
+		t.Fatalf("changed upsert replaced stable identity/creation: %+v", got)
+	}
+	if got.UpdatedAtMS != messageTestTimeMS+2_000 ||
+		got.Body != updatedMessage.Body ||
+		got.State != MessageStateEdited ||
+		got.ReplyToRemoteID == nil ||
+		*got.ReplyToRemoteID != *updatedMessage.ReplyToRemoteID {
+		t.Fatalf("changed upsert message = %+v, want updated normalized fields", got)
+	}
+	assertInboxProcessedAt(t, store, thirdInbox.InboxID, messageTestTimeMS+2_000)
+	unprocessed, err := repository.Unprocessed(context.Background())
+	if err != nil {
+		t.Fatalf("Unprocessed(): %v", err)
+	}
+	if len(unprocessed) != 0 {
+		t.Fatalf("unprocessed inbox records = %d, want 0", len(unprocessed))
+	}
+}
+
+func TestProcessedInboxReplayStillValidatesMessage(t *testing.T) {
+	store, repository := openMessageTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
+	)
+	seedMessageProjectionGraph(t, store)
+	inbox := messageTestInbox("inbox-validated-replay", "account-a", "event-validated-replay", []byte("frame"))
+	if _, err := repository.AppendInbox(context.Background(), inbox); err != nil {
+		t.Fatalf("AppendInbox(): %v", err)
+	}
+	message := messageTestMessage("message-validated-replay", "conversation-a", "account-a", "remote-validated-replay", pointer("identity-a"))
+	projection := MessageProjection{InboxID: inbox.InboxID, Message: message}
+	if err := repository.ProjectMessage(context.Background(), projection); err != nil {
+		t.Fatalf("ProjectMessage(first): %v", err)
+	}
+
+	orphanReplay := message
+	orphanReplay.SenderIdentityID = pointer("identity-missing")
+	err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: inbox.InboxID,
+		Message: orphanReplay,
+	})
+	for _, want := range []error{
+		ErrInvalidMessage,
+		ErrConstraintViolation,
+		ErrOrphanMessage,
+		ErrOrphanMessageIdentity,
+	} {
+		if !errors.Is(err, want) {
+			t.Fatalf("ProjectMessage(orphan replay) error = %v, want %v", err, want)
+		}
+	}
+
+	changedReplay := message
+	changedReplay.Body = "different content for processed inbox"
+	err = repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: inbox.InboxID,
+		Message: changedReplay,
+	})
+	for _, want := range []error{ErrInvalidMessage, ErrInboxProjectionConflict} {
+		if !errors.Is(err, want) {
+			t.Fatalf("ProjectMessage(changed replay) error = %v, want %v", err, want)
+		}
+	}
+
+	differentMessage := message
+	differentMessage.MessageID = "message-different-replay"
+	differentMessage.RemoteMessageID = "remote-different-replay"
+	err = repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: inbox.InboxID,
+		Message: differentMessage,
+	})
+	for _, want := range []error{ErrInvalidMessage, ErrInboxProjectionConflict} {
+		if !errors.Is(err, want) {
+			t.Fatalf("ProjectMessage(different replay) error = %v, want %v", err, want)
+		}
+	}
+	assertRowCount(t, store.db, "messages", 1)
+	assertInboxProcessedAt(t, store, inbox.InboxID, messageTestTimeMS)
+	got, err := repository.GetMessage(context.Background(), message.MessageID)
+	if err != nil {
+		t.Fatalf("GetMessage() after rejected replays: %v", err)
+	}
+	if got.SenderIdentityID == nil || *got.SenderIdentityID != "identity-a" {
+		t.Fatalf("sender after rejected replays = %v, want identity-a", got.SenderIdentityID)
+	}
+	if got.Body != message.Body {
+		t.Fatalf("body after rejected replays = %q, want %q", got.Body, message.Body)
+	}
+}
+
+func TestInboxProjectionCrashReplaySurvivesReopen(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.sqlite3")
+	firstStore, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open(): %v", err)
+	}
+	seedMessageProjectionGraph(t, firstStore)
+	firstRepository := mustMessageRepository(t, firstStore, messageTestTimeMS)
+	record := messageTestInbox("inbox-replay", "account-a", "event-replay", []byte("durable raw frame"))
+	if _, err := firstRepository.AppendInbox(ctx, record); err != nil {
+		_ = firstStore.Close()
+		t.Fatalf("AppendInbox(): %v", err)
+	}
+	if err := firstStore.Close(); err != nil {
+		t.Fatalf("close after inbox append: %v", err)
+	}
+
+	secondStore, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open(): %v", err)
+	}
+	secondRepository := mustMessageRepository(t, secondStore, messageTestTimeMS+500)
+	pending, err := secondRepository.Unprocessed(ctx)
+	if err != nil {
+		_ = secondStore.Close()
+		t.Fatalf("Unprocessed() after restart: %v", err)
+	}
+	if len(pending) != 1 || !bytes.Equal(pending[0].Payload, record.Payload) {
+		_ = secondStore.Close()
+		t.Fatalf("pending records after restart = %+v, want durable raw frame", pending)
+	}
+	message := messageTestMessage("message-replay", "conversation-a", "account-a", "remote-replay", pointer("identity-a"))
+	projection := MessageProjection{InboxID: record.InboxID, Message: message}
+	if err := secondRepository.ProjectMessage(ctx, projection); err != nil {
+		_ = secondStore.Close()
+		t.Fatalf("ProjectMessage() after restart: %v", err)
+	}
+	if err := secondStore.Close(); err != nil {
+		t.Fatalf("close after projection: %v", err)
+	}
+
+	thirdStore, err := Open(path)
+	if err != nil {
+		t.Fatalf("third Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := thirdStore.Close(); err != nil {
+			t.Errorf("third Close(): %v", err)
+		}
+	})
+	thirdRepository := mustMessageRepository(t, thirdStore, messageTestTimeMS+5_000)
+	if err := thirdRepository.ProjectMessage(ctx, projection); err != nil {
+		t.Fatalf("ProjectMessage() replay after second restart: %v", err)
+	}
+	assertRowCount(t, thirdStore.db, "messages", 1)
+	assertInboxProcessedAt(t, thirdStore, record.InboxID, messageTestTimeMS+500)
+	got, err := thirdRepository.GetMessage(ctx, message.MessageID)
+	if err != nil {
+		t.Fatalf("GetMessage() after replay: %v", err)
+	}
+	if got.CreatedAtMS != messageTestTimeMS+500 || got.UpdatedAtMS != messageTestTimeMS+500 {
+		t.Fatalf("message timestamps after replay = (%d, %d), want first projection time", got.CreatedAtMS, got.UpdatedAtMS)
+	}
+}
+
+func TestProjectMessageRollsBackMessageWhenInboxMarkFails(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageProjectionGraph(t, store)
+	inbox := messageTestInbox("inbox-clock-rollback", "account-a", "event-clock-rollback", []byte("frame"))
+	if _, err := repository.AppendInbox(context.Background(), inbox); err != nil {
+		t.Fatalf("AppendInbox(): %v", err)
+	}
+
+	// The inbox CHECK rejects a processed time before receipt. The preceding
+	// valid message upsert must roll back with that failed update.
+	clock.Set(messageTestTimeMS - 1)
+	message := messageTestMessage("message-clock-rollback", "conversation-a", "account-a", "remote-clock-rollback", pointer("identity-a"))
+	err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: inbox.InboxID,
+		Message: message,
+	})
+	for _, want := range []error{ErrInvalidMessage, ErrConstraintViolation} {
+		if !errors.Is(err, want) {
+			t.Fatalf("ProjectMessage() error = %v, want %v", err, want)
+		}
+	}
+	assertRowCount(t, store.db, "messages", 0)
+	assertInboxUnprocessed(t, store, inbox.InboxID)
+}
+
+func TestProjectMessageMapsSQLiteOwnershipFailures(t *testing.T) {
+	store, repository := openMessageTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
+	)
+	seedMessageProjectionGraph(t, store)
+	seedMessageAccount(t, store, "account-b", "whatsapp")
+	seedMessageIdentity(t, store, "identity-b", "account-b")
+	seedMessageConversation(t, store, "conversation-b", "account-b")
+
+	tests := []struct {
+		name         string
+		conversation string
+		sender       *string
+		want         error
+		wantDetail   error
+	}{
+		{
+			name:         "cross-account conversation",
+			conversation: "conversation-b",
+			sender:       pointer("identity-a"),
+			want:         ErrCrossAccountMessage,
+		},
+		{
+			name:         "cross-account sender",
+			conversation: "conversation-a",
+			sender:       pointer("identity-b"),
+			want:         ErrCrossAccountMessage,
+		},
+		{
+			name:         "orphan conversation",
+			conversation: "conversation-missing",
+			sender:       pointer("identity-a"),
+			want:         ErrOrphanMessage,
+			wantDetail:   ErrOrphanMessageConversation,
+		},
+		{
+			name:         "orphan sender",
+			conversation: "conversation-a",
+			sender:       pointer("identity-missing"),
+			want:         ErrOrphanMessage,
+			wantDetail:   ErrOrphanMessageIdentity,
+		},
+	}
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inbox := messageTestInbox(
+				fmt.Sprintf("inbox-invalid-%d", i),
+				"account-a",
+				fmt.Sprintf("event-invalid-%d", i),
+				[]byte(test.name),
+			)
+			if _, err := repository.AppendInbox(context.Background(), inbox); err != nil {
+				t.Fatalf("AppendInbox(): %v", err)
+			}
+			message := messageTestMessage(
+				fmt.Sprintf("message-invalid-%d", i),
+				test.conversation,
+				"account-a",
+				fmt.Sprintf("remote-invalid-%d", i),
+				test.sender,
+			)
+			err := repository.ProjectMessage(context.Background(), MessageProjection{
+				InboxID: inbox.InboxID,
+				Message: message,
+			})
+			for _, want := range []error{ErrInvalidMessage, ErrConstraintViolation, test.want} {
+				if !errors.Is(err, want) {
+					t.Fatalf("ProjectMessage() error = %v, want %v", err, want)
+				}
+			}
+			if test.wantDetail != nil && !errors.Is(err, test.wantDetail) {
+				t.Fatalf("ProjectMessage() error = %v, want %v", err, test.wantDetail)
+			}
+			assertInboxUnprocessed(t, store, inbox.InboxID)
+		})
+	}
+	assertRowCount(t, store.db, "messages", 0)
+
+	// The composite foreign keys themselves are the enforcement boundary, not
+	// only repository-side ownership checks.
+	_, err := store.db.Exec(`
+		INSERT INTO messages (
+			message_id, conversation_id, account_id, remote_message_id,
+			sender_identity_id, direction, occurred_at_ms, created_at_ms, updated_at_ms
+		) VALUES ('message-direct-sql', 'conversation-a', 'account-a',
+		          'remote-direct-sql', 'identity-b', 'incoming', ?, ?, ?)
+	`, messageTestTimeMS, messageTestTimeMS, messageTestTimeMS)
+	if !isSQLiteErrorCode(err, sqliteConstraintForeignKeyCode) {
+		t.Fatalf("direct cross-account message error = %v, want SQLite foreign-key constraint", err)
+	}
+}
+
+func TestProjectMessageAllowsNilSystemSender(t *testing.T) {
+	store, repository := openMessageTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
+	)
+	seedMessageProjectionGraph(t, store)
+	inbox := messageTestInbox("inbox-system", "account-a", "event-system", []byte("system"))
+	if _, err := repository.AppendInbox(context.Background(), inbox); err != nil {
+		t.Fatalf("AppendInbox(): %v", err)
+	}
+	message := messageTestMessage("message-system", "conversation-a", "account-a", "remote-system", nil)
+	if err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: inbox.InboxID,
+		Message: message,
+	}); err != nil {
+		t.Fatalf("ProjectMessage(nil sender): %v", err)
+	}
+	got, err := repository.GetMessage(context.Background(), message.MessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(): %v", err)
+	}
+	if got.SenderIdentityID != nil {
+		t.Fatalf("sender identity = %v, want nil", got.SenderIdentityID)
+	}
+}
+
+func TestMessagesInboxMigrationIsChecksummedAndStrict(t *testing.T) {
+	store, _ := openMessageTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
+	)
+	if len(embeddedMigrations) != 4 {
+		t.Fatalf("embedded migrations = %d, want 4", len(embeddedMigrations))
+	}
+	assertPragmaInt(t, store.db, "user_version", 4)
+	ledger := readLedgerRow(t, store.db, 4)
+	if ledger.name != "messages_inbox" {
+		t.Fatalf("migration 0004 name = %q, want messages_inbox", ledger.name)
+	}
+	if ledger.checksum != embeddedMigrations[3].checksumSHA256 {
+		t.Fatalf("migration 0004 checksum = %q, want %q", ledger.checksum, embeddedMigrations[3].checksumSHA256)
+	}
+	for _, table := range []string{"inbox", "messages"} {
+		var strict int
+		if err := store.db.QueryRow(`
+			SELECT strict
+			FROM pragma_table_list
+			WHERE schema = 'main' AND name = ?
+		`, table).Scan(&strict); err != nil {
+			t.Fatalf("read %s STRICT flag: %v", table, err)
+		}
+		if strict != 1 {
+			t.Fatalf("%s strict = %d, want 1", table, strict)
+		}
+	}
+}
+
+type messageTestClock struct {
+	mu    sync.Mutex
+	nowMS int64
+}
+
+func newMessageTestClock(nowMS int64) *messageTestClock {
+	return &messageTestClock{nowMS: nowMS}
+}
+
+func (c *messageTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return time.UnixMilli(c.nowMS)
+}
+
+func (c *messageTestClock) Set(nowMS int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.nowMS = nowMS
+}
+
+func openMessageTestRepository(
+	t *testing.T,
+	now func() time.Time,
+) (*Store, *MessageRepository) {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+	repository, err := NewMessageRepository(store, now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	return store, repository
+}
+
+func mustMessageRepository(t *testing.T, store *Store, nowMS int64) *MessageRepository {
+	t.Helper()
+	repository, err := NewMessageRepository(
+		store,
+		func() time.Time { return time.UnixMilli(nowMS) },
+	)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	return repository
+}
+
+func seedMessageProjectionGraph(t *testing.T, store *Store) {
+	t.Helper()
+	seedMessageAccount(t, store, "account-a", "signal")
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+}
+
+func seedMessageAccount(t *testing.T, store *Store, accountID, bridgeKey string) {
+	t.Helper()
+	account := repositoryTestAccount(accountID)
+	account.BridgeKey = bridgeKey
+	mustRepositoryWrite(t, "seed UpsertAccount", store.UpsertAccount(account))
+}
+
+func seedMessageIdentity(t *testing.T, store *Store, identityID, accountID string) {
+	t.Helper()
+	identity := repositoryTestIdentity(identityID, accountID, identityID)
+	mustRepositoryWrite(t, "seed UpsertIdentity", store.UpsertIdentity(identity))
+}
+
+func seedMessageConversation(t *testing.T, store *Store, conversationID, accountID string) {
+	t.Helper()
+	conversation := Conversation{
+		ConversationID:       conversationID,
+		AccountID:            accountID,
+		RemoteConversationID: "remote-" + conversationID,
+		Kind:                 ConversationKindDirect,
+		NotificationMode:     NotificationModeAll,
+		MetadataJSON:         `{}`,
+		CreatedAtMS:          repositoryTestTimeMS,
+		UpdatedAtMS:          repositoryTestTimeMS,
+	}
+	mustRepositoryWrite(t, "seed UpsertConversation", store.UpsertConversation(conversation))
+}
+
+func messageTestInbox(inboxID, accountID, dedupeKey string, payload []byte) InboxRecord {
+	return InboxRecord{
+		InboxID:      inboxID,
+		AccountID:    accountID,
+		Generation:   1,
+		DedupeKey:    dedupeKey,
+		Codec:        "test.frame",
+		CodecVersion: 1,
+		Payload:      payload,
+	}
+}
+
+func messageTestMessage(
+	messageID string,
+	conversationID string,
+	accountID string,
+	remoteMessageID string,
+	senderIdentityID *string,
+) Message {
+	return Message{
+		MessageID:        messageID,
+		ConversationID:   conversationID,
+		AccountID:        accountID,
+		RemoteMessageID:  remoteMessageID,
+		SenderIdentityID: senderIdentityID,
+		Direction:        MessageDirectionIncoming,
+		Body:             "hello",
+		State:            MessageStateActive,
+		OccurredAtMS:     messageTestTimeMS - 1_000,
+	}
+}
+
+func assertInboxProcessedAt(t *testing.T, store *Store, inboxID string, want int64) {
+	t.Helper()
+	var got int64
+	if err := store.db.QueryRow(`
+		SELECT processed_at_ms
+		FROM inbox
+		WHERE inbox_id = ?
+	`, inboxID).Scan(&got); err != nil {
+		t.Fatalf("read inbox %q processed_at_ms: %v", inboxID, err)
+	}
+	if got != want {
+		t.Fatalf("inbox %q processed_at_ms = %d, want %d", inboxID, got, want)
+	}
+}
+
+func assertInboxUnprocessed(t *testing.T, store *Store, inboxID string) {
+	t.Helper()
+	var processed bool
+	if err := store.db.QueryRow(`
+		SELECT processed_at_ms IS NOT NULL
+		FROM inbox
+		WHERE inbox_id = ?
+	`, inboxID).Scan(&processed); err != nil {
+		t.Fatalf("read inbox %q processing state: %v", inboxID, err)
+	}
+	if processed {
+		t.Fatalf("inbox %q is processed after failed projection", inboxID)
+	}
+}
+
+func pointer(value string) *string {
+	return &value
+}

--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -45,10 +45,14 @@ var migration0002SQL string
 //go:embed migrations/0003_attachments.sql
 var migration0003SQL string
 
+//go:embed migrations/0004_messages_inbox.sql
+var migration0004SQL string
+
 var embeddedMigrations = []migration{
 	newMigration(1, "storage_shell", migration0001SQL, newStorageShellArguments),
 	newMigration(2, "identity_graph", migration0002SQL, nil),
 	newMigration(3, "attachments", migration0003SQL, nil),
+	newMigration(4, "messages_inbox", migration0004SQL, nil),
 }
 
 func newMigration(

--- a/internal/storage/sqlite/migrations/0004_messages_inbox.sql
+++ b/internal/storage/sqlite/migrations/0004_messages_inbox.sql
@@ -1,0 +1,61 @@
+-- Transport frames are committed here before decoding or projection. An empty
+-- dedupe key is allowed for transports that do not expose a stable event ID.
+CREATE TABLE inbox (
+    inbox_id         TEXT PRIMARY KEY CHECK (trim(inbox_id) <> ''),
+    account_id       TEXT NOT NULL,
+    generation       INTEGER NOT NULL CHECK (generation >= 0),
+    dedupe_key       TEXT NOT NULL DEFAULT '' CHECK (
+        dedupe_key = '' OR trim(dedupe_key) <> ''
+    ),
+    codec            TEXT NOT NULL CHECK (trim(codec) <> ''),
+    codec_version    INTEGER NOT NULL CHECK (codec_version >= 0),
+    received_at_ms   INTEGER NOT NULL CHECK (received_at_ms > 0),
+    payload          BLOB NOT NULL,
+    processed_at_ms  INTEGER CHECK (
+        processed_at_ms IS NULL OR processed_at_ms >= received_at_ms
+    ),
+    FOREIGN KEY (account_id)
+        REFERENCES accounts(account_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE UNIQUE INDEX inbox_dedupe_uq
+    ON inbox(account_id, dedupe_key)
+    WHERE dedupe_key <> '';
+
+CREATE INDEX inbox_unprocessed_idx
+    ON inbox(received_at_ms, inbox_id)
+    WHERE processed_at_ms IS NULL;
+
+-- account_id participates in both foreign keys. SQLite therefore rejects a
+-- message whose conversation or sender belongs to a different account, as
+-- well as references to rows that do not exist.
+CREATE TABLE messages (
+    message_id          TEXT PRIMARY KEY CHECK (trim(message_id) <> ''),
+    conversation_id     TEXT NOT NULL,
+    account_id          TEXT NOT NULL,
+    remote_message_id   TEXT NOT NULL CHECK (trim(remote_message_id) <> ''),
+    sender_identity_id  TEXT,
+    direction           TEXT NOT NULL
+                        CHECK (direction IN ('incoming', 'outgoing')),
+    body                TEXT NOT NULL DEFAULT '',
+    reply_to_remote_id  TEXT CHECK (
+        reply_to_remote_id IS NULL OR trim(reply_to_remote_id) <> ''
+    ),
+    state               TEXT NOT NULL DEFAULT 'active'
+                        CHECK (state IN ('active', 'edited', 'deleted')),
+    occurred_at_ms      INTEGER NOT NULL CHECK (occurred_at_ms > 0),
+    created_at_ms       INTEGER NOT NULL CHECK (created_at_ms > 0),
+    updated_at_ms       INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    FOREIGN KEY (account_id, conversation_id)
+        REFERENCES conversations(account_id, conversation_id) ON DELETE CASCADE,
+    FOREIGN KEY (account_id, sender_identity_id)
+        REFERENCES identities(account_id, identity_id) ON DELETE RESTRICT,
+    UNIQUE (account_id, conversation_id, remote_message_id)
+) STRICT;
+
+CREATE INDEX messages_conversation_time_idx
+    ON messages(conversation_id, occurred_at_ms DESC, message_id DESC);
+
+CREATE INDEX messages_sender_time_idx
+    ON messages(sender_identity_id, occurred_at_ms DESC)
+    WHERE sender_identity_id IS NOT NULL;

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -78,6 +78,8 @@ func TestOpenInitializesBlankDatabase(t *testing.T) {
 		"conversations",
 		"devices",
 		"identities",
+		"inbox",
+		"messages",
 		"people",
 		"person_identities",
 		"schema_migrations",


### PR DESCRIPTION
Wave 2 / S5 — the durable ingest + projection layer. Implemented by Sol, reviewed by Claude. Additive (reuses S6's blob/attachments); no deploy.

- **inbox** — durable raw ingress so a transport frame is persisted **before** it is decoded (this is what closes the Signal poison-loss window). `UNIQUE(account_id, dedupe_key)` → each remote event ingested once; ordered unprocessed index.
- **messages** — normalized, keyed `UNIQUE(account_id, conversation_id, remote_message_id)` for idempotent projection; nullable system sender; composite FKs to `conversations(account_id, conversation_id)` + `identities(account_id, sender_identity_id)` over a shared `account_id`, so a cross-account or orphan message fails at SQLite (same pattern as S4).
- **Projection** — `AppendInbox` idempotent on `(account_id, dedupe_key)`; `ProjectMessage` upserts the message **and** marks its inbox row processed in **one transaction**, so a crash after append/before projection replays to the same state; conflicting already-processed replay is rejected; FK failures map to typed orphan/cross-account errors.

`go test -race` green — concurrent dedupe, restart replay, rollback atomicity, direct account-scope enforcement. Migrations 0001–0003 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
