### PR TITLE
Add durable outbox with lease-based delivery and uncertainty recovery (rebuild Wave 2 / S7)

### DIFF
--- a/internal/storage/sqlite/attachments_test.go
+++ b/internal/storage/sqlite/attachments_test.go
@@ -233,8 +233,8 @@ func openAttachmentTestRepository(t *testing.T) (*Store, *AttachmentRepository) 
 		}
 	})
 
-	if len(embeddedMigrations) != 4 {
-		t.Fatalf("embedded migrations = %d, want 4", len(embeddedMigrations))
+	if len(embeddedMigrations) != 5 {
+		t.Fatalf("embedded migrations = %d, want 5", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 3)

--- a/internal/storage/sqlite/errors.go
+++ b/internal/storage/sqlite/errors.go
@@ -57,4 +57,12 @@ var (
 	// ErrInboxProjectionConflict means an already-processed inbox row was
 	// replayed with different message identity or normalized content.
 	ErrInboxProjectionConflict = errors.New("inbox projection conflict")
+
+	// ErrIdempotencyConflict means an existing account-scoped idempotency key
+	// names a different outbound intent.
+	ErrIdempotencyConflict = errors.New("outbox idempotency conflict")
+
+	// ErrLeaseLost means an outbox mutation no longer owns the row's active
+	// dispatch lease.
+	ErrLeaseLost = errors.New("outbox lease lost")
 )

--- a/internal/storage/sqlite/identity_graph_test.go
+++ b/internal/storage/sqlite/identity_graph_test.go
@@ -162,8 +162,8 @@ func openIdentityGraphTestStore(t *testing.T) *Store {
 		}
 	})
 
