### PR TITLE
Add MessageService text send over the durable outbox (rebuild Wave 2 / M1)

### DIFF
--- a/internal/messaging/dispatch.go
+++ b/internal/messaging/dispatch.go
@@ -1,0 +1,454 @@
+package messaging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+// Run recovers expired work once at startup and then periodically dispatches
+// due durable intents until ctx is canceled.
+func (s *MessageService) Run(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("run message service: context is nil")
+	}
+	recovered, err := s.outbox.RecoverExpiredLeases(ctx, s.clock.Now())
+	if err != nil {
+		return fmt.Errorf("run message service: recover expired leases: %w", err)
+	}
+	if recovered.NotDispatched > 0 || recovered.Uncertain > 0 {
+		s.signalChange()
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if _, err := s.DispatchDue(ctx, s.batchLimit); err != nil {
+			return fmt.Errorf("run message service: %w", err)
+		}
+
+		timer := s.clock.NewTimer(s.pollDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-s.wake:
+			timer.Stop()
+		case <-timer.C():
+		}
+	}
+}
+
+// DispatchDue claims and synchronously processes at most limit due intents.
+// Transport failures become durable states; only local state-machine failures
+// are returned.
+func (s *MessageService) DispatchDue(ctx context.Context, limit int) (int, error) {
+	if ctx == nil {
+		return 0, fmt.Errorf("dispatch due messages: context is nil")
+	}
+	if limit <= 0 {
+		return 0, fmt.Errorf("dispatch due messages: limit must be positive")
+	}
+	leases, err := s.outbox.LeaseDue(ctx, sqlite.LeaseRequest{
+		Owner:    workerOwner,
+		Now:      s.clock.Now(),
+		Duration: s.leaseTime,
+		Limit:    limit,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("lease due messages: %w", err)
+	}
+
+	processed := 0
+	for index, lease := range leases {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return processed, errors.Join(ctxErr, s.releaseUntouched(ctx, leases[index:]))
+		}
+		if lease.LeaseExpiresAtMS != nil && *lease.LeaseExpiresAtMS <= s.clock.Now().UnixMilli() {
+			mutationCtx, cancel := s.storageMutationContext(ctx)
+			recovered, recoverErr := s.outbox.RecoverExpiredLeases(mutationCtx, s.clock.Now())
+			cancel()
+			if recovered.NotDispatched > 0 || recovered.Uncertain > 0 {
+				s.signalChange()
+			}
+			if recoverErr != nil {
+				return processed, fmt.Errorf("recover leases expired during dispatch: %w", recoverErr)
+			}
+			break
+		}
+		if err := s.dispatchTextLease(ctx, lease); err != nil {
+			return processed, errors.Join(err, s.releaseUntouched(ctx, leases[index+1:]))
+		}
+		processed++
+	}
+	return processed, nil
+}
+
+func (s *MessageService) dispatchTextLease(ctx context.Context, outboxLease sqlite.Lease) error {
+	item := outboxLease.OutboxItem
+	if item.LeaseToken == nil {
+		return fmt.Errorf("dispatch outbox item %q: storage returned no lease token", item.OutboxID)
+	}
+	if item.Kind != sqlite.OutboxKindText {
+		return s.releaseUnavailable(ctx, item, fmt.Errorf(
+			"text dispatcher does not handle outbox kind %q",
+			item.Kind,
+		))
+	}
+
+	dispatchLease, err := s.bridges.Acquire(ctx, item.AccountID, bridge.CapabilityTextSend)
+	if err != nil {
+		if releaseErr := s.releaseUnavailable(ctx, item, err); releaseErr != nil {
+			return releaseErr
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return nil
+	}
+	if dispatchLease == nil || dispatchLease.Text == nil {
+		if dispatchLease != nil {
+			dispatchLease.Close()
+		}
+		return s.releaseUnavailable(ctx, item, bridge.ErrCapabilityUnavailable)
+	}
+	defer dispatchLease.Close()
+
+	message, err := s.messageForLease(ctx, item)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_message",
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	conversation, err := s.store.GetConversation(item.ConversationID)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_conversation",
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	if conversation.AccountID != item.AccountID {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"cross_account_conversation",
+			fmt.Errorf("conversation %q belongs to account %q", item.ConversationID, conversation.AccountID),
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+
+	if err := s.outbox.MarkTransportCalled(ctx, sqlite.Attempt{
+		OutboxID:             item.OutboxID,
+		LeaseToken:           *item.LeaseToken,
+		AttemptToken:         item.OutboxID + ":" + *item.LeaseToken,
+		ConnectionGeneration: uint64(dispatchLease.Generation),
+		StartedAt:            s.clock.Now(),
+	}); err != nil {
+		if ctx.Err() != nil {
+			return errors.Join(ctx.Err(), s.releaseUnavailable(ctx, item, err))
+		}
+		return fmt.Errorf("dispatch outbox item %q: mark transport called: %w", item.OutboxID, err)
+	}
+	s.signalChange()
+
+	request := bridge.TextRequest{
+		AccountID: item.AccountID,
+		Conversation: bridge.ConversationRef{
+			RemoteID: conversation.RemoteConversationID,
+		},
+		Body:      message.Body,
+		RequestID: item.TransportRequestID,
+	}
+	if message.ReplyToRemoteID != nil {
+		request.ReplyTo = &bridge.MessageRef{RemoteID: *message.ReplyToRemoteID}
+	}
+	result, sendErr := dispatchLease.Text.SendText(ctx, request)
+	mutationCtx, cancel := s.storageMutationContext(ctx)
+	defer cancel()
+	if sendErr != nil {
+		return s.recordSendError(mutationCtx, item, sendErr)
+	}
+	if strings.TrimSpace(result.RemoteMessageID) == "" {
+		if err := s.outbox.MarkUncertain(
+			mutationCtx,
+			item.OutboxID,
+			*item.LeaseToken,
+			"unknown",
+			"missing_remote_message_id",
+			"transport returned success without a remote message ID",
+		); err != nil {
+			return fmt.Errorf("dispatch outbox item %q: record invalid transport result: %w", item.OutboxID, err)
+		}
+		s.signalChange()
+		return nil
+	}
+
+	confirmation := sqlite.Confirmation{
+		OutboxID:       item.OutboxID,
+		LeaseToken:     *item.LeaseToken,
+		ResultRemoteID: result.RemoteMessageID,
+	}
+	if err := s.outbox.Confirm(mutationCtx, confirmation); err != nil {
+		storeErr := s.outbox.MarkStoreFailed(
+			mutationCtx,
+			item.OutboxID,
+			*item.LeaseToken,
+			result.RemoteMessageID,
+			err.Error(),
+		)
+		if storeErr != nil {
+			return fmt.Errorf(
+				"dispatch outbox item %q: confirm: %w",
+				item.OutboxID,
+				errors.Join(err, storeErr),
+			)
+		}
+	}
+	s.signalChange()
+	return nil
+}
+
+func (s *MessageService) messageForLease(
+	ctx context.Context,
+	item sqlite.OutboxItem,
+) (sqlite.Message, error) {
+	if item.LocalMessageID == nil {
+		return sqlite.Message{}, fmt.Errorf("outbox item has no local message ID")
+	}
+	message, err := s.messages.GetMessage(ctx, *item.LocalMessageID)
+	if err != nil {
+		return sqlite.Message{}, err
+	}
+	if message.AccountID != item.AccountID || message.ConversationID != item.ConversationID {
+		return sqlite.Message{}, fmt.Errorf("local message does not match outbox account/conversation")
+	}
+	return message, nil
+}
+
+func (s *MessageService) releaseUnavailable(
+	ctx context.Context,
+	item sqlite.OutboxItem,
+	cause error,
+) error {
+	if item.LeaseToken == nil {
+		return fmt.Errorf("release unavailable outbox item %q: lease token is missing", item.OutboxID)
+	}
+	mutationCtx, cancel := s.storageMutationContext(ctx)
+	defer cancel()
+	if err := s.outbox.ReleaseUnavailable(mutationCtx, item.OutboxID, *item.LeaseToken); err != nil {
+		return fmt.Errorf(
+			"release unavailable outbox item %q after %v: %w",
+			item.OutboxID,
+			cause,
+			err,
+		)
+	}
+	s.signalChange()
+	return nil
+}
+
+func (s *MessageService) markPreCallFailure(
+	ctx context.Context,
+	item sqlite.OutboxItem,
+	class, code string,
+	cause error,
+	retryAt time.Time,
+) error {
+	if item.LeaseToken == nil {
+		return fmt.Errorf("mark outbox item %q not dispatched: lease token is missing", item.OutboxID)
+	}
+	mutationCtx, cancel := s.storageMutationContext(ctx)
+	defer cancel()
+	if err := s.outbox.MarkNotDispatched(
+		mutationCtx,
+		item.OutboxID,
+		*item.LeaseToken,
+		class,
+		code,
+		cause.Error(),
+		retryAt,
+	); err != nil {
+		return fmt.Errorf("mark outbox item %q not dispatched: %w", item.OutboxID, err)
+	}
+	s.signalChange()
+	return nil
+}
+
+func (s *MessageService) releaseUntouched(ctx context.Context, leases []sqlite.Lease) error {
+	if len(leases) == 0 {
+		return nil
+	}
+	mutationCtx, cancel := s.storageMutationContext(ctx)
+	defer cancel()
+
+	var releaseErrors []error
+	released := false
+	for _, lease := range leases {
+		if lease.LeaseToken == nil {
+			releaseErrors = append(releaseErrors, fmt.Errorf(
+				"release untouched outbox item %q: lease token is missing",
+				lease.OutboxID,
+			))
+			continue
+		}
+		if err := s.outbox.ReleaseUnavailable(
+			mutationCtx,
+			lease.OutboxID,
+			*lease.LeaseToken,
+		); err != nil {
+			releaseErrors = append(releaseErrors, fmt.Errorf(
+				"release untouched outbox item %q: %w",
+				lease.OutboxID,
+				err,
+			))
+			continue
+		}
+		released = true
+	}
+	if released {
+		s.signalChange()
+	}
+	return errors.Join(releaseErrors...)
+}
+
+func (s *MessageService) storageMutationContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), defaultFinalizeTime)
+}
+
+func (s *MessageService) recordSendError(
+	ctx context.Context,
+	item sqlite.OutboxItem,
+	sendErr error,
+) error {
+	opErr, classified := asOpError(sendErr)
+	class := "unknown"
+	code := "send_text"
+	retryAt := s.clock.Now().Add(s.retryDelay)
+	if classified {
+		if opErr.Class != "" {
+			class = string(opErr.Class)
+		}
+		if opErr.Operation != "" {
+			code = opErr.Operation
+		}
+		if !opErr.RetryAt.IsZero() {
+			retryAt = opErr.RetryAt
+		}
+
+		// An explicitly ambiguous result can never be converted into a safe or
+		// terminal outcome based only on its failure class.
+		if opErr.Dispatch == bridge.DispatchUncertain {
+			return s.markSendUncertain(ctx, item, class, code, sendErr)
+		}
+
+		if terminalFailure(opErr.Class) {
+			if err := s.outbox.Reject(
+				ctx,
+				item.OutboxID,
+				*item.LeaseToken,
+				class,
+				code,
+				sendErr.Error(),
+			); err != nil {
+				return fmt.Errorf("reject outbox item %q: %w", item.OutboxID, err)
+			}
+			s.signalChange()
+			return nil
+		}
+
+		if retryableFailure(opErr.Class) && opErr.Dispatch == bridge.DispatchNotCalled {
+			if err := s.outbox.MarkCalledNotDispatched(
+				ctx,
+				item.OutboxID,
+				*item.LeaseToken,
+				class,
+				code,
+				sendErr.Error(),
+				retryAt,
+			); err != nil {
+				return fmt.Errorf(
+					"mark called outbox item %q not dispatched: %w",
+					item.OutboxID,
+					err,
+				)
+			}
+			s.signalChange()
+			return nil
+		}
+	}
+	if contextError(sendErr) {
+		code = "timeout"
+	}
+	return s.markSendUncertain(ctx, item, class, code, sendErr)
+}
+
+func (s *MessageService) markSendUncertain(
+	ctx context.Context,
+	item sqlite.OutboxItem,
+	class, code string,
+	sendErr error,
+) error {
+	if err := s.outbox.MarkUncertain(
+		ctx,
+		item.OutboxID,
+		*item.LeaseToken,
+		class,
+		code,
+		sendErr.Error(),
+	); err != nil {
+		return fmt.Errorf("mark outbox item %q uncertain: %w", item.OutboxID, err)
+	}
+	s.signalChange()
+	return nil
+}
+
+func retryableFailure(class bridge.FailureClass) bool {
+	switch class {
+	case bridge.FailureTransient,
+		bridge.FailureRateLimited,
+		bridge.FailureCredentialsExpired:
+		return true
+	default:
+		return false
+	}
+}
+
+func terminalFailure(class bridge.FailureClass) bool {
+	switch class {
+	case bridge.FailureReauthRequired,
+		bridge.FailureUpgradeRequired,
+		bridge.FailureMisconfigured,
+		bridge.FailureUnsupported:
+		return true
+	default:
+		return false
+	}
+}
+
+func asOpError(err error) (bridge.OpError, bool) {
+	var pointer *bridge.OpError
+	if errors.As(err, &pointer) && pointer != nil {
+		return *pointer, true
+	}
+	var value bridge.OpError
+	if errors.As(err, &value) {
+		return value, true
+	}
+	return bridge.OpError{}, false
+}

