### PR TITLE
Wire Google lifecycle behind the per-account supervisor (rebuild Wave 1 / C4)

### DIFF
--- a/cmd/google_supervisor.go
+++ b/cmd/google_supervisor.go
@@ -1,0 +1,326 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+const (
+	googleAccountID             = "google-primary"
+	googleSupervisorStopTimeout = 30 * time.Second
+)
+
+func googleSupervisorPolicy() bridge.Policy {
+	return bridge.Policy{
+		ConnectTimeout:     2*time.Minute + 30*time.Second,
+		ProbeEvery:         time.Minute,
+		ProbeTimeout:       75 * time.Second,
+		LivenessTimeout:    12 * time.Minute,
+		MinBackoff:         5 * time.Second,
+		MaxBackoff:         5 * time.Minute,
+		MaxSameFingerprint: 5,
+	}
+}
+
+type googleWallClock struct{}
+
+func (googleWallClock) Now() time.Time { return time.Now() }
+
+func (googleWallClock) NewTimer(delay time.Duration) bridge.Timer {
+	return &googleWallTimer{timer: time.NewTimer(delay)}
+}
+
+type googleWallTimer struct{ timer *time.Timer }
+
+func (t *googleWallTimer) C() <-chan time.Time { return t.timer.C }
+func (t *googleWallTimer) Stop() bool          { return t.timer.Stop() }
+
+type googleRandom struct{}
+
+func (googleRandom) Int63n(n int64) int64 { return rand.Int63n(n) }
+
+type googleCredentialRepairer struct {
+	sessionPath string
+	canRepair   func() bool
+	refresh     func(context.Context, string) error
+	flagRepair  func()
+	clearRepair func()
+}
+
+func newGoogleCredentialRepairer(
+	sessionPath string,
+	canRepair func() bool,
+	refresh func(context.Context, string) error,
+	flagRepair func(),
+	clearRepair func(),
+) bridge.CredentialRepairer {
+	return &googleCredentialRepairer{
+		sessionPath: sessionPath,
+		canRepair:   canRepair,
+		refresh:     refresh,
+		flagRepair:  flagRepair,
+		clearRepair: clearRepair,
+	}
+}
+
+func (r *googleCredentialRepairer) RepairCredentials(
+	ctx context.Context,
+	_ string,
+	_ bridge.OpError,
+) error {
+	if r.canRepair == nil || !r.canRepair() || r.refresh == nil {
+		if r.flagRepair != nil {
+			r.flagRepair()
+		}
+		return bridge.OpError{
+			Class:       bridge.FailureUpgradeRequired,
+			Operation:   "refresh_google_session_cookies",
+			Fingerprint: "google_cookie_refresh_unavailable",
+			Cause:       errors.New("Google cookie refresh is unavailable; pair again"),
+		}
+	}
+
+	repairCtx, cancel := context.WithTimeout(ctx, googleCookieRefreshTimeout)
+	defer cancel()
+	if err := r.refresh(repairCtx, r.sessionPath); err != nil {
+		if r.flagRepair != nil {
+			r.flagRepair()
+		}
+		return fmt.Errorf("refresh Google session cookies: %w", err)
+	}
+	if r.clearRepair != nil {
+		r.clearRepair()
+	}
+	return nil
+}
+
+type googleSupervisorControl struct {
+	supervisor    *bridge.Supervisor
+	newSupervisor func() (*bridge.Supervisor, error)
+	sessionPath   string
+
+	mu                sync.Mutex
+	inputFingerprint  string
+	supervisorStopped bool
+	stopping          bool
+	closed            bool
+}
+
+func newGoogleSupervisorControl(
+	supervisor *bridge.Supervisor,
+	sessionPath string,
+	newSupervisor func() (*bridge.Supervisor, error),
+) *googleSupervisorControl {
+	fingerprint, _ := googleSessionFingerprint(sessionPath)
+	return &googleSupervisorControl{
+		supervisor:       supervisor,
+		newSupervisor:    newSupervisor,
+		sessionPath:      sessionPath,
+		inputFingerprint: fingerprint,
+	}
+}
+
+func (c *googleSupervisorControl) Reconnect() error {
+	c.mu.Lock()
+	if c.closed || c.stopping {
+		c.mu.Unlock()
+		return bridge.ErrSupervisorStopped
+	}
+	if c.supervisorStopped {
+		fingerprint, err := googleSessionFingerprint(c.sessionPath)
+		if err != nil {
+			c.mu.Unlock()
+			return errors.New("Google Messages must be paired before reconnecting")
+		}
+		if c.newSupervisor == nil {
+			c.mu.Unlock()
+			return errors.New("Google Messages supervisor cannot be restarted")
+		}
+		supervisor, err := c.newSupervisor()
+		if err != nil {
+			c.mu.Unlock()
+			return fmt.Errorf("rebuild Google Messages supervisor: %w", err)
+		}
+		c.supervisor = supervisor
+		c.inputFingerprint = fingerprint
+		c.supervisorStopped = false
+	}
+	supervisor := c.supervisor
+	inputFingerprint := c.inputFingerprint
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), googleSupervisorPolicy().ConnectTimeout)
+	defer cancel()
+
+	snapshot := supervisor.Snapshot()
+	switch snapshot.State {
+	case bridge.StateStopped:
+		err := supervisor.Start(ctx, bridge.StartRequest{})
+		if errors.Is(err, bridge.ErrSupervisorBusy) {
+			return nil
+		}
+		return err
+	case bridge.StateBlocked:
+		fingerprint, err := googleSessionFingerprint(c.sessionPath)
+		if err != nil {
+			return err
+		}
+		changed := fingerprint != inputFingerprint
+		if !changed {
+			return supervisor.RetryBlocked(ctx)
+		}
+		if err := supervisor.InputsChanged(ctx, fingerprint); err != nil {
+			return err
+		}
+		c.mu.Lock()
+		if c.supervisor == supervisor && !c.supervisorStopped {
+			c.inputFingerprint = fingerprint
+		}
+		c.mu.Unlock()
+		return nil
+	case bridge.StateOnline, bridge.StateConnecting, bridge.StateDegraded,
+		bridge.StateBackoff, bridge.StateRepairingCredentials:
+		// A reconnect or repair is already owned by this supervisor. Treat a
+		// duplicate button press as successful admission, never a second owner.
+		return nil
+	case bridge.StateUnpaired:
+		return errors.New("Google Messages must be paired before reconnecting")
+	case bridge.StateStopping:
+		return bridge.ErrSupervisorStopped
+	default:
+		return fmt.Errorf("Google Messages cannot reconnect from supervisor state %q", snapshot.State)
+	}
+}
+
+func (c *googleSupervisorControl) StopAndUnpair(unpair func() error) error {
+	c.mu.Lock()
+	if c.closed || c.stopping {
+		c.mu.Unlock()
+		return bridge.ErrSupervisorStopped
+	}
+	c.stopping = true
+	supervisor := c.supervisor
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), googleSupervisorStopTimeout)
+	defer cancel()
+	stopErr := supervisor.Stop(ctx)
+	if stopErr != nil {
+		// Stop is terminal once requested, but a timed-out caller does not prove
+		// that the old adapter generation has joined yet. Keep reconnects gated
+		// until it has, so a replacement supervisor can never overlap it.
+		go c.awaitStoppedSupervisor(supervisor)
+		return fmt.Errorf("stop Google Messages connection: %w", stopErr)
+	}
+	unpairErr := unpair()
+
+	c.mu.Lock()
+	c.supervisorStopped = true
+	c.stopping = false
+	c.mu.Unlock()
+	return unpairErr
+}
+
+func (c *googleSupervisorControl) awaitStoppedSupervisor(supervisor *bridge.Supervisor) {
+	_ = supervisor.Stop(context.Background())
+	c.mu.Lock()
+	if c.supervisor == supervisor && !c.closed {
+		c.supervisorStopped = true
+		c.stopping = false
+	}
+	c.mu.Unlock()
+}
+
+func (c *googleSupervisorControl) Stop(ctx context.Context) error {
+	c.mu.Lock()
+	if c.supervisor == nil {
+		c.closed = true
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	c.stopping = true
+	supervisor := c.supervisor
+	c.mu.Unlock()
+
+	err := supervisor.Stop(ctx)
+	c.mu.Lock()
+	c.supervisorStopped = true
+	c.stopping = false
+	c.mu.Unlock()
+	return err
+}
+
+func googleSessionFingerprint(sessionPath string) (string, error) {
+	data, err := os.ReadFile(sessionPath)
+	if err != nil {
+		return "", fmt.Errorf("read Google session fingerprint: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("sha256:%x", sum[:]), nil
+}
+
+func waitForGoogleOnline(ctx context.Context, supervisor *bridge.Supervisor) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		snapshot := supervisor.Snapshot()
+		switch snapshot.State {
+		case bridge.StateOnline:
+			return nil
+		case bridge.StateBlocked, bridge.StateStopped, bridge.StateUnpaired:
+			return fmt.Errorf(
+				"Google Messages supervisor entered %s (%s: %s)",
+				snapshot.State,
+				snapshot.ErrorClass,
+				snapshot.ErrorFingerprint,
+			)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// startGoogleBackfill preserves the pre-supervisor startup modes, but is only
+// called after Run.Ready has put the Google supervisor online.
+func startGoogleBackfill(a *app.App, logger zerolog.Logger) {
+	runShallowBackfill := func() {
+		if err := a.Backfill(); err != nil {
+			logger.Warn().Err(err).Msg("Backfill failed")
+		}
+	}
+	switch startupBackfillMode() {
+	case "off":
+		logger.Info().Msg("Startup backfill disabled")
+	case "deep":
+		logger.Info().Msg("Starting deep startup backfill")
+		a.DeepBackfill()
+	case "shallow":
+		runShallowBackfill()
+	default:
+		smsCount, err := a.Store.MessageCount("sms")
+		if err != nil {
+			logger.Warn().Err(err).Msg("Failed to inspect local SMS cache; falling back to shallow backfill")
+			runShallowBackfill()
+		} else if smsCount == 0 {
+			logger.Info().Msg("No cached SMS history found; starting deep startup backfill")
+			a.DeepBackfill()
+		} else {
+			runShallowBackfill()
+		}
+	}
+}

--- a/cmd/google_supervisor_test.go
+++ b/cmd/google_supervisor_test.go
@@ -1,0 +1,340 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+func TestGoogleSupervisorCredentialRepairControlsGenerationStart(t *testing.T) {
+	tests := []struct {
+		name             string
+		canRepair        bool
+		refreshErr       error
+		wantRefreshCalls int32
+		wantStarts       int
+		wantState        bridge.State
+		wantFlagCalls    int32
+		wantClearCalls   int32
+	}{
+		{
+			name:          "unavailable refresh parks without reconnect",
+			wantStarts:    1,
+			wantState:     bridge.StateBlocked,
+			wantFlagCalls: 1,
+		},
+		{
+			name:             "failed refresh parks without reconnect",
+			canRepair:        true,
+			refreshErr:       errors.New("Chrome cookie database unavailable"),
+			wantRefreshCalls: 1,
+			wantStarts:       1,
+			wantState:        bridge.StateBlocked,
+			wantFlagCalls:    1,
+		},
+		{
+			name:             "successful refresh starts exactly one new generation",
+			canRepair:        true,
+			wantRefreshCalls: 1,
+			wantStarts:       2,
+			wantState:        bridge.StateOnline,
+			wantClearCalls:   1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lifecycle := &googleRepairTestLifecycle{}
+			var refreshCalls atomic.Int32
+			var flagCalls atomic.Int32
+			var clearCalls atomic.Int32
+			repairer := newGoogleCredentialRepairer(
+				"session.json",
+				func() bool { return tc.canRepair },
+				func(context.Context, string) error {
+					refreshCalls.Add(1)
+					return tc.refreshErr
+				},
+				func() { flagCalls.Add(1) },
+				func() { clearCalls.Add(1) },
+			)
+			supervisor, err := bridge.NewSupervisor(
+				googleAccountID,
+				bridge.PlatformGoogle,
+				lifecycle,
+				googleSupervisorPolicy(),
+				googleWallClock{},
+				googleRandom{},
+				bridge.WithCredentialRepairer(repairer),
+			)
+			if err != nil {
+				t.Fatalf("NewSupervisor() error = %v", err)
+			}
+			t.Cleanup(func() {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				if err := supervisor.Stop(ctx); err != nil {
+					t.Errorf("Supervisor.Stop() error = %v", err)
+				}
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			if err := supervisor.Start(ctx, bridge.StartRequest{}); err != nil {
+				cancel()
+				t.Fatalf("Start() error = %v", err)
+			}
+			cancel()
+			awaitGoogleSupervisorState(t, supervisor, bridge.StateOnline)
+			lifecycle.Run(0).Fail(bridge.OpError{
+				Class:       bridge.FailureCredentialsExpired,
+				Operation:   "listen",
+				Fingerprint: "google_auth_expired",
+				Cause:       errors.New("HTTP 401: invalid authentication credentials"),
+			})
+
+			if tc.wantStarts > 1 {
+				awaitGoogleSupervisorGenerationState(t, supervisor, tc.wantState, bridge.Generation(tc.wantStarts))
+			} else {
+				awaitGoogleSupervisorState(t, supervisor, tc.wantState)
+			}
+			if got := lifecycle.StartCount(); got != tc.wantStarts {
+				t.Fatalf("generation starts = %d, want %d", got, tc.wantStarts)
+			}
+			if got := refreshCalls.Load(); got != tc.wantRefreshCalls {
+				t.Fatalf("refresh calls = %d, want %d", got, tc.wantRefreshCalls)
+			}
+			if got := flagCalls.Load(); got != tc.wantFlagCalls {
+				t.Fatalf("needs_repair flag calls = %d, want %d", got, tc.wantFlagCalls)
+			}
+			if got := clearCalls.Load(); got != tc.wantClearCalls {
+				t.Fatalf("repair-clear calls = %d, want %d", got, tc.wantClearCalls)
+			}
+		})
+	}
+}
+
+func TestGoogleSupervisorManualReconnectUsesOwnedCommands(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(sessionPath, []byte("session-v1"), 0o600); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+	lifecycle := &googleRepairTestLifecycle{}
+	supervisor, err := bridge.NewSupervisor(
+		googleAccountID,
+		bridge.PlatformGoogle,
+		lifecycle,
+		googleSupervisorPolicy(),
+		googleWallClock{},
+		googleRandom{},
+	)
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := supervisor.Stop(ctx); err != nil {
+			t.Errorf("Supervisor.Stop() error = %v", err)
+		}
+	})
+	control := newGoogleSupervisorControl(supervisor, sessionPath, nil)
+
+	if err := control.Reconnect(); err != nil {
+		t.Fatalf("Reconnect() from stopped: %v", err)
+	}
+	awaitGoogleSupervisorGenerationState(t, supervisor, bridge.StateOnline, 1)
+
+	terminal := func(run *googleRepairTestRun) {
+		run.Fail(bridge.OpError{
+			Class:       bridge.FailureUpgradeRequired,
+			Operation:   "repair",
+			Fingerprint: "google_manual_repair_required",
+			Cause:       errors.New("pair again"),
+		})
+		awaitGoogleSupervisorState(t, supervisor, bridge.StateBlocked)
+	}
+
+	terminal(lifecycle.Run(0))
+	if err := control.Reconnect(); err != nil {
+		t.Fatalf("Reconnect() via RetryBlocked: %v", err)
+	}
+	awaitGoogleSupervisorGenerationState(t, supervisor, bridge.StateOnline, 2)
+
+	terminal(lifecycle.Run(1))
+	if err := os.WriteFile(sessionPath, []byte("session-v2"), 0o600); err != nil {
+		t.Fatalf("replace session: %v", err)
+	}
+	if err := control.Reconnect(); err != nil {
+		t.Fatalf("Reconnect() via InputsChanged: %v", err)
+	}
+	awaitGoogleSupervisorGenerationState(t, supervisor, bridge.StateOnline, 3)
+	if got := lifecycle.StartCount(); got != 3 {
+		t.Fatalf("generation starts = %d, want 3", got)
+	}
+}
+
+func TestGoogleSupervisorControlReconnectAfterUnpairRebuildsSupervisor(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(sessionPath, []byte("session-v1"), 0o600); err != nil {
+		t.Fatalf("write initial session: %v", err)
+	}
+
+	lifecycle := &googleRepairTestLifecycle{}
+	var supervisorCount atomic.Int32
+	newSupervisor := func() (*bridge.Supervisor, error) {
+		supervisorCount.Add(1)
+		return bridge.NewSupervisor(
+			googleAccountID,
+			bridge.PlatformGoogle,
+			lifecycle,
+			googleSupervisorPolicy(),
+			googleWallClock{},
+			googleRandom{},
+		)
+	}
+	firstSupervisor, err := newSupervisor()
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	control := newGoogleSupervisorControl(firstSupervisor, sessionPath, newSupervisor)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := control.Stop(ctx); err != nil {
+			t.Errorf("control.Stop() error = %v", err)
+		}
+	})
+
+	if err := control.Reconnect(); err != nil {
+		t.Fatalf("initial Reconnect() error = %v", err)
+	}
+	awaitGoogleSupervisorGenerationState(t, firstSupervisor, bridge.StateOnline, 1)
+
+	if err := control.StopAndUnpair(func() error { return os.Remove(sessionPath) }); err != nil {
+		t.Fatalf("StopAndUnpair() error = %v", err)
+	}
+	if err := os.WriteFile(sessionPath, []byte("session-v2"), 0o600); err != nil {
+		t.Fatalf("write re-paired session: %v", err)
+	}
+	if err := control.Reconnect(); err != nil {
+		t.Fatalf("Reconnect() after re-pair error = %v", err)
+	}
+
+	control.mu.Lock()
+	secondSupervisor := control.supervisor
+	control.mu.Unlock()
+	if secondSupervisor == firstSupervisor {
+		t.Fatal("Reconnect() reused the terminal supervisor after re-pair")
+	}
+	awaitGoogleSupervisorGenerationState(t, secondSupervisor, bridge.StateOnline, 1)
+	if got := lifecycle.StartCount(); got != 2 {
+		t.Fatalf("generation starts = %d, want 2", got)
+	}
+	if got := supervisorCount.Load(); got != 2 {
+		t.Fatalf("supervisors constructed = %d, want 2", got)
+	}
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
+	if err := control.Stop(shutdownCtx); err != nil {
+		shutdownCancel()
+		t.Fatalf("control.Stop() error = %v", err)
+	}
+	shutdownCancel()
+	if err := control.Reconnect(); !errors.Is(err, bridge.ErrSupervisorStopped) {
+		t.Fatalf("Reconnect() after terminal control stop error = %v, want ErrSupervisorStopped", err)
+	}
+	if got := supervisorCount.Load(); got != 2 {
+		t.Fatalf("supervisors after terminal stop = %d, want 2", got)
+	}
+}
+
+type googleRepairTestLifecycle struct {
+	mu   sync.Mutex
+	runs []*googleRepairTestRun
+}
+
+func (l *googleRepairTestLifecycle) Start(
+	_ context.Context,
+	_ bridge.StartRequest,
+	_ bridge.ConnectionSink,
+) (bridge.Run, error) {
+	run := &googleRepairTestRun{ready: make(chan struct{}), done: make(chan error, 1)}
+	close(run.ready)
+	l.mu.Lock()
+	l.runs = append(l.runs, run)
+	l.mu.Unlock()
+	return run, nil
+}
+
+func (l *googleRepairTestLifecycle) StartCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.runs)
+}
+
+func (l *googleRepairTestLifecycle) Run(index int) *googleRepairTestRun {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.runs[index]
+}
+
+type googleRepairTestRun struct {
+	ready chan struct{}
+	done  chan error
+	once  sync.Once
+}
+
+func (r *googleRepairTestRun) Ready() <-chan struct{} { return r.ready }
+func (r *googleRepairTestRun) Done() <-chan error     { return r.done }
+func (r *googleRepairTestRun) Probe(context.Context) (bridge.Liveness, error) {
+	return bridge.Liveness{AliveAt: time.Now(), Detail: "test"}, nil
+}
+func (r *googleRepairTestRun) Stop(context.Context) error { return nil }
+func (r *googleRepairTestRun) Fail(err error) {
+	r.once.Do(func() {
+		r.done <- err
+		close(r.done)
+	})
+}
+
+func awaitGoogleSupervisorState(t *testing.T, supervisor *bridge.Supervisor, want bridge.State) bridge.Snapshot {
+	return awaitGoogleSupervisorGenerationState(t, supervisor, want, 0)
+}
+
+func awaitGoogleSupervisorGenerationState(
+	t *testing.T,
+	supervisor *bridge.Supervisor,
+	want bridge.State,
+	wantGeneration bridge.Generation,
+) bridge.Snapshot {
+	t.Helper()
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		snapshot := supervisor.Snapshot()
+		if snapshot.State == want && (wantGeneration == 0 || snapshot.Generation == wantGeneration) {
+			return snapshot
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf(
+				"supervisor state/generation = %q/%d, want %q/%d (snapshot %+v)",
+				snapshot.State,
+				snapshot.Generation,
+				want,
+				wantGeneration,
+				snapshot,
+			)
+		case <-ticker.C:
+		}
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -19,6 +21,8 @@ import (
 	"golang.org/x/term"
 
 	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/bridge"
+	googleadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/google"
 	"github.com/maxghenis/openmessage/internal/db"
 	"github.com/maxghenis/openmessage/internal/googlecookies"
 	"github.com/maxghenis/openmessage/internal/importer"
@@ -83,7 +87,6 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	isDemo := app.DemoMode()
 
 	events := web.NewEventBroker()
-	googleReconnectNow := make(chan struct{}, 1)
 	isConnected := func() bool {
 		if isDemo {
 			return true
@@ -95,15 +98,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	}
 	a.OnConversationsChange = events.PublishConversations
 	a.OnMessagesChange = events.PublishMessages
-	a.OnStatusChange = func(connected bool) {
-		publishOverallStatus()
-		if !connected {
-			select {
-			case googleReconnectNow <- struct{}{}:
-			default:
-			}
-		}
-	}
+	a.OnStatusChange = func(bool) { publishOverallStatus() }
 	a.OnTypingChange = events.PublishTyping
 	a.OnWhatsAppStatusChange = func() {
 		publishOverallStatus()
@@ -118,41 +113,70 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	}
 	a.OnIncomingMessage = macNotifier.NotifyIncomingMessage
 
-	// Connect to Google Messages (skip in demo mode)
+	var googleLifecycle *googleadapter.Adapter
+	var googleSupervisor *bridge.Supervisor
+	var googleControl *googleSupervisorControl
+
+	// Google has one lifecycle owner. Transient retry, liveness probes,
+	// credential repair, and terminal parking all flow through this supervisor;
+	// the legacy Connected flag remains a UI projection only.
 	if !isDemo {
-		if err := a.LoadAndConnect(); err != nil {
-			logger.Warn().Err(err).Msg("Google Messages unavailable")
-		} else {
-			mode := startupBackfillMode()
-			runShallowBackfill := func() {
-				go func() {
-					if err := a.Backfill(); err != nil {
-						logger.Warn().Err(err).Msg("Backfill failed")
-					}
-				}()
+		googleLifecycle = googleadapter.New(googleAccountID, a, canRefreshGoogleCookies)
+		a.SetGoogleLifecycleNotifier(googleLifecycle)
+		repairer := newGoogleCredentialRepairer(
+			a.SessionPath,
+			canRefreshGoogleCookies,
+			refreshGoogleSessionCookies,
+			a.FlagGoogleNeedsRepair,
+			a.ClearGoogleRepairFlag,
+		)
+		newGoogleSupervisor := func() (*bridge.Supervisor, error) {
+			return bridge.NewSupervisor(
+				googleAccountID,
+				bridge.PlatformGoogle,
+				googleLifecycle,
+				googleSupervisorPolicy(),
+				googleWallClock{},
+				googleRandom{},
+				bridge.WithCredentialRepairer(repairer),
+			)
+		}
+		googleSupervisor, err = newGoogleSupervisor()
+		if err != nil {
+			return fmt.Errorf("init Google Messages supervisor: %w", err)
+		}
+		googleControl = newGoogleSupervisorControl(googleSupervisor, a.SessionPath, newGoogleSupervisor)
+		googleStartupCtx, cancelGoogleStartup := context.WithCancel(context.Background())
+		var googleStartupWG sync.WaitGroup
+		defer func() {
+			cancelGoogleStartup()
+			ctx, cancel := context.WithTimeout(context.Background(), googleSupervisorStopTimeout)
+			defer cancel()
+			if err := googleControl.Stop(ctx); err != nil {
+				logger.Warn().Err(err).Msg("Failed to stop Google Messages supervisor cleanly")
 			}
-			switch mode {
-			case "off":
-				logger.Info().Msg("Startup backfill disabled")
-			case "deep":
-				if a.StartDeepBackfill() {
-					logger.Info().Msg("Started deep startup backfill")
+			googleStartupWG.Wait()
+		}()
+
+		if a.GooglePaired() {
+			googleStartupWG.Add(1)
+			go func(supervisor *bridge.Supervisor) {
+				defer googleStartupWG.Done()
+				ctx, cancel := context.WithTimeout(googleStartupCtx, googleSupervisorPolicy().ConnectTimeout)
+				defer cancel()
+				startErr := supervisor.Start(ctx, bridge.StartRequest{})
+				waitErr := waitForGoogleOnline(ctx, supervisor)
+				if waitErr != nil {
+					logger.Warn().Err(errors.Join(startErr, waitErr)).Msg("Google Messages unavailable")
+					return
 				}
-			case "shallow":
-				runShallowBackfill()
-			default:
-				smsCount, err := a.Store.MessageCount("sms")
-				if err != nil {
-					logger.Warn().Err(err).Msg("Failed to inspect local SMS cache; falling back to shallow backfill")
-					runShallowBackfill()
-				} else if smsCount == 0 {
-					if a.StartDeepBackfill() {
-						logger.Info().Msg("No cached SMS history found; started deep startup backfill")
-					}
-				} else {
-					runShallowBackfill()
+				select {
+				case <-ctx.Done():
+					return
+				default:
 				}
-			}
+				startGoogleBackfill(a, logger)
+			}(googleSupervisor)
 		}
 	} else {
 		logger.Info().Msg("Demo mode — skipping phone connection")
@@ -208,67 +232,6 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				}
 				if err := a.StartSignalConnect(); err != nil {
 					logger.Warn().Err(err).Msg("Signal reconnect attempt failed")
-				}
-			}
-		}()
-	}
-
-	// Google Messages reconnect watchdog. libgm has no auto-reconnect and the
-	// long-poll goroutine can die (panic, ping failure, transient fatal error)
-	// while the session stays valid. Without this, SMS silently freezes with
-	// Connected=true forever. Only reconnect a paired-but-disconnected session;
-	// skip when it genuinely needs re-pairing (session deleted) so we don't
-	// hammer a known-bad state.
-	if !isDemo {
-		go func() {
-			ticker := time.NewTicker(15 * time.Second)
-			defer ticker.Stop()
-			lastAttempt := time.Time{}
-			attemptReconnect := func(trigger string) {
-				if !lastAttempt.IsZero() && time.Since(lastAttempt) < 5*time.Second {
-					return
-				}
-				lastAttempt = time.Now()
-				g := a.GoogleStatus()
-				switch planGoogleReconnect(g, canRefreshGoogleCookies()) {
-				case googleReconnectSkip:
-					return
-				case googleReconnectPark:
-					// Dead linked-device session with no way to auto-recover
-					// (no cookie-refresh script). Stop reconnecting so we don't
-					// hammer Google's auth endpoint every cycle; flag it so the
-					// UI prompts a manual re-pair. A successful re-pair clears
-					// the flag and reconnect resumes.
-					a.FlagGoogleNeedsRepair()
-					return
-				case googleReconnectRefresh:
-					// Cookies expired but a refresh script is configured: refresh
-					// then reconnect, even if the session was flagged for repair.
-					logger.Info().Msg("Google auth expired - refreshing Chrome cookies before reconnect")
-					ctx, cancel := context.WithTimeout(context.Background(), googleCookieRefreshTimeout)
-					err := refreshGoogleSessionCookies(ctx, a.SessionPath)
-					cancel()
-					if err != nil {
-						logger.Warn().Err(err).Msg("Google cookie refresh before reconnect failed")
-					} else {
-						logger.Info().Msg("Refreshed Google cookies before reconnect")
-					}
-					a.ClearGoogleRepairFlag()
-				case googleReconnectRetry:
-					// Ordinary transient disconnect — just reconnect.
-				}
-				logger.Info().Str("trigger", trigger).Msg("Google Messages disconnected - attempting reconnect")
-				if err := a.ReconnectGoogleMessages(); err != nil {
-					a.HandleGoogleAuthExpiredError(err)
-					logger.Warn().Err(err).Msg("Google Messages reconnect attempt failed")
-				}
-			}
-			for {
-				select {
-				case <-ticker.C:
-					attemptReconnect("timer")
-				case <-googleReconnectNow:
-					attemptReconnect("status-change")
 				}
 			}
 		}()
@@ -416,6 +379,17 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		}
 		return a.GoogleStatus()
 	}
+	recordGoogleSend := a.RecordGoogleSendOutcome
+	recordGoogleSendError := a.RecordGoogleSendError
+	markGoogleAuthExpired := a.HandleGoogleAuthExpiredError
+	reconnectGoogle := a.ReconnectGoogleMessages
+	unpairGoogle := a.Unpair
+	if googleControl != nil {
+		reconnectGoogle = googleControl.Reconnect
+		unpairGoogle = func() error {
+			return googleControl.StopAndUnpair(a.Unpair)
+		}
+	}
 
 	// Background loop that sends due scheduled ("send later") messages.
 	a.StartScheduler()
@@ -430,12 +404,12 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				IdentityName:          identityName,
 				IsConnected:           isConnected,
 				GoogleStatus:          googleStatus,
-				RecordGoogleSend:      a.RecordGoogleSendOutcome,
-				RecordGoogleSendError: a.RecordGoogleSendError,
+				RecordGoogleSend:      recordGoogleSend,
+				RecordGoogleSendError: recordGoogleSendError,
 				GooglePhoneResponding: a.GooglePhoneResponding,
-				MarkGoogleAuthExpired: a.HandleGoogleAuthExpiredError,
-				ReconnectGoogle:       a.ReconnectGoogleMessages,
-				Unpair:                a.Unpair,
+				MarkGoogleAuthExpired: markGoogleAuthExpired,
+				ReconnectGoogle:       reconnectGoogle,
+				Unpair:                unpairGoogle,
 				WhatsAppStatus:        func() any { return a.WhatsAppStatus() },
 				ConnectWhatsApp:       a.StartWhatsAppConnect,
 				PairWhatsAppPhone:     a.PairWhatsAppPhone,
@@ -638,51 +612,11 @@ func startupBackfillMode() string {
 
 const googleCookieRefreshTimeout = 20 * time.Second
 
-func googleStatusNeedsCookieRefresh(g app.GoogleStatusSnapshot) bool {
-	return g.AuthExpired || app.IsGoogleAuthExpiredError(fmt.Errorf("%s", g.LastError))
-}
-
-// googleReconnectAction is the reconnect watchdog's decision for a Google
-// Messages session that is currently disconnected.
-type googleReconnectAction int
-
-const (
-	googleReconnectSkip    googleReconnectAction = iota // connected, unpaired, or awaiting first-time pairing
-	googleReconnectRefresh                              // cookies expired and a refresh script is available
-	googleReconnectPark                                 // dead session, no automated recovery — wait for manual re-pair
-	googleReconnectRetry                                // ordinary transient disconnect
-)
-
-// planGoogleReconnect decides what the reconnect watchdog should do for a
-// disconnected Google Messages session. It is pure so the back-off behaviour
-// can be unit-tested without driving the live loop.
-//
-// Key invariant: a session whose cookies have expired is only retried
-// automatically when a cookie-refresh script is configured. Without one (e.g.
-// the macOS app) a reconnect just 401s again, so we park and let the UI prompt
-// a manual re-pair instead of spinning a reconnect storm against Google's auth
-// endpoint — the failure docs/agent-runbook.md warns about.
-func planGoogleReconnect(g app.GoogleStatusSnapshot, hasRefreshScript bool) googleReconnectAction {
-	if !g.Paired || g.Connected || g.NeedsPairing {
-		return googleReconnectSkip
-	}
-	if googleStatusNeedsCookieRefresh(g) {
-		if hasRefreshScript {
-			return googleReconnectRefresh
-		}
-		return googleReconnectPark
-	}
-	if g.NeedsRepair {
-		return googleReconnectPark
-	}
-	return googleReconnectRetry
-}
-
 // canRefreshGoogleCookies reports whether an expired Google session can be
 // recovered automatically — either via a configured external refresh script or
 // the built-in native refresh (macOS with a Chrome profile). When neither is
-// available (e.g. a Linux install with no script), planGoogleReconnect parks
-// the session and the UI prompts a manual re-pair instead of spinning 401s.
+// available, the adapter classifies auth expiry as a blocked condition and the
+// existing needs_repair status prompts a manual re-pair instead of spinning.
 func canRefreshGoogleCookies() bool {
 	if strings.TrimSpace(os.Getenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT")) != "" {
 		return true
@@ -693,8 +627,8 @@ func canRefreshGoogleCookies() bool {
 // refreshGoogleSessionCookies rewrites the Google cookies in sessionPath. It
 // prefers an explicitly configured OPENMESSAGE_COOKIE_REFRESH_SCRIPT (so the
 // operator can override the mechanism), otherwise falls back to the built-in
-// native refresh. Returning nil with no work done is fine — the caller
-// reconnects afterwards regardless.
+// native refresh. The supervisor starts a new generation only after this
+// function succeeds.
 var refreshGoogleSessionCookies = func(ctx context.Context, sessionPath string) error {
 	script := strings.TrimSpace(os.Getenv("OPENMESSAGE_COOKIE_REFRESH_SCRIPT"))
 	if script != "" {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	mcpserver "github.com/mark3labs/mcp-go/server"
-
-	"github.com/maxghenis/openmessage/internal/app"
 )
 
 func TestHTTPServerSurvivesIndependently(t *testing.T) {
@@ -185,28 +183,6 @@ func TestRefreshGoogleSessionCookiesUsesEnvScript(t *testing.T) {
 	}
 }
 
-func TestGoogleStatusNeedsCookieRefreshUsesExplicitAuthExpiredFlag(t *testing.T) {
-	status := app.GoogleStatusSnapshot{
-		Paired:      true,
-		AuthExpired: true,
-		LastError:   "Google Messages connection lost; reconnecting...",
-	}
-	if !googleStatusNeedsCookieRefresh(status) {
-		t.Fatal("expected explicit auth-expired flag to trigger cookie refresh")
-	}
-
-	status.AuthExpired = false
-	status.LastError = "Google Messages session cookie expired; refreshing and reconnecting..."
-	if !googleStatusNeedsCookieRefresh(status) {
-		t.Fatal("expected auth-expired last error to trigger cookie refresh")
-	}
-
-	status.LastError = "Google Messages connection lost; reconnecting..."
-	if googleStatusNeedsCookieRefresh(status) {
-		t.Fatal("generic reconnect status should not trigger cookie refresh")
-	}
-}
-
 func TestParseServeOptions(t *testing.T) {
 	t.Run("defaults to web only", func(t *testing.T) {
 		opts, err := parseServeOptions(nil)
@@ -305,75 +281,5 @@ func TestConfigureServeEnvRestoresPreviousValue(t *testing.T) {
 	restore()
 	if got := os.Getenv("OPENMESSAGES_DEMO"); got != "existing" {
 		t.Fatalf("OPENMESSAGES_DEMO=%q, want existing after restore", got)
-	}
-}
-
-func TestPlanGoogleReconnect(t *testing.T) {
-	const authErr = "send message: HTTP 401: Request had invalid authentication credentials"
-	tests := []struct {
-		name      string
-		status    app.GoogleStatusSnapshot
-		hasScript bool
-		want      googleReconnectAction
-	}{
-		{
-			name:   "connected does nothing",
-			status: app.GoogleStatusSnapshot{Paired: true, Connected: true},
-			want:   googleReconnectSkip,
-		},
-		{
-			name:   "unpaired does nothing",
-			status: app.GoogleStatusSnapshot{Paired: false},
-			want:   googleReconnectSkip,
-		},
-		{
-			name:   "awaiting first-time pairing does nothing",
-			status: app.GoogleStatusSnapshot{Paired: true, NeedsPairing: true},
-			want:   googleReconnectSkip,
-		},
-		{
-			name:   "ordinary disconnect retries",
-			status: app.GoogleStatusSnapshot{Paired: true},
-			want:   googleReconnectRetry,
-		},
-		{
-			name:      "auth expired with refresh script refreshes",
-			status:    app.GoogleStatusSnapshot{Paired: true, AuthExpired: true},
-			hasScript: true,
-			want:      googleReconnectRefresh,
-		},
-		{
-			name:   "auth expired without refresh script parks (no storm)",
-			status: app.GoogleStatusSnapshot{Paired: true, AuthExpired: true},
-			want:   googleReconnectPark,
-		},
-		{
-			name:   "auth expired via last-error text without script parks",
-			status: app.GoogleStatusSnapshot{Paired: true, LastError: authErr},
-			want:   googleReconnectPark,
-		},
-		{
-			name:      "dead session flagged for repair still refreshes when a script can recover it",
-			status:    app.GoogleStatusSnapshot{Paired: true, NeedsRepair: true, AuthExpired: true},
-			hasScript: true,
-			want:      googleReconnectRefresh,
-		},
-		{
-			name:   "dead session flagged for repair without script parks (macOS)",
-			status: app.GoogleStatusSnapshot{Paired: true, NeedsRepair: true, AuthExpired: true},
-			want:   googleReconnectPark,
-		},
-		{
-			name:   "zombie session needs repair but not auth-expired parks",
-			status: app.GoogleStatusSnapshot{Paired: true, NeedsRepair: true},
-			want:   googleReconnectPark,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := planGoogleReconnect(tc.status, tc.hasScript); got != tc.want {
-				t.Fatalf("planGoogleReconnect(%+v, hasScript=%v) = %d, want %d", tc.status, tc.hasScript, got, tc.want)
-			}
-		})
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -114,6 +114,7 @@ func (p *BackfillProgress) snapshot() BackfillSnapshot {
 type App struct {
 	clientMu               sync.RWMutex
 	Client                 *client.Client
+	googleGeneration       *GoogleGeneration
 	Store                  *db.Store
 	EventHandler           *client.EventHandler
 	Logger                 zerolog.Logger
@@ -161,6 +162,8 @@ type App struct {
 	googleAuthExpired         atomic.Bool
 	googlePhoneResponding     atomic.Bool
 	googlePhoneRespondingSeen atomic.Bool
+	googleLifecycleMu         sync.RWMutex
+	googleLifecycleNotifier   GoogleLifecycleNotifier
 	tempDataDir               string
 	pendingMediaMu            sync.Mutex
 	pendingMedia              map[string]struct{}
@@ -205,7 +208,7 @@ func (a *App) RecordGoogleSendOutcomeWithPhone(success bool, phoneResponding boo
 		return
 	}
 	if a.googleSendFailures.Add(1) >= googleRepairThreshold {
-		a.googleNeedsRepair.Store(true)
+		a.markGoogleNeedsRepairAndPark(errGoogleSendsRepeatedlyFailed)
 	}
 }
 
@@ -214,7 +217,7 @@ func (a *App) RecordGoogleSendOutcomeWithPhone(success bool, phoneResponding boo
 // the session for re-pair; transient network errors should remain recoverable.
 func (a *App) RecordGoogleSendError(err error) {
 	if isGoogleAuthInvalid(err) {
-		a.googleNeedsRepair.Store(true)
+		a.markGoogleNeedsRepairAndPark(err)
 	}
 }
 

--- a/internal/app/google_auth.go
+++ b/internal/app/google_auth.go
@@ -29,9 +29,12 @@ func (a *App) HandleGoogleAuthExpiredError(err error) bool {
 		return false
 	}
 	a.Connected.Store(false)
-	a.googleAuthExpired.Store(true)
+	firstNotification := a.googleAuthExpired.CompareAndSwap(false, true)
 	a.setGoogleLastError(googleAuthExpiredStatusMessage)
 	a.emitStatusChange(false)
 	a.Logger.Warn().Err(err).Msg("Google auth expired; marking disconnected")
+	if firstNotification {
+		a.reportGoogleLifecycleError(err)
+	}
 	return true
 }

--- a/internal/app/google_generation.go
+++ b/internal/app/google_generation.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"os"
+
+	"github.com/maxghenis/openmessage/internal/client"
+)
+
+// GoogleGeneration binds the legacy App callbacks and client pointer to one
+// supervisor-owned Google connection generation. Every mutating method first
+// verifies that the generation is still current.
+type GoogleGeneration struct {
+	app     *App
+	Client  *client.Client
+	Handler *client.EventHandler
+}
+
+// BeginGoogleGeneration installs a fresh legacy client for the unchanged
+// send/read/media paths and builds a generation-local event handler. Callers
+// must capture Handler directly; a libgm callback must never look up
+// App.EventHandler after it has been installed.
+func (a *App) BeginGoogleGeneration(cli *client.Client) *GoogleGeneration {
+	generation := &GoogleGeneration{app: a, Client: cli}
+	generation.Handler = &client.EventHandler{
+		Store:       a.Store,
+		Logger:      a.Logger,
+		SessionPath: a.SessionPath,
+		Client:      cli,
+		OnConversationsChange: func() {
+			a.emitConversationsChange()
+		},
+		OnIncomingMessage: a.OnIncomingMessage,
+		OnPendingMedia: func(conversationID, messageID string) {
+			a.StartPendingMediaRefresh(conversationID, messageID)
+		},
+		OnMessagesChange: func(conversationID string) {
+			a.emitMessagesChange(conversationID)
+		},
+		OnTypingChange:           a.OnTypingChange,
+		OnGoogleAvatarCandidates: a.QueueGoogleAvatarCandidates,
+		OnRealtimeGapRecovered: func(reason string) {
+			a.StartRecentReconcile(reason)
+		},
+		OnPhoneRespondingChange: generation.PhoneResponding,
+		OnConnectionLost:        generation.ConnectionLost,
+		OnSessionInvalid:        generation.SessionInvalid,
+	}
+
+	a.clientMu.Lock()
+	a.Client = cli
+	a.EventHandler = generation.Handler
+	a.googleGeneration = generation
+	a.Connected.Store(false)
+	a.clientMu.Unlock()
+	return generation
+}
+
+func (g *GoogleGeneration) current() bool {
+	if g == nil || g.app == nil {
+		return false
+	}
+	g.app.clientMu.RLock()
+	current := g.Client != nil && g.app.googleGeneration == g && g.app.Client == g.Client
+	g.app.clientMu.RUnlock()
+	return current
+}
+
+// Ready publishes compatibility status only after the adapter has observed a
+// real long-poll event. The Connected bit remains a UI/send-path projection;
+// it is never used by the supervisor as liveness evidence.
+func (g *GoogleGeneration) Ready() bool {
+	if !g.current() {
+		return false
+	}
+	a := g.app
+	a.ClearGoogleRepairFlag()
+	a.googleAuthExpired.Store(false)
+	a.RecordGooglePhoneResponding(true)
+	a.Connected.Store(true)
+	a.setGoogleLastError("")
+	a.emitStatusChange(true)
+	a.Logger.Info().Msg("Connected to Google Messages")
+	a.StartGoogleContactSync()
+	return true
+}
+
+func (g *GoogleGeneration) PhoneResponding(responding bool) {
+	if !g.current() {
+		return
+	}
+	a := g.app
+	a.RecordGooglePhoneResponding(responding)
+	if !responding {
+		a.setGoogleLastError("Your phone isn't responding to OpenMessage right now; make sure it's on and online.")
+	} else {
+		a.clearGoogleLastErrorIf("Your phone isn't responding to OpenMessage right now; make sure it's on and online.")
+	}
+	a.emitStatusChange(a.Connected.Load())
+}
+
+func (g *GoogleGeneration) ConnectionLost() {
+	if !g.current() {
+		return
+	}
+	a := g.app
+	a.Connected.Store(false)
+	a.setGoogleLastError("Google Messages connection lost; reconnecting…")
+	a.emitStatusChange(false)
+	a.Logger.Warn().Msg("Google Messages connection lost; will attempt to reconnect")
+}
+
+func (g *GoogleGeneration) AuthExpired(err error) {
+	if !g.current() || !IsGoogleAuthExpiredError(err) {
+		return
+	}
+	a := g.app
+	a.Connected.Store(false)
+	a.googleAuthExpired.Store(true)
+	a.setGoogleLastError(googleAuthExpiredStatusMessage)
+	a.emitStatusChange(false)
+	a.Logger.Warn().Err(err).Msg("Google auth expired; marking disconnected")
+}
+
+func (g *GoogleGeneration) SessionInvalid() {
+	if !g.current() {
+		return
+	}
+	a := g.app
+	a.Connected.Store(false)
+	a.clientMu.Lock()
+	if a.googleGeneration == g && a.Client == g.Client {
+		a.Client = nil
+		a.EventHandler = nil
+	}
+	a.clientMu.Unlock()
+	if err := os.Remove(a.SessionPath); err != nil && !os.IsNotExist(err) {
+		a.Logger.Warn().Err(err).Msg("Failed to remove invalidated Google Messages session")
+	}
+	a.setGoogleLastError("Google Messages session invalidated; pair again")
+	a.emitStatusChange(false)
+	a.Logger.Warn().Msg("Disconnected from Google Messages")
+}
+
+func (g *GoogleGeneration) SyncInterrupted() {
+	if !g.current() {
+		return
+	}
+	a := g.app
+	a.Connected.Store(false)
+	a.setGoogleLastError("Google Messages sync interrupted; reconnecting…")
+	a.emitStatusChange(false)
+}
+
+// Release clears the legacy client only if this is still the installed
+// generation, so a delayed Stop from generation N cannot clear generation N+1.
+func (g *GoogleGeneration) Release() {
+	if g == nil || g.app == nil {
+		return
+	}
+	a := g.app
+	released := false
+	a.clientMu.Lock()
+	if a.googleGeneration == g {
+		if a.Client == g.Client {
+			a.Client = nil
+		}
+		if a.EventHandler == g.Handler {
+			a.EventHandler = nil
+		}
+		a.googleGeneration = nil
+		released = true
+	}
+	a.clientMu.Unlock()
+	if released && a.Connected.Swap(false) {
+		a.emitStatusChange(false)
+	}
+}

--- a/internal/app/google_lifecycle_notify.go
+++ b/internal/app/google_lifecycle_notify.go
@@ -1,0 +1,48 @@
+package app
+
+import "errors"
+
+var errGoogleSendsRepeatedlyFailed = errors.New("Google sends repeatedly failed while the phone was responding")
+
+// GoogleLifecycleNotifier lets legacy App send paths report lifecycle changes
+// without owning reconnect or repair. The Google bridge adapter implements
+// this interface and leaves all generation changes to the supervisor.
+type GoogleLifecycleNotifier interface {
+	// ReportError ends the current generation with an error that the
+	// supervisor classifies, including recoverable credential expiry.
+	ReportError(error) bool
+	// ParkCurrent ends the current generation in a terminal manual-repair
+	// state for a known-dead linked session.
+	ParkCurrent(error) bool
+}
+
+// SetGoogleLifecycleNotifier installs the lifecycle owner notified by every
+// App Google send path. It is safe to replace or clear the notifier while send
+// operations are in flight.
+func (a *App) SetGoogleLifecycleNotifier(notifier GoogleLifecycleNotifier) {
+	a.googleLifecycleMu.Lock()
+	a.googleLifecycleNotifier = notifier
+	a.googleLifecycleMu.Unlock()
+}
+
+func (a *App) googleLifecycle() GoogleLifecycleNotifier {
+	a.googleLifecycleMu.RLock()
+	notifier := a.googleLifecycleNotifier
+	a.googleLifecycleMu.RUnlock()
+	return notifier
+}
+
+func (a *App) reportGoogleLifecycleError(err error) {
+	if notifier := a.googleLifecycle(); notifier != nil {
+		notifier.ReportError(err)
+	}
+}
+
+func (a *App) markGoogleNeedsRepairAndPark(err error) {
+	if !a.googleNeedsRepair.CompareAndSwap(false, true) {
+		return
+	}
+	if notifier := a.googleLifecycle(); notifier != nil {
+		notifier.ParkCurrent(err)
+	}
+}

--- a/internal/app/google_lifecycle_notify_test.go
+++ b/internal/app/google_lifecycle_notify_test.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+type recordingGoogleLifecycleNotifier struct {
+	reported []error
+	parked   []error
+}
+
+func (n *recordingGoogleLifecycleNotifier) ReportError(err error) bool {
+	n.reported = append(n.reported, err)
+	return true
+}
+
+func (n *recordingGoogleLifecycleNotifier) ParkCurrent(err error) bool {
+	n.parked = append(n.parked, err)
+	return true
+}
+
+func TestGoogleLifecycleNotifierReportsAuthExpiryOnce(t *testing.T) {
+	a := &App{Logger: zerolog.Nop()}
+	notifier := &recordingGoogleLifecycleNotifier{}
+	a.SetGoogleLifecycleNotifier(notifier)
+
+	transient := errors.New("dial tcp: i/o timeout")
+	if a.HandleGoogleAuthExpiredError(transient) {
+		t.Fatal("transient error treated as auth expiry")
+	}
+	if len(notifier.reported) != 0 || len(notifier.parked) != 0 {
+		t.Fatal("transient auth check notified the lifecycle")
+	}
+
+	authErr := errors.New("send message: HTTP 401: invalid authentication credentials")
+	if !a.HandleGoogleAuthExpiredError(authErr) {
+		t.Fatal("auth-expiry error was not handled")
+	}
+	if len(notifier.reported) != 1 || notifier.reported[0] != authErr {
+		t.Fatalf("reported = %v, want exactly [%v]", notifier.reported, authErr)
+	}
+	if len(notifier.parked) != 0 {
+		t.Fatalf("auth expiry parked lifecycle: %v", notifier.parked)
+	}
+
+	if !a.HandleGoogleAuthExpiredError(authErr) {
+		t.Fatal("repeated auth-expiry error was not handled")
+	}
+	if len(notifier.reported) != 1 {
+		t.Fatalf("repeated auth expiry reported %d times, want 1", len(notifier.reported))
+	}
+}
+
+func TestGoogleLifecycleNotifierParksOnRepairThresholdOnce(t *testing.T) {
+	a := &App{}
+	notifier := &recordingGoogleLifecycleNotifier{}
+	a.SetGoogleLifecycleNotifier(notifier)
+
+	for range googleRepairThreshold - 1 {
+		a.RecordGoogleSendOutcome(false)
+	}
+	if len(notifier.parked) != 0 {
+		t.Fatalf("parked before repair threshold: %v", notifier.parked)
+	}
+
+	a.RecordGoogleSendOutcome(false)
+	if len(notifier.parked) != 1 {
+		t.Fatalf("park notifications = %d, want 1", len(notifier.parked))
+	}
+	if !strings.Contains(notifier.parked[0].Error(), "repeatedly failed") {
+		t.Fatalf("park error = %q, want repeated-send detail", notifier.parked[0])
+	}
+
+	a.RecordGoogleSendOutcome(false)
+	if len(notifier.parked) != 1 {
+		t.Fatalf("failure after threshold produced %d park notifications, want 1", len(notifier.parked))
+	}
+
+	a.RecordGoogleSendOutcome(true)
+	for range googleRepairThreshold {
+		a.RecordGoogleSendOutcome(false)
+	}
+	if len(notifier.parked) != 2 {
+		t.Fatalf("new failure streak produced %d total park notifications, want 2", len(notifier.parked))
+	}
+}
+
+func TestGoogleLifecycleNotifierKeepsPhoneOfflineFailuresRecoverable(t *testing.T) {
+	a := &App{}
+	notifier := &recordingGoogleLifecycleNotifier{}
+	a.SetGoogleLifecycleNotifier(notifier)
+
+	for range googleRepairThreshold * 2 {
+		a.RecordGoogleSendOutcomeWithPhone(false, false)
+	}
+	if len(notifier.parked) != 0 || len(notifier.reported) != 0 {
+		t.Fatalf("phone-offline failures notified lifecycle: parked=%v reported=%v", notifier.parked, notifier.reported)
+	}
+	if a.googleNeedsRepair.Load() {
+		t.Fatal("phone-offline failures marked Google for repair")
+	}
+}
+
+func TestGoogleLifecycleNotifierParksAuthInvalidSendErrorNotTransient(t *testing.T) {
+	a := &App{}
+	notifier := &recordingGoogleLifecycleNotifier{}
+	a.SetGoogleLifecycleNotifier(notifier)
+
+	a.RecordGoogleSendError(errors.New("dial tcp: i/o timeout"))
+	if len(notifier.parked) != 0 || len(notifier.reported) != 0 {
+		t.Fatalf("transient send error notified lifecycle: parked=%v reported=%v", notifier.parked, notifier.reported)
+	}
+
+	authErr := errors.New("rpc error: code = Unauthenticated desc = linked device rejected")
+	a.RecordGoogleSendError(authErr)
+	if len(notifier.parked) != 1 || notifier.parked[0] != authErr {
+		t.Fatalf("parked = %v, want exactly [%v]", notifier.parked, authErr)
+	}
+	if len(notifier.reported) != 0 {
+		t.Fatalf("auth-invalid send error was reported for refresh instead of parked: %v", notifier.reported)
+	}
+
+	a.RecordGoogleSendError(authErr)
+	if len(notifier.parked) != 1 {
+		t.Fatalf("repeated auth-invalid error parked %d times, want 1", len(notifier.parked))
+	}
+}
+
+func TestGoogleLifecycleNotifierCanBeCleared(t *testing.T) {
+	a := &App{}
+	notifier := &recordingGoogleLifecycleNotifier{}
+	a.SetGoogleLifecycleNotifier(notifier)
+	a.SetGoogleLifecycleNotifier(nil)
+
+	a.RecordGoogleSendError(errors.New("rpc error: code = Unauthenticated"))
+	if len(notifier.parked) != 0 || len(notifier.reported) != 0 {
+		t.Fatalf("cleared notifier was invoked: parked=%v reported=%v", notifier.parked, notifier.reported)
+	}
+}

--- a/internal/bridge/supervisor.go
+++ b/internal/bridge/supervisor.go
@@ -1136,7 +1136,7 @@ func (l *supervisorLoop) routeFailure(failure OpError) {
 	l.snapshot.RetryAt = time.Time{}
 	l.snapshot.LivenessDeadline = time.Time{}
 
-	if l.recordFingerprint(failure.Fingerprint) {
+	if l.recordFingerprint(failure.Class, failure.Fingerprint) {
 		l.snapshot.State = StateBlocked
 		l.publish()
 		return
@@ -1179,7 +1179,14 @@ func (l *supervisorLoop) routeFailure(failure OpError) {
 	}
 }
 
-func (l *supervisorLoop) recordFingerprint(fingerprint string) bool {
+func (l *supervisorLoop) recordFingerprint(class FailureClass, fingerprint string) bool {
+	// Connectivity failures are paced by bounded exponential backoff and must
+	// remain recoverable without user action, even when every attempt reports
+	// the same transport fingerprint. The circuit remains available for
+	// repeated non-transient failures such as an ineffective credential repair.
+	if class == FailureTransient {
+		return false
+	}
 	if fingerprint == "" {
 		l.sameFingerprint = ""
 		l.sameFailureCount = 0

--- a/internal/bridge/supervisor_test.go
+++ b/internal/bridge/supervisor_test.go
@@ -315,44 +315,99 @@ func TestSupervisorRateLimitedHonorsRetryAt(t *testing.T) {
 	}
 }
 
-func TestSupervisorRepeatedFingerprintOpensCircuit(t *testing.T) {
+func TestSupervisorRepeatedTransientFingerprintRecoversAfterCircuitThreshold(t *testing.T) {
 	clock := newSupervisorManualClock(supervisorTestEpoch)
 	policy := supervisorTestPolicy()
 	policy.MaxSameFingerprint = 3
-	lifecycle := &supervisorTestLifecycle{scripts: []supervisorStartScript{
-		{err: transientSupervisorError("same-poison")},
-		{err: transientSupervisorError("same-poison")},
-		{err: transientSupervisorError("same-poison")},
-	}}
-	random := &supervisorScriptedRandom{values: []int64{
-		int64(time.Second),
-		int64(2 * time.Second),
-	}}
+	const transientFailures = 6
+	recoveredRun := newSupervisorTestRun()
+	scripts := make([]supervisorStartScript, 0, transientFailures+1)
+	randomValues := make([]int64, 0, transientFailures)
+	for range transientFailures {
+		scripts = append(scripts, supervisorStartScript{
+			err: transientSupervisorError("connect_failed"),
+		})
+		randomValues = append(randomValues, int64(time.Second))
+	}
+	scripts = append(scripts, supervisorStartScript{run: recoveredRun})
+	lifecycle := &supervisorTestLifecycle{scripts: scripts}
+	random := &supervisorScriptedRandom{values: randomValues}
 	supervisor := newTestSupervisor(t, lifecycle, policy, clock, random)
 
 	if err := supervisorStart(t, supervisor, StartRequest{}); err == nil {
 		t.Fatal("Start() error = nil, want transient failure")
 	}
-	for generation := Generation(1); generation < 3; generation++ {
-		snapshot := awaitSupervisorSnapshot(t, supervisor, "pre-circuit backoff", func(snapshot Snapshot) bool {
+	for generation := Generation(1); generation <= transientFailures; generation++ {
+		snapshot := awaitSupervisorSnapshot(t, supervisor, "transient backoff", func(snapshot Snapshot) bool {
 			return snapshot.State == StateBackoff && snapshot.Generation == generation
 		})
+		if snapshot.ErrorClass != FailureTransient || snapshot.ErrorFingerprint != "connect_failed" {
+			t.Fatalf("generation %d snapshot = %+v, want transient connect_failed backoff", generation, snapshot)
+		}
 		clock.Advance(snapshot.RetryAt.Sub(clock.Now()))
 		awaitSupervisorStartCount(t, lifecycle, int(generation)+1)
 	}
-	blocked := awaitSupervisorSnapshot(t, supervisor, "open circuit", func(snapshot Snapshot) bool {
-		return snapshot.State == StateBlocked && snapshot.Generation == 3
+
+	recoveredRun.MarkReady()
+	online := awaitSupervisorSnapshot(t, supervisor, "automatic recovery", func(snapshot Snapshot) bool {
+		return snapshot.State == StateOnline && snapshot.Generation == transientFailures+1
 	})
-	if blocked.ErrorFingerprint != "same-poison" || blocked.ErrorClass != FailureTransient {
-		t.Fatalf("circuit snapshot = %+v", blocked)
+	if !online.RetryAt.IsZero() || online.ErrorClass != "" || online.ErrorFingerprint != "" {
+		t.Fatalf("recovered snapshot retains failure state: %+v", online)
 	}
-	if !blocked.RetryAt.IsZero() {
-		t.Fatalf("circuit RetryAt = %s, want zero", blocked.RetryAt)
+}
+
+func TestSupervisorRepeatedCredentialFingerprintStillOpensCircuit(t *testing.T) {
+	clock := newSupervisorManualClock(supervisorTestEpoch)
+	policy := supervisorTestPolicy()
+	policy.MaxSameFingerprint = 3
+	failure := OpError{
+		Class:       FailureCredentialsExpired,
+		Operation:   "start",
+		Fingerprint: "expired-cookie-set",
+	}
+	lifecycle := &supervisorTestLifecycle{scripts: []supervisorStartScript{
+		{err: failure},
+		{err: failure},
+		{err: failure},
+	}}
+	repairer := newSupervisorControlledRepairer()
+	supervisor := newTestSupervisor(
+		t,
+		lifecycle,
+		policy,
+		clock,
+		&supervisorScriptedRandom{},
+		WithCredentialRepairer(repairer),
+	)
+
+	if err := supervisorStart(t, supervisor, StartRequest{}); err == nil {
+		t.Fatal("Start() error = nil, want credentials-expired failure")
+	}
+	for generation := Generation(1); generation < Generation(policy.MaxSameFingerprint); generation++ {
+		call := receiveSupervisorValue(t, repairer.started, "credential repair start")
+		if call.failure.Fingerprint != failure.Fingerprint {
+			t.Fatalf("generation %d repair fingerprint = %q, want %q", generation, call.failure.Fingerprint, failure.Fingerprint)
+		}
+		sendSupervisorValue(t, repairer.responses, error(nil), "successful credential repair")
+		awaitSupervisorStartCount(t, lifecycle, int(generation)+1)
+	}
+
+	blocked := awaitSupervisorSnapshot(t, supervisor, "credential circuit", func(snapshot Snapshot) bool {
+		return snapshot.State == StateBlocked && snapshot.Generation == Generation(policy.MaxSameFingerprint)
+	})
+	if blocked.ErrorClass != FailureCredentialsExpired || blocked.ErrorFingerprint != failure.Fingerprint {
+		t.Fatalf("credential circuit snapshot = %+v", blocked)
+	}
+	select {
+	case call := <-repairer.started:
+		t.Fatalf("credential repair ran after circuit opened: %+v", call)
+	default:
 	}
 	clock.Advance(24 * time.Hour)
 	supervisorSync(t, supervisor)
-	if got := lifecycle.CallCount(); got != 3 {
-		t.Fatalf("starts after circuit opened = %d, want 3", got)
+	if got := lifecycle.CallCount(); got != policy.MaxSameFingerprint {
+		t.Fatalf("starts after credential circuit opened = %d, want %d", got, policy.MaxSameFingerprint)
 	}
 }
 

--- a/internal/bridgeadapters/google/google.go
+++ b/internal/bridgeadapters/google/google.go
@@ -1,0 +1,608 @@
+// Package google adapts the pinned libgm connection lifecycle to one
+// generation-owned bridge.Run. Legacy send/read/media operations continue to
+// use app.App.GetClient and are intentionally outside this adapter.
+package google
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+
+	"go.mau.fi/mautrix-gmessages/pkg/libgm"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/events"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/client"
+)
+
+type transportClient interface {
+	SetEventHandler(libgm.EventHandler)
+	Connect() error
+	Disconnect()
+	NotifyDittoActivity() (<-chan *libgm.IncomingRPCMessage, error)
+}
+
+type clientFactory func() (*client.Client, transportClient, error)
+
+// Adapter owns Google connection generations while leaving the legacy
+// transport operations installed on App.
+type Adapter struct {
+	accountID string
+	host      *app.App
+	canRepair func() bool
+	newClient clientFactory
+
+	mu       sync.Mutex
+	current  *run
+	starting bool
+}
+
+func New(accountID string, host *app.App, canRepair func() bool) *Adapter {
+	a := &Adapter{accountID: accountID, host: host, canRepair: canRepair}
+	a.newClient = a.loadClient
+	return a
+}
+
+func (a *Adapter) AccountID() string { return a.accountID }
+
+func (a *Adapter) Platform() bridge.Platform { return bridge.PlatformGoogle }
+
+func (a *Adapter) DeclaredCapabilities() bridge.CapabilitySet {
+	return bridge.CapabilitySet{
+		StartConversation: true,
+		TextSend:          true,
+		MediaSend:         true,
+		Reactions:         true,
+		ReadReceipts:      true,
+		PairQR:            true,
+		MediaDownload:     true,
+	}
+}
+
+func (a *Adapter) loadClient() (*client.Client, transportClient, error) {
+	data, err := client.LoadSession(a.host.SessionPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load Google session: %w", err)
+	}
+	legacy, err := client.NewFromSession(data, a.host.Logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create Google client: %w", err)
+	}
+	return legacy, legacy.GM, nil
+}
+
+func (a *Adapter) Start(
+	ctx context.Context,
+	req bridge.StartRequest,
+	sink bridge.ConnectionSink,
+) (bridge.Run, error) {
+	overlapFailure := func() bridge.OpError {
+		return bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "overlapping_google_generation",
+			Cause:       errors.New("a Google generation is already active"),
+		}
+	}
+	if ctx == nil {
+		return nil, errors.New("google lifecycle: nil start context")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if a == nil {
+		return nil, bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "google_adapter_unconfigured",
+			Cause:       errors.New("Google lifecycle adapter is nil"),
+		}
+	}
+	if req.AccountID != a.accountID {
+		return nil, fmt.Errorf("google lifecycle: account %q does not match %q", req.AccountID, a.accountID)
+	}
+	if a.host == nil || a.newClient == nil {
+		return nil, bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "google_adapter_unconfigured",
+			Cause:       errors.New("Google lifecycle adapter is not configured"),
+		}
+	}
+
+	// Reserve the only start slot before loading or installing a client. The
+	// supervisor is the production caller, but this guard also prevents a
+	// concurrent accidental Start from replacing App's active generation
+	// before the overlap is detected.
+	a.mu.Lock()
+	if a.current != nil || a.starting {
+		a.mu.Unlock()
+		return nil, overlapFailure()
+	}
+	a.starting = true
+	a.mu.Unlock()
+	installed := false
+	defer func() {
+		if installed {
+			return
+		}
+		a.mu.Lock()
+		a.starting = false
+		a.mu.Unlock()
+	}()
+
+	legacy, transport, err := a.newClient()
+	if err != nil {
+		failure := classifyStartError(err)
+		if a.host.GooglePaired() {
+			a.host.FlagGoogleNeedsRepair()
+		}
+		return nil, failure
+	}
+	if legacy == nil || transport == nil {
+		return nil, bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "google_client_factory_nil",
+			Cause:       errors.New("Google client factory returned a nil client"),
+		}
+	}
+	generation := a.host.BeginGoogleGeneration(legacy)
+	r := &run{
+		adapter:    a,
+		request:    req,
+		sink:       sink,
+		transport:  transport,
+		generation: generation,
+		ready:      make(chan struct{}),
+		done:       make(chan error, 1),
+		stopped:    make(chan struct{}),
+		finish:     make(chan error, 1),
+		activity:   make(chan struct{}),
+		admitting:  true,
+	}
+	transport.SetEventHandler(r.handleEvent)
+	a.mu.Lock()
+	a.current = r
+	a.starting = false
+	installed = true
+	a.mu.Unlock()
+
+	if err := transport.Connect(); err != nil {
+		failure := a.classifyTransportError(err, "connect", "connect_failed")
+		r.applyFailureStatus(failure)
+		r.closeAdmission()
+		transport.SetEventHandler(nil)
+		transport.Disconnect()
+		r.callbacks.Wait()
+		generation.Release()
+		a.clearCurrent(r)
+		return nil, failure
+	}
+	go r.coordinate(ctx)
+	return r, nil
+}
+
+// ReportError terminates the current generation from an unchanged legacy
+// operation path (notably a send/read HTTP 401). The supervisor remains the
+// sole owner of repair and reconnect.
+func (a *Adapter) ReportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	r := a.currentRun()
+	if r == nil || !r.admitCallback() {
+		return false
+	}
+	defer r.callbacks.Done()
+	failure := a.classifyTransportError(err, "operation", "operation_failed")
+	r.applyFailureStatus(failure)
+	r.requestFinish(failure)
+	return true
+}
+
+// ParkCurrent reports a terminal blocked condition such as a known-dead
+// linked session for which no automatic cookie refresh is available.
+func (a *Adapter) ParkCurrent(err error) bool {
+	if err == nil {
+		err = errors.New("Google connection requires manual repair")
+	}
+	r := a.currentRun()
+	if r == nil || !r.admitCallback() {
+		return false
+	}
+	defer r.callbacks.Done()
+	failure := bridge.OpError{
+		Class:       bridge.FailureUpgradeRequired,
+		Operation:   "repair",
+		Fingerprint: "google_manual_repair_required",
+		Cause:       err,
+	}
+	r.applyFailureStatus(failure)
+	r.requestFinish(failure)
+	return true
+}
+
+func (a *Adapter) currentRun() *run {
+	a.mu.Lock()
+	r := a.current
+	a.mu.Unlock()
+	return r
+}
+
+func (a *Adapter) clearCurrent(candidate *run) {
+	a.mu.Lock()
+	if a.current == candidate {
+		a.current = nil
+	}
+	a.mu.Unlock()
+}
+
+func (a *Adapter) repairAvailable() bool {
+	return a.canRepair != nil && a.canRepair()
+}
+
+func (a *Adapter) classifyTransportError(err error, operation, fingerprint string) bridge.OpError {
+	if err == nil {
+		err = errors.New("Google transport ended without an error")
+	}
+	if failure, ok := asOpError(err); ok {
+		return failure
+	}
+	if app.IsGoogleAuthExpiredError(err) {
+		class := bridge.FailureCredentialsExpired
+		if !a.repairAvailable() {
+			class = bridge.FailureUpgradeRequired
+		}
+		return bridge.OpError{
+			Class:       class,
+			Operation:   operation,
+			Fingerprint: "google_auth_expired",
+			Cause:       err,
+		}
+	}
+	lower := strings.ToLower(err.Error())
+	if strings.Contains(lower, "no auth token") || strings.Contains(lower, "not logged in") {
+		return bridge.OpError{
+			Class:       bridge.FailureReauthRequired,
+			Operation:   operation,
+			Fingerprint: "google_session_invalid",
+			Cause:       err,
+		}
+	}
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   operation,
+		Fingerprint: fingerprint,
+		Cause:       err,
+	}
+}
+
+func classifyStartError(err error) bridge.OpError {
+	class := bridge.FailureReauthRequired
+	fingerprint := "google_session_unusable"
+	if !errors.Is(err, os.ErrNotExist) && !strings.Contains(strings.ToLower(err.Error()), "unmarshal") {
+		class = bridge.FailureMisconfigured
+		fingerprint = "google_session_load_failed"
+	}
+	return bridge.OpError{
+		Class:       class,
+		Operation:   "load_credentials",
+		Fingerprint: fingerprint,
+		Cause:       err,
+	}
+}
+
+func asOpError(err error) (bridge.OpError, bool) {
+	var pointer *bridge.OpError
+	if errors.As(err, &pointer) && pointer != nil {
+		return *pointer, true
+	}
+	var value bridge.OpError
+	if errors.As(err, &value) {
+		return value, true
+	}
+	return bridge.OpError{}, false
+}
+
+type run struct {
+	adapter    *Adapter
+	request    bridge.StartRequest
+	sink       bridge.ConnectionSink
+	transport  transportClient
+	generation *app.GoogleGeneration
+
+	ready      chan struct{}
+	done       chan error
+	stopped    chan struct{}
+	finish     chan error
+	readyOnce  sync.Once
+	finishOnce sync.Once
+
+	admissionMu sync.Mutex
+	admitting   bool
+	callbacks   sync.WaitGroup
+
+	activityMu         sync.Mutex
+	activity           chan struct{}
+	lastActivityAt     time.Time
+	lastActivityDetail string
+	phoneNotResponding bool
+}
+
+func (r *run) Ready() <-chan struct{} { return r.ready }
+
+func (r *run) Done() <-chan error { return r.done }
+
+func (r *run) Probe(ctx context.Context) (bridge.Liveness, error) {
+	if ctx == nil {
+		return bridge.Liveness{}, errors.New("google probe: nil context")
+	}
+	response, err := r.transport.NotifyDittoActivity()
+	if err != nil {
+		failure := r.adapter.classifyTransportError(err, "probe", "google_probe_send_failed")
+		return bridge.Liveness{}, failure
+	}
+	if liveness, activity := r.probeActivity(); liveness.Detail == "phone_not_responding" {
+		// NotifyDittoActivity is answered by the Android phone, not by the
+		// Google long-poll service. Once libgm's own pinger has established
+		// that the phone is offline, an absent response is expected and must
+		// not turn a healthy linked-device generation into reconnect churn.
+		return liveness, nil
+	} else {
+		select {
+		case _, ok := <-response:
+			if !ok {
+				return bridge.Liveness{}, bridge.OpError{
+					Class:       bridge.FailureTransient,
+					Operation:   "probe",
+					Fingerprint: "google_probe_response_closed",
+					Cause:       errors.New("Google liveness response closed"),
+				}
+			}
+			return bridge.Liveness{AliveAt: time.Now(), Detail: "notify_ditto_activity"}, nil
+		case <-activity:
+			// A pinger or long-poll event racing the probe is direct evidence
+			// that the client machinery is still running. In particular, a
+			// PhoneNotResponding event proves the missing probe response is a
+			// phone-reachability condition rather than a dead Google link.
+			liveness, _ := r.probeActivity()
+			return liveness, nil
+		case <-r.stopped:
+			return bridge.Liveness{}, errors.New("Google generation ended during liveness probe")
+		case <-ctx.Done():
+			if liveness, _ := r.probeActivity(); liveness.Detail == "phone_not_responding" {
+				return liveness, nil
+			}
+			return bridge.Liveness{}, ctx.Err()
+		}
+	}
+}
+
+func (r *run) Stop(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("google run: nil stop context")
+	}
+	r.requestFinish(nil)
+	select {
+	case <-r.stopped:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *run) coordinate(ctx context.Context) {
+	var terminal error
+	select {
+	case terminal = <-r.finish:
+	case <-ctx.Done():
+		terminal = ctx.Err()
+	}
+
+	r.closeAdmission()
+	r.transport.SetEventHandler(nil)
+	r.transport.Disconnect()
+	r.callbacks.Wait()
+	if terminal == nil || errors.Is(terminal, context.Canceled) {
+		r.generation.ConnectionLost()
+	}
+	r.generation.Release()
+	r.adapter.clearCurrent(r)
+	r.done <- terminal
+	close(r.done)
+	close(r.stopped)
+}
+
+func (r *run) requestFinish(err error) {
+	r.finishOnce.Do(func() {
+		// Make the terminal decision close callback admission immediately. This
+		// prevents a second libgm or legacy-operation callback from racing in
+		// with a different failure class before the supervisor retires the run.
+		r.closeAdmission()
+		r.finish <- err
+	})
+}
+
+func (r *run) closeAdmission() {
+	r.admissionMu.Lock()
+	r.admitting = false
+	r.admissionMu.Unlock()
+}
+
+func (r *run) admitCallback() bool {
+	r.admissionMu.Lock()
+	defer r.admissionMu.Unlock()
+	if !r.admitting {
+		return false
+	}
+	r.callbacks.Add(1)
+	return true
+}
+
+func (r *run) handleEvent(evt any) {
+	if !r.admitCallback() {
+		return
+	}
+	defer r.callbacks.Done()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			r.adapter.host.Logger.Error().
+				Interface("panic", recovered).
+				Bytes("stack", debug.Stack()).
+				Msg("Recovered from panic in Google Messages event handler")
+			r.generation.SyncInterrupted()
+			r.requestFinish(bridge.OpError{
+				Class:       bridge.FailureTransient,
+				Operation:   "event",
+				Fingerprint: "google_event_handler_panic",
+				Cause:       fmt.Errorf("panic in Google Messages event handler: %v", recovered),
+			})
+		}
+	}()
+
+	eventAt := time.Now()
+	if eventProvidesLiveness(evt) {
+		detail := googleEventDetail(evt)
+		r.recordActivity(evt, eventAt, detail)
+		if r.sink != nil {
+			r.sink.Beat(r.request.Generation, eventAt, detail)
+		}
+	}
+	if eventMakesReady(evt) {
+		r.readyOnce.Do(func() {
+			if r.generation.Ready() {
+				close(r.ready)
+			}
+		})
+	}
+
+	r.generation.Handler.Handle(evt)
+	if failure, terminal := r.classifyEvent(evt); terminal {
+		if failure.Class == bridge.FailureCredentialsExpired ||
+			failure.Class == bridge.FailureUpgradeRequired {
+			r.applyFailureStatus(failure)
+		}
+		r.requestFinish(failure)
+	}
+}
+
+func (r *run) classifyEvent(evt any) (bridge.OpError, bool) {
+	switch event := evt.(type) {
+	case *events.ListenFatalError:
+		// ListenFatalError still keeps the stored linked-device session. Its
+		// cause decides whether the supervisor retries that session directly or
+		// repairs expired Google cookies before starting a new generation.
+		return r.adapter.classifyTransportError(
+			event.Error,
+			"listen",
+			"google_listen_fatal",
+		), true
+	case *events.GaiaLoggedOut:
+		return bridge.OpError{
+			Class:       bridge.FailureReauthRequired,
+			Operation:   "listen",
+			Fingerprint: "google_gaia_logged_out",
+			Cause:       errors.New("Google account logged out server-side"),
+		}, true
+	case *events.PingFailed:
+		if event.ErrorCount >= 3 {
+			return bridge.OpError{
+				Class:       bridge.FailureTransient,
+				Operation:   "ping",
+				Fingerprint: "google_ping_failed",
+				Cause:       event.Error,
+			}, true
+		}
+	}
+	return bridge.OpError{}, false
+}
+
+func (r *run) applyFailureStatus(failure bridge.OpError) {
+	switch failure.Class {
+	case bridge.FailureCredentialsExpired:
+		r.generation.AuthExpired(failure.Cause)
+	case bridge.FailureUpgradeRequired, bridge.FailureMisconfigured, bridge.FailureUnsupported:
+		if app.IsGoogleAuthExpiredError(failure.Cause) {
+			r.generation.AuthExpired(failure.Cause)
+		}
+		r.adapter.host.FlagGoogleNeedsRepair()
+	case bridge.FailureReauthRequired:
+		// GaiaLoggedOut is applied by the legacy handler, which also preserves
+		// the exact session deletion behavior. Other reauth failures merely end
+		// the generation and park the still-present stored session for the UI.
+		if r.adapter.host.GooglePaired() {
+			r.adapter.host.FlagGoogleNeedsRepair()
+		}
+	default:
+		r.generation.ConnectionLost()
+	}
+}
+
+func eventMakesReady(evt any) bool {
+	switch evt.(type) {
+	case *events.ListenRecovered, *events.PhoneNotResponding,
+		*events.PhoneRespondingAgain, *events.NoDataReceived,
+		*libgm.WrappedMessage, *gmproto.Conversation, *gmproto.TypingData:
+		return true
+	default:
+		return false
+	}
+}
+
+func eventProvidesLiveness(evt any) bool {
+	switch evt.(type) {
+	case *libgm.WrappedMessage, *gmproto.Conversation, *gmproto.TypingData,
+		*events.ListenRecovered, *events.PhoneNotResponding,
+		*events.PhoneRespondingAgain, *events.NoDataReceived:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *run) recordActivity(evt any, at time.Time, detail string) {
+	r.activityMu.Lock()
+	r.lastActivityAt = at
+	r.lastActivityDetail = detail
+	switch evt.(type) {
+	case *events.PhoneNotResponding:
+		r.phoneNotResponding = true
+	case *events.PhoneRespondingAgain:
+		r.phoneNotResponding = false
+	}
+	close(r.activity)
+	r.activity = make(chan struct{})
+	r.activityMu.Unlock()
+}
+
+func (r *run) probeActivity() (bridge.Liveness, <-chan struct{}) {
+	r.activityMu.Lock()
+	defer r.activityMu.Unlock()
+	liveness := bridge.Liveness{
+		AliveAt: r.lastActivityAt,
+		Detail:  r.lastActivityDetail,
+	}
+	if r.phoneNotResponding {
+		liveness.AliveAt = time.Now()
+		liveness.Detail = "phone_not_responding"
+	}
+	return liveness, r.activity
+}
+
+func googleEventDetail(evt any) string {
+	return fmt.Sprintf("event:%T", evt)
+}
+
+var (
+	_ bridge.Adapter            = (*Adapter)(nil)
+	_ bridge.CapabilityDeclarer = (*Adapter)(nil)
+	_ bridge.Run                = (*run)(nil)
+)

--- a/internal/bridgeadapters/google/google_test.go
+++ b/internal/bridgeadapters/google/google_test.go
@@ -1,0 +1,545 @@
+package google
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/events"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/client"
+)
+
+func TestEventFailureClassification(t *testing.T) {
+	a := New("google-primary", nil, func() bool { return true })
+	r := &run{adapter: a}
+
+	tests := []struct {
+		name      string
+		event     any
+		terminal  bool
+		wantClass bridge.FailureClass
+	}{
+		{
+			name:      "listen fatal transient",
+			event:     &events.ListenFatalError{Error: errors.New("temporary token refresh failure")},
+			terminal:  true,
+			wantClass: bridge.FailureTransient,
+		},
+		{
+			name:      "listen fatal without cause is transient",
+			event:     &events.ListenFatalError{},
+			terminal:  true,
+			wantClass: bridge.FailureTransient,
+		},
+		{
+			name:      "listen fatal auth expiry requires credential repair",
+			event:     &events.ListenFatalError{Error: errors.New("HTTP 401: invalid authentication credentials")},
+			terminal:  true,
+			wantClass: bridge.FailureCredentialsExpired,
+		},
+		{
+			name:      "Gaia logout requires reauth",
+			event:     &events.GaiaLoggedOut{},
+			terminal:  true,
+			wantClass: bridge.FailureReauthRequired,
+		},
+		{
+			name:     "second ping is tolerated",
+			event:    &events.PingFailed{ErrorCount: 2},
+			terminal: false,
+		},
+		{
+			name:      "third ping ends generation",
+			event:     &events.PingFailed{ErrorCount: 3, Error: errors.New("phone ping failed")},
+			terminal:  true,
+			wantClass: bridge.FailureTransient,
+		},
+		{
+			name:     "phone offline is not credential failure",
+			event:    &events.PhoneNotResponding{},
+			terminal: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			failure, terminal := r.classifyEvent(test.event)
+			if terminal != test.terminal {
+				t.Fatalf("terminal = %v, want %v", terminal, test.terminal)
+			}
+			if failure.Class != test.wantClass {
+				t.Fatalf("class = %q, want %q", failure.Class, test.wantClass)
+			}
+		})
+	}
+}
+
+func TestAuthExpiredWithoutRepairIsBlocked(t *testing.T) {
+	a := New("google-primary", nil, func() bool { return false })
+	failure := a.classifyTransportError(
+		errors.New("HTTP 401: invalid authentication credentials"),
+		"connect",
+		"connect_failed",
+	)
+	if failure.Class != bridge.FailureUpgradeRequired {
+		t.Fatalf("class = %q, want %q", failure.Class, bridge.FailureUpgradeRequired)
+	}
+}
+
+func TestReadyUsesForkRealPingerSignal(t *testing.T) {
+	host := newTestApp(t)
+	fake := &fakeTransport{probeResponse: make(chan *libgm.IncomingRPCMessage, 1)}
+	a := newTestAdapter(t, host, fake)
+	sink := &recordingSink{}
+
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 1,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+
+	assertNotClosed(t, run.Ready(), "Connect return")
+	fake.emit(&events.AuthTokenRefreshed{})
+	assertNotClosed(t, run.Ready(), "AuthTokenRefreshed")
+
+	fake.emit(&events.PhoneNotResponding{})
+	select {
+	case <-run.Ready():
+	case <-time.After(time.Second):
+		t.Fatal("Ready did not close after the fork's PhoneNotResponding pinger signal")
+	}
+	if !host.Connected.Load() {
+		t.Fatal("compatibility Connected status was not published on readiness")
+	}
+	if host.GoogleStatus().PhoneResponding {
+		t.Fatal("PhoneNotResponding readiness evidence was mistaken for phone reachability")
+	}
+	if got := sink.beatCount(); got != 1 {
+		t.Fatalf("liveness beats = %d, want 1", got)
+	}
+}
+
+func TestReadyUsesForkRealLongPollDataEvidence(t *testing.T) {
+	tests := []struct {
+		name  string
+		event any
+	}{
+		{name: "no data pinger signal", event: &events.NoDataReceived{}},
+		{name: "phone responding pinger signal", event: &events.PhoneRespondingAgain{}},
+		{name: "conversation", event: &gmproto.Conversation{ConversationID: "ready-conversation"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			host := newTestApp(t)
+			fake := &fakeTransport{}
+			a := newTestAdapter(t, host, fake)
+			run, err := a.Start(context.Background(), bridge.StartRequest{
+				AccountID:  "google-primary",
+				Generation: 1,
+			}, nil)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			t.Cleanup(func() { stopRun(t, run) })
+
+			fake.emit(test.event)
+			select {
+			case <-run.Ready():
+			case <-time.After(time.Second):
+				t.Fatalf("Ready did not close after %T", test.event)
+			}
+		})
+	}
+}
+
+func TestLateCallbackCannotMutateNewGeneration(t *testing.T) {
+	host := newTestApp(t)
+	firstTransport := &fakeTransport{}
+	secondTransport := &fakeTransport{}
+	transports := []*fakeTransport{firstTransport, secondTransport}
+	a := New("google-primary", host, func() bool { return true })
+	a.newClient = func() (*client.Client, transportClient, error) {
+		transport := transports[0]
+		transports = transports[1:]
+		return newLegacyClient(t), transport, nil
+	}
+
+	first, err := a.Start(context.Background(), bridge.StartRequest{AccountID: "google-primary", Generation: 1}, nil)
+	if err != nil {
+		t.Fatalf("first Start() error = %v", err)
+	}
+	firstHandler := firstTransport.currentHandler()
+	firstTransport.emit(&events.PhoneNotResponding{})
+	<-first.Ready()
+	a.ReportError(errors.New("temporary disconnect"))
+	terminalError(t, first.Done(), bridge.FailureTransient)
+
+	second, err := a.Start(context.Background(), bridge.StartRequest{AccountID: "google-primary", Generation: 2}, nil)
+	if err != nil {
+		t.Fatalf("second Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, second) })
+	secondTransport.emit(&gmproto.Conversation{ConversationID: "generation-2-ready"})
+	<-second.Ready()
+	current := host.GetClient()
+
+	firstHandler(&events.GaiaLoggedOut{})
+	if host.GetClient() != current {
+		t.Fatal("late generation-1 callback replaced or cleared generation-2 client")
+	}
+	if !host.Connected.Load() {
+		t.Fatal("late generation-1 callback marked generation 2 disconnected")
+	}
+	if !host.GooglePaired() {
+		t.Fatal("late generation-1 callback deleted current stored session")
+	}
+}
+
+func TestRecoveredHandlerPanicEndsGenerationTransient(t *testing.T) {
+	host := newTestApp(t)
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	run, err := a.Start(context.Background(), bridge.StartRequest{AccountID: "google-primary", Generation: 1}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	host.EventHandler.OnSessionInvalid = func() { panic("malformed Google event") }
+	fake.emit(&events.GaiaLoggedOut{})
+	terminalError(t, run.Done(), bridge.FailureTransient)
+	if host.Connected.Load() {
+		t.Fatal("recovered callback panic left Google connected")
+	}
+}
+
+func TestParkCurrentClearsConnectedAndSurfacesNeedsRepair(t *testing.T) {
+	host := newTestApp(t)
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	fake.emit(&gmproto.Conversation{ConversationID: "park-ready"})
+	<-run.Ready()
+	if !host.Connected.Load() {
+		t.Fatal("precondition: generation did not publish connected status")
+	}
+
+	if !a.ParkCurrent(errors.New("linked device requires repair")) {
+		t.Fatal("ParkCurrent() did not terminate the active generation")
+	}
+	terminalError(t, run.Done(), bridge.FailureUpgradeRequired)
+	if host.Connected.Load() {
+		t.Fatal("parked generation left compatibility Connected=true")
+	}
+	if !host.GoogleStatus().NeedsRepair {
+		t.Fatal("parked generation did not surface needs_repair")
+	}
+}
+
+func TestStopWaitsForAdmittedCallback(t *testing.T) {
+	host := newTestApp(t)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	host.OnStatusChange = func(connected bool) {
+		if connected {
+			close(entered)
+			<-release
+		}
+	}
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	run, err := a.Start(context.Background(), bridge.StartRequest{AccountID: "google-primary", Generation: 1}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	go fake.emit(&gmproto.Conversation{ConversationID: "stop-ready"})
+	<-entered
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := run.Stop(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop() error = %v, want deadline while callback is admitted", err)
+	}
+	close(release)
+	stopRun(t, run)
+	if fake.disconnectCount() != 1 {
+		t.Fatalf("Disconnect calls = %d, want 1", fake.disconnectCount())
+	}
+}
+
+func TestProbeCompletionCannotConsumeRunTerminalError(t *testing.T) {
+	host := newTestApp(t)
+	fake := &fakeTransport{probeResponse: make(chan *libgm.IncomingRPCMessage)}
+	a := newTestAdapter(t, host, fake)
+	run, err := a.Start(context.Background(), bridge.StartRequest{AccountID: "google-primary", Generation: 1}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	probeDone := make(chan error, 1)
+	go func() {
+		_, probeErr := run.Probe(context.Background())
+		probeDone <- probeErr
+	}()
+	a.ReportError(errors.New("temporary disconnect"))
+	select {
+	case err := <-probeDone:
+		if err == nil {
+			t.Fatal("Probe unexpectedly succeeded after generation ended")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Probe did not stop with its generation")
+	}
+	terminalError(t, run.Done(), bridge.FailureTransient)
+}
+
+func TestProbeWithoutProtocolActivityStillTimesOut(t *testing.T) {
+	host := newTestApp(t)
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, probeErr := run.Probe(ctx); !errors.Is(probeErr, context.DeadlineExceeded) {
+		t.Fatalf("Probe error = %v, want deadline with no pinger or long-poll activity", probeErr)
+	}
+}
+
+func TestPhoneUnreachableSurvivesRepeatedLivenessWindowsAndRecovers(t *testing.T) {
+	host := newTestApp(t)
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	sink := &recordingSink{}
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 1,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+
+	// The pinned fork emits this after its first ditto ping times out. It is
+	// readiness evidence for the linked-device session, but not evidence that
+	// the Android phone itself is reachable.
+	fake.emit(&events.PhoneNotResponding{})
+	select {
+	case <-run.Ready():
+	case <-time.After(time.Second):
+		t.Fatal("PhoneNotResponding did not make the generation ready")
+	}
+	if host.GoogleStatus().PhoneResponding {
+		t.Fatal("precondition: phone should be recorded as unreachable")
+	}
+
+	// Model three consecutive supervisor liveness windows. NotifyDittoActivity
+	// has no phone response in any window, but the known phone-off state keeps
+	// the healthy generation alive instead of triggering reconnect churn.
+	for window := 1; window <= 3; window++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		liveness, probeErr := run.Probe(ctx)
+		cancel()
+		if probeErr != nil {
+			t.Fatalf("Probe window %d error = %v", window, probeErr)
+		}
+		if liveness.Detail != "phone_not_responding" {
+			t.Fatalf("Probe window %d detail = %q, want phone_not_responding", window, liveness.Detail)
+		}
+		select {
+		case err := <-run.Done():
+			t.Fatalf("generation ended during phone-off window %d: %v", window, err)
+		default:
+		}
+	}
+	if got := fake.probeCount(); got != 3 {
+		t.Fatalf("NotifyDittoActivity calls = %d, want 3", got)
+	}
+
+	// Because the generation and its callback remain installed, the fork's
+	// recovery signal is still handled and renews liveness/reconciliation.
+	fake.emit(&events.PhoneRespondingAgain{})
+	if !host.GoogleStatus().PhoneResponding {
+		t.Fatal("PhoneRespondingAgain was ignored after repeated phone-off probes")
+	}
+	if got := sink.beatCount(); got != 2 {
+		t.Fatalf("liveness beats = %d, want 2 (offline and recovery)", got)
+	}
+	select {
+	case err := <-run.Done():
+		t.Fatalf("generation ended instead of accepting PhoneRespondingAgain: %v", err)
+	default:
+	}
+}
+
+func newTestApp(t *testing.T) *app.App {
+	t.Helper()
+	t.Setenv("OPENMESSAGES_DATA_DIR", t.TempDir())
+	t.Setenv("OPENMESSAGE_GOOGLE_AVATAR_SYNC", "0")
+	host, err := app.New(zerolog.Nop())
+	if err != nil {
+		t.Fatalf("app.New() error = %v", err)
+	}
+	if err := client.SaveSession(host.SessionPath, &client.SessionData{AuthDataJSON: []byte(`{}`)}); err != nil {
+		host.Close()
+		t.Fatalf("SaveSession() error = %v", err)
+	}
+	t.Cleanup(host.Close)
+	return host
+}
+
+func newLegacyClient(t *testing.T) *client.Client {
+	t.Helper()
+	legacy, err := client.NewFromSession(
+		&client.SessionData{AuthDataJSON: []byte(`{}`)},
+		zerolog.Nop(),
+	)
+	if err != nil {
+		t.Fatalf("NewFromSession() error = %v", err)
+	}
+	return legacy
+}
+
+func newTestAdapter(t *testing.T, host *app.App, fake *fakeTransport) *Adapter {
+	t.Helper()
+	a := New("google-primary", host, func() bool { return true })
+	a.newClient = func() (*client.Client, transportClient, error) {
+		return newLegacyClient(t), fake, nil
+	}
+	return a
+}
+
+func assertNotClosed(t *testing.T, channel <-chan struct{}, after string) {
+	t.Helper()
+	select {
+	case <-channel:
+		t.Fatalf("Ready closed after %s without a real long-poll event", after)
+	default:
+	}
+}
+
+func terminalError(t *testing.T, done <-chan error, want bridge.FailureClass) {
+	t.Helper()
+	select {
+	case err := <-done:
+		failure, ok := asOpError(err)
+		if !ok || failure.Class != want {
+			t.Fatalf("Done error = %v, want class %q", err, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Run.Done")
+	}
+}
+
+func stopRun(t *testing.T, run bridge.Run) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := run.Stop(ctx); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+}
+
+type fakeTransport struct {
+	mu            sync.Mutex
+	handler       libgm.EventHandler
+	connectErr    error
+	disconnects   int
+	probeResponse chan *libgm.IncomingRPCMessage
+	probeErr      error
+	probes        int
+}
+
+func (f *fakeTransport) SetEventHandler(handler libgm.EventHandler) {
+	f.mu.Lock()
+	f.handler = handler
+	f.mu.Unlock()
+}
+
+func (f *fakeTransport) Connect() error { return f.connectErr }
+
+func (f *fakeTransport) Disconnect() {
+	f.mu.Lock()
+	f.disconnects++
+	f.mu.Unlock()
+}
+
+func (f *fakeTransport) NotifyDittoActivity() (<-chan *libgm.IncomingRPCMessage, error) {
+	f.mu.Lock()
+	f.probes++
+	response, err := f.probeResponse, f.probeErr
+	f.mu.Unlock()
+	return response, err
+}
+
+func (f *fakeTransport) emit(event any) {
+	if handler := f.currentHandler(); handler != nil {
+		handler(event)
+	}
+}
+
+func (f *fakeTransport) currentHandler() libgm.EventHandler {
+	f.mu.Lock()
+	handler := f.handler
+	f.mu.Unlock()
+	return handler
+}
+
+func (f *fakeTransport) disconnectCount() int {
+	f.mu.Lock()
+	count := f.disconnects
+	f.mu.Unlock()
+	return count
+}
+
+func (f *fakeTransport) probeCount() int {
+	f.mu.Lock()
+	count := f.probes
+	f.mu.Unlock()
+	return count
+}
+
+type recordingSink struct {
+	mu    sync.Mutex
+	beats int
+}
+
+func (*recordingSink) AppendIngress(context.Context, bridge.RawIngressRecord) error { return nil }
+
+func (*recordingSink) EmitEphemeral(context.Context, bridge.EphemeralEvent) error { return nil }
+
+func (s *recordingSink) Beat(bridge.Generation, time.Time, string) {
+	s.mu.Lock()
+	s.beats++
+	s.mu.Unlock()
+}
+
+func (s *recordingSink) beatCount() int {
+	s.mu.Lock()
+	count := s.beats
+	s.mu.Unlock()
+	return count
+}


### PR DESCRIPTION
Wave 1 / C4 — the first live bridge on the C3 reliability core. Implemented by Sol; **two independent Fable adversarial reviews** + live verification by Claude. Runtime-affecting (deploys after live verification).

Replaces the `planGoogleReconnect` watchdog with a `bridge.Supervisor` owning the Google (libgm) connection generation. Send/read/media and the crown-jewel files (googlecookies, gm.go payloads, client.go extraction, panic-recover, token persistence) are untouched.

- **Adapter** maps the frozen event classification to `FailureClass` (transient→backoff, `IsGoogleAuthExpiredError`→credentials_expired/upgrade_required, GaiaLoggedOut→reauth, 3× PingFailed→terminal, PhoneNotResponding non-terminal). Readiness/liveness use **only events the pinned fork actually emits** (`ListenRecovered` on first poll, PhoneNotResponding/RespondingAgain, NoDataReceived, data events) — never `events.ClientReady`, which the fork never fires. The probe is **phone-aware** (a phone merely off holds a degraded generation, not a teardown).
- **Supervisor** owns reconnect (transient full-jitter backoff, **exempt from the fingerprint circuit** so a wifi/phone outage retries forever like the old watchdog; credential/upgrade loops still circuit-break), credential repair (a new generation starts **only** on a successful refresh, never after a failed one), and parking. An App-level notifier routes auth-expiry/park from **all** send paths incl. MCP. Unpair→re-pair rebuilds a fresh supervisor in-process. Startup connect/backfill runs in a tracked goroutine (WhatsApp/Signal/HTTP/MCP come up immediately; teardown joins it before the store closes).

## Why two reviews
The first adversarial pass caught that green tests **masked a live-fatal defect** — they drove readiness with `events.ClientReady`, which the fork never emits, so an ordinary wifi drop would have latched Google into permanent `StateBlocked` (silent death). The 7-item fix list was applied; the second pass verified every fix against the actual fork source (`ListenRecovered`/pinger semantics) and returned **mergeable**. `go test -race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