-	if len(embeddedMigrations) != 4 {
-		t.Fatalf("embedded migrations = %d, want 4", len(embeddedMigrations))
+	if len(embeddedMigrations) != 5 {
+		t.Fatalf("embedded migrations = %d, want 5", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 2)

--- a/internal/storage/sqlite/messages_test.go
+++ b/internal/storage/sqlite/messages_test.go
@@ -542,10 +542,10 @@ func TestMessagesInboxMigrationIsChecksummedAndStrict(t *testing.T) {
 		t,
 		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
 	)
-	if len(embeddedMigrations) != 4 {
-		t.Fatalf("embedded migrations = %d, want 4", len(embeddedMigrations))
+	if len(embeddedMigrations) != 5 {
+		t.Fatalf("embedded migrations = %d, want 5", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 4)
+	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 4)
 	if ledger.name != "messages_inbox" {
 		t.Fatalf("migration 0004 name = %q, want messages_inbox", ledger.name)

--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -48,11 +48,15 @@ var migration0003SQL string
 //go:embed migrations/0004_messages_inbox.sql
 var migration0004SQL string
 
+//go:embed migrations/0005_outbox.sql
+var migration0005SQL string
+
 var embeddedMigrations = []migration{
 	newMigration(1, "storage_shell", migration0001SQL, newStorageShellArguments),
 	newMigration(2, "identity_graph", migration0002SQL, nil),
 	newMigration(3, "attachments", migration0003SQL, nil),
 	newMigration(4, "messages_inbox", migration0004SQL, nil),
+	newMigration(5, "outbox", migration0005SQL, nil),
 }
 
 func newMigration(

--- a/internal/storage/sqlite/migrations/0005_outbox.sql
+++ b/internal/storage/sqlite/migrations/0005_outbox.sql
@@ -1,0 +1,74 @@
+-- Durable outbound intents are claimed with short leases. The
+-- transport_called_at_ms marker records the point after which retrying the
+-- same intent could duplicate a remote operation.
+CREATE TABLE outbox (
+    outbox_id                 TEXT PRIMARY KEY CHECK (trim(outbox_id) <> ''),
+    account_id                TEXT NOT NULL,
+    conversation_id           TEXT NOT NULL CHECK (trim(conversation_id) <> ''),
+    kind                      TEXT NOT NULL
+                              CHECK (kind IN ('text', 'media', 'reaction', 'read')),
+    idempotency_key           TEXT NOT NULL CHECK (trim(idempotency_key) <> ''),
+    payload_hash              TEXT NOT NULL CHECK (trim(payload_hash) <> ''),
+    operation                 TEXT NOT NULL CHECK (trim(operation) <> ''),
+    state                     TEXT NOT NULL CHECK (
+        state IN (
+            'queued', 'dispatching', 'not_dispatched', 'uncertain',
+            'confirmed', 'store_failed', 'rejected', 'canceled'
+        )
+    ),
+    local_message_id          TEXT CHECK (
+        local_message_id IS NULL OR trim(local_message_id) <> ''
+    ),
+    transport_request_id      TEXT NOT NULL
+                              CHECK (trim(transport_request_id) <> ''),
+    result_remote_id          TEXT CHECK (
+        result_remote_id IS NULL OR trim(result_remote_id) <> ''
+    ),
+    error_class               TEXT,
+    error_code                TEXT,
+    error_detail              TEXT,
+    attempt_count             INTEGER NOT NULL DEFAULT 0
+                              CHECK (attempt_count >= 0),
+    lease_owner               TEXT CHECK (
+        lease_owner IS NULL OR trim(lease_owner) <> ''
+    ),
+    lease_token               TEXT CHECK (
+        lease_token IS NULL OR trim(lease_token) <> ''
+    ),
+    lease_expires_at_ms       INTEGER CHECK (
+        lease_expires_at_ms IS NULL OR lease_expires_at_ms > 0
+    ),
+    transport_called_at_ms    INTEGER CHECK (
+        transport_called_at_ms IS NULL OR transport_called_at_ms > 0
+    ),
+    scheduled_for_ms          INTEGER NOT NULL CHECK (scheduled_for_ms > 0),
+    next_attempt_at_ms        INTEGER CHECK (
+        next_attempt_at_ms IS NULL OR next_attempt_at_ms > 0
+    ),
+    created_at_ms             INTEGER NOT NULL CHECK (created_at_ms > 0),
+    updated_at_ms             INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    FOREIGN KEY (account_id)
+        REFERENCES accounts(account_id) ON DELETE CASCADE,
+    UNIQUE (account_id, idempotency_key),
+    UNIQUE (account_id, transport_request_id),
+    CHECK (
+        (state = 'dispatching'
+         AND lease_owner IS NOT NULL
+         AND lease_token IS NOT NULL
+         AND lease_expires_at_ms IS NOT NULL)
+        OR
+        (state <> 'dispatching'
+         AND lease_owner IS NULL
+         AND lease_token IS NULL
+         AND lease_expires_at_ms IS NULL
+         AND transport_called_at_ms IS NULL)
+    ),
+    CHECK (state <> 'not_dispatched' OR next_attempt_at_ms IS NOT NULL)
+) STRICT;
+
+CREATE INDEX outbox_due_idx
+    ON outbox(state, scheduled_for_ms, next_attempt_at_ms);
+
+CREATE INDEX outbox_expired_lease_idx
+    ON outbox(lease_expires_at_ms)
+    WHERE state = 'dispatching';

--- a/internal/storage/sqlite/outbox.go
+++ b/internal/storage/sqlite/outbox.go
@@ -1,0 +1,903 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// OutboxKind identifies the shape of an outbound intent.
+type OutboxKind string
+
+const (
+	OutboxKindText     OutboxKind = "text"
+	OutboxKindMedia    OutboxKind = "media"
+	OutboxKindReaction OutboxKind = "reaction"
+	OutboxKindRead     OutboxKind = "read"
+)
+
+// OutboxState is the persisted delivery state of an outbound intent.
+type OutboxState string
+
+const (
+	OutboxQueued        OutboxState = "queued"
+	OutboxDispatching   OutboxState = "dispatching"
+	OutboxNotDispatched OutboxState = "not_dispatched"
+	OutboxUncertain     OutboxState = "uncertain"
+	OutboxConfirmed     OutboxState = "confirmed"
+	OutboxStoreFailed   OutboxState = "store_failed"
+	OutboxRejected      OutboxState = "rejected"
+	OutboxCanceled      OutboxState = "canceled"
+)
+
+// EnqueueDisposition describes whether Enqueue inserted a new intent or
+// returned the row already associated with its idempotency key.
+type EnqueueDisposition string
+
+const (
+	EnqueueInserted EnqueueDisposition = "inserted"
+	EnqueueExisting EnqueueDisposition = "existing"
+
+	// Longer aliases keep call sites self-documenting when the shorter names
+	// would be ambiguous next to other repository results.
+	EnqueueDispositionInserted = EnqueueInserted
+	EnqueueDispositionExisting = EnqueueExisting
+)
+
+// NewOutboxItem contains the caller-owned identity and intent fields for a new
+// durable outbound operation. A zero ScheduledFor means immediately eligible.
+type NewOutboxItem struct {
+	OutboxID           string
+	AccountID          string
+	ConversationID     string
+	Kind               OutboxKind
+	IdempotencyKey     string
+	PayloadHash        string
+	Operation          string
+	LocalMessageID     string
+	TransportRequestID string
+	ScheduledFor       time.Time
+	ScheduledForMS     int64
+}
+
+// OutboxItem mirrors one row in outbox. Nullable database fields are pointers.
+type OutboxItem struct {
+	OutboxID            string
+	AccountID           string
+	ConversationID      string
+	Kind                OutboxKind
+	IdempotencyKey      string
+	PayloadHash         string
+	Operation           string
+	State               OutboxState
+	LocalMessageID      *string
+	TransportRequestID  string
+	ResultRemoteID      *string
+	ErrorClass          *string
+	ErrorCode           *string
+	ErrorDetail         *string
+	AttemptCount        int64
+	LeaseOwner          *string
+	LeaseToken          *string
+	LeaseExpiresAtMS    *int64
+	TransportCalledAtMS *int64
+	ScheduledForMS      int64
+	NextAttemptAtMS     *int64
+	CreatedAtMS         int64
+	UpdatedAtMS         int64
+}
+
+// LeaseRequest controls one atomic due-row claim.
+type LeaseRequest struct {
+	Owner    string
+	Now      time.Time
+	Duration time.Duration
+	Limit    int
+}
+
+// Lease is an outbox row with an active dispatch lease. OutboxItem is embedded
+// so callers can use the persisted fields directly.
+type Lease struct {
+	OutboxItem
+}
+
+// Attempt identifies the active lease crossing the transport-call boundary.
+// AttemptToken and ConnectionGeneration are reserved for the dispatcher layer;
+// this repository persists only the lease phase and stable request identity.
+type Attempt struct {
+	OutboxID             string
+	LeaseToken           string
+	AttemptToken         string
+	ConnectionGeneration uint64
+	StartedAt            time.Time
+}
+
+// Confirmation records a known remote result for the active lease.
+type Confirmation struct {
+	OutboxID          string
+	LeaseToken        string
+	ResultRemoteID    string
+	TransportResultID string
+}
+
+// RecoveredLeases reports how expired dispatch leases were classified.
+type RecoveredLeases struct {
+	NotDispatched int
+	Uncertain     int
+}
+
+// OutboxRepository owns durable outbound intent, leasing, and phase changes.
+type OutboxRepository struct {
+	store *Store
+	now   func() time.Time
+}
+
+// NewOutboxRepository creates an outbox repository. The clock is required so
+// all storage-owned timestamps are deterministic in tests.
+func NewOutboxRepository(
+	store *Store,
+	now func() time.Time,
+) (*OutboxRepository, error) {
+	if store == nil || store.db == nil {
+		return nil, fmt.Errorf("create outbox repository: store is nil")
+	}
+	if now == nil {
+		return nil, fmt.Errorf("create outbox repository: now function is nil")
+	}
+	return &OutboxRepository{store: store, now: now}, nil
+}
+
+// Enqueue inserts a queued outbound intent. Reusing an account-scoped
+// idempotency key returns the original row only when operation, conversation,
+// and payload hash are identical.
+func (r *OutboxRepository) Enqueue(
+	ctx context.Context,
+	item NewOutboxItem,
+) (OutboxItem, EnqueueDisposition, error) {
+	if err := validateNewOutboxItem(item); err != nil {
+		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item: %w", err)
+	}
+	nowMS, err := r.nowMS("enqueue outbox item")
+	if err != nil {
+		return OutboxItem{}, "", err
+	}
+	scheduledForMS, err := scheduledForMilliseconds(item, nowMS)
+	if err != nil {
+		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item %q: %w", item.OutboxID, err)
+	}
+
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item %q: begin transaction: %w", item.OutboxID, err)
+	}
+	defer tx.Rollback()
+
+	result, err := tx.ExecContext(ctx, `
+		INSERT INTO outbox (
+			outbox_id,
+			account_id,
+			conversation_id,
+			kind,
+			idempotency_key,
+			payload_hash,
+			operation,
+			state,
+			local_message_id,
+			transport_request_id,
+			attempt_count,
+			scheduled_for_ms,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?, ?, ?)
+		ON CONFLICT(account_id, idempotency_key) DO NOTHING
+	`,
+		item.OutboxID,
+		item.AccountID,
+		item.ConversationID,
+		item.Kind,
+		item.IdempotencyKey,
+		item.PayloadHash,
+		item.Operation,
+		nullableOutboxText(item.LocalMessageID),
+		item.TransportRequestID,
+		scheduledForMS,
+		nowMS,
+		nowMS,
+	)
+	if err != nil {
+		return OutboxItem{}, "", fmt.Errorf(
+			"enqueue outbox item %q: %w",
+			item.OutboxID,
+			mapConstraintError(err),
+		)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item %q: read rows affected: %w", item.OutboxID, err)
+	}
+
+	disposition := EnqueueInserted
+	var row OutboxItem
+	switch affected {
+	case 1:
+		row, err = scanOutboxItem(tx.QueryRowContext(ctx, `
+			SELECT `+outboxColumns+`
+			FROM outbox
+			WHERE outbox_id = ?
+		`, item.OutboxID))
+	case 0:
+		disposition = EnqueueExisting
+		row, err = scanOutboxItem(tx.QueryRowContext(ctx, `
+			SELECT `+outboxColumns+`
+			FROM outbox
+			WHERE account_id = ? AND idempotency_key = ?
+		`, item.AccountID, item.IdempotencyKey))
+		if err == nil && (row.Operation != item.Operation ||
+			row.ConversationID != item.ConversationID ||
+			row.PayloadHash != item.PayloadHash) {
+			return OutboxItem{}, "", fmt.Errorf(
+				"enqueue outbox item %q for account %q and idempotency key %q: %w",
+				item.OutboxID,
+				item.AccountID,
+				item.IdempotencyKey,
+				ErrIdempotencyConflict,
+			)
+		}
+	default:
+		return OutboxItem{}, "", fmt.Errorf(
+			"enqueue outbox item %q: affected %d rows, want 0 or 1",
+			item.OutboxID,
+			affected,
+		)
+	}
+	if err != nil {
+		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item %q: read effective row: %w", item.OutboxID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item %q: commit: %w", item.OutboxID, err)
+	}
+	return row, disposition, nil
+}
+
+// LeaseDue atomically claims due queued, retryable, and explicitly eligible
+// uncertain rows. Uncertain rows produced by recovery have no next-attempt time
+// and therefore are never auto-leased.
+func (r *OutboxRepository) LeaseDue(
+	ctx context.Context,
+	req LeaseRequest,
+) ([]Lease, error) {
+	if strings.TrimSpace(req.Owner) == "" {
+		return nil, fmt.Errorf("lease due outbox items: owner is empty")
+	}
+	if req.Limit <= 0 {
+		return nil, fmt.Errorf("lease due outbox items: limit must be positive")
+	}
+	if req.Duration <= 0 {
+		return nil, fmt.Errorf("lease due outbox items: duration must be positive")
+	}
+	nowMS := req.Now.UnixMilli()
+	if nowMS <= 0 {
+		return nil, fmt.Errorf("lease due outbox items: current Unix time is not positive")
+	}
+	expiresAtMS := req.Now.Add(req.Duration).UnixMilli()
+	if expiresAtMS <= nowMS {
+		return nil, fmt.Errorf("lease due outbox items: lease expiry must be after now")
+	}
+
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("lease due outbox items: begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT outbox_id
+		FROM outbox
+		WHERE scheduled_for_ms <= ?
+		  AND (
+			state IN ('queued', 'not_dispatched')
+			OR (state = 'uncertain' AND next_attempt_at_ms IS NOT NULL)
+		  )
+		  AND (next_attempt_at_ms IS NULL OR next_attempt_at_ms <= ?)
+		  AND (lease_expires_at_ms IS NULL OR lease_expires_at_ms <= ?)
+		ORDER BY COALESCE(next_attempt_at_ms, scheduled_for_ms), created_at_ms, outbox_id
+		LIMIT ?
+	`, nowMS, nowMS, nowMS, req.Limit)
+	if err != nil {
+		return nil, fmt.Errorf("lease due outbox items: select candidates: %w", err)
+	}
+	ids, err := collectRows(rows, func(row rowScanner) (string, error) {
+		var id string
+		err := row.Scan(&id)
+		return id, err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("lease due outbox items: scan candidates: %w", err)
+	}
+
+	leases := make([]Lease, 0, len(ids))
+	for _, id := range ids {
+		token, err := newOutboxLeaseToken()
+		if err != nil {
+			return nil, fmt.Errorf("lease outbox item %q: generate token: %w", id, err)
+		}
+		result, err := tx.ExecContext(ctx, `
+			UPDATE outbox
+			SET state = 'dispatching',
+				error_class = NULL,
+				error_code = NULL,
+				error_detail = NULL,
+				lease_owner = ?,
+				lease_token = ?,
+				lease_expires_at_ms = ?,
+				transport_called_at_ms = NULL,
+				next_attempt_at_ms = NULL,
+				updated_at_ms = ?
+			WHERE outbox_id = ?
+			  AND scheduled_for_ms <= ?
+			  AND (
+				state IN ('queued', 'not_dispatched')
+				OR (state = 'uncertain' AND next_attempt_at_ms IS NOT NULL)
+			  )
+			  AND (next_attempt_at_ms IS NULL OR next_attempt_at_ms <= ?)
+			  AND (lease_expires_at_ms IS NULL OR lease_expires_at_ms <= ?)
+		`, req.Owner, token, expiresAtMS, nowMS, id, nowMS, nowMS, nowMS)
+		if err != nil {
+			return nil, fmt.Errorf("lease outbox item %q: update: %w", id, err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return nil, fmt.Errorf("lease outbox item %q: read rows affected: %w", id, err)
+		}
+		if affected != 1 {
+			return nil, fmt.Errorf("lease outbox item %q: affected %d rows, want 1", id, affected)
+		}
+		item, err := scanOutboxItem(tx.QueryRowContext(ctx, `
+			SELECT `+outboxColumns+`
+			FROM outbox
+			WHERE outbox_id = ?
+		`, id))
+		if err != nil {
+			return nil, fmt.Errorf("lease outbox item %q: read claimed row: %w", id, err)
+		}
+		leases = append(leases, Lease{OutboxItem: item})
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("lease due outbox items: commit: %w", err)
+	}
+	return leases, nil
+}
+
+// MarkTransportCalled durably crosses the boundary after which an unknown
+// outcome must not be retried automatically. A dispatcher commits this marker
+// immediately before issuing the transport call, and the call consumes one
+// attempt.
+func (r *OutboxRepository) MarkTransportCalled(
+	ctx context.Context,
+	attempt Attempt,
+) error {
+	if strings.TrimSpace(attempt.OutboxID) == "" {
+		return fmt.Errorf("mark transport called: outbox ID is empty")
+	}
+	if strings.TrimSpace(attempt.LeaseToken) == "" {
+		return fmt.Errorf("mark transport called for outbox item %q: lease token is empty", attempt.OutboxID)
+	}
+	nowMS, err := r.nowMS("mark transport called")
+	if err != nil {
+		return err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE outbox
+		SET transport_called_at_ms = ?,
+			attempt_count = attempt_count + 1,
+			updated_at_ms = ?
+		WHERE outbox_id = ?
+		  AND state = 'dispatching'
+		  AND lease_token = ?
+		  AND lease_expires_at_ms > ?
+		  AND transport_called_at_ms IS NULL
+	`, nowMS, nowMS, attempt.OutboxID, attempt.LeaseToken, nowMS)
+	if err != nil {
+		return fmt.Errorf("mark transport called for outbox item %q: %w", attempt.OutboxID, err)
+	}
+	return r.requireLeaseMutation(ctx, "mark transport called", attempt.OutboxID, result)
+}
+
+// MarkNotDispatched records a pre-call failure and makes the row safe to retry
+// at retryAt.
+func (r *OutboxRepository) MarkNotDispatched(
+	ctx context.Context,
+	outboxID, leaseToken, class, code, detail string,
+	retryAt time.Time,
+) error {
+	retryAtMS := retryAt.UnixMilli()
+	if retryAtMS <= 0 {
+		return fmt.Errorf("mark outbox item %q not dispatched: retry time is not positive", outboxID)
+	}
+	nowMS, err := r.nowMS("mark outbox item not dispatched")
+	if err != nil {
+		return err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE outbox
+		SET state = 'not_dispatched',
+			error_class = ?,
+			error_code = ?,
+			error_detail = ?,
+			next_attempt_at_ms = ?,
+			lease_owner = NULL,
+			lease_token = NULL,
+			lease_expires_at_ms = NULL,
+			transport_called_at_ms = NULL,
+			updated_at_ms = ?
+		WHERE outbox_id = ?
+		  AND state = 'dispatching'
+		  AND lease_token = ?
+		  AND transport_called_at_ms IS NULL
+	`,
+		nullableOutboxText(class),
+		nullableOutboxText(code),
+		nullableOutboxText(detail),
+		retryAtMS,
+		nowMS,
+		outboxID,
+		leaseToken,
+	)
+	if err != nil {
+		return fmt.Errorf("mark outbox item %q not dispatched: %w", outboxID, err)
+	}
+	return r.requireLeaseMutation(ctx, "mark not dispatched", outboxID, result)
+}
+
+// MarkUncertain records an unknown outcome after the transport call boundary.
+// The resulting row has no next-attempt time and is not auto-retryable.
+func (r *OutboxRepository) MarkUncertain(
+	ctx context.Context,
+	outboxID, leaseToken, class, code, detail string,
+) error {
+	nowMS, err := r.nowMS("mark outbox item uncertain")
+	if err != nil {
+		return err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE outbox
+		SET state = 'uncertain',
+			error_class = ?,
+			error_code = ?,
+			error_detail = ?,
+			next_attempt_at_ms = NULL,
+			lease_owner = NULL,
+			lease_token = NULL,
+			lease_expires_at_ms = NULL,
+			transport_called_at_ms = NULL,
+			updated_at_ms = ?
+		WHERE outbox_id = ?
+		  AND state = 'dispatching'
+		  AND lease_token = ?
+		  AND transport_called_at_ms IS NOT NULL
+	`,
+		nullableOutboxText(class),
+		nullableOutboxText(code),
+		nullableOutboxText(detail),
+		nowMS,
+		outboxID,
+		leaseToken,
+	)
+	if err != nil {
+		return fmt.Errorf("mark outbox item %q uncertain: %w", outboxID, err)
+	}
+	return r.requireLeaseMutation(ctx, "mark uncertain", outboxID, result)
+}
+
+// Reject records a terminal rejection. A rejection may occur on either side of
+// the call boundary, so only active lease ownership is required.
+func (r *OutboxRepository) Reject(
+	ctx context.Context,
+	outboxID, leaseToken, class, code, detail string,
+) error {
+	nowMS, err := r.nowMS("reject outbox item")
+	if err != nil {
+		return err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE outbox
+		SET state = 'rejected',
+			error_class = ?,
+			error_code = ?,
+			error_detail = ?,
+			next_attempt_at_ms = NULL,
+			lease_owner = NULL,
+			lease_token = NULL,
+			lease_expires_at_ms = NULL,
+			transport_called_at_ms = NULL,
+			updated_at_ms = ?
+		WHERE outbox_id = ?
+		  AND state = 'dispatching'
+		  AND lease_token = ?
+	`,
+		nullableOutboxText(class),
+		nullableOutboxText(code),
+		nullableOutboxText(detail),
+		nowMS,
+		outboxID,
+		leaseToken,
+	)
+	if err != nil {
+		return fmt.Errorf("reject outbox item %q: %w", outboxID, err)
+	}
+	return r.requireLeaseMutation(ctx, "reject", outboxID, result)
+}
+
+// Confirm atomically records a known remote result for the active called
+// transport lease.
+func (r *OutboxRepository) Confirm(
+	ctx context.Context,
+	confirmation Confirmation,
+) error {
+	resultRemoteID := confirmation.ResultRemoteID
+	if resultRemoteID == "" {
+		resultRemoteID = confirmation.TransportResultID
+	}
+	if strings.TrimSpace(resultRemoteID) == "" {
+		return fmt.Errorf("confirm outbox item %q: remote result ID is empty", confirmation.OutboxID)
+	}
+	nowMS, err := r.nowMS("confirm outbox item")
+	if err != nil {
+		return err
+	}
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("confirm outbox item %q: begin transaction: %w", confirmation.OutboxID, err)
+	}
+	defer tx.Rollback()
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE outbox
+		SET state = 'confirmed',
+			result_remote_id = ?,
+			error_class = NULL,
+			error_code = NULL,
+			error_detail = NULL,
+			next_attempt_at_ms = NULL,
+			lease_owner = NULL,
+			lease_token = NULL,
+			lease_expires_at_ms = NULL,
+			transport_called_at_ms = NULL,
+			updated_at_ms = ?
+		WHERE outbox_id = ?
+		  AND state = 'dispatching'
+		  AND lease_token = ?
+		  AND transport_called_at_ms IS NOT NULL
+	`, resultRemoteID, nowMS, confirmation.OutboxID, confirmation.LeaseToken)
+	if err != nil {
+		return fmt.Errorf("confirm outbox item %q: update: %w", confirmation.OutboxID, err)
+	}
+	if err := r.requireLeaseMutationWithQueryer(ctx, tx, "confirm", confirmation.OutboxID, result); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("confirm outbox item %q: commit: %w", confirmation.OutboxID, err)
+	}
+	return nil
+}
+
+// MarkStoreFailed records that the remote operation was accepted but its local
+// result could not be committed by the projection layer.
+func (r *OutboxRepository) MarkStoreFailed(
+	ctx context.Context,
+	outboxID, leaseToken, transportResultID, detail string,
+) error {
+	if strings.TrimSpace(transportResultID) == "" {
+		return fmt.Errorf("mark outbox item %q store failed: transport result ID is empty", outboxID)
+	}
+	nowMS, err := r.nowMS("mark outbox item store failed")
+	if err != nil {
+		return err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE outbox
+		SET state = 'store_failed',
+			result_remote_id = ?,
+			error_detail = ?,
+			next_attempt_at_ms = NULL,
+			lease_owner = NULL,
+			lease_token = NULL,
+			lease_expires_at_ms = NULL,
+			transport_called_at_ms = NULL,
+			updated_at_ms = ?
+		WHERE outbox_id = ?
+		  AND state = 'dispatching'
+		  AND lease_token = ?
+		  AND transport_called_at_ms IS NOT NULL
+	`,
+		transportResultID,
+		nullableOutboxText(detail),
+		nowMS,
+		outboxID,
+		leaseToken,
+	)
+	if err != nil {
+		return fmt.Errorf("mark outbox item %q store failed: %w", outboxID, err)
+	}
+	return r.requireLeaseMutation(ctx, "mark store failed", outboxID, result)
+}
+
+// RecoverExpiredLeases makes expired pre-call leases immediately retryable and
+// makes expired post-call leases uncertain. Both classifications commit in one
+// transaction.
+func (r *OutboxRepository) RecoverExpiredLeases(
+	ctx context.Context,
+	now time.Time,
+) (RecoveredLeases, error) {
+	nowMS := now.UnixMilli()
+	if nowMS <= 0 {
+		return RecoveredLeases{}, fmt.Errorf("recover expired outbox leases: current Unix time is not positive")
+	}
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return RecoveredLeases{}, fmt.Errorf("recover expired outbox leases: begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	preCall, err := tx.ExecContext(ctx, `
+		UPDATE outbox
+		SET state = 'not_dispatched',
+			next_attempt_at_ms = ?,
+			lease_owner = NULL,
+			lease_token = NULL,
+			lease_expires_at_ms = NULL,
+			transport_called_at_ms = NULL,
+			updated_at_ms = ?
+		WHERE state = 'dispatching'
+		  AND lease_expires_at_ms <= ?
+		  AND transport_called_at_ms IS NULL
+	`, nowMS, nowMS, nowMS)
+	if err != nil {
+		return RecoveredLeases{}, fmt.Errorf("recover expired pre-call outbox leases: %w", err)
+	}
+	postCall, err := tx.ExecContext(ctx, `
+		UPDATE outbox
+		SET state = 'uncertain',
+			next_attempt_at_ms = NULL,
+			lease_owner = NULL,
+			lease_token = NULL,
+			lease_expires_at_ms = NULL,
+			transport_called_at_ms = NULL,
+			updated_at_ms = ?
+		WHERE state = 'dispatching'
+		  AND lease_expires_at_ms <= ?
+		  AND transport_called_at_ms IS NOT NULL
+	`, nowMS, nowMS)
+	if err != nil {
+		return RecoveredLeases{}, fmt.Errorf("recover expired post-call outbox leases: %w", err)
+	}
+	preCallCount, err := preCall.RowsAffected()
+	if err != nil {
+		return RecoveredLeases{}, fmt.Errorf("recover expired pre-call outbox leases: read rows affected: %w", err)
+	}
+	postCallCount, err := postCall.RowsAffected()
+	if err != nil {
+		return RecoveredLeases{}, fmt.Errorf("recover expired post-call outbox leases: read rows affected: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return RecoveredLeases{}, fmt.Errorf("recover expired outbox leases: commit: %w", err)
+	}
+	return RecoveredLeases{
+		NotDispatched: int(preCallCount),
+		Uncertain:     int(postCallCount),
+	}, nil
+}
+
+// FindByID returns an outbox row by its globally unique ID.
+func (r *OutboxRepository) FindByID(
+	ctx context.Context,
+	outboxID string,
+) (OutboxItem, error) {
+	item, err := scanOutboxItem(r.store.db.QueryRowContext(ctx, `
+		SELECT `+outboxColumns+`
+		FROM outbox
+		WHERE outbox_id = ?
+	`, outboxID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return OutboxItem{}, notFound("outbox item", outboxID)
+	}
+	if err != nil {
+		return OutboxItem{}, fmt.Errorf("find outbox item %q: %w", outboxID, err)
+	}
+	return item, nil
+}
+
+// FindByTransportRequestID returns the account-scoped row carrying the stable
+// request ID supplied to the transport.
+func (r *OutboxRepository) FindByTransportRequestID(
+	ctx context.Context,
+	accountID, requestID string,
+) (OutboxItem, error) {
+	item, err := scanOutboxItem(r.store.db.QueryRowContext(ctx, `
+		SELECT `+outboxColumns+`
+		FROM outbox
+		WHERE account_id = ? AND transport_request_id = ?
+	`, accountID, requestID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return OutboxItem{}, notFound("outbox transport request", accountID+"/"+requestID)
+	}
+	if err != nil {
+		return OutboxItem{}, fmt.Errorf(
+			"find outbox transport request %q for account %q: %w",
+			requestID,
+			accountID,
+			err,
+		)
+	}
+	return item, nil
+}
+
+const outboxColumns = `
+	outbox_id,
+	account_id,
+	conversation_id,
+	kind,
+	idempotency_key,
+	payload_hash,
+	operation,
+	state,
+	local_message_id,
+	transport_request_id,
+	result_remote_id,
+	error_class,
+	error_code,
+	error_detail,
+	attempt_count,
+	lease_owner,
+	lease_token,
+	lease_expires_at_ms,
+	transport_called_at_ms,
+	scheduled_for_ms,
+	next_attempt_at_ms,
+	created_at_ms,
+	updated_at_ms`
+
+func scanOutboxItem(row rowScanner) (OutboxItem, error) {
+	var item OutboxItem
+	err := row.Scan(
+		&item.OutboxID,
+		&item.AccountID,
+		&item.ConversationID,
+		&item.Kind,
+		&item.IdempotencyKey,
+		&item.PayloadHash,
+		&item.Operation,
+		&item.State,
+		&item.LocalMessageID,
+		&item.TransportRequestID,
+		&item.ResultRemoteID,
+		&item.ErrorClass,
+		&item.ErrorCode,
+		&item.ErrorDetail,
+		&item.AttemptCount,
+		&item.LeaseOwner,
+		&item.LeaseToken,
+		&item.LeaseExpiresAtMS,
+		&item.TransportCalledAtMS,
+		&item.ScheduledForMS,
+		&item.NextAttemptAtMS,
+		&item.CreatedAtMS,
+		&item.UpdatedAtMS,
+	)
+	return item, err
+}
+
+func validateNewOutboxItem(item NewOutboxItem) error {
+	checks := []struct {
+		name  string
+		value string
+	}{
+		{name: "outbox ID", value: item.OutboxID},
+		{name: "account ID", value: item.AccountID},
+		{name: "conversation ID", value: item.ConversationID},
+		{name: "idempotency key", value: item.IdempotencyKey},
+		{name: "payload hash", value: item.PayloadHash},
+		{name: "operation", value: item.Operation},
+		{name: "transport request ID", value: item.TransportRequestID},
+	}
+	for _, check := range checks {
+		if strings.TrimSpace(check.value) == "" {
+			return fmt.Errorf("%s is empty", check.name)
+		}
+	}
+	switch item.Kind {
+	case OutboxKindText, OutboxKindMedia, OutboxKindReaction, OutboxKindRead:
+	default:
+		return fmt.Errorf("kind %q is invalid", item.Kind)
+	}
+	if item.ScheduledForMS < 0 {
+		return fmt.Errorf("scheduled time is negative")
+	}
+	if !item.ScheduledFor.IsZero() && item.ScheduledForMS != 0 {
+		return fmt.Errorf("ScheduledFor and ScheduledForMS are both set")
+	}
+	return nil
+}
+
+func scheduledForMilliseconds(item NewOutboxItem, nowMS int64) (int64, error) {
+	scheduledForMS := item.ScheduledForMS
+	if !item.ScheduledFor.IsZero() {
+		scheduledForMS = item.ScheduledFor.UnixMilli()
+	}
+	if scheduledForMS == 0 {
+		scheduledForMS = nowMS
+	}
+	if scheduledForMS <= 0 {
+		return 0, fmt.Errorf("scheduled Unix time is not positive")
+	}
+	return scheduledForMS, nil
+}
+
+func nullableOutboxText(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func newOutboxLeaseToken() (string, error) {
+	var token [16]byte
+	if _, err := rand.Read(token[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(token[:]), nil
+}
+
+func (r *OutboxRepository) nowMS(operation string) (int64, error) {
+	nowMS := r.now().UnixMilli()
+	if nowMS <= 0 {
+		return 0, fmt.Errorf("%s: current Unix time is not positive", operation)
+	}
+	return nowMS, nil
+}
+
+func (r *OutboxRepository) requireLeaseMutation(
+	ctx context.Context,
+	operation, outboxID string,
+	result sql.Result,
+) error {
+	return r.requireLeaseMutationWithQueryer(ctx, r.store.db, operation, outboxID, result)
+}
+
+type outboxQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (r *OutboxRepository) requireLeaseMutationWithQueryer(
+	ctx context.Context,
+	queryer outboxQueryer,
+	operation, outboxID string,
+	result sql.Result,
+) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("%s outbox item %q: read rows affected: %w", operation, outboxID, err)
+	}
+	if affected == 1 {
+		return nil
+	}
+	if affected != 0 {
+		return fmt.Errorf("%s outbox item %q: affected %d rows, want 1", operation, outboxID, affected)
+	}
+	var exists bool
+	if err := queryer.QueryRowContext(ctx, `
+		SELECT EXISTS (SELECT 1 FROM outbox WHERE outbox_id = ?)
+	`, outboxID).Scan(&exists); err != nil {
+		return fmt.Errorf("%s outbox item %q: inspect lost lease: %w", operation, outboxID, err)
+	}
+	if !exists {
+		return notFound("outbox item", outboxID)
+	}
+	return fmt.Errorf("%s outbox item %q: %w", operation, outboxID, ErrLeaseLost)
+}

--- a/internal/storage/sqlite/outbox_test.go
+++ b/internal/storage/sqlite/outbox_test.go
@@ -1,0 +1,589 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+const outboxTestTimeMS int64 = 2_000_000_000_000
+
+func TestOutboxEnqueueIdempotencyAndConflict(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+
+	original := outboxTestItem("original")
+	row, disposition, err := repository.Enqueue(ctx, original)
+	if err != nil {
+		t.Fatalf("Enqueue(original): %v", err)
+	}
+	if disposition != EnqueueInserted {
+		t.Fatalf("Enqueue(original) disposition = %q, want %q", disposition, EnqueueInserted)
+	}
+	if row.OutboxID != original.OutboxID || row.State != OutboxQueued {
+		t.Fatalf("Enqueue(original) row = %+v", row)
+	}
+	if row.CreatedAtMS != outboxTestTimeMS || row.ScheduledForMS != outboxTestTimeMS {
+		t.Fatalf("Enqueue(original) timestamps = %+v", row)
+	}
+
+	clock.Set(outboxTestTimeMS + 500)
+	duplicate := original
+	duplicate.OutboxID = "outbox-duplicate"
+	duplicate.TransportRequestID = "request-duplicate"
+	duplicate.LocalMessageID = "message-duplicate"
+	duplicateRow, disposition, err := repository.Enqueue(ctx, duplicate)
+	if err != nil {
+		t.Fatalf("Enqueue(duplicate): %v", err)
+	}
+	if disposition != EnqueueExisting {
+		t.Fatalf("Enqueue(duplicate) disposition = %q, want %q", disposition, EnqueueExisting)
+	}
+	if duplicateRow.OutboxID != original.OutboxID || duplicateRow.CreatedAtMS != outboxTestTimeMS {
+		t.Fatalf("Enqueue(duplicate) returned %+v, want original row", duplicateRow)
+	}
+
+	conflicts := []struct {
+		name   string
+		mutate func(*NewOutboxItem)
+	}{
+		{name: "operation", mutate: func(item *NewOutboxItem) { item.Operation = "edit_text" }},
+		{name: "conversation", mutate: func(item *NewOutboxItem) { item.ConversationID = "conversation-b" }},
+		{name: "payload hash", mutate: func(item *NewOutboxItem) { item.PayloadHash = "different-hash" }},
+	}
+	for i, test := range conflicts {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := original
+			candidate.OutboxID = fmt.Sprintf("outbox-conflict-%d", i)
+			candidate.TransportRequestID = fmt.Sprintf("request-conflict-%d", i)
+			test.mutate(&candidate)
+			_, _, err := repository.Enqueue(ctx, candidate)
+			if !errors.Is(err, ErrIdempotencyConflict) {
+				t.Fatalf("Enqueue(conflict) error = %v, want ErrIdempotencyConflict", err)
+			}
+		})
+	}
+	assertRowCount(t, store.db, "outbox", 1)
+
+	byRequest, err := repository.FindByTransportRequestID(ctx, original.AccountID, original.TransportRequestID)
+	if err != nil {
+		t.Fatalf("FindByTransportRequestID(): %v", err)
+	}
+	if byRequest.OutboxID != original.OutboxID {
+		t.Fatalf("FindByTransportRequestID() ID = %q, want %q", byRequest.OutboxID, original.OutboxID)
+	}
+	if _, err := repository.FindByID(ctx, "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("FindByID(missing) error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestOutboxLeaseDueRespectsScheduleRetryAndLiveLease(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	now := clock.Now()
+
+	live := outboxTestItem("live")
+	live.ScheduledFor = now.Add(-time.Second)
+	mustEnqueueOutbox(t, repository, live)
+	liveLease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker-live", Now: now, Duration: 10 * time.Second, Limit: 1,
+	})
+
+	retry := outboxTestItem("retry")
+	mustEnqueueOutbox(t, repository, retry)
+	retryLease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker-retry", Now: now, Duration: 10 * time.Second, Limit: 1,
+	})
+	if err := repository.MarkNotDispatched(
+		ctx,
+		retry.OutboxID,
+		mustLeaseToken(t, retryLease),
+		"offline",
+		"not_connected",
+		"bridge is offline",
+		now.Add(5*time.Second),
+	); err != nil {
+		t.Fatalf("MarkNotDispatched(): %v", err)
+	}
+
+	due := outboxTestItem("due")
+	mustEnqueueOutbox(t, repository, due)
+	future := outboxTestItem("future")
+	future.ScheduledFor = now.Add(10 * time.Second)
+	mustEnqueueOutbox(t, repository, future)
+
+	leases, err := repository.LeaseDue(ctx, LeaseRequest{
+		Owner: "worker-due", Now: now, Duration: 3 * time.Second, Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("LeaseDue(): %v", err)
+	}
+	if len(leases) != 1 || leases[0].OutboxID != due.OutboxID {
+		t.Fatalf("LeaseDue() leases = %+v, want only %q", leases, due.OutboxID)
+	}
+	lease := leases[0]
+	if lease.LeaseOwner == nil || *lease.LeaseOwner != "worker-due" ||
+		lease.LeaseToken == nil || *lease.LeaseToken == "" ||
+		lease.LeaseExpiresAtMS == nil || *lease.LeaseExpiresAtMS != now.Add(3*time.Second).UnixMilli() {
+		t.Fatalf("claimed lease fields = %+v", lease.OutboxItem)
+	}
+
+	again, err := repository.LeaseDue(ctx, LeaseRequest{
+		Owner: "worker-other", Now: now, Duration: time.Second, Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("LeaseDue(again): %v", err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("LeaseDue(again) = %+v, want no live/scheduled/retry leases", again)
+	}
+	if got, err := repository.FindByID(ctx, live.OutboxID); err != nil {
+		t.Fatalf("FindByID(live): %v", err)
+	} else if got.State != OutboxDispatching || got.LeaseToken == nil || *got.LeaseToken != mustLeaseToken(t, liveLease) {
+		t.Fatalf("live row changed unexpectedly: %+v", got)
+	}
+}
+
+func TestOutboxPreCallExpiredLeaseRetriesAndStaleTokenLoses(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	item := outboxTestItem("pre-call")
+	mustEnqueueOutbox(t, repository, item)
+	first := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker-a", Now: clock.Now(), Duration: time.Second, Limit: 1,
+	})
+	firstToken := mustLeaseToken(t, first)
+
+	clock.Set(outboxTestTimeMS + 1_000)
+	recovered, err := repository.RecoverExpiredLeases(ctx, clock.Now())
+	if err != nil {
+		t.Fatalf("RecoverExpiredLeases(): %v", err)
+	}
+	if recovered.NotDispatched != 1 || recovered.Uncertain != 0 {
+		t.Fatalf("RecoverExpiredLeases() = %+v", recovered)
+	}
+	retryable, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(recovered): %v", err)
+	}
+	if retryable.State != OutboxNotDispatched || retryable.NextAttemptAtMS == nil ||
+		*retryable.NextAttemptAtMS != clock.Now().UnixMilli() || retryable.LeaseToken != nil {
+		t.Fatalf("pre-call recovered row = %+v", retryable)
+	}
+
+	second := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker-b", Now: clock.Now(), Duration: time.Second, Limit: 1,
+	})
+	secondToken := mustLeaseToken(t, second)
+	if secondToken == firstToken {
+		t.Fatal("re-leased row reused its stale lease token")
+	}
+	err = repository.MarkNotDispatched(
+		ctx,
+		item.OutboxID,
+		firstToken,
+		"late",
+		"stale_worker",
+		"late result",
+		clock.Now().Add(time.Second),
+	)
+	if !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("late MarkNotDispatched() error = %v, want ErrLeaseLost", err)
+	}
+	stillLeased, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(re-leased): %v", err)
+	}
+	if stillLeased.State != OutboxDispatching || stillLeased.LeaseToken == nil || *stillLeased.LeaseToken != secondToken {
+		t.Fatalf("stale mutation changed re-leased row: %+v", stillLeased)
+	}
+}
+
+func TestOutboxPostCallExpiredLeaseBecomesUncertain(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	item := outboxTestItem("post-call")
+	mustEnqueueOutbox(t, repository, item)
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Second, Limit: 1,
+	})
+	if err := repository.MarkTransportCalled(ctx, Attempt{
+		OutboxID: item.OutboxID, LeaseToken: mustLeaseToken(t, lease),
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(): %v", err)
+	}
+	called, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(called): %v", err)
+	}
+	if called.AttemptCount != 1 || called.TransportCalledAtMS == nil {
+		t.Fatalf("called row = %+v", called)
+	}
+
+	clock.Set(outboxTestTimeMS + 1_000)
+	recovered, err := repository.RecoverExpiredLeases(ctx, clock.Now())
+	if err != nil {
+		t.Fatalf("RecoverExpiredLeases(): %v", err)
+	}
+	if recovered.NotDispatched != 0 || recovered.Uncertain != 1 {
+		t.Fatalf("RecoverExpiredLeases() = %+v", recovered)
+	}
+	uncertain, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(uncertain): %v", err)
+	}
+	if uncertain.State != OutboxUncertain || uncertain.NextAttemptAtMS != nil || uncertain.LeaseToken != nil {
+		t.Fatalf("post-call recovered row = %+v", uncertain)
+	}
+	leases, err := repository.LeaseDue(ctx, LeaseRequest{
+		Owner: "worker-later", Now: clock.Now().Add(time.Hour), Duration: time.Second, Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("LeaseDue(uncertain): %v", err)
+	}
+	if len(leases) != 0 {
+		t.Fatalf("LeaseDue(uncertain) = %+v, want no automatic retry", leases)
+	}
+}
+
+func TestOutboxLateConfirmationWinsBeforeRecovery(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	item := mustEnqueueOutbox(t, repository, outboxTestItem("late-confirmation"))
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Second, Limit: 1,
+	})
+	token := mustLeaseToken(t, lease)
+	if err := repository.MarkTransportCalled(ctx, Attempt{
+		OutboxID: item.OutboxID, LeaseToken: token,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(): %v", err)
+	}
+
+	// Expiry makes the row recoverable, but recovery has not fenced this token
+	// yet. A definitive result and recovery serialize; the first commit wins.
+	clock.Set(outboxTestTimeMS + 1_000)
+	if err := repository.Confirm(ctx, Confirmation{
+		OutboxID: item.OutboxID, LeaseToken: token, ResultRemoteID: "remote-late",
+	}); err != nil {
+		t.Fatalf("Confirm(after expiry, before recovery): %v", err)
+	}
+	recovered, err := repository.RecoverExpiredLeases(ctx, clock.Now())
+	if err != nil {
+		t.Fatalf("RecoverExpiredLeases(): %v", err)
+	}
+	if recovered != (RecoveredLeases{}) {
+		t.Fatalf("RecoverExpiredLeases() = %+v, want no recovered terminal row", recovered)
+	}
+	confirmed, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(): %v", err)
+	}
+	if confirmed.State != OutboxConfirmed || confirmed.ResultRemoteID == nil || *confirmed.ResultRemoteID != "remote-late" {
+		t.Fatalf("late confirmed row = %+v", confirmed)
+	}
+}
+
+func TestOutboxConcurrentLeaseDueClaimsEachRowOnce(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	const itemCount = 12
+	for i := range itemCount {
+		mustEnqueueOutbox(t, repository, outboxTestItem(fmt.Sprintf("concurrent-%02d", i)))
+	}
+
+	type leaseResult struct {
+		leases []Lease
+		err    error
+	}
+	start := make(chan struct{})
+	results := make(chan leaseResult, 2)
+	for _, owner := range []string{"worker-a", "worker-b"} {
+		go func(owner string) {
+			<-start
+			leases, err := repository.LeaseDue(context.Background(), LeaseRequest{
+				Owner: owner, Now: clock.Now(), Duration: time.Minute, Limit: itemCount,
+			})
+			results <- leaseResult{leases: leases, err: err}
+		}(owner)
+	}
+	close(start)
+
+	seenIDs := make(map[string]string, itemCount)
+	for range 2 {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("concurrent LeaseDue(): %v", result.err)
+		}
+		for _, lease := range result.leases {
+			token := mustLeaseToken(t, lease.OutboxItem)
+			if previous, exists := seenIDs[lease.OutboxID]; exists {
+				t.Fatalf("outbox item %q leased twice with tokens %q and %q", lease.OutboxID, previous, token)
+			}
+			seenIDs[lease.OutboxID] = token
+		}
+	}
+	if len(seenIDs) != itemCount {
+		t.Fatalf("concurrent LeaseDue() claimed %d unique rows, want %d", len(seenIDs), itemCount)
+	}
+}
+
+func TestOutboxTerminalAndUncertainTransitions(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantState  OutboxState
+		transition func(context.Context, *OutboxRepository, OutboxItem, string) error
+		assert     func(*testing.T, OutboxItem)
+	}{
+		{
+			name: "confirm", wantState: OutboxConfirmed,
+			transition: func(ctx context.Context, repository *OutboxRepository, item OutboxItem, token string) error {
+				return repository.Confirm(ctx, Confirmation{
+					OutboxID: item.OutboxID, LeaseToken: token, ResultRemoteID: "remote-confirmed",
+				})
+			},
+			assert: func(t *testing.T, item OutboxItem) {
+				if item.ResultRemoteID == nil || *item.ResultRemoteID != "remote-confirmed" {
+					t.Fatalf("confirmed result = %+v", item.ResultRemoteID)
+				}
+			},
+		},
+		{
+			name: "reject", wantState: OutboxRejected,
+			transition: func(ctx context.Context, repository *OutboxRepository, item OutboxItem, token string) error {
+				return repository.Reject(ctx, item.OutboxID, token, "permanent", "blocked", "recipient blocked")
+			},
+			assert: func(t *testing.T, item OutboxItem) {
+				assertOutboxText(t, "error class", item.ErrorClass, "permanent")
+				assertOutboxText(t, "error code", item.ErrorCode, "blocked")
+				assertOutboxText(t, "error detail", item.ErrorDetail, "recipient blocked")
+			},
+		},
+		{
+			name: "store failed", wantState: OutboxStoreFailed,
+			transition: func(ctx context.Context, repository *OutboxRepository, item OutboxItem, token string) error {
+				return repository.MarkStoreFailed(ctx, item.OutboxID, token, "remote-accepted", "disk full")
+			},
+			assert: func(t *testing.T, item OutboxItem) {
+				assertOutboxText(t, "result remote ID", item.ResultRemoteID, "remote-accepted")
+				assertOutboxText(t, "error detail", item.ErrorDetail, "disk full")
+			},
+		},
+		{
+			name: "uncertain", wantState: OutboxUncertain,
+			transition: func(ctx context.Context, repository *OutboxRepository, item OutboxItem, token string) error {
+				return repository.MarkUncertain(ctx, item.OutboxID, token, "timeout", "deadline", "outcome unknown")
+			},
+			assert: func(t *testing.T, item OutboxItem) {
+				assertOutboxText(t, "error class", item.ErrorClass, "timeout")
+				if item.NextAttemptAtMS != nil {
+					t.Fatalf("uncertain next attempt = %v, want nil", item.NextAttemptAtMS)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := newOutboxTestClock(outboxTestTimeMS)
+			_, repository := openOutboxTestRepository(t, clock.Now)
+			ctx := context.Background()
+			input := outboxTestItem(stringsForOutboxID(test.name))
+			item := mustEnqueueOutbox(t, repository, input)
+			lease := mustLeaseOne(t, repository, LeaseRequest{
+				Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+			})
+			token := mustLeaseToken(t, lease)
+			if err := repository.MarkTransportCalled(ctx, Attempt{
+				OutboxID: item.OutboxID, LeaseToken: token,
+			}); err != nil {
+				t.Fatalf("MarkTransportCalled(): %v", err)
+			}
+			if err := test.transition(ctx, repository, item, token); err != nil {
+				t.Fatalf("transition: %v", err)
+			}
+			got, err := repository.FindByID(ctx, item.OutboxID)
+			if err != nil {
+				t.Fatalf("FindByID(): %v", err)
+			}
+			if got.State != test.wantState || got.LeaseToken != nil || got.LeaseOwner != nil || got.LeaseExpiresAtMS != nil {
+				t.Fatalf("terminal row = %+v, want state %q and no lease", got, test.wantState)
+			}
+			test.assert(t, got)
+		})
+	}
+}
+
+func TestOutboxPhaseTransitionsRejectWrongSideOfCallBoundary(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	item := mustEnqueueOutbox(t, repository, outboxTestItem("phase"))
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	token := mustLeaseToken(t, lease)
+	if err := repository.MarkUncertain(ctx, item.OutboxID, token, "", "", ""); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("pre-call MarkUncertain() error = %v, want ErrLeaseLost", err)
+	}
+	if err := repository.MarkTransportCalled(ctx, Attempt{OutboxID: item.OutboxID, LeaseToken: token}); err != nil {
+		t.Fatalf("MarkTransportCalled(): %v", err)
+	}
+	if err := repository.MarkNotDispatched(
+		ctx, item.OutboxID, token, "", "", "", clock.Now().Add(time.Second),
+	); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("post-call MarkNotDispatched() error = %v, want ErrLeaseLost", err)
+	}
+}
+
+func TestOutboxMigrationIsChecksummedAndStrict(t *testing.T) {
+	store, _ := openOutboxTestRepository(t, func() time.Time {
+		return time.UnixMilli(outboxTestTimeMS)
+	})
+	if len(embeddedMigrations) != 5 {
+		t.Fatalf("embedded migrations = %d, want 5", len(embeddedMigrations))
+	}
+	assertPragmaInt(t, store.db, "user_version", 5)
+	ledger := readLedgerRow(t, store.db, 5)
+	if ledger.name != "outbox" {
+		t.Fatalf("migration 0005 name = %q, want outbox", ledger.name)
+	}
+	if ledger.checksum != embeddedMigrations[4].checksumSHA256 {
+		t.Fatalf("migration 0005 checksum = %q, want %q", ledger.checksum, embeddedMigrations[4].checksumSHA256)
+	}
+	var strict int
+	if err := store.db.QueryRow(`
+		SELECT strict
+		FROM pragma_table_list
+		WHERE schema = 'main' AND name = 'outbox'
+	`).Scan(&strict); err != nil {
+		t.Fatalf("read outbox STRICT flag: %v", err)
+	}
+	if strict != 1 {
+		t.Fatalf("outbox strict = %d, want 1", strict)
+	}
+}
+
+type outboxTestClock struct {
+	mu    sync.Mutex
+	nowMS int64
+}
+
+func newOutboxTestClock(nowMS int64) *outboxTestClock {
+	return &outboxTestClock{nowMS: nowMS}
+}
+
+func (c *outboxTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return time.UnixMilli(c.nowMS)
+}
+
+func (c *outboxTestClock) Set(nowMS int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.nowMS = nowMS
+}
+
+func openOutboxTestRepository(
+	t *testing.T,
+	now func() time.Time,
+) (*Store, *OutboxRepository) {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+	seedMessageAccount(t, store, "account-a", "test")
+	repository, err := NewOutboxRepository(store, now)
+	if err != nil {
+		t.Fatalf("NewOutboxRepository(): %v", err)
+	}
+	return store, repository
+}
+
+func outboxTestItem(id string) NewOutboxItem {
+	return NewOutboxItem{
+		OutboxID:           "outbox-" + id,
+		AccountID:          "account-a",
+		ConversationID:     "conversation-a",
+		Kind:               OutboxKindText,
+		IdempotencyKey:     "idempotency-" + id,
+		PayloadHash:        "payload-hash-" + id,
+		Operation:          "send_text",
+		LocalMessageID:     "message-" + id,
+		TransportRequestID: "request-" + id,
+	}
+}
+
+func mustEnqueueOutbox(
+	t *testing.T,
+	repository *OutboxRepository,
+	item NewOutboxItem,
+) OutboxItem {
+	t.Helper()
+	row, disposition, err := repository.Enqueue(context.Background(), item)
+	if err != nil {
+		t.Fatalf("Enqueue(%q): %v", item.OutboxID, err)
+	}
+	if disposition != EnqueueInserted {
+		t.Fatalf("Enqueue(%q) disposition = %q, want %q", item.OutboxID, disposition, EnqueueInserted)
+	}
+	return row
+}
+
+func mustLeaseOne(
+	t *testing.T,
+	repository *OutboxRepository,
+	req LeaseRequest,
+) OutboxItem {
+	t.Helper()
+	leases, err := repository.LeaseDue(context.Background(), req)
+	if err != nil {
+		t.Fatalf("LeaseDue(): %v", err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("LeaseDue() returned %d leases, want 1: %+v", len(leases), leases)
+	}
+	return leases[0].OutboxItem
+}
+
+func mustLeaseToken(t *testing.T, item OutboxItem) string {
+	t.Helper()
+	if item.LeaseToken == nil || *item.LeaseToken == "" {
+		t.Fatalf("outbox item %q has no lease token: %+v", item.OutboxID, item)
+	}
+	return *item.LeaseToken
+}
+
+func assertOutboxText(t *testing.T, field string, got *string, want string) {
+	t.Helper()
+	if got == nil || *got != want {
+		t.Fatalf("%s = %v, want %q", field, got, want)
+	}
+}
+
+func stringsForOutboxID(value string) string {
+	result := make([]byte, 0, len(value))
+	for i := range len(value) {
+		if value[i] == ' ' {
+			result = append(result, '-')
+			continue
+		}
+		result = append(result, value[i])
+	}
+	return string(result)
+}

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -80,6 +80,7 @@ func TestOpenInitializesBlankDatabase(t *testing.T) {
 		"identities",
 		"inbox",
 		"messages",
+		"outbox",
 		"people",
 		"person_identities",
 		"schema_migrations",


### PR DESCRIPTION
Wave 2 / S7 — the storage core of the broken-Retry fix (review finding #3: today a failed idempotency key is a permanent 409 tombstone). Implemented by Sol, reviewed by Claude. Additive (nothing routes through it until the M-series); no deploy.

- **outbox** — states `queued/dispatching/not_dispatched/uncertain/confirmed/store_failed/rejected/canceled`; `UNIQUE(account_id, idempotency_key)`; caller-owned `transport_request_id`, `payload_hash`, lease owner/token/expiry, `transport_called_at_ms`, `scheduled_for_ms` (future sends are just rows), `next_attempt_at_ms`; a due-leasing index.
- **Enqueue** idempotent on identical `(account_id, idempotency_key)` + operation/conversation/payload; any mismatch → `ErrIdempotencyConflict`.
- **LeaseDue** atomically claims due rows under an owner/token; every transition guards `lease_token` so a stale lease can't mutate a re-leased row.
- **RecoverExpiredLeases** — the exit criterion: expired lease that had **not** called the transport → `not_dispatched` (safe retry); one that **had** → `uncertain` (never auto-retried), keyed on `transport_called_at_ms`.

`go test -race` green — idempotency+conflict, schedule/retry/live-lease leasing, pre-call retry, post-call uncertain, late-confirmation-before-recovery, concurrent single-claim leasing, wrong-side-of-boundary rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