--- a/internal/messaging/service.go
+++ b/internal/messaging/service.go
@@ -1,0 +1,404 @@
+package messaging
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+const (
+	textOperation       = "send_text"
+	defaultLeaseTime    = 30 * time.Second
+	defaultFinalizeTime = 5 * time.Second
+	defaultRetryDelay   = 5 * time.Second
+	defaultPollDelay    = time.Second
+	defaultBatchLimit   = 32
+	workerOwner         = "message-service"
+)
+
+// MessageService owns text intent submission and durable dispatch. Concrete
+// platform selection remains behind bridge.Registry.
+type MessageService struct {
+	store    *sqlite.Store
+	outbox   *sqlite.OutboxRepository
+	messages messageRepository
+	bridges  bridge.Registry
+	clock    Clock
+	ids      IDSource
+
+	leaseTime  time.Duration
+	retryDelay time.Duration
+	pollDelay  time.Duration
+	batchLimit int
+
+	wake chan struct{}
+
+	changeMu sync.Mutex
+	changed  chan struct{}
+}
+
+// NewMessageService constructs the text service over an existing SQLite
+// store. The caller retains ownership of the store and registry.
+func NewMessageService(
+	store *sqlite.Store,
+	bridges bridge.Registry,
+	clock Clock,
+	ids IDSource,
+) (*MessageService, error) {
+	if store == nil {
+		return nil, fmt.Errorf("create message service: store is nil")
+	}
+	if bridges == nil {
+		return nil, fmt.Errorf("create message service: bridge registry is nil")
+	}
+	if clock == nil {
+		return nil, fmt.Errorf("create message service: clock is nil")
+	}
+	if ids == nil {
+		return nil, fmt.Errorf("create message service: ID source is nil")
+	}
+	outbox, err := sqlite.NewOutboxRepository(store, clock.Now)
+	if err != nil {
+		return nil, fmt.Errorf("create message service outbox: %w", err)
+	}
+	messages, err := sqlite.NewMessageRepository(store, clock.Now)
+	if err != nil {
+		return nil, fmt.Errorf("create message service messages: %w", err)
+	}
+	return &MessageService{
+		store:      store,
+		outbox:     outbox,
+		messages:   messages,
+		bridges:    bridges,
+		clock:      clock,
+		ids:        ids,
+		leaseTime:  defaultLeaseTime,
+		retryDelay: defaultRetryDelay,
+		pollDelay:  defaultPollDelay,
+		batchLimit: defaultBatchLimit,
+		wake:       make(chan struct{}, 1),
+		changed:    make(chan struct{}),
+	}, nil
+}
+
+// SendText atomically creates an optimistic outgoing message and its durable
+// outbox intent. An identical account-scoped idempotent submission returns the
+// original durable identities.
+func (s *MessageService) SendText(
+	ctx context.Context,
+	cmd SendTextCommand,
+) (Submission, error) {
+	if ctx == nil {
+		return Submission{}, fmt.Errorf("send text: context is nil")
+	}
+	if err := validateSendTextCommand(cmd); err != nil {
+		return Submission{}, err
+	}
+
+	conversation, err := s.store.GetConversation(cmd.ConversationID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("send text: read conversation: %w", err)
+	}
+	if conversation.AccountID != cmd.AccountID {
+		return Submission{}, fmt.Errorf(
+			"%w: conversation %q belongs to account %q, not %q",
+			ErrInvalidCommand,
+			cmd.ConversationID,
+			conversation.AccountID,
+			cmd.AccountID,
+		)
+	}
+
+	var replyToRemoteID *string
+	if cmd.ReplyToMessageID != "" {
+		reply, err := s.messages.GetMessage(ctx, cmd.ReplyToMessageID)
+		if err != nil {
+			return Submission{}, fmt.Errorf("send text: read reply target: %w", err)
+		}
+		if reply.AccountID != cmd.AccountID || reply.ConversationID != cmd.ConversationID {
+			return Submission{}, fmt.Errorf(
+				"%w: reply target %q is outside conversation %q",
+				ErrInvalidCommand,
+				cmd.ReplyToMessageID,
+				cmd.ConversationID,
+			)
+		}
+		replyToRemoteID = &reply.RemoteMessageID
+	}
+
+	outboxID, localMessageID, requestID, err := s.newSubmissionIDs()
+	if err != nil {
+		return Submission{}, err
+	}
+	now := s.clock.Now()
+	scheduledFor := cmd.NotBefore
+	if scheduledFor.IsZero() {
+		scheduledFor = now
+	}
+	payloadHash, err := textPayloadHash(cmd.Body, cmd.ReplyToMessageID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("send text: hash payload: %w", err)
+	}
+
+	item, disposition, err := s.outbox.EnqueueOutgoingMessage(ctx, sqlite.NewOutboxItem{
+		OutboxID:           outboxID,
+		AccountID:          cmd.AccountID,
+		ConversationID:     cmd.ConversationID,
+		Kind:               sqlite.OutboxKindText,
+		IdempotencyKey:     cmd.IdempotencyKey,
+		PayloadHash:        payloadHash,
+		Operation:          textOperation,
+		LocalMessageID:     localMessageID,
+		TransportRequestID: requestID,
+		ScheduledFor:       scheduledFor,
+	}, sqlite.Message{
+		MessageID:       localMessageID,
+		ConversationID:  cmd.ConversationID,
+		AccountID:       cmd.AccountID,
+		RemoteMessageID: requestID,
+		Direction:       sqlite.MessageDirectionOutgoing,
+		Body:            cmd.Body,
+		ReplyToRemoteID: replyToRemoteID,
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    now.UnixMilli(),
+	})
+	if err != nil {
+		return Submission{}, fmt.Errorf("send text: %w", err)
+	}
+
+	submission := submissionFromItem(item)
+	if disposition == sqlite.EnqueueInserted {
+		s.signalChange()
+		s.signalWake()
+	}
+	return submission, nil
+}
+
+// Get returns the current durable delivery state.
+func (s *MessageService) Get(ctx context.Context, outboxID string) (Delivery, error) {
+	if ctx == nil {
+		return Delivery{}, fmt.Errorf("get delivery: context is nil")
+	}
+	if strings.TrimSpace(outboxID) == "" {
+		return Delivery{}, fmt.Errorf("get delivery: outbox ID is empty")
+	}
+	item, err := s.outbox.FindByID(ctx, outboxID)
+	if err != nil {
+		return Delivery{}, fmt.Errorf("get delivery: %w", err)
+	}
+	return deliveryFromItem(item), nil
+}
+
+// Wait blocks until the intent reaches a user-actionable or terminal state.
+func (s *MessageService) Wait(ctx context.Context, outboxID string) (Delivery, error) {
+	if ctx == nil {
+		return Delivery{}, fmt.Errorf("wait for delivery: context is nil")
+	}
+	for {
+		changed := s.changeChannel()
+		delivery, err := s.Get(ctx, outboxID)
+		if err != nil || deliverySettled(delivery.State) {
+			return delivery, err
+		}
+
+		timer := s.clock.NewTimer(s.pollDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return delivery, ctx.Err()
+		case <-changed:
+			timer.Stop()
+		case <-timer.C():
+		}
+	}
+}
+
+// Cancel cancels work that has not crossed the transport boundary.
+func (s *MessageService) Cancel(ctx context.Context, outboxID string) (Delivery, error) {
+	current, err := s.Get(ctx, outboxID)
+	if err != nil {
+		return Delivery{}, err
+	}
+	if current.State != OutboxQueued && current.State != OutboxNotDispatched {
+		return current, fmt.Errorf(
+			"%w: cannot cancel outbox item %q from %q",
+			ErrInvalidState,
+			outboxID,
+			current.State,
+		)
+	}
+	if err := s.outbox.Cancel(ctx, outboxID); err != nil {
+		if errors.Is(err, sqlite.ErrInvalidOutboxState) {
+			return current, fmt.Errorf("%w: cancel outbox item %q: %w", ErrInvalidState, outboxID, err)
+		}
+		return Delivery{}, fmt.Errorf("cancel delivery: %w", err)
+	}
+	s.signalChange()
+	return s.Get(ctx, outboxID)
+}
+
+// RetryNotDispatched makes a proven-safe intent immediately due while reusing
+// its stable transport request ID.
+func (s *MessageService) RetryNotDispatched(
+	ctx context.Context,
+	outboxID string,
+) (Delivery, error) {
+	current, err := s.Get(ctx, outboxID)
+	if err != nil {
+		return Delivery{}, err
+	}
+	if current.State != OutboxNotDispatched {
+		return current, fmt.Errorf(
+			"%w: cannot retry outbox item %q from %q",
+			ErrInvalidState,
+			outboxID,
+			current.State,
+		)
+	}
+	if err := s.outbox.RetryNotDispatched(ctx, outboxID); err != nil {
+		if errors.Is(err, sqlite.ErrInvalidOutboxState) {
+			return current, fmt.Errorf("%w: retry outbox item %q: %w", ErrInvalidState, outboxID, err)
+		}
+		return Delivery{}, fmt.Errorf("retry delivery: %w", err)
+	}
+	s.signalChange()
+	s.signalWake()
+	return s.Get(ctx, outboxID)
+}
+
+// SendAgain is reserved for M5, where the new intent can be durably linked to
+// the ambiguous or rejected prior intent.
+func (s *MessageService) SendAgain(
+	context.Context,
+	string,
+	string,
+) (Submission, error) {
+	return Submission{}, fmt.Errorf("send again: %w", ErrNotImplemented)
+}
+
+// ObserveTransportEcho is reserved for the M5 reconciliation path.
+func (s *MessageService) ObserveTransportEcho(context.Context, TransportEcho) error {
+	return fmt.Errorf("observe transport echo: %w", ErrNotImplemented)
+}
+
+func (s *MessageService) newSubmissionIDs() (string, string, string, error) {
+	values := make([]string, 3)
+	for i := range values {
+		value, err := s.ids.NewID()
+		if err != nil {
+			return "", "", "", fmt.Errorf("send text: generate durable ID: %w", err)
+		}
+		if strings.TrimSpace(value) == "" {
+			return "", "", "", fmt.Errorf("send text: ID source returned an empty ID")
+		}
+		values[i] = value
+	}
+	return values[0], values[1], values[2], nil
+}
+
+func validateSendTextCommand(cmd SendTextCommand) error {
+	checks := []struct {
+		name  string
+		value string
+	}{
+		{name: "account ID", value: cmd.AccountID},
+		{name: "conversation ID", value: cmd.ConversationID},
+		{name: "idempotency key", value: cmd.IdempotencyKey},
+		{name: "body", value: cmd.Body},
+	}
+	for _, check := range checks {
+		if strings.TrimSpace(check.value) == "" {
+			return fmt.Errorf("%w: %s is empty", ErrInvalidCommand, check.name)
+		}
+	}
+	if !cmd.NotBefore.IsZero() && cmd.NotBefore.UnixMilli() <= 0 {
+		return fmt.Errorf("%w: scheduled Unix time is not positive", ErrInvalidCommand)
+	}
+	return nil
+}
+
+func textPayloadHash(body, replyToMessageID string) (string, error) {
+	payload, err := json.Marshal(struct {
+		Body             string `json:"body"`
+		ReplyToMessageID string `json:"reply_to_message_id,omitempty"`
+	}{Body: body, ReplyToMessageID: replyToMessageID})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func submissionFromItem(item sqlite.OutboxItem) Submission {
+	return Submission{
+		OutboxID:       item.OutboxID,
+		LocalMessageID: stringValue(item.LocalMessageID),
+		State:          item.State,
+		ScheduledFor:   time.UnixMilli(item.ScheduledForMS),
+	}
+}
+
+func deliveryFromItem(item sqlite.OutboxItem) Delivery {
+	delivery := Delivery{
+		OutboxID:        item.OutboxID,
+		State:           item.State,
+		LocalMessageID:  stringValue(item.LocalMessageID),
+		RemoteMessageID: stringValue(item.ResultRemoteID),
+		ErrorClass:      stringValue(item.ErrorClass),
+		ErrorCode:       stringValue(item.ErrorCode),
+	}
+	if item.State == sqlite.OutboxUncertain {
+		delivery.Warning = "delivery outcome is unknown"
+	}
+	return delivery
+}
+
+func deliverySettled(state OutboxState) bool {
+	switch state {
+	case OutboxNotDispatched, OutboxUncertain, OutboxConfirmed,
+		OutboxStoreFailed, OutboxRejected, OutboxCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func (s *MessageService) signalWake() {
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (s *MessageService) signalChange() {
+	s.changeMu.Lock()
+	close(s.changed)
+	s.changed = make(chan struct{})
+	s.changeMu.Unlock()
+}
+
+func (s *MessageService) changeChannel() <-chan struct{} {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	return s.changed
+}
+
+func contextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}

--- a/internal/messaging/service_test.go
+++ b/internal/messaging/service_test.go
@@ -1,0 +1,629 @@
+package messaging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+var messagingTestTime = time.Date(2026, time.July, 12, 12, 0, 0, 0, time.UTC)
+
+func TestUnavailableTextReturnsToQueuedWithoutAttempt(t *testing.T) {
+	for _, platform := range []bridge.Platform{"scripted-alpha", "future-platform"} {
+		t.Run(string(platform), func(t *testing.T) {
+			clock := newManualClock(messagingTestTime)
+			store := openMessagingTestStore(t, clock.Now())
+			sender := &scriptedTextSender{steps: []sendStep{{
+				result: bridge.SendResult{RemoteMessageID: "remote-available"},
+			}}}
+			registry := newScriptedRegistry(platform, sender)
+			service := newMessagingTestService(t, store, registry, clock)
+			submission := mustSendText(t, service, SendTextCommand{
+				CommonCommand: testCommonCommand("key-unavailable"),
+				Body:          "durable hello",
+			})
+
+			processed, err := service.DispatchDue(context.Background(), 8)
+			if err != nil || processed != 1 {
+				t.Fatalf("DispatchDue(unavailable) = %d, %v; want 1, nil", processed, err)
+			}
+			row := mustOutboxItem(t, service, submission.OutboxID)
+			if row.State != sqlite.OutboxQueued || row.AttemptCount != 0 || row.NextAttemptAtMS != nil {
+				t.Fatalf("unavailable row = %+v, want queued/attempt=0/no next-attempt", row)
+			}
+			if got := sender.requestCount(); got != 0 {
+				t.Fatalf("unavailable send count = %d, want 0", got)
+			}
+
+			registry.setAvailable(true)
+			processed, err = service.DispatchDue(context.Background(), 8)
+			if err != nil || processed != 1 {
+				t.Fatalf("DispatchDue(available) = %d, %v; want 1, nil", processed, err)
+			}
+			if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxConfirmed ||
+				got.RemoteMessageID != "remote-available" {
+				t.Fatalf("available delivery = %+v, want confirmed", got)
+			}
+		})
+	}
+}
+
+func TestAvailableTextDispatchesOnceAndConfirms(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-1", AcceptedAt: clock.Now()},
+	}}}
+	registry := newScriptedRegistry("not-hard-coded", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-confirm"),
+		Body:          "hello once",
+	})
+
+	processed, err := service.DispatchDue(context.Background(), 4)
+	if err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+	processed, err = service.DispatchDue(context.Background(), 4)
+	if err != nil || processed != 0 {
+		t.Fatalf("DispatchDue(after confirm) = %d, %v; want 0, nil", processed, err)
+	}
+	requests := sender.snapshotRequests()
+	if len(requests) != 1 {
+		t.Fatalf("requests = %+v, want one", requests)
+	}
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	if row.State != sqlite.OutboxConfirmed || row.AttemptCount != 1 ||
+		requests[0].RequestID != row.TransportRequestID ||
+		requests[0].Conversation.RemoteID != "remote-conversation" ||
+		requests[0].Body != "hello once" {
+		t.Fatalf("request/row = %+v / %+v", requests[0], row)
+	}
+}
+
+func TestRetryableNotDispatchedReusesTransportRequestID(t *testing.T) {
+	classes := []bridge.FailureClass{
+		bridge.FailureTransient,
+		bridge.FailureRateLimited,
+		bridge.FailureCredentialsExpired,
+	}
+	for _, class := range classes {
+		class := class
+		t.Run(string(class), func(t *testing.T) {
+			clock := newManualClock(messagingTestTime)
+			store := openMessagingTestStore(t, clock.Now())
+			cause := error(errors.New("failed before remote dispatch"))
+			if class == bridge.FailureTransient {
+				// An explicit clean not-dispatched result remains safe even when
+				// the adapter's preflight cause is a deadline.
+				cause = context.DeadlineExceeded
+			}
+			sender := &scriptedTextSender{steps: []sendStep{
+				{err: bridge.OpError{
+					Class:     class,
+					Operation: "prepare_send",
+					Dispatch:  bridge.DispatchNotCalled,
+					Cause:     cause,
+				}},
+				{result: bridge.SendResult{RemoteMessageID: "remote-retry"}},
+			}}
+			registry := newScriptedRegistry("retry-platform", sender)
+			registry.setAvailable(true)
+			service := newMessagingTestService(t, store, registry, clock)
+			submission := mustSendText(t, service, SendTextCommand{
+				CommonCommand: testCommonCommand("key-retry-" + string(class)),
+				Body:          "retry safely",
+			})
+
+			if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+				t.Fatalf("DispatchDue(first) = %d, %v", processed, err)
+			}
+			first := mustDelivery(t, service, submission.OutboxID)
+			if first.State != OutboxNotDispatched || first.ErrorClass != string(class) {
+				t.Fatalf("first delivery = %+v, want %q not_dispatched", first, class)
+			}
+			row := mustOutboxItem(t, service, submission.OutboxID)
+			if row.AttemptCount != 1 {
+				t.Fatalf("attempt count = %d, want 1", row.AttemptCount)
+			}
+
+			retried, err := service.RetryNotDispatched(context.Background(), submission.OutboxID)
+			if err != nil || retried.State != OutboxNotDispatched {
+				t.Fatalf("RetryNotDispatched() = %+v, %v; want due not_dispatched", retried, err)
+			}
+			if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+				t.Fatalf("DispatchDue(retry) = %d, %v", processed, err)
+			}
+			if got := mustDelivery(t, service, submission.OutboxID).State; got != OutboxConfirmed {
+				t.Fatalf("retry state = %q, want confirmed", got)
+			}
+			requests := sender.snapshotRequests()
+			if len(requests) != 2 || requests[0].RequestID == "" ||
+				requests[0].RequestID != requests[1].RequestID {
+				t.Fatalf("request IDs = %+v, want same stable ID", requests)
+			}
+		})
+	}
+}
+
+func TestContextCanceledDuringTransportStillRecordsUncertain(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	ctx, cancel := context.WithCancel(context.Background())
+	sender := &scriptedTextSender{
+		steps:  []sendStep{{err: context.Canceled}},
+		onSend: cancel,
+	}
+	registry := newScriptedRegistry("cancel-during-send", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-cancel-during-send"),
+		Body:          "record my ambiguous cancellation",
+	})
+
+	if processed, err := service.DispatchDue(ctx, 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(canceled send) = %d, %v; want 1, nil", processed, err)
+	}
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	if row.State != sqlite.OutboxUncertain || row.AttemptCount != 1 || row.LeaseToken != nil {
+		t.Fatalf("canceled transport row = %+v, want uncertain finalized row", row)
+	}
+}
+
+func TestDispatchDueRecoversLaterLeasesThatExpireWithinBatch(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	var advanceOnce sync.Once
+	sender := &scriptedTextSender{
+		steps: []sendStep{
+			{result: bridge.SendResult{RemoteMessageID: "remote-slow-first"}},
+			{result: bridge.SendResult{RemoteMessageID: "remote-second"}},
+		},
+		onSend: func() {
+			advanceOnce.Do(func() { clock.Advance(defaultLeaseTime + time.Second) })
+		},
+	}
+	registry := newScriptedRegistry("batch-expiry", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	first := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-slow-first"),
+		Body:          "first",
+	})
+	second := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-expired-second"),
+		Body:          "second",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 2); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(expiring batch) = %d, %v; want 1, nil", processed, err)
+	}
+	if got := mustDelivery(t, service, first.OutboxID).State; got != OutboxConfirmed {
+		t.Fatalf("first state = %q, want confirmed", got)
+	}
+	secondRow := mustOutboxItem(t, service, second.OutboxID)
+	if secondRow.State != sqlite.OutboxNotDispatched || secondRow.AttemptCount != 0 || secondRow.LeaseToken != nil {
+		t.Fatalf("expired later lease = %+v, want recoverable not_dispatched", secondRow)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(recovered second) = %d, %v; want 1, nil", processed, err)
+	}
+	if got := mustDelivery(t, service, second.OutboxID).State; got != OutboxConfirmed {
+		t.Fatalf("second state = %q, want confirmed", got)
+	}
+}
+
+func TestPostCallTimeoutBecomesUncertainAndIsNotRedispatched(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{err: bridge.OpError{
+		Class:     bridge.FailureTransient,
+		Operation: "send_text",
+		Dispatch:  bridge.DispatchUncertain,
+		Cause:     context.DeadlineExceeded,
+	}}}}
+	registry := newScriptedRegistry("timeout-platform", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-timeout"),
+		Body:          "ambiguous text",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 4); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(timeout) = %d, %v", processed, err)
+	}
+	if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxUncertain || got.Warning == "" {
+		t.Fatalf("timeout delivery = %+v, want uncertain warning", got)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 4); err != nil || processed != 0 {
+		t.Fatalf("DispatchDue(after timeout) = %d, %v; want 0, nil", processed, err)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("timeout send count = %d, want 1", got)
+	}
+}
+
+func TestTerminalFailuresAreRejected(t *testing.T) {
+	classes := []bridge.FailureClass{
+		bridge.FailureReauthRequired,
+		bridge.FailureUpgradeRequired,
+		bridge.FailureMisconfigured,
+		bridge.FailureUnsupported,
+	}
+	for _, class := range classes {
+		class := class
+		t.Run(string(class), func(t *testing.T) {
+			clock := newManualClock(messagingTestTime)
+			store := openMessagingTestStore(t, clock.Now())
+			sender := &scriptedTextSender{steps: []sendStep{{err: bridge.OpError{
+				Class:     class,
+				Operation: "send_text",
+				Dispatch:  bridge.DispatchNotCalled,
+				Cause:     errors.New("terminal failure"),
+			}}}}
+			registry := newScriptedRegistry("terminal-platform", sender)
+			registry.setAvailable(true)
+			service := newMessagingTestService(t, store, registry, clock)
+			submission := mustSendText(t, service, SendTextCommand{
+				CommonCommand: testCommonCommand("key-terminal-" + string(class)),
+				Body:          "cannot send",
+			})
+
+			if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+				t.Fatalf("DispatchDue() = %d, %v", processed, err)
+			}
+			delivery := mustDelivery(t, service, submission.OutboxID)
+			if delivery.State != OutboxRejected || delivery.ErrorClass != string(class) {
+				t.Fatalf("delivery = %+v, want rejected %q", delivery, class)
+			}
+			if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 0 {
+				t.Fatalf("DispatchDue(after reject) = %d, %v", processed, err)
+			}
+		})
+	}
+}
+
+func TestNewServiceOverSameStoreDispatchesQueuedText(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	unavailable := newScriptedRegistry("before-restart", &scriptedTextSender{})
+	first := newMessagingTestService(t, store, unavailable, clock)
+	submission := mustSendText(t, first, SendTextCommand{
+		CommonCommand: testCommonCommand("key-restart"),
+		Body:          "survive service restart",
+	})
+
+	sender := &scriptedTextSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-after-restart"},
+	}}}
+	available := newScriptedRegistry("after-restart", sender)
+	available.setAvailable(true)
+	restarted := newMessagingTestService(t, store, available, clock)
+
+	if before := mustDelivery(t, restarted, submission.OutboxID); before.State != OutboxQueued ||
+		before.LocalMessageID != submission.LocalMessageID {
+		t.Fatalf("restarted delivery = %+v, want original queued IDs", before)
+	}
+	if processed, err := restarted.DispatchDue(context.Background(), 4); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(restarted) = %d, %v", processed, err)
+	}
+	if after := mustDelivery(t, restarted, submission.OutboxID); after.State != OutboxConfirmed ||
+		after.RemoteMessageID != "remote-after-restart" {
+		t.Fatalf("delivery after restart = %+v", after)
+	}
+	requests := sender.snapshotRequests()
+	if len(requests) != 1 || requests[0].Body != "survive service restart" {
+		t.Fatalf("request after restart = %+v", requests)
+	}
+}
+
+func TestDuplicateSendTextReturnsSameSubmissionAndDispatchesOnce(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-deduplicated"},
+	}}}
+	registry := newScriptedRegistry("duplicate-platform", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	command := SendTextCommand{
+		CommonCommand: testCommonCommand("same-key"),
+		Body:          "same body",
+	}
+
+	first := mustSendText(t, service, command)
+	second := mustSendText(t, service, command)
+	if first != second {
+		t.Fatalf("duplicate submissions differ: first=%+v second=%+v", first, second)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 4); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v", processed, err)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("duplicate send count = %d, want 1", got)
+	}
+
+	command.Body = "changed body"
+	if _, err := service.SendText(context.Background(), command); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("SendText(mismatch) error = %v, want ErrIdempotencyConflict", err)
+	}
+}
+
+func TestCancelAndDeferredAPIs(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	service := newMessagingTestService(
+		t,
+		store,
+		newScriptedRegistry("cancel-platform", &scriptedTextSender{}),
+		clock,
+	)
+	command := SendTextCommand{
+		CommonCommand: testCommonCommand("key-cancel"),
+		Body:          "cancel me",
+	}
+	command.NotBefore = clock.Now().Add(time.Hour)
+	submission := mustSendText(t, service, command)
+	if _, err := service.RetryNotDispatched(context.Background(), submission.OutboxID); !errors.Is(err, ErrInvalidState) {
+		t.Fatalf("RetryNotDispatched(queued) error = %v, want ErrInvalidState", err)
+	}
+
+	canceled, err := service.Cancel(context.Background(), submission.OutboxID)
+	if err != nil || canceled.State != OutboxCanceled {
+		t.Fatalf("Cancel() = %+v, %v", canceled, err)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 0 {
+		t.Fatalf("DispatchDue(canceled) = %d, %v", processed, err)
+	}
+	if _, err := service.SendAgain(context.Background(), submission.OutboxID, "new-key"); !errors.Is(err, ErrNotImplemented) {
+		t.Fatalf("SendAgain() error = %v, want ErrNotImplemented", err)
+	}
+	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{}); !errors.Is(err, ErrNotImplemented) {
+		t.Fatalf("ObserveTransportEcho() error = %v, want ErrNotImplemented", err)
+	}
+}
+
+type sendStep struct {
+	result bridge.SendResult
+	err    error
+}
+
+type scriptedTextSender struct {
+	mu       sync.Mutex
+	steps    []sendStep
+	requests []bridge.TextRequest
+	onSend   func()
+}
+
+func (s *scriptedTextSender) SendText(
+	_ context.Context,
+	request bridge.TextRequest,
+) (bridge.SendResult, error) {
+	s.mu.Lock()
+	s.requests = append(s.requests, request)
+	var step sendStep
+	if len(s.steps) == 0 {
+		s.mu.Unlock()
+		if s.onSend != nil {
+			s.onSend()
+		}
+		return bridge.SendResult{}, nil
+	}
+	step = s.steps[0]
+	s.steps = s.steps[1:]
+	onSend := s.onSend
+	s.mu.Unlock()
+	if onSend != nil {
+		onSend()
+	}
+	return step.result, step.err
+}
+
+func (s *scriptedTextSender) requestCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.requests)
+}
+
+func (s *scriptedTextSender) snapshotRequests() []bridge.TextRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]bridge.TextRequest(nil), s.requests...)
+}
+
+type scriptedRegistry struct {
+	mu        sync.Mutex
+	platform  bridge.Platform
+	sender    bridge.TextSender
+	available bool
+}
+
+func newScriptedRegistry(platform bridge.Platform, sender bridge.TextSender) *scriptedRegistry {
+	return &scriptedRegistry{platform: platform, sender: sender}
+}
+
+func (r *scriptedRegistry) setAvailable(available bool) {
+	r.mu.Lock()
+	r.available = available
+	r.mu.Unlock()
+}
+
+func (r *scriptedRegistry) Snapshot(accountID string) (bridge.Snapshot, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if accountID != "account-1" {
+		return bridge.Snapshot{}, false
+	}
+	return bridge.Snapshot{
+		AccountID:  accountID,
+		Platform:   r.platform,
+		Generation: 7,
+	}, true
+}
+
+func (r *scriptedRegistry) Acquire(
+	ctx context.Context,
+	accountID string,
+	capability bridge.Capability,
+) (*bridge.DispatchLease, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if accountID != "account-1" || !r.available {
+		return nil, fmt.Errorf("%w: %s", bridge.ErrAccountNotRegistered, accountID)
+	}
+	if capability != bridge.CapabilityTextSend || r.sender == nil {
+		return nil, bridge.ErrCapabilityUnavailable
+	}
+	return &bridge.DispatchLease{
+		AccountID:  accountID,
+		Platform:   r.platform,
+		Generation: 7,
+		Ctx:        ctx,
+		Text:       r.sender,
+	}, nil
+}
+
+func (r *scriptedRegistry) Capabilities(accountID string) bridge.CapabilitySet {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return bridge.CapabilitySet{TextSend: accountID == "account-1" && r.sender != nil}
+}
+
+type sequentialIDs struct {
+	mu   sync.Mutex
+	next int
+}
+
+func (s *sequentialIDs) NewID() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.next++
+	return fmt.Sprintf("id-%03d", s.next), nil
+}
+
+type manualClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newManualClock(now time.Time) *manualClock { return &manualClock{now: now} }
+
+func (c *manualClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *manualClock) Advance(delay time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(delay)
+	c.mu.Unlock()
+}
+
+func (c *manualClock) NewTimer(delay time.Duration) Timer {
+	return systemTimer{Timer: time.NewTimer(delay)}
+}
+
+func newMessagingTestService(
+	t *testing.T,
+	store *sqlite.Store,
+	registry bridge.Registry,
+	clock Clock,
+) *MessageService {
+	t.Helper()
+	service, err := NewMessageService(store, registry, clock, &sequentialIDs{})
+	if err != nil {
+		t.Fatalf("NewMessageService(): %v", err)
+	}
+	return service
+}
+
+func openMessagingTestStore(t *testing.T, now time.Time) *sqlite.Store {
+	t.Helper()
+	store, err := sqlite.Open(filepath.Join(t.TempDir(), "message.sqlite"))
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	seedMessagingStore(t, store, now)
+	return store
+}
+
+func seedMessagingStore(t *testing.T, store *sqlite.Store, now time.Time) {
+	t.Helper()
+	nowMS := now.UnixMilli()
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   "account-1",
+		BridgeKey:   "scripted",
+		DisplayName: "Scripted account",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: nowMS,
+		UpdatedAtMS: nowMS,
+	}); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	if err := store.UpsertConversation(sqlite.Conversation{
+		ConversationID:       "conversation-1",
+		AccountID:            "account-1",
+		RemoteConversationID: "remote-conversation",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Test conversation",
+		NotificationMode:     sqlite.NotificationModeAll,
+		MetadataJSON:         `{}`,
+		CreatedAtMS:          nowMS,
+		UpdatedAtMS:          nowMS,
+	}); err != nil {
+		t.Fatalf("UpsertConversation(): %v", err)
+	}
+}
+
+func testCommonCommand(key string) CommonCommand {
+	return CommonCommand{
+		AccountID:      "account-1",
+		ConversationID: "conversation-1",
+		IdempotencyKey: key,
+	}
+}
+
+func mustSendText(t *testing.T, service *MessageService, command SendTextCommand) Submission {
+	t.Helper()
+	submission, err := service.SendText(context.Background(), command)
+	if err != nil {
+		t.Fatalf("SendText(): %v", err)
+	}
+	return submission
+}
+
+func mustDelivery(t *testing.T, service *MessageService, outboxID string) Delivery {
+	t.Helper()
+	delivery, err := service.Get(context.Background(), outboxID)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", outboxID, err)
+	}
+	return delivery
+}
+
+func mustOutboxItem(t *testing.T, service *MessageService, outboxID string) sqlite.OutboxItem {
+	t.Helper()
+	item, err := service.outbox.FindByID(context.Background(), outboxID)
+	if err != nil {
+		t.Fatalf("FindByID(%q): %v", outboxID, err)
+	}
+	return item
+}

--- a/internal/messaging/types.go
+++ b/internal/messaging/types.go
@@ -1,0 +1,132 @@
+// Package messaging owns durable outbound message submission and delivery.
+package messaging
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+// OutboxState is the platform-independent state of a durable outbound intent.
+type OutboxState = sqlite.OutboxState
+
+const (
+	OutboxQueued        = sqlite.OutboxQueued
+	OutboxDispatching   = sqlite.OutboxDispatching
+	OutboxNotDispatched = sqlite.OutboxNotDispatched
+	OutboxUncertain     = sqlite.OutboxUncertain
+	OutboxConfirmed     = sqlite.OutboxConfirmed
+	OutboxStoreFailed   = sqlite.OutboxStoreFailed
+	OutboxRejected      = sqlite.OutboxRejected
+	OutboxCanceled      = sqlite.OutboxCanceled
+)
+
+var (
+	// ErrIdempotencyConflict means the account-scoped key already names a
+	// different outbound intent.
+	ErrIdempotencyConflict = sqlite.ErrIdempotencyConflict
+
+	// ErrInvalidCommand means a submission is incomplete or inconsistent.
+	ErrInvalidCommand = errors.New("messaging: invalid command")
+
+	// ErrInvalidState means the requested delivery transition is unsafe from
+	// the intent's current state.
+	ErrInvalidState = errors.New("messaging: invalid outbox state")
+
+	// ErrNotImplemented marks API seams reserved for later rebuild items.
+	ErrNotImplemented = errors.New("messaging: not implemented")
+)
+
+type CommonCommand struct {
+	AccountID      string
+	ConversationID string
+	IdempotencyKey string
+	NotBefore      time.Time // zero means now
+}
+
+type SendTextCommand struct {
+	CommonCommand
+	Body             string
+	ReplyToMessageID string
+}
+
+type Submission struct {
+	OutboxID       string
+	LocalMessageID string
+	State          OutboxState
+	ScheduledFor   time.Time
+}
+
+type Delivery struct {
+	OutboxID        string
+	State           OutboxState
+	LocalMessageID  string
+	RemoteMessageID string
+	ErrorClass      string
+	ErrorCode       string
+	Warning         string
+}
+
+// TransportEcho is the transport-neutral correlation shape reserved for M5.
+type TransportEcho struct {
+	AccountID          string
+	TransportRequestID string
+	RemoteMessageID    string
+}
+
+// Timer is the one-shot timer seam used by Run and Wait.
+type Timer interface {
+	C() <-chan time.Time
+	Stop() bool
+}
+
+// Clock is MessageService's only source of time and timers.
+type Clock interface {
+	Now() time.Time
+	NewTimer(time.Duration) Timer
+}
+
+// IDSource supplies opaque durable IDs.
+type IDSource interface {
+	NewID() (string, error)
+}
+
+// IDSourceFunc adapts a function to IDSource.
+type IDSourceFunc func() (string, error)
+
+func (f IDSourceFunc) NewID() (string, error) { return f() }
+
+// CryptoIDSource produces 128-bit random hexadecimal IDs.
+type CryptoIDSource struct{}
+
+func (CryptoIDSource) NewID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate messaging ID: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+// SystemClock is the production wall-clock implementation.
+type SystemClock struct{}
+
+func (SystemClock) Now() time.Time { return time.Now() }
+
+func (SystemClock) NewTimer(delay time.Duration) Timer {
+	return systemTimer{Timer: time.NewTimer(delay)}
+}
+
+type systemTimer struct{ *time.Timer }
+
+func (t systemTimer) C() <-chan time.Time { return t.Timer.C }
+
+// messageRepository is private so MessageService does not leak persistence
+// operations through its application-facing API.
+type messageRepository interface {
+	GetMessage(context.Context, string) (sqlite.Message, error)
+}

--- a/internal/storage/sqlite/errors.go
+++ b/internal/storage/sqlite/errors.go
@@ -65,4 +65,8 @@ var (
 	// ErrLeaseLost means an outbox mutation no longer owns the row's active
 	// dispatch lease.
 	ErrLeaseLost = errors.New("outbox lease lost")
+
+	// ErrInvalidOutboxState means an outbox operation is not allowed from the
+	// row's current delivery state.
+	ErrInvalidOutboxState = errors.New("invalid outbox state transition")
 )

--- a/internal/storage/sqlite/outbox.go
+++ b/internal/storage/sqlite/outbox.go
@@ -159,6 +159,26 @@ func (r *OutboxRepository) Enqueue(
 	ctx context.Context,
 	item NewOutboxItem,
 ) (OutboxItem, EnqueueDisposition, error) {
+	return r.enqueue(ctx, item, nil)
+}
+
+// EnqueueOutgoingMessage atomically inserts an outbound intent and its
+// optimistic outgoing message. When the idempotency key already names the same
+// intent, it returns the existing outbox row without validating or writing the
+// candidate message.
+func (r *OutboxRepository) EnqueueOutgoingMessage(
+	ctx context.Context,
+	item NewOutboxItem,
+	message Message,
+) (OutboxItem, EnqueueDisposition, error) {
+	return r.enqueue(ctx, item, &message)
+}
+
+func (r *OutboxRepository) enqueue(
+	ctx context.Context,
+	item NewOutboxItem,
+	message *Message,
+) (OutboxItem, EnqueueDisposition, error) {
 	if err := validateNewOutboxItem(item); err != nil {
 		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item: %w", err)
 	}
@@ -258,10 +278,143 @@ func (r *OutboxRepository) Enqueue(
 	if err != nil {
 		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item %q: read effective row: %w", item.OutboxID, err)
 	}
+	if disposition == EnqueueExisting && message != nil {
+		if err := validateExistingOutgoingPair(ctx, tx, row); err != nil {
+			return OutboxItem{}, "", err
+		}
+	}
+	if disposition == EnqueueInserted && message != nil {
+		if err := r.insertOutgoingMessage(ctx, tx, item, *message, nowMS); err != nil {
+			return OutboxItem{}, "", err
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item %q: commit: %w", item.OutboxID, err)
 	}
 	return row, disposition, nil
+}
+
+func (r *OutboxRepository) insertOutgoingMessage(
+	ctx context.Context,
+	tx *sql.Tx,
+	item NewOutboxItem,
+	message Message,
+	nowMS int64,
+) error {
+	if message.Direction != MessageDirectionOutgoing {
+		return fmt.Errorf(
+			"enqueue outgoing message %q: %w: direction %q is not outgoing",
+			message.MessageID,
+			ErrInvalidMessage,
+			message.Direction,
+		)
+	}
+	if message.State != MessageStateActive {
+		return fmt.Errorf(
+			"enqueue outgoing message %q: %w: state %q is not active",
+			message.MessageID,
+			ErrInvalidMessage,
+			message.State,
+		)
+	}
+	if item.LocalMessageID == "" || message.MessageID != item.LocalMessageID {
+		return fmt.Errorf(
+			"enqueue outgoing message %q: %w: message ID does not match outbox local message ID %q",
+			message.MessageID,
+			ErrInvalidMessage,
+			item.LocalMessageID,
+		)
+	}
+	if message.AccountID != item.AccountID || message.ConversationID != item.ConversationID {
+		return fmt.Errorf(
+			"enqueue outgoing message %q: %w: message account/conversation does not match outbox intent",
+			message.MessageID,
+			ErrInvalidMessage,
+		)
+	}
+
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO messages (
+			message_id,
+			conversation_id,
+			account_id,
+			remote_message_id,
+			sender_identity_id,
+			direction,
+			body,
+			reply_to_remote_id,
+			state,
+			occurred_at_ms,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		message.MessageID,
+		message.ConversationID,
+		message.AccountID,
+		message.RemoteMessageID,
+		message.SenderIdentityID,
+		message.Direction,
+		message.Body,
+		message.ReplyToRemoteID,
+		message.State,
+		message.OccurredAtMS,
+		nowMS,
+		nowMS,
+	)
+	if err == nil {
+		return nil
+	}
+	messageRepository := &MessageRepository{store: r.store, now: r.now}
+	return messageRepository.mapMessageWriteError(ctx, tx, message, err)
+}
+
+func validateExistingOutgoingPair(
+	ctx context.Context,
+	tx *sql.Tx,
+	item OutboxItem,
+) error {
+	if item.LocalMessageID == nil {
+		return fmt.Errorf(
+			"enqueue outgoing message for existing outbox item %q: %w: local message ID is missing",
+			item.OutboxID,
+			ErrInvalidMessage,
+		)
+	}
+	message, err := scanMessage(tx.QueryRowContext(ctx, `
+		SELECT `+messageColumns+`
+		FROM messages
+		WHERE message_id = ?
+	`, *item.LocalMessageID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf(
+			"enqueue outgoing message for existing outbox item %q: %w: message %q does not exist",
+			item.OutboxID,
+			ErrInvalidMessage,
+			*item.LocalMessageID,
+		)
+	}
+	if err != nil {
+		return fmt.Errorf(
+			"enqueue outgoing message for existing outbox item %q: read message %q: %w",
+			item.OutboxID,
+			*item.LocalMessageID,
+			err,
+		)
+	}
+	if message.AccountID != item.AccountID ||
+		message.ConversationID != item.ConversationID ||
+		message.Direction != MessageDirectionOutgoing ||
+		message.State != MessageStateActive ||
+		message.RemoteMessageID != item.TransportRequestID {
+		return fmt.Errorf(
+			"enqueue outgoing message for existing outbox item %q: %w: message %q is not its active request-bound outgoing pair",
+			item.OutboxID,
+			ErrInvalidMessage,
+			message.MessageID,
+		)
+	}
+	return nil
 }
 
 // LeaseDue atomically claims due queued, retryable, and explicitly eligible
@@ -416,6 +569,26 @@ func (r *OutboxRepository) MarkNotDispatched(
 	outboxID, leaseToken, class, code, detail string,
 	retryAt time.Time,
 ) error {
+	return r.markNotDispatched(ctx, outboxID, leaseToken, class, code, detail, retryAt, false)
+}
+
+// MarkCalledNotDispatched records a transport result that explicitly proves no
+// remote dispatch occurred even though the conservative transport-call marker
+// was already committed. Crashes after that marker still recover as uncertain.
+func (r *OutboxRepository) MarkCalledNotDispatched(
+	ctx context.Context,
+	outboxID, leaseToken, class, code, detail string,
+	retryAt time.Time,
+) error {
+	return r.markNotDispatched(ctx, outboxID, leaseToken, class, code, detail, retryAt, true)
+}
+
+func (r *OutboxRepository) markNotDispatched(
+	ctx context.Context,
+	outboxID, leaseToken, class, code, detail string,
+	retryAt time.Time,
+	called bool,
+) error {
 	retryAtMS := retryAt.UnixMilli()
 	if retryAtMS <= 0 {
 		return fmt.Errorf("mark outbox item %q not dispatched: retry time is not positive", outboxID)
@@ -423,6 +596,12 @@ func (r *OutboxRepository) MarkNotDispatched(
 	nowMS, err := r.nowMS("mark outbox item not dispatched")
 	if err != nil {
 		return err
+	}
+	calledPredicate := "transport_called_at_ms IS NULL"
+	operation := "mark not dispatched"
+	if called {
+		calledPredicate = "transport_called_at_ms IS NOT NULL"
+		operation = "mark called not dispatched"
 	}
 	result, err := r.store.db.ExecContext(ctx, `
 		UPDATE outbox
@@ -439,7 +618,7 @@ func (r *OutboxRepository) MarkNotDispatched(
 		WHERE outbox_id = ?
 		  AND state = 'dispatching'
 		  AND lease_token = ?
-		  AND transport_called_at_ms IS NULL
+		  AND `+calledPredicate+`
 	`,
 		nullableOutboxText(class),
 		nullableOutboxText(code),
@@ -452,7 +631,81 @@ func (r *OutboxRepository) MarkNotDispatched(
 	if err != nil {
 		return fmt.Errorf("mark outbox item %q not dispatched: %w", outboxID, err)
 	}
-	return r.requireLeaseMutation(ctx, "mark not dispatched", outboxID, result)
+	return r.requireLeaseMutation(ctx, operation, outboxID, result)
+}
+
+// ReleaseUnavailable returns an uncalled dispatch lease to queued state
+// without consuming a transport attempt or scheduling a retry time.
+func (r *OutboxRepository) ReleaseUnavailable(
+	ctx context.Context,
+	outboxID, leaseToken string,
+) error {
+	nowMS, err := r.nowMS("release unavailable outbox item")
+	if err != nil {
+		return err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE outbox
+		SET state = 'queued',
+			next_attempt_at_ms = NULL,
+			lease_owner = NULL,
+			lease_token = NULL,
+			lease_expires_at_ms = NULL,
+			transport_called_at_ms = NULL,
+			updated_at_ms = ?
+		WHERE outbox_id = ?
+		  AND state = 'dispatching'
+		  AND lease_token = ?
+		  AND transport_called_at_ms IS NULL
+	`, nowMS, outboxID, leaseToken)
+	if err != nil {
+		return fmt.Errorf("release unavailable outbox item %q: %w", outboxID, err)
+	}
+	return r.requireLeaseMutation(ctx, "release unavailable", outboxID, result)
+}
+
+// RetryNotDispatched makes one explicitly safe-to-retry row immediately due
+// while preserving its transport request identity.
+func (r *OutboxRepository) RetryNotDispatched(
+	ctx context.Context,
+	outboxID string,
+) error {
+	nowMS, err := r.nowMS("retry not-dispatched outbox item")
+	if err != nil {
+		return err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE outbox
+		SET next_attempt_at_ms = ?,
+			updated_at_ms = ?
+		WHERE outbox_id = ?
+		  AND state = 'not_dispatched'
+	`, nowMS, nowMS, outboxID)
+	if err != nil {
+		return fmt.Errorf("retry not-dispatched outbox item %q: %w", outboxID, err)
+	}
+	return r.requireStateMutation(ctx, "retry not dispatched", outboxID, result)
+}
+
+// Cancel transitions pending work to a terminal canceled state. Active or
+// already-terminal rows are rejected so a transport call cannot race a cancel.
+func (r *OutboxRepository) Cancel(ctx context.Context, outboxID string) error {
+	nowMS, err := r.nowMS("cancel outbox item")
+	if err != nil {
+		return err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE outbox
+		SET state = 'canceled',
+			next_attempt_at_ms = NULL,
+			updated_at_ms = ?
+		WHERE outbox_id = ?
+		  AND state IN ('queued', 'not_dispatched')
+	`, nowMS, outboxID)
+	if err != nil {
+		return fmt.Errorf("cancel outbox item %q: %w", outboxID, err)
+	}
+	return r.requireStateMutation(ctx, "cancel", outboxID, result)
 }
 
 // MarkUncertain records an unknown outcome after the transport call boundary.
@@ -868,6 +1121,33 @@ func (r *OutboxRepository) requireLeaseMutation(
 	result sql.Result,
 ) error {
 	return r.requireLeaseMutationWithQueryer(ctx, r.store.db, operation, outboxID, result)
+}
+
+func (r *OutboxRepository) requireStateMutation(
+	ctx context.Context,
+	operation, outboxID string,
+	result sql.Result,
+) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("%s outbox item %q: read rows affected: %w", operation, outboxID, err)
+	}
+	if affected == 1 {
+		return nil
+	}
+	if affected != 0 {
+		return fmt.Errorf("%s outbox item %q: affected %d rows, want 1", operation, outboxID, affected)
+	}
+	var exists bool
+	if err := r.store.db.QueryRowContext(ctx, `
+		SELECT EXISTS (SELECT 1 FROM outbox WHERE outbox_id = ?)
+	`, outboxID).Scan(&exists); err != nil {
+		return fmt.Errorf("%s outbox item %q: inspect state: %w", operation, outboxID, err)
+	}
+	if !exists {
+		return notFound("outbox item", outboxID)
+	}
+	return fmt.Errorf("%s outbox item %q: %w", operation, outboxID, ErrInvalidOutboxState)
 }
 
 type outboxQueryer interface {

--- a/internal/storage/sqlite/outbox_test.go
+++ b/internal/storage/sqlite/outbox_test.go
@@ -82,6 +82,94 @@ func TestOutboxEnqueueIdempotencyAndConflict(t *testing.T) {
 	}
 }
 
+func TestOutboxEnqueueOutgoingMessageIsAtomicAndDeduplicated(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	ctx := context.Background()
+
+	item := outboxTestItem("outgoing")
+	message := outboxTestOutgoingMessage(item, "hello from the durable outbox")
+	row, disposition, err := repository.EnqueueOutgoingMessage(ctx, item, message)
+	if err != nil {
+		t.Fatalf("EnqueueOutgoingMessage(): %v", err)
+	}
+	if disposition != EnqueueInserted || row.OutboxID != item.OutboxID {
+		t.Fatalf("EnqueueOutgoingMessage() = (%+v, %q), want inserted", row, disposition)
+	}
+	messageRepository, err := NewMessageRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	gotMessage, err := messageRepository.GetMessage(ctx, item.LocalMessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(): %v", err)
+	}
+	if gotMessage.Body != message.Body || gotMessage.Direction != MessageDirectionOutgoing ||
+		gotMessage.State != MessageStateActive || gotMessage.RemoteMessageID != message.RemoteMessageID ||
+		gotMessage.SenderIdentityID == nil || *gotMessage.SenderIdentityID != "identity-a" {
+		t.Fatalf("optimistic message = %+v, want %+v", gotMessage, message)
+	}
+	assertRowCount(t, store.db, "inbox", 0)
+
+	clock.Set(outboxTestTimeMS + 500)
+	duplicate := item
+	duplicate.OutboxID = "outbox-unused-duplicate"
+	duplicate.LocalMessageID = "message-unused-duplicate"
+	duplicate.TransportRequestID = "request-unused-duplicate"
+	duplicateRow, disposition, err := repository.EnqueueOutgoingMessage(ctx, duplicate, Message{})
+	if err != nil {
+		t.Fatalf("EnqueueOutgoingMessage(duplicate with invalid candidate): %v", err)
+	}
+	if disposition != EnqueueExisting || duplicateRow.OutboxID != item.OutboxID {
+		t.Fatalf("duplicate result = (%+v, %q), want original", duplicateRow, disposition)
+	}
+
+	conflict := duplicate
+	conflict.PayloadHash = "different-payload-hash"
+	if _, _, err := repository.EnqueueOutgoingMessage(ctx, conflict, Message{}); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("EnqueueOutgoingMessage(conflict) error = %v, want ErrIdempotencyConflict", err)
+	}
+
+	generic := outboxTestItem("generic-collision")
+	mustEnqueueOutbox(t, repository, generic)
+	if _, _, err := repository.EnqueueOutgoingMessage(
+		ctx,
+		generic,
+		outboxTestOutgoingMessage(generic, "missing optimistic pair"),
+	); !errors.Is(err, ErrInvalidMessage) {
+		t.Fatalf("EnqueueOutgoingMessage(generic collision) error = %v, want ErrInvalidMessage", err)
+	}
+	foreignPair := outboxTestItem("foreign-pair")
+	if _, _, err := repository.EnqueueOutgoingMessage(
+		ctx,
+		foreignPair,
+		outboxTestOutgoingMessage(foreignPair, "belongs to another request"),
+	); err != nil {
+		t.Fatalf("EnqueueOutgoingMessage(foreign pair): %v", err)
+	}
+	genericWithForeignMessage := outboxTestItem("generic-foreign-message")
+	genericWithForeignMessage.LocalMessageID = foreignPair.LocalMessageID
+	mustEnqueueOutbox(t, repository, genericWithForeignMessage)
+	if _, _, err := repository.EnqueueOutgoingMessage(
+		ctx,
+		genericWithForeignMessage,
+		outboxTestOutgoingMessage(genericWithForeignMessage, "candidate is not used"),
+	); !errors.Is(err, ErrInvalidMessage) {
+		t.Fatalf("EnqueueOutgoingMessage(foreign message collision) error = %v, want ErrInvalidMessage", err)
+	}
+
+	invalidItem := outboxTestItem("invalid-outgoing")
+	invalidMessage := outboxTestOutgoingMessage(invalidItem, "must roll back")
+	invalidMessage.State = MessageStateEdited
+	if _, _, err := repository.EnqueueOutgoingMessage(ctx, invalidItem, invalidMessage); !errors.Is(err, ErrInvalidMessage) {
+		t.Fatalf("EnqueueOutgoingMessage(invalid) error = %v, want ErrInvalidMessage", err)
+	}
+	assertRowCount(t, store.db, "outbox", 4)
+	assertRowCount(t, store.db, "messages", 2)
+}
+
 func TestOutboxLeaseDueRespectsScheduleRetryAndLiveLease(t *testing.T) {
 	clock := newOutboxTestClock(outboxTestTimeMS)
 	_, repository := openOutboxTestRepository(t, clock.Now)
@@ -444,6 +532,159 @@ func TestOutboxPhaseTransitionsRejectWrongSideOfCallBoundary(t *testing.T) {
 	}
 }
 
+func TestOutboxReleaseUnavailableReturnsLeaseToQueuedWithoutAttempt(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	item := outboxTestItem("unavailable")
+	mustEnqueueOutbox(t, repository, item)
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	token := mustLeaseToken(t, lease)
+	if err := repository.ReleaseUnavailable(ctx, item.OutboxID, "stale-token"); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("ReleaseUnavailable(stale token) error = %v, want ErrLeaseLost", err)
+	}
+	if err := repository.ReleaseUnavailable(ctx, item.OutboxID, token); err != nil {
+		t.Fatalf("ReleaseUnavailable(): %v", err)
+	}
+	queued, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(): %v", err)
+	}
+	if queued.State != OutboxQueued || queued.AttemptCount != 0 || queued.LeaseToken != nil ||
+		queued.NextAttemptAtMS != nil || queued.TransportCalledAtMS != nil ||
+		queued.TransportRequestID != item.TransportRequestID {
+		t.Fatalf("released unavailable row = %+v", queued)
+	}
+}
+
+func TestOutboxMarkCalledNotDispatchedRecordsExplicitSafeRetry(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	item := outboxTestItem("called-not-dispatched")
+	mustEnqueueOutbox(t, repository, item)
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	token := mustLeaseToken(t, lease)
+	if err := repository.MarkCalledNotDispatched(
+		ctx, item.OutboxID, token, "transient", "preflight", "not sent", clock.Now().Add(time.Minute),
+	); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("MarkCalledNotDispatched(pre-call) error = %v, want ErrLeaseLost", err)
+	}
+	if err := repository.MarkTransportCalled(ctx, Attempt{OutboxID: item.OutboxID, LeaseToken: token}); err != nil {
+		t.Fatalf("MarkTransportCalled(): %v", err)
+	}
+	retryAt := clock.Now().Add(time.Minute)
+	if err := repository.MarkCalledNotDispatched(
+		ctx, item.OutboxID, token, "transient", "preflight", "transport proved no dispatch", retryAt,
+	); err != nil {
+		t.Fatalf("MarkCalledNotDispatched(): %v", err)
+	}
+	notDispatched, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(): %v", err)
+	}
+	if notDispatched.State != OutboxNotDispatched || notDispatched.TransportCalledAtMS != nil ||
+		notDispatched.NextAttemptAtMS == nil || *notDispatched.NextAttemptAtMS != retryAt.UnixMilli() ||
+		notDispatched.TransportRequestID != item.TransportRequestID || notDispatched.AttemptCount != 1 {
+		t.Fatalf("called-not-dispatched row = %+v", notDispatched)
+	}
+	assertOutboxText(t, "error class", notDispatched.ErrorClass, "transient")
+	assertOutboxText(t, "error code", notDispatched.ErrorCode, "preflight")
+}
+
+func TestOutboxRetryNotDispatchedMakesRowDueWithSameRequestID(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	item := outboxTestItem("manual-retry")
+	mustEnqueueOutbox(t, repository, item)
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	if err := repository.MarkNotDispatched(
+		ctx, item.OutboxID, mustLeaseToken(t, lease), "transient", "offline", "retry later", clock.Now().Add(time.Hour),
+	); err != nil {
+		t.Fatalf("MarkNotDispatched(): %v", err)
+	}
+	clock.Set(outboxTestTimeMS + 1_000)
+	if err := repository.RetryNotDispatched(ctx, item.OutboxID); err != nil {
+		t.Fatalf("RetryNotDispatched(): %v", err)
+	}
+	retryable, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(): %v", err)
+	}
+	if retryable.State != OutboxNotDispatched || retryable.NextAttemptAtMS == nil ||
+		*retryable.NextAttemptAtMS != clock.Now().UnixMilli() ||
+		retryable.TransportRequestID != item.TransportRequestID || retryable.ErrorClass == nil ||
+		*retryable.ErrorClass != "transient" {
+		t.Fatalf("manual retry row = %+v", retryable)
+	}
+	queuedItem := outboxTestItem("manual-retry-wrong-state")
+	mustEnqueueOutbox(t, repository, queuedItem)
+	if err := repository.RetryNotDispatched(ctx, queuedItem.OutboxID); !errors.Is(err, ErrInvalidOutboxState) {
+		t.Fatalf("RetryNotDispatched(queued) error = %v, want ErrInvalidOutboxState", err)
+	}
+	if err := repository.RetryNotDispatched(ctx, "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("RetryNotDispatched(missing) error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestOutboxCancelAllowsOnlyQueuedOrNotDispatched(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+
+	queuedItem := outboxTestItem("cancel-queued")
+	mustEnqueueOutbox(t, repository, queuedItem)
+	if err := repository.Cancel(ctx, queuedItem.OutboxID); err != nil {
+		t.Fatalf("Cancel(queued): %v", err)
+	}
+	canceled, err := repository.FindByID(ctx, queuedItem.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(canceled): %v", err)
+	}
+	if canceled.State != OutboxCanceled || canceled.NextAttemptAtMS != nil {
+		t.Fatalf("canceled queued row = %+v", canceled)
+	}
+	if err := repository.Cancel(ctx, queuedItem.OutboxID); !errors.Is(err, ErrInvalidOutboxState) {
+		t.Fatalf("Cancel(canceled) error = %v, want ErrInvalidOutboxState", err)
+	}
+
+	notDispatchedItem := outboxTestItem("cancel-not-dispatched")
+	mustEnqueueOutbox(t, repository, notDispatchedItem)
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	if err := repository.MarkNotDispatched(
+		ctx, notDispatchedItem.OutboxID, mustLeaseToken(t, lease), "transient", "offline", "retry later", clock.Now().Add(time.Hour),
+	); err != nil {
+		t.Fatalf("MarkNotDispatched(): %v", err)
+	}
+	if err := repository.Cancel(ctx, notDispatchedItem.OutboxID); err != nil {
+		t.Fatalf("Cancel(not dispatched): %v", err)
+	}
+
+	dispatchingItem := outboxTestItem("cancel-dispatching")
+	mustEnqueueOutbox(t, repository, dispatchingItem)
+	lease = mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	if lease.OutboxID != dispatchingItem.OutboxID {
+		t.Fatalf("LeaseDue(cancel dispatching) = %+v, want %q", lease, dispatchingItem.OutboxID)
+	}
+	if err := repository.Cancel(ctx, dispatchingItem.OutboxID); !errors.Is(err, ErrInvalidOutboxState) {
+		t.Fatalf("Cancel(dispatching) error = %v, want ErrInvalidOutboxState", err)
+	}
+	if err := repository.Cancel(ctx, "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Cancel(missing) error = %v, want ErrNotFound", err)
+	}
+}
+
 func TestOutboxMigrationIsChecksummedAndStrict(t *testing.T) {
 	store, _ := openOutboxTestRepository(t, func() time.Time {
 		return time.UnixMilli(outboxTestTimeMS)
@@ -526,6 +767,21 @@ func outboxTestItem(id string) NewOutboxItem {
 		Operation:          "send_text",
 		LocalMessageID:     "message-" + id,
 		TransportRequestID: "request-" + id,
+	}
+}
+
+func outboxTestOutgoingMessage(item NewOutboxItem, body string) Message {
+	senderIdentityID := "identity-a"
+	return Message{
+		MessageID:        item.LocalMessageID,
+		ConversationID:   item.ConversationID,
+		AccountID:        item.AccountID,
+		RemoteMessageID:  item.TransportRequestID,
+		SenderIdentityID: &senderIdentityID,
+		Direction:        MessageDirectionOutgoing,
+		Body:             body,
+		State:            MessageStateActive,
+		OccurredAtMS:     outboxTestTimeMS,
 	}
 }
 


### PR DESCRIPTION
Wave 2 / M1 — the app-owned send path. Implemented by Sol (it correctly stopped and flagged a real storage-API gap first; I authorized the minimal additive fix), reviewed by Claude. Additive (not wired into serve/HTTP yet — A-series); no deploy.

Every text now goes through **one durable outbox + the bridge registry**, ending the browser-owned second delivery engine and the broken-Retry tombstone (finding #3).

**Storage (additive, no migration/schema change):**
- `EnqueueOutgoingMessage` — optimistic `messages` row + `outbox` row in **one transaction**, idempotent on `(account_id, idempotency_key)` with payload-hash conflict detection.
- `ReleaseUnavailable` (lease returned, zero attempts consumed), `MarkCalledNotDispatched` (transport marked-called but cleanly reported no dispatch), `RetryNotDispatched` (reuses `transport_request_id`), `Cancel`.

**`internal/messaging`** (deps: bridge + storage/sqlite + stdlib only):
- `SendText` → `EnqueueOutgoingMessage`; duplicate key → same Submission.
- `DispatchDue` is a **synchronous, deterministic** pass: LeaseDue → Acquire text capability → bridge-down = release (no attempt) / else MarkTransportCalled → `SendText(RequestID=transport_request_id)` → Confirm / not_dispatched / rejected / uncertain by class. `Run()` is a thin loop over it + `RecoverExpiredLeases` on start.

Tests drive `DispatchDue` directly (no async timing) — unavailable→queued/zero-attempts, dispatch-once+Confirm, pre-call retry with same request id, post-call uncertain, **restart survival** over the same store, duplicate-key single enqueue. `go test -race -count=10` green (**no flake** — the prior attempt flaked on async timing; this one is deterministic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
