### PR TITLE
Wire WhatsApp lifecycle behind the per-account supervisor (rebuild Wave 1 / C5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ output/
 /genviz
 /cc.json
 /.tmp-*.sql
+.gitnexus

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,6 +23,7 @@ import (
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/bridge"
 	googleadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/google"
+	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
 	"github.com/maxghenis/openmessage/internal/db"
 	"github.com/maxghenis/openmessage/internal/googlecookies"
 	"github.com/maxghenis/openmessage/internal/importer"
@@ -30,6 +31,7 @@ import (
 	"github.com/maxghenis/openmessage/internal/telemetry"
 	"github.com/maxghenis/openmessage/internal/tools"
 	"github.com/maxghenis/openmessage/internal/web"
+	"github.com/maxghenis/openmessage/internal/whatsapplive"
 )
 
 type serveOptions struct {
@@ -116,6 +118,8 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	var googleLifecycle *googleadapter.Adapter
 	var googleSupervisor *bridge.Supervisor
 	var googleControl *googleSupervisorControl
+	var whatsappSupervisor *bridge.Supervisor
+	var whatsappControl *whatsappSupervisorControl
 
 	// Google has one lifecycle owner. Transient retry, liveness probes,
 	// credential repair, and terminal parking all flow through this supervisor;
@@ -183,8 +187,61 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	}
 
 	if !isDemo {
-		if err := a.LoadAndConnectWhatsApp(); err != nil {
-			logger.Warn().Err(err).Msg("WhatsApp live bridge unavailable")
+		whatsappBridge, initialized := initializeWhatsAppForServe(logger, a.InitializeWhatsApp)
+		if initialized {
+			whatsappLifecycle := whatsappadapter.New(whatsappAccountID, whatsappBridge)
+			a.SetWhatsAppLifecycleNotifier(whatsappLifecycle)
+			newWhatsAppSupervisor := func(initial bridge.State) (*bridge.Supervisor, error) {
+				return bridge.NewSupervisor(
+					whatsappAccountID,
+					bridge.PlatformWhatsApp,
+					whatsappLifecycle,
+					whatsappSupervisorPolicy(),
+					whatsappWallClock{},
+					whatsappRandom{},
+					bridge.WithPairer(whatsappLifecycle),
+					bridge.WithInitialState(initial),
+				)
+			}
+			initialState := bridge.StateUnpaired
+			if whatsappBridge.PairedAccount().Paired {
+				initialState = bridge.StateStopped
+			}
+			whatsappSupervisor, err = newWhatsAppSupervisor(initialState)
+			if err != nil {
+				return fmt.Errorf("init WhatsApp supervisor: %w", err)
+			}
+			whatsappControl = newWhatsAppSupervisorControl(
+				whatsappSupervisor,
+				newWhatsAppSupervisor,
+				func() bool { return whatsappBridge.PairedAccount().Paired },
+			)
+			whatsappStartupCtx, cancelWhatsAppStartup := context.WithCancel(context.Background())
+			var whatsappStartupWG sync.WaitGroup
+			defer func() {
+				cancelWhatsAppStartup()
+				ctx, cancel := context.WithTimeout(context.Background(), whatsappSupervisorStopTimeout)
+				defer cancel()
+				if err := whatsappControl.Stop(ctx); err != nil {
+					logger.Warn().Err(err).Msg("WhatsApp supervisor stop timed out; waiting for generation teardown")
+					// App.Close runs after this defer. Wait without a deadline so the
+					// whatsmeow session store is never closed under a live generation.
+					_ = whatsappControl.Stop(context.Background())
+				}
+				whatsappStartupWG.Wait()
+			}()
+
+			if initialState == bridge.StateStopped {
+				whatsappStartupWG.Add(1)
+				go func(supervisor *bridge.Supervisor) {
+					defer whatsappStartupWG.Done()
+					ctx, cancel := context.WithTimeout(whatsappStartupCtx, whatsappSupervisorPolicy().ConnectTimeout)
+					defer cancel()
+					if err := supervisor.Start(ctx, bridge.StartRequest{}); err != nil {
+						logger.Warn().Err(err).Msg("WhatsApp live bridge unavailable")
+					}
+				}(whatsappSupervisor)
+			}
 		}
 	} else {
 		logger.Info().Msg("Demo mode — skipping WhatsApp live bridge")
@@ -196,22 +253,6 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		}
 	} else {
 		logger.Info().Msg("Demo mode — skipping Signal live bridge")
-	}
-
-	if !isDemo {
-		go func() {
-			ticker := time.NewTicker(5 * time.Second)
-			defer ticker.Stop()
-			for range ticker.C {
-				status := a.WhatsAppStatus()
-				if !status.Paired || status.Connected || status.Pairing || status.Connecting {
-					continue
-				}
-				if err := a.StartWhatsAppConnect(); err != nil {
-					logger.Warn().Err(err).Msg("WhatsApp reconnect attempt failed")
-				}
-			}
-		}()
 	}
 
 	if !isDemo {
@@ -390,6 +431,16 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 			return googleControl.StopAndUnpair(a.Unpair)
 		}
 	}
+	connectWhatsApp := a.StartWhatsAppConnect
+	pairWhatsAppPhone := a.PairWhatsAppPhone
+	unpairWhatsApp := a.UnpairWhatsApp
+	if whatsappControl != nil {
+		connectWhatsApp = whatsappControl.Reconnect
+		pairWhatsAppPhone = whatsappControl.PairPhone
+		unpairWhatsApp = func() error {
+			return whatsappControl.StopAndUnpair(a.UnpairWhatsApp)
+		}
+	}
 
 	// Background loop that sends due scheduled ("send later") messages.
 	a.StartScheduler()
@@ -411,9 +462,9 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				ReconnectGoogle:       reconnectGoogle,
 				Unpair:                unpairGoogle,
 				WhatsAppStatus:        func() any { return a.WhatsAppStatus() },
-				ConnectWhatsApp:       a.StartWhatsAppConnect,
-				PairWhatsAppPhone:     a.PairWhatsAppPhone,
-				UnpairWhatsApp:        a.UnpairWhatsApp,
+				ConnectWhatsApp:       connectWhatsApp,
+				PairWhatsAppPhone:     pairWhatsAppPhone,
+				UnpairWhatsApp:        unpairWhatsApp,
 				SignalStatus:          func() any { return a.SignalStatus() },
 				ConnectSignal:         a.StartSignalConnect,
 				ReplaySignalRecovery:  a.ReplaySignalRecoveryQueue,
@@ -490,6 +541,18 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	<-sigCh
 	logger.Info().Msg("Shutting down")
 	return nil
+}
+
+func initializeWhatsAppForServe(
+	logger zerolog.Logger,
+	initialize func() (*whatsapplive.Bridge, error),
+) (*whatsapplive.Bridge, bool) {
+	whatsappBridge, err := initialize()
+	if err != nil {
+		logger.Warn().Err(err).Msg("WhatsApp live bridge unavailable")
+		return nil, false
+	}
+	return whatsappBridge, true
 }
 
 func newMCPHTTPHandler(mcpSrv *mcpserver.MCPServer, baseURL string) http.Handler {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -14,7 +15,31 @@ import (
 	"time"
 
 	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/whatsapplive"
 )
+
+func TestInitializeWhatsAppForServeSkipsSupervisorOnInitializationError(t *testing.T) {
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	initErr := errors.New("unable to open WhatsApp database")
+
+	whatsappBridge, initialized := initializeWhatsAppForServe(logger, func() (*whatsapplive.Bridge, error) {
+		return nil, initErr
+	})
+
+	if initialized {
+		t.Fatal("expected WhatsApp supervisor wiring to be skipped")
+	}
+	if whatsappBridge != nil {
+		t.Fatal("expected no WhatsApp bridge after initialization failure")
+	}
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "WhatsApp live bridge unavailable") || !strings.Contains(logOutput, initErr.Error()) {
+		t.Fatalf("warning log = %q, want unavailable message and initialization error", logOutput)
+	}
+}
 
 func TestHTTPServerSurvivesIndependently(t *testing.T) {
 	// Mirrors the RunServe architecture: HTTP server in a goroutine

--- a/cmd/whatsapp_supervisor.go
+++ b/cmd/whatsapp_supervisor.go
@@ -1,0 +1,446 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+const (
+	whatsappAccountID             = "whatsapp-primary"
+	whatsappSupervisorStopTimeout = 30 * time.Second
+	whatsappPairCodeTimeout       = 35 * time.Second
+)
+
+func whatsappSupervisorPolicy() bridge.Policy {
+	return bridge.Policy{
+		ConnectTimeout:     45 * time.Second,
+		ProbeEvery:         30 * time.Second,
+		ProbeTimeout:       20 * time.Second,
+		LivenessTimeout:    3 * time.Minute,
+		MinBackoff:         5 * time.Second,
+		MaxBackoff:         5 * time.Minute,
+		MaxSameFingerprint: 3,
+	}
+}
+
+type whatsappWallClock struct{}
+
+func (whatsappWallClock) Now() time.Time { return time.Now() }
+
+func (whatsappWallClock) NewTimer(delay time.Duration) bridge.Timer {
+	return &whatsappWallTimer{timer: time.NewTimer(delay)}
+}
+
+type whatsappWallTimer struct{ timer *time.Timer }
+
+func (t *whatsappWallTimer) C() <-chan time.Time { return t.timer.C }
+func (t *whatsappWallTimer) Stop() bool          { return t.timer.Stop() }
+
+type whatsappRandom struct{}
+
+func (whatsappRandom) Int63n(n int64) int64 { return rand.Int63n(n) }
+
+// whatsappSupervisorControl is the only command-side entry point for
+// WhatsApp connect, reconnect, pairing, and unpairing. It never dials the
+// transport itself: every attempt is admitted by the account supervisor.
+type whatsappSupervisorControl struct {
+	supervisor    *bridge.Supervisor
+	newSupervisor func(bridge.State) (*bridge.Supervisor, error)
+	paired        func() bool
+
+	mu                sync.Mutex
+	supervisorStopped bool
+	stopping          bool
+	closed            bool
+	pairWatchActive   bool
+	pairWatchCancel   context.CancelFunc
+	pairWatchEpoch    uint64
+	pairWatchWG       sync.WaitGroup
+}
+
+func newWhatsAppSupervisorControl(
+	supervisor *bridge.Supervisor,
+	newSupervisor func(bridge.State) (*bridge.Supervisor, error),
+	paired func() bool,
+) *whatsappSupervisorControl {
+	return &whatsappSupervisorControl{
+		supervisor:    supervisor,
+		newSupervisor: newSupervisor,
+		paired:        paired,
+	}
+}
+
+// Reconnect starts a paired lifecycle generation or, for an unpaired account,
+// admits one user-initiated QR pairing attempt. Duplicate requests while the
+// supervisor is already working are successful no-ops.
+func (c *whatsappSupervisorControl) Reconnect() error {
+	supervisor, err := c.activeSupervisor()
+	if err != nil {
+		return err
+	}
+
+	snapshot := supervisor.Snapshot()
+	switch snapshot.State {
+	case bridge.StateStopped:
+		if !c.isPaired() {
+			return c.beginPairing(supervisor, bridge.PairRequest{Method: bridge.PairQR}, nil)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), whatsappSupervisorPolicy().ConnectTimeout)
+		defer cancel()
+		err := supervisor.Start(ctx, bridge.StartRequest{})
+		if errors.Is(err, bridge.ErrSupervisorBusy) {
+			return nil
+		}
+		return err
+	case bridge.StateUnpaired:
+		return c.beginPairing(supervisor, bridge.PairRequest{Method: bridge.PairQR}, nil)
+	case bridge.StatePairing, bridge.StateConnecting, bridge.StateOnline,
+		bridge.StateDegraded, bridge.StateBackoff, bridge.StateRepairingCredentials:
+		return nil
+	case bridge.StateBlocked:
+		if !c.isPaired() {
+			supervisor, err = c.rebuildUnpairedSupervisor(supervisor)
+			if err != nil {
+				return err
+			}
+			return c.beginPairing(supervisor, bridge.PairRequest{Method: bridge.PairQR}, nil)
+		}
+		return fmt.Errorf(
+			"WhatsApp requires re-pairing before reconnecting (%s: %s)",
+			snapshot.ErrorClass,
+			snapshot.ErrorFingerprint,
+		)
+	case bridge.StateStopping:
+		return bridge.ErrSupervisorStopped
+	default:
+		return fmt.Errorf("WhatsApp cannot reconnect from supervisor state %q", snapshot.State)
+	}
+}
+
+// PairPhone admits one phone-code pairing attempt and waits only until the
+// display code is available. The supervisor-owned Pairer remains active until
+// PairSuccess, failure, or cancellation.
+func (c *whatsappSupervisorControl) PairPhone(phone string) (string, error) {
+	phone = strings.TrimSpace(phone)
+	if phone == "" {
+		return "", errors.New("WhatsApp phone number is required")
+	}
+	supervisor, err := c.activeSupervisor()
+	if err != nil {
+		return "", err
+	}
+	snapshot := supervisor.Snapshot()
+	if snapshot.State == bridge.StateBlocked && !c.isPaired() {
+		supervisor, err = c.rebuildUnpairedSupervisor(supervisor)
+		if err != nil {
+			return "", err
+		}
+		snapshot = supervisor.Snapshot()
+	}
+	if snapshot.State != bridge.StateUnpaired {
+		if snapshot.State == bridge.StatePairing {
+			return "", bridge.ErrPairingInProgress
+		}
+		return "", fmt.Errorf("%w: state %q", bridge.ErrPairingNotAllowed, snapshot.State)
+	}
+
+	sink := newWhatsAppPairCodeSink()
+	if err := c.beginPairing(supervisor, bridge.PairRequest{
+		Method: bridge.PairPhoneCode,
+		Phone:  phone,
+	}, sink); err != nil {
+		return "", err
+	}
+
+	timer := time.NewTimer(whatsappPairCodeTimeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case event := <-sink.events:
+			switch event.Kind {
+			case "code":
+				if strings.TrimSpace(event.Payload) == "" {
+					return "", errors.New("WhatsApp returned an empty pairing code")
+				}
+				return event.Payload, nil
+			case "blocked":
+				return "", fmt.Errorf("%w until %s", bridge.ErrPairingRateLimited, event.ExpiresAt.Format(time.RFC3339Nano))
+			}
+		case <-ticker.C:
+			snapshot := supervisor.Snapshot()
+			if snapshot.State != bridge.StatePairing {
+				return "", fmt.Errorf(
+					"WhatsApp pairing ended before a code was available (%s: %s)",
+					snapshot.ErrorClass,
+					snapshot.ErrorFingerprint,
+				)
+			}
+		case <-timer.C:
+			return "", errors.New("timed out waiting for WhatsApp pairing code")
+		}
+	}
+}
+
+func (c *whatsappSupervisorControl) beginPairing(
+	supervisor *bridge.Supervisor,
+	request bridge.PairRequest,
+	sink bridge.PairSink,
+) error {
+	ctx, cancel := context.WithTimeout(context.Background(), whatsappSupervisorPolicy().ConnectTimeout)
+	defer cancel()
+	if err := supervisor.BeginPairing(ctx, request, sink); err != nil {
+		return err
+	}
+	c.startPairWatcher(supervisor)
+	return nil
+}
+
+// startPairWatcher performs the one required post-pair lifecycle Start. Pairer
+// returns only after credentials have been installed and its pairing transport
+// has been disconnected, so StateStopped is the handoff point between the two
+// supervisor-owned activities.
+func (c *whatsappSupervisorControl) startPairWatcher(supervisor *bridge.Supervisor) {
+	c.mu.Lock()
+	if c.closed || c.stopping || c.supervisor != supervisor || c.pairWatchActive {
+		c.mu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	c.pairWatchEpoch++
+	epoch := c.pairWatchEpoch
+	c.pairWatchActive = true
+	c.pairWatchCancel = cancel
+	c.pairWatchWG.Add(1)
+	c.mu.Unlock()
+
+	go func() {
+		defer c.pairWatchWG.Done()
+		defer func() {
+			c.mu.Lock()
+			if c.supervisor == supervisor && c.pairWatchEpoch == epoch {
+				c.pairWatchActive = false
+				c.pairWatchCancel = nil
+			}
+			c.mu.Unlock()
+		}()
+
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			switch supervisor.Snapshot().State {
+			case bridge.StateStopped:
+				startCtx, startCancel := context.WithTimeout(ctx, whatsappSupervisorPolicy().ConnectTimeout)
+				err := supervisor.Start(startCtx, bridge.StartRequest{})
+				startCancel()
+				if err == nil || errors.Is(err, bridge.ErrSupervisorBusy) || errors.Is(err, context.Canceled) {
+					return
+				}
+				return
+			case bridge.StatePairing:
+			case bridge.StateUnpaired, bridge.StateBlocked, bridge.StateStopping:
+				return
+			case bridge.StateConnecting, bridge.StateOnline, bridge.StateDegraded,
+				bridge.StateBackoff, bridge.StateRepairingCredentials:
+				return
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
+func (c *whatsappSupervisorControl) activeSupervisor() (*bridge.Supervisor, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed || c.stopping {
+		return nil, bridge.ErrSupervisorStopped
+	}
+	if c.supervisorStopped {
+		if c.newSupervisor == nil {
+			return nil, errors.New("WhatsApp supervisor cannot be restarted")
+		}
+		initial := bridge.StateUnpaired
+		if c.isPairedLocked() {
+			initial = bridge.StateStopped
+		}
+		supervisor, err := c.newSupervisor(initial)
+		if err != nil {
+			return nil, fmt.Errorf("rebuild WhatsApp supervisor: %w", err)
+		}
+		c.supervisor = supervisor
+		c.supervisorStopped = false
+	}
+	if c.supervisor == nil {
+		return nil, errors.New("WhatsApp supervisor is unavailable")
+	}
+	return c.supervisor, nil
+}
+
+func (c *whatsappSupervisorControl) isPaired() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.isPairedLocked()
+}
+
+func (c *whatsappSupervisorControl) isPairedLocked() bool {
+	return c.paired != nil && c.paired()
+}
+
+// rebuildUnpairedSupervisor terminally joins a blocked supervisor whose
+// remote logout already removed the local session, then reuses the normal
+// stopped-supervisor rebuild path. The replacement is therefore admitted in
+// StateUnpaired and can own a fresh pairing attempt.
+func (c *whatsappSupervisorControl) rebuildUnpairedSupervisor(
+	supervisor *bridge.Supervisor,
+) (*bridge.Supervisor, error) {
+	c.mu.Lock()
+	if c.closed || c.stopping {
+		c.mu.Unlock()
+		return nil, bridge.ErrSupervisorStopped
+	}
+	if c.supervisor != supervisor {
+		c.mu.Unlock()
+		return c.activeSupervisor()
+	}
+	c.stopping = true
+	cancelWatcher := c.pairWatchCancel
+	c.mu.Unlock()
+
+	if cancelWatcher != nil {
+		cancelWatcher()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), whatsappSupervisorStopTimeout)
+	defer cancel()
+	if err := supervisor.Stop(ctx); err != nil {
+		go c.awaitStoppedSupervisor(supervisor)
+		return nil, fmt.Errorf("stop blocked WhatsApp supervisor: %w", err)
+	}
+	c.pairWatchWG.Wait()
+
+	c.mu.Lock()
+	if c.closed {
+		c.stopping = false
+		c.mu.Unlock()
+		return nil, bridge.ErrSupervisorStopped
+	}
+	if c.supervisor == supervisor {
+		c.supervisorStopped = true
+		c.pairWatchActive = false
+		c.pairWatchCancel = nil
+	}
+	c.stopping = false
+	c.mu.Unlock()
+
+	return c.activeSupervisor()
+}
+
+func (c *whatsappSupervisorControl) StopAndUnpair(unpair func() error) error {
+	c.mu.Lock()
+	if c.closed || c.stopping {
+		c.mu.Unlock()
+		return bridge.ErrSupervisorStopped
+	}
+	c.stopping = true
+	supervisor := c.supervisor
+	cancelWatcher := c.pairWatchCancel
+	c.mu.Unlock()
+
+	if cancelWatcher != nil {
+		cancelWatcher()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), whatsappSupervisorStopTimeout)
+	defer cancel()
+	stopErr := supervisor.Stop(ctx)
+	if stopErr != nil {
+		go c.awaitStoppedSupervisor(supervisor)
+		return fmt.Errorf("stop WhatsApp connection: %w", stopErr)
+	}
+	c.pairWatchWG.Wait()
+
+	var unpairErr error
+	if unpair != nil {
+		unpairErr = unpair()
+	}
+	c.mu.Lock()
+	c.supervisorStopped = true
+	c.stopping = false
+	c.pairWatchActive = false
+	c.pairWatchCancel = nil
+	c.mu.Unlock()
+	return unpairErr
+}
+
+func (c *whatsappSupervisorControl) awaitStoppedSupervisor(supervisor *bridge.Supervisor) {
+	_ = supervisor.Stop(context.Background())
+	c.pairWatchWG.Wait()
+	c.mu.Lock()
+	if c.supervisor == supervisor && !c.closed {
+		c.supervisorStopped = true
+		c.stopping = false
+		c.pairWatchActive = false
+		c.pairWatchCancel = nil
+	}
+	c.mu.Unlock()
+}
+
+func (c *whatsappSupervisorControl) Stop(ctx context.Context) error {
+	c.mu.Lock()
+	if c.supervisor == nil {
+		c.closed = true
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	c.stopping = true
+	supervisor := c.supervisor
+	cancelWatcher := c.pairWatchCancel
+	c.mu.Unlock()
+
+	if cancelWatcher != nil {
+		cancelWatcher()
+	}
+	err := supervisor.Stop(ctx)
+	if err != nil {
+		return err
+	}
+	c.pairWatchWG.Wait()
+	c.mu.Lock()
+	c.supervisorStopped = true
+	c.stopping = false
+	c.pairWatchActive = false
+	c.pairWatchCancel = nil
+	c.mu.Unlock()
+	return nil
+}
+
+type whatsappPairCodeSink struct {
+	events chan bridge.PairEvent
+}
+
+func newWhatsAppPairCodeSink() *whatsappPairCodeSink {
+	return &whatsappPairCodeSink{events: make(chan bridge.PairEvent, 4)}
+}
+
+func (s *whatsappPairCodeSink) EmitPairEvent(ctx context.Context, event bridge.PairEvent) error {
+	select {
+	case s.events <- event:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+var _ bridge.PairSink = (*whatsappPairCodeSink)(nil)

--- a/cmd/whatsapp_supervisor_test.go
+++ b/cmd/whatsapp_supervisor_test.go
@@ -1,0 +1,329 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+func TestWhatsAppSupervisorControlRemoteLoggedOutCanPairAgain(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantMethod bridge.PairMethod
+		recover    func(*whatsappSupervisorControl) error
+	}{
+		{
+			name:       "Reconnect starts QR pairing",
+			wantMethod: bridge.PairQR,
+			recover:    (*whatsappSupervisorControl).Reconnect,
+		},
+		{
+			name:       "PairPhone starts phone-code pairing",
+			wantMethod: bridge.PairPhoneCode,
+			recover: func(control *whatsappSupervisorControl) error {
+				code, err := control.PairPhone("+15551234567")
+				if err == nil && code != whatsappControlTestPairCode {
+					return errors.New("PairPhone returned the wrong code")
+				}
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			harness := newWhatsAppControlTestHarness(t, bridge.StateStopped, true)
+
+			if err := harness.control.Reconnect(); err != nil {
+				t.Fatalf("initial Reconnect() error = %v", err)
+			}
+			awaitWhatsAppControlState(t, harness.first, bridge.StateOnline)
+
+			// whatsapplive deletes the local session before publishing LoggedOut.
+			// The adapter then completes the active generation with ReauthRequired.
+			harness.adapter.paired.Store(false)
+			harness.adapter.Run(0).Fail(bridge.OpError{
+				Class:       bridge.FailureReauthRequired,
+				Operation:   "event",
+				Fingerprint: "whatsapp_logged_out",
+				Cause:       errors.New("remote device logged out"),
+			})
+			awaitWhatsAppControlState(t, harness.first, bridge.StateBlocked)
+
+			if err := test.recover(harness.control); err != nil {
+				t.Fatalf("re-pair after remote LoggedOut error = %v", err)
+			}
+			replacement := harness.currentSupervisor()
+			if replacement == harness.first {
+				t.Fatal("re-pair reused the blocked supervisor after remote LoggedOut")
+			}
+			awaitWhatsAppControlState(t, replacement, bridge.StateOnline)
+
+			if got := harness.adapter.PairCount(); got != 1 {
+				t.Fatalf("pair attempts = %d, want 1", got)
+			}
+			if request := harness.adapter.PairRequest(0); request.Method != test.wantMethod {
+				t.Fatalf("pair method = %q, want %q", request.Method, test.wantMethod)
+			}
+			if got := harness.adapter.StartCount(); got != 2 {
+				t.Fatalf("connection starts = %d, want initial start plus one post-pair start", got)
+			}
+			if got := harness.supervisorCount.Load(); got != 2 {
+				t.Fatalf("supervisors constructed = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestWhatsAppSupervisorControlUnpairCanPairPhoneAgain(t *testing.T) {
+	harness := newWhatsAppControlTestHarness(t, bridge.StateStopped, true)
+
+	if err := harness.control.Reconnect(); err != nil {
+		t.Fatalf("initial Reconnect() error = %v", err)
+	}
+	awaitWhatsAppControlState(t, harness.first, bridge.StateOnline)
+	if err := harness.control.StopAndUnpair(func() error {
+		harness.adapter.paired.Store(false)
+		return nil
+	}); err != nil {
+		t.Fatalf("StopAndUnpair() error = %v", err)
+	}
+
+	code, err := harness.control.PairPhone(" +15551234567 ")
+	if err != nil {
+		t.Fatalf("PairPhone() after unpair error = %v", err)
+	}
+	if code != whatsappControlTestPairCode {
+		t.Fatalf("PairPhone() code = %q, want %q", code, whatsappControlTestPairCode)
+	}
+	replacement := harness.currentSupervisor()
+	if replacement == harness.first {
+		t.Fatal("PairPhone() reused the terminal supervisor after unpair")
+	}
+	awaitWhatsAppControlState(t, replacement, bridge.StateOnline)
+
+	request := harness.adapter.PairRequest(0)
+	if request.Method != bridge.PairPhoneCode || request.Phone != "+15551234567" {
+		t.Fatalf("pair request = %+v, want trimmed phone-code request", request)
+	}
+	if got := harness.adapter.StartCount(); got != 2 {
+		t.Fatalf("connection starts = %d, want initial start plus one post-pair start", got)
+	}
+}
+
+func TestWhatsAppSupervisorPairWatcherStartsExactlyOnce(t *testing.T) {
+	harness := newWhatsAppControlTestHarness(t, bridge.StateUnpaired, false)
+
+	code, err := harness.control.PairPhone("+15557654321")
+	if err != nil {
+		t.Fatalf("PairPhone() error = %v", err)
+	}
+	if code != whatsappControlTestPairCode {
+		t.Fatalf("PairPhone() code = %q, want %q", code, whatsappControlTestPairCode)
+	}
+	awaitWhatsAppControlState(t, harness.first, bridge.StateOnline)
+
+	// Give any duplicate watcher enough time to observe StateStopped and issue
+	// another Start. The supervisor itself would reject overlap, while the
+	// lifecycle count proves the handoff performed exactly one real start.
+	time.Sleep(50 * time.Millisecond)
+	if got := harness.adapter.StartCount(); got != 1 {
+		t.Fatalf("post-pair connection starts = %d, want exactly 1", got)
+	}
+	if got := harness.adapter.PairCount(); got != 1 {
+		t.Fatalf("pair attempts = %d, want exactly 1", got)
+	}
+}
+
+const whatsappControlTestPairCode = "1234-5678"
+
+type whatsappControlTestHarness struct {
+	control         *whatsappSupervisorControl
+	adapter         *whatsappControlTestAdapter
+	first           *bridge.Supervisor
+	supervisorCount atomic.Int32
+}
+
+func newWhatsAppControlTestHarness(
+	t *testing.T,
+	initial bridge.State,
+	paired bool,
+) *whatsappControlTestHarness {
+	t.Helper()
+	harness := &whatsappControlTestHarness{adapter: &whatsappControlTestAdapter{}}
+	harness.adapter.paired.Store(paired)
+	newSupervisor := func(initial bridge.State) (*bridge.Supervisor, error) {
+		harness.supervisorCount.Add(1)
+		return bridge.NewSupervisor(
+			whatsappAccountID,
+			bridge.PlatformWhatsApp,
+			harness.adapter,
+			whatsappSupervisorPolicy(),
+			whatsappWallClock{},
+			whatsappRandom{},
+			bridge.WithPairer(harness.adapter),
+			bridge.WithInitialState(initial),
+		)
+	}
+	first, err := newSupervisor(initial)
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	harness.first = first
+	harness.control = newWhatsAppSupervisorControl(
+		first,
+		newSupervisor,
+		func() bool { return harness.adapter.paired.Load() },
+	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := harness.control.Stop(ctx); err != nil {
+			t.Errorf("control.Stop() error = %v", err)
+		}
+	})
+	return harness
+}
+
+func (h *whatsappControlTestHarness) currentSupervisor() *bridge.Supervisor {
+	h.control.mu.Lock()
+	defer h.control.mu.Unlock()
+	return h.control.supervisor
+}
+
+type whatsappControlTestAdapter struct {
+	paired atomic.Bool
+
+	mu           sync.Mutex
+	runs         []*whatsappControlTestRun
+	pairRequests []bridge.PairRequest
+}
+
+func (a *whatsappControlTestAdapter) Start(
+	_ context.Context,
+	_ bridge.StartRequest,
+	_ bridge.ConnectionSink,
+) (bridge.Run, error) {
+	run := newWhatsAppControlTestRun()
+	a.mu.Lock()
+	a.runs = append(a.runs, run)
+	a.mu.Unlock()
+	return run, nil
+}
+
+func (a *whatsappControlTestAdapter) Pair(
+	ctx context.Context,
+	request bridge.PairRequest,
+	sink bridge.PairSink,
+) (bridge.PairResult, error) {
+	a.mu.Lock()
+	a.pairRequests = append(a.pairRequests, request)
+	a.mu.Unlock()
+	if request.Method == bridge.PairPhoneCode {
+		if err := sink.EmitPairEvent(ctx, bridge.PairEvent{
+			Kind:      "code",
+			Payload:   whatsappControlTestPairCode,
+			ExpiresAt: time.Now().Add(time.Minute),
+		}); err != nil {
+			return bridge.PairResult{}, err
+		}
+	}
+	a.paired.Store(true)
+	return bridge.PairResult{
+		RemoteAccountID: "whatsapp-user",
+		RemoteDeviceID:  "whatsapp-device",
+	}, nil
+}
+
+func (a *whatsappControlTestAdapter) Unpair(context.Context, string) error {
+	a.paired.Store(false)
+	return nil
+}
+
+func (a *whatsappControlTestAdapter) StartCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.runs)
+}
+
+func (a *whatsappControlTestAdapter) PairCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.pairRequests)
+}
+
+func (a *whatsappControlTestAdapter) Run(index int) *whatsappControlTestRun {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.runs[index]
+}
+
+func (a *whatsappControlTestAdapter) PairRequest(index int) bridge.PairRequest {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.pairRequests[index]
+}
+
+type whatsappControlTestRun struct {
+	ready chan struct{}
+	done  chan error
+	once  sync.Once
+}
+
+func newWhatsAppControlTestRun() *whatsappControlTestRun {
+	run := &whatsappControlTestRun{
+		ready: make(chan struct{}),
+		done:  make(chan error, 1),
+	}
+	close(run.ready)
+	return run
+}
+
+func (r *whatsappControlTestRun) Ready() <-chan struct{} { return r.ready }
+func (r *whatsappControlTestRun) Done() <-chan error     { return r.done }
+func (r *whatsappControlTestRun) Probe(context.Context) (bridge.Liveness, error) {
+	return bridge.Liveness{AliveAt: time.Now(), Detail: "test"}, nil
+}
+func (r *whatsappControlTestRun) Stop(context.Context) error {
+	r.finish(nil)
+	return nil
+}
+func (r *whatsappControlTestRun) Fail(err error) { r.finish(err) }
+func (r *whatsappControlTestRun) finish(err error) {
+	r.once.Do(func() {
+		if err != nil {
+			r.done <- err
+		}
+		close(r.done)
+	})
+}
+
+func awaitWhatsAppControlState(
+	t *testing.T,
+	supervisor *bridge.Supervisor,
+	want bridge.State,
+) bridge.Snapshot {
+	t.Helper()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		snapshot := supervisor.Snapshot()
+		if snapshot.State == want {
+			return snapshot
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("supervisor state = %q, want %q (snapshot %+v)", snapshot.State, want, snapshot)
+		case <-ticker.C:
+		}
+	}
+}
+
+var _ bridge.Lifecycle = (*whatsappControlTestAdapter)(nil)
+var _ bridge.Pairer = (*whatsappControlTestAdapter)(nil)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -112,21 +112,21 @@ func (p *BackfillProgress) snapshot() BackfillSnapshot {
 }
 
 type App struct {
-	clientMu               sync.RWMutex
-	Client                 *client.Client
-	googleGeneration       *GoogleGeneration
-	Store                  *db.Store
-	EventHandler           *client.EventHandler
-	Logger                 zerolog.Logger
-	DataDir                string
-	SessionPath            string
-	WhatsAppSessionPath    string
-	SignalConfigPath       string
+	clientMu            sync.RWMutex
+	Client              *client.Client
+	googleGeneration    *GoogleGeneration
+	Store               *db.Store
+	EventHandler        *client.EventHandler
+	Logger              zerolog.Logger
+	DataDir             string
+	SessionPath         string
+	WhatsAppSessionPath string
+	SignalConfigPath    string
 	// sendTextOverride lets tests substitute the scheduler's send. Nil in prod.
 	sendTextOverride func(conversationID, body, replyToID string) (*db.Message, error)
 	// sendMediaOverride lets tests substitute the scheduler's media send. Nil in prod.
-	sendMediaOverride func(conversationID string, data []byte, filename, mime, caption, replyToID string) (*db.Message, error)
-	Connected         atomic.Bool
+	sendMediaOverride      func(conversationID string, data []byte, filename, mime, caption, replyToID string) (*db.Message, error)
+	Connected              atomic.Bool
 	OnConversationsChange  func()
 	OnIncomingMessage      func(*db.Message)
 	OnMessagesChange       func(string)
@@ -137,22 +137,24 @@ type App struct {
 
 	// gmClient is used by backfill methods. If nil, it's derived from Client.GM.
 	// Set this field directly in tests to inject a mock.
-	gmClient         GMClient
-	BackfillProgress BackfillProgress
-	backfillRunning  atomic.Bool
-	reconcileRunning atomic.Bool
-	avatarSyncMu     sync.Mutex
-	avatarSyncOnce   sync.Once
-	avatarSyncWG     sync.WaitGroup
-	avatarSyncClosed bool
-	avatarSyncQueue  chan db.ContactAvatarCandidate
-	avatarSyncStop   chan struct{}
-	whatsAppMu       sync.Mutex
-	WhatsApp         *whatsapplive.Bridge
-	signalMu         sync.Mutex
-	Signal           *signallive.Bridge
-	statusMu         sync.Mutex
-	googleLastError  string
+	gmClient                  GMClient
+	BackfillProgress          BackfillProgress
+	backfillRunning           atomic.Bool
+	reconcileRunning          atomic.Bool
+	avatarSyncMu              sync.Mutex
+	avatarSyncOnce            sync.Once
+	avatarSyncWG              sync.WaitGroup
+	avatarSyncClosed          bool
+	avatarSyncQueue           chan db.ContactAvatarCandidate
+	avatarSyncStop            chan struct{}
+	whatsAppMu                sync.Mutex
+	WhatsApp                  *whatsapplive.Bridge
+	whatsAppLifecycleMu       sync.RWMutex
+	whatsAppLifecycleNotifier WhatsAppLifecycleNotifier
+	signalMu                  sync.Mutex
+	Signal                    *signallive.Bridge
+	statusMu                  sync.Mutex
+	googleLastError           string
 	// A lapsed Google Messages linked-device session keeps reporting
 	// Connected=true while every send comes back UNKNOWN (the phone has
 	// silently unlinked us). Count consecutive non-SUCCESS Google sends so

--- a/internal/app/whatsapp.go
+++ b/internal/app/whatsapp.go
@@ -19,6 +19,7 @@ func (a *App) ensureWhatsApp() (*whatsapplive.Bridge, error) {
 		OnConversationsChange: a.emitConversationsChange,
 		OnIncomingMessage:     a.OnIncomingMessage,
 		OnMessagesChange:      a.emitMessagesChange,
+		OnConnectionError:     a.reportWhatsAppLifecycleError,
 		OnStatusChange: func() {
 			if a.OnWhatsAppStatusChange != nil {
 				a.OnWhatsAppStatusChange()
@@ -38,6 +39,13 @@ func (a *App) GetWhatsApp() *whatsapplive.Bridge {
 	a.whatsAppMu.Lock()
 	defer a.whatsAppMu.Unlock()
 	return a.WhatsApp
+}
+
+// InitializeWhatsApp constructs the legacy operation surface without starting
+// a transport. Runtime connection and pairing ownership belongs to the bridge
+// supervisor assembled by cmd.
+func (a *App) InitializeWhatsApp() (*whatsapplive.Bridge, error) {
+	return a.ensureWhatsApp()
 }
 
 func (a *App) LoadAndConnectWhatsApp() error {

--- a/internal/app/whatsapp_lifecycle_notify.go
+++ b/internal/app/whatsapp_lifecycle_notify.go
@@ -1,0 +1,32 @@
+package app
+
+// WhatsAppLifecycleNotifier lets the legacy WhatsApp bridge report transport
+// failures without owning reconnect or repair. The WhatsApp bridge adapter
+// implements this interface and leaves generation changes to the supervisor.
+type WhatsAppLifecycleNotifier interface {
+	// ReportError ends the current generation with an error classified by the
+	// supervisor-owned lifecycle adapter.
+	ReportError(error) bool
+}
+
+// SetWhatsAppLifecycleNotifier installs the lifecycle owner notified by the
+// legacy WhatsApp bridge. It is safe to replace or clear the notifier while
+// bridge operations are in flight.
+func (a *App) SetWhatsAppLifecycleNotifier(notifier WhatsAppLifecycleNotifier) {
+	a.whatsAppLifecycleMu.Lock()
+	a.whatsAppLifecycleNotifier = notifier
+	a.whatsAppLifecycleMu.Unlock()
+}
+
+func (a *App) whatsAppLifecycle() WhatsAppLifecycleNotifier {
+	a.whatsAppLifecycleMu.RLock()
+	notifier := a.whatsAppLifecycleNotifier
+	a.whatsAppLifecycleMu.RUnlock()
+	return notifier
+}
+
+func (a *App) reportWhatsAppLifecycleError(err error) {
+	if notifier := a.whatsAppLifecycle(); notifier != nil {
+		notifier.ReportError(err)
+	}
+}

--- a/internal/app/whatsapp_lifecycle_notify_test.go
+++ b/internal/app/whatsapp_lifecycle_notify_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+type recordingWhatsAppLifecycleNotifier struct {
+	mu       sync.Mutex
+	reported []error
+}
+
+func (n *recordingWhatsAppLifecycleNotifier) ReportError(err error) bool {
+	n.mu.Lock()
+	n.reported = append(n.reported, err)
+	n.mu.Unlock()
+	return true
+}
+
+func (n *recordingWhatsAppLifecycleNotifier) errors() []error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return append([]error(nil), n.reported...)
+}
+
+func TestWhatsAppLifecycleNotifierReportsConnectionError(t *testing.T) {
+	a := &App{}
+	notifier := &recordingWhatsAppLifecycleNotifier{}
+	a.SetWhatsAppLifecycleNotifier(notifier)
+
+	want := errors.New("WhatsApp transport disconnected")
+	a.reportWhatsAppLifecycleError(want)
+
+	reported := notifier.errors()
+	if len(reported) != 1 || reported[0] != want {
+		t.Fatalf("reported = %v, want exactly [%v]", reported, want)
+	}
+}
+
+func TestWhatsAppLifecycleNotifierCanBeReplacedAndCleared(t *testing.T) {
+	a := &App{}
+	first := &recordingWhatsAppLifecycleNotifier{}
+	second := &recordingWhatsAppLifecycleNotifier{}
+	a.SetWhatsAppLifecycleNotifier(first)
+	a.SetWhatsAppLifecycleNotifier(second)
+
+	want := errors.New("send failed")
+	a.reportWhatsAppLifecycleError(want)
+	if reported := first.errors(); len(reported) != 0 {
+		t.Fatalf("replaced notifier was invoked: %v", reported)
+	}
+	if reported := second.errors(); len(reported) != 1 || reported[0] != want {
+		t.Fatalf("replacement reported = %v, want exactly [%v]", reported, want)
+	}
+
+	a.SetWhatsAppLifecycleNotifier(nil)
+	a.reportWhatsAppLifecycleError(errors.New("ignored after clear"))
+	if reported := second.errors(); len(reported) != 1 {
+		t.Fatalf("cleared notifier was invoked: %v", reported)
+	}
+}

--- a/internal/bridgeadapters/whatsapp/whatsapp.go
+++ b/internal/bridgeadapters/whatsapp/whatsapp.go
@@ -1,0 +1,743 @@
+// Package whatsapp adapts one whatsmeow-backed live bridge to a
+// generation-owned bridge.Run. Legacy message/media operations stay on App;
+// all connection, retry, liveness, and pairing decisions belong to Supervisor.
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	wastore "go.mau.fi/whatsmeow/store"
+	waevents "go.mau.fi/whatsmeow/types/events"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/whatsapplive"
+)
+
+type Adapter struct {
+	accountID string
+	host      *whatsapplive.Bridge
+
+	connect        func(context.Context) error
+	disconnect     func()
+	probe          func(context.Context) error
+	accountInfo    func() whatsapplive.AccountInfo
+	cooldown       func() time.Time
+	prepareQR      func(context.Context) (<-chan whatsmeow.QRChannelItem, error)
+	connectPairing func(context.Context) error
+	applyQR        func(whatsmeow.QRChannelItem) whatsapplive.QRSnapshot
+	pairPhone      func(context.Context, string) (string, error)
+	unpair         func() error
+	now            func() time.Time
+
+	mu       sync.Mutex
+	current  *run
+	starting bool
+	pairing  *pairAttempt
+}
+
+func New(accountID string, host *whatsapplive.Bridge) *Adapter {
+	a := &Adapter{
+		accountID: accountID,
+		host:      host,
+		now:       time.Now,
+	}
+	if host != nil {
+		a.connect = host.ConnectPaired
+		a.disconnect = host.DisconnectTransport
+		a.probe = host.ProbeKeepAlive
+		a.accountInfo = host.PairedAccount
+		a.cooldown = host.TemporaryBanDeadline
+		a.prepareQR = host.PrepareQRPairing
+		a.connectPairing = host.ConnectPairing
+		a.applyQR = host.ApplyQRItem
+		a.pairPhone = host.PairPhoneContext
+		a.unpair = host.Unpair
+		host.ObserveLifecycle(a.handleLifecycleEvent)
+	}
+	return a
+}
+
+func (a *Adapter) AccountID() string { return a.accountID }
+
+func (a *Adapter) Platform() bridge.Platform { return bridge.PlatformWhatsApp }
+
+func (a *Adapter) DeclaredCapabilities() bridge.CapabilitySet {
+	return bridge.CapabilitySet{
+		StartConversation: true,
+		TextSend:          true,
+		MediaSend:         true,
+		Reactions:         true,
+		ReadReceipts:      true,
+		PairQR:            true,
+		PairPhone:         true,
+		MediaDownload:     true,
+	}
+}
+
+func (a *Adapter) Start(
+	ctx context.Context,
+	req bridge.StartRequest,
+	sink bridge.ConnectionSink,
+) (bridge.Run, error) {
+	if ctx == nil {
+		return nil, errors.New("whatsapp lifecycle: nil start context")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if a == nil || a.host == nil || a.connect == nil || a.disconnect == nil ||
+		a.probe == nil || a.accountInfo == nil || a.cooldown == nil || a.now == nil {
+		return nil, bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "whatsapp_adapter_unconfigured",
+			Cause:       errors.New("WhatsApp lifecycle adapter is not configured"),
+		}
+	}
+	if req.AccountID != a.accountID {
+		return nil, fmt.Errorf("whatsapp lifecycle: account %q does not match %q", req.AccountID, a.accountID)
+	}
+	if failure := a.cooldownFailure("connect"); failure != nil {
+		return nil, *failure
+	}
+	if !a.accountInfo().Paired {
+		return nil, bridge.OpError{
+			Class:       bridge.FailureReauthRequired,
+			Operation:   "connect",
+			Fingerprint: "whatsapp_not_paired",
+			Cause:       whatsmeow.ErrNotLoggedIn,
+		}
+	}
+
+	a.mu.Lock()
+	if a.current != nil || a.starting || a.pairing != nil {
+		a.mu.Unlock()
+		return nil, bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "overlapping_whatsapp_generation",
+			Cause:       errors.New("a WhatsApp connect or pair attempt is already active"),
+		}
+	}
+	a.starting = true
+	a.mu.Unlock()
+
+	runCtx, cancel := context.WithCancel(ctx)
+	r := &run{
+		adapter:   a,
+		request:   req,
+		sink:      sink,
+		ctx:       runCtx,
+		cancel:    cancel,
+		ready:     make(chan struct{}),
+		done:      make(chan error, 1),
+		stopped:   make(chan struct{}),
+		finish:    make(chan error, 1),
+		admitting: true,
+	}
+	r.workers.Add(1)
+	a.mu.Lock()
+	a.current = r
+	a.starting = false
+	a.mu.Unlock()
+
+	go r.coordinate()
+	go r.connect()
+	return r, nil
+}
+
+// ReportError retires the current generation after a legacy send/media/group
+// operation reports a reconnect-worthy failure. It never calls Connect.
+func (a *Adapter) ReportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	a.mu.Lock()
+	r := a.current
+	a.mu.Unlock()
+	if r == nil || !r.admitCallback() {
+		return false
+	}
+	defer r.callbacks.Done()
+	select {
+	case <-r.ready:
+	default:
+		return false
+	}
+	failure := a.classifyError(err, "operation", "whatsapp_operation_failed")
+	r.requestFinish(failure)
+	return true
+}
+
+func (a *Adapter) handleLifecycleEvent(event whatsapplive.LifecycleEvent) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			a.mu.Lock()
+			r := a.current
+			a.mu.Unlock()
+			if r != nil {
+				r.requestFinish(bridge.OpError{
+					Class:       bridge.FailureTransient,
+					Operation:   "event",
+					Fingerprint: "whatsapp_event_handler_panic",
+					Cause:       fmt.Errorf("panic in WhatsApp lifecycle event handler: %v\n%s", recovered, debug.Stack()),
+				})
+			}
+		}
+	}()
+
+	a.mu.Lock()
+	r := a.current
+	pairing := a.pairing
+	a.mu.Unlock()
+	if pairing != nil {
+		pairing.deliver(event)
+	}
+	if r == nil || !r.admitCallback() {
+		return
+	}
+	defer r.callbacks.Done()
+	r.handleEvent(event)
+}
+
+func (a *Adapter) cooldownFailure(operation string) *bridge.OpError {
+	if a.cooldown == nil || a.now == nil {
+		return nil
+	}
+	retryAt := a.cooldown()
+	if retryAt.IsZero() || !a.now().Before(retryAt) {
+		return nil
+	}
+	return &bridge.OpError{
+		Class:       bridge.FailureRateLimited,
+		Operation:   operation,
+		RetryAt:     retryAt,
+		Fingerprint: "whatsapp_temporary_ban",
+		Cause:       &whatsapplive.TemporaryBanError{RetryAt: retryAt},
+	}
+}
+
+func (a *Adapter) classifyError(err error, operation, fingerprint string) bridge.OpError {
+	if err == nil {
+		err = errors.New("WhatsApp transport ended without an error")
+	}
+	if failure, ok := asOpError(err); ok {
+		return failure
+	}
+	var ban *whatsapplive.TemporaryBanError
+	if errors.As(err, &ban) && ban != nil {
+		return bridge.OpError{
+			Class:       bridge.FailureRateLimited,
+			Operation:   operation,
+			RetryAt:     ban.RetryAt,
+			Fingerprint: "whatsapp_temporary_ban",
+			Cause:       err,
+		}
+	}
+	if errors.Is(err, whatsmeow.ErrNotLoggedIn) || errors.Is(err, wastore.ErrDeviceDeleted) {
+		return bridge.OpError{
+			Class:       bridge.FailureReauthRequired,
+			Operation:   operation,
+			Fingerprint: "whatsapp_session_invalid",
+			Cause:       err,
+		}
+	}
+	if errors.Is(err, whatsmeow.ErrAlreadyConnected) ||
+		strings.Contains(strings.ToLower(err.Error()), "already in progress") {
+		return bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   operation,
+			Fingerprint: "overlapping_whatsapp_connect",
+			Cause:       err,
+		}
+	}
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   operation,
+		Fingerprint: fingerprint,
+		Cause:       err,
+	}
+}
+
+func (a *Adapter) classifyEvent(event whatsapplive.LifecycleEvent) (bridge.OpError, bool) {
+	if event.PersistenceError != nil {
+		return bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "persist_ban",
+			Fingerprint: "whatsapp_ban_persistence_failed",
+			Cause:       event.PersistenceError,
+		}, true
+	}
+	switch raw := event.Raw.(type) {
+	case *waevents.Disconnected:
+		return transientEvent("disconnect", "whatsapp_disconnected", errors.New("WhatsApp disconnected")), true
+	case *waevents.LoggedOut:
+		return bridge.OpError{
+			Class:       bridge.FailureReauthRequired,
+			Operation:   "connect",
+			Fingerprint: "whatsapp_logged_out",
+			Cause:       errors.New(raw.PermanentDisconnectDescription()),
+		}, true
+	case *waevents.TemporaryBan:
+		retryAt := event.RetryAt
+		if retryAt.IsZero() && raw.Expire > 0 {
+			retryAt = event.At.Add(raw.Expire)
+		}
+		if retryAt.IsZero() {
+			return bridge.OpError{
+				Class:       bridge.FailureReauthRequired,
+				Operation:   "connect",
+				Fingerprint: "whatsapp_temporary_ban_without_expiry",
+				Cause:       errors.New(raw.PermanentDisconnectDescription()),
+			}, true
+		}
+		return bridge.OpError{
+			Class:       bridge.FailureRateLimited,
+			Operation:   "connect",
+			RetryAt:     retryAt,
+			Fingerprint: fmt.Sprintf("whatsapp_temporary_ban_%d", raw.Code),
+			Cause:       errors.New(raw.PermanentDisconnectDescription()),
+		}, true
+	case *waevents.ClientOutdated:
+		return bridge.OpError{
+			Class:       bridge.FailureUpgradeRequired,
+			Operation:   "connect",
+			Fingerprint: "whatsapp_client_outdated",
+			Cause:       errors.New("WhatsApp client is outdated"),
+		}, true
+	case *waevents.ConnectFailure:
+		class := bridge.FailureTransient
+		if raw.Reason.IsLoggedOut() {
+			class = bridge.FailureReauthRequired
+		}
+		return bridge.OpError{
+			Class:       class,
+			Operation:   "connect",
+			Fingerprint: fmt.Sprintf("whatsapp_connect_failure_%d", raw.Reason),
+			Cause:       errors.New(raw.PermanentDisconnectDescription()),
+		}, true
+	case *waevents.StreamReplaced:
+		return transientEvent("connect", "whatsapp_stream_replaced", errors.New("WhatsApp stream replaced")), true
+	case *waevents.ManualLoginReconnect:
+		return transientEvent("connect", "whatsapp_manual_login_reconnect", errors.New("WhatsApp requested a supervised login reconnect")), true
+	case *waevents.CATRefreshError:
+		return transientEvent("connect", "whatsapp_cat_refresh_failed", raw.Error), true
+	case *waevents.StreamError:
+		return transientEvent("connect", "whatsapp_stream_error_"+raw.Code, errors.New("WhatsApp stream error")), true
+	}
+	return bridge.OpError{}, false
+}
+
+func transientEvent(operation, fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   operation,
+		Fingerprint: fingerprint,
+		Cause:       cause,
+	}
+}
+
+func asOpError(err error) (bridge.OpError, bool) {
+	var pointer *bridge.OpError
+	if errors.As(err, &pointer) && pointer != nil {
+		return *pointer, true
+	}
+	var value bridge.OpError
+	if errors.As(err, &value) {
+		return value, true
+	}
+	return bridge.OpError{}, false
+}
+
+type run struct {
+	adapter *Adapter
+	request bridge.StartRequest
+	sink    bridge.ConnectionSink
+	ctx     context.Context
+	cancel  context.CancelFunc
+
+	ready      chan struct{}
+	done       chan error
+	stopped    chan struct{}
+	finish     chan error
+	readyOnce  sync.Once
+	finishOnce sync.Once
+
+	admissionMu sync.Mutex
+	admitting   bool
+	callbacks   sync.WaitGroup
+	workers     sync.WaitGroup
+}
+
+func (r *run) Ready() <-chan struct{} { return r.ready }
+func (r *run) Done() <-chan error     { return r.done }
+
+func (r *run) connect() {
+	defer r.workers.Done()
+	if err := r.adapter.connect(r.ctx); err != nil && r.ctx.Err() == nil {
+		r.requestFinish(r.adapter.classifyError(err, "connect", "whatsapp_connect_failed"))
+	}
+}
+
+func (r *run) Probe(ctx context.Context) (bridge.Liveness, error) {
+	if ctx == nil {
+		return bridge.Liveness{}, errors.New("whatsapp probe: nil context")
+	}
+	if err := r.adapter.probe(ctx); err != nil {
+		failure := r.adapter.classifyError(err, "probe", "whatsapp_keepalive_failed")
+		return bridge.Liveness{}, failure
+	}
+	return bridge.Liveness{AliveAt: r.adapter.now(), Detail: "whatsapp_keepalive"}, nil
+}
+
+func (r *run) Stop(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("whatsapp run: nil stop context")
+	}
+	r.requestFinish(nil)
+	select {
+	case <-r.stopped:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *run) coordinate() {
+	var terminal error
+	select {
+	case terminal = <-r.finish:
+	case <-r.ctx.Done():
+		terminal = r.ctx.Err()
+	}
+
+	r.closeAdmission()
+	r.cancel()
+	r.adapter.disconnect()
+	r.workers.Wait()
+	r.callbacks.Wait()
+	r.adapter.clearCurrent(r)
+	r.done <- terminal
+	close(r.done)
+	close(r.stopped)
+}
+
+func (r *run) requestFinish(err error) {
+	r.finishOnce.Do(func() {
+		r.closeAdmission()
+		r.finish <- err
+	})
+}
+
+func (r *run) closeAdmission() {
+	r.admissionMu.Lock()
+	r.admitting = false
+	r.admissionMu.Unlock()
+}
+
+func (r *run) admitCallback() bool {
+	r.admissionMu.Lock()
+	defer r.admissionMu.Unlock()
+	if !r.admitting {
+		return false
+	}
+	r.callbacks.Add(1)
+	return true
+}
+
+func (r *run) handleEvent(event whatsapplive.LifecycleEvent) {
+	if _, ok := event.Raw.(*waevents.Connected); ok && event.Paired {
+		r.readyOnce.Do(func() { close(r.ready) })
+		if r.sink != nil {
+			r.sink.Beat(r.request.Generation, event.At, "event:whatsapp.connected")
+		}
+		return
+	}
+	if event.Paired && eventProvidesLiveness(event.Raw) && r.sink != nil {
+		r.sink.Beat(r.request.Generation, event.At, fmt.Sprintf("event:%T", event.Raw))
+	}
+	if failure, terminal := r.adapter.classifyEvent(event); terminal {
+		r.requestFinish(failure)
+	}
+}
+
+func eventProvidesLiveness(raw any) bool {
+	switch raw.(type) {
+	case *waevents.Message, *waevents.Receipt, *waevents.HistorySync,
+		*waevents.GroupInfo, *waevents.ChatPresence, *waevents.KeepAliveRestored:
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *Adapter) clearCurrent(candidate *run) {
+	a.mu.Lock()
+	if a.current == candidate {
+		a.current = nil
+	}
+	a.mu.Unlock()
+}
+
+type pairAttempt struct {
+	events chan whatsapplive.LifecycleEvent
+}
+
+func (p *pairAttempt) deliver(event whatsapplive.LifecycleEvent) {
+	select {
+	case p.events <- event:
+	default:
+		// Pairing emits only a small fixed set of lifecycle events. If an
+		// unexpected event flood fills the channel, dropping non-terminal noise
+		// is safer than blocking whatsmeow's event dispatcher.
+	}
+}
+
+func (a *Adapter) Pair(
+	ctx context.Context,
+	req bridge.PairRequest,
+	sink bridge.PairSink,
+) (bridge.PairResult, error) {
+	if ctx == nil {
+		return bridge.PairResult{}, errors.New("whatsapp pair: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.PairResult{}, err
+	}
+	if req.AccountID != a.accountID {
+		return bridge.PairResult{}, fmt.Errorf("whatsapp pair: account %q does not match %q", req.AccountID, a.accountID)
+	}
+	if failure := a.cooldownFailure("pair"); failure != nil {
+		if sink != nil {
+			_ = sink.EmitPairEvent(ctx, bridge.PairEvent{
+				Kind:      "blocked",
+				ExpiresAt: failure.RetryAt,
+				Message:   failure.Fingerprint,
+			})
+		}
+		return bridge.PairResult{}, *failure
+	}
+	if a.accountInfo().Paired {
+		return bridge.PairResult{}, errors.New("WhatsApp is already paired")
+	}
+
+	attempt := &pairAttempt{events: make(chan whatsapplive.LifecycleEvent, 64)}
+	a.mu.Lock()
+	if a.current != nil || a.starting || a.pairing != nil {
+		a.mu.Unlock()
+		return bridge.PairResult{}, bridge.ErrPairingInProgress
+	}
+	a.pairing = attempt
+	a.mu.Unlock()
+	defer func() {
+		a.disconnect()
+		a.mu.Lock()
+		if a.pairing == attempt {
+			a.pairing = nil
+		}
+		a.mu.Unlock()
+	}()
+
+	switch req.Method {
+	case bridge.PairPhoneCode:
+		code, err := a.pairPhone(ctx, req.Phone)
+		if err != nil {
+			return bridge.PairResult{}, a.classifyError(err, "pair", "whatsapp_phone_pair_failed")
+		}
+		if sink != nil {
+			if err := sink.EmitPairEvent(ctx, bridge.PairEvent{Kind: "code", Payload: code}); err != nil {
+				return bridge.PairResult{}, err
+			}
+		}
+		return a.waitPairResult(ctx, attempt, sink)
+	case bridge.PairQR:
+		qrItems, err := a.prepareQR(ctx)
+		if err != nil {
+			return bridge.PairResult{}, a.classifyError(err, "pair", "whatsapp_qr_prepare_failed")
+		}
+		if err := a.connectPairing(ctx); err != nil {
+			return bridge.PairResult{}, a.classifyError(err, "pair", "whatsapp_qr_connect_failed")
+		}
+		return a.waitQRPairResult(ctx, attempt, sink, qrItems)
+	default:
+		return bridge.PairResult{}, bridge.OpError{
+			Class:       bridge.FailureUnsupported,
+			Operation:   "pair",
+			Fingerprint: "whatsapp_pair_method_unsupported",
+			Cause:       fmt.Errorf("unsupported WhatsApp pair method %q", req.Method),
+		}
+	}
+}
+
+func (a *Adapter) waitQRPairResult(
+	ctx context.Context,
+	attempt *pairAttempt,
+	sink bridge.PairSink,
+	items <-chan whatsmeow.QRChannelItem,
+) (bridge.PairResult, error) {
+	for {
+		select {
+		case event := <-attempt.events:
+			if result, err, terminal := a.pairEventResult(ctx, event, sink); terminal {
+				return result, err
+			}
+		case item, ok := <-items:
+			if !ok {
+				items = nil
+				continue
+			}
+			snapshot := a.applyQR(item)
+			if item.Event == whatsmeow.QRChannelEventCode {
+				if sink != nil {
+					// QRs rotate within one attempt. The UI expiry remains in the
+					// legacy snapshot; omitting PairEvent.ExpiresAt prevents the
+					// shared supervisor from cancelling at the first rotation.
+					if err := sink.EmitPairEvent(ctx, bridge.PairEvent{
+						Kind:    "qr",
+						Payload: item.Code,
+					}); err != nil {
+						return bridge.PairResult{}, err
+					}
+				}
+				continue
+			}
+			if item.Event != whatsmeow.QRChannelSuccess.Event {
+				message := snapshot.Error
+				if message == "" {
+					message = item.Event
+				}
+				return bridge.PairResult{}, bridge.OpError{
+					Class:       bridge.FailureTransient,
+					Operation:   "pair",
+					Fingerprint: "whatsapp_qr_" + item.Event,
+					Cause:       errors.New(message),
+				}
+			}
+		case <-ctx.Done():
+			return bridge.PairResult{}, ctx.Err()
+		}
+	}
+}
+
+func (a *Adapter) waitPairResult(
+	ctx context.Context,
+	attempt *pairAttempt,
+	sink bridge.PairSink,
+) (bridge.PairResult, error) {
+	for {
+		select {
+		case event := <-attempt.events:
+			if result, err, terminal := a.pairEventResult(ctx, event, sink); terminal {
+				return result, err
+			}
+		case <-ctx.Done():
+			return bridge.PairResult{}, ctx.Err()
+		}
+	}
+}
+
+func (a *Adapter) pairEventResult(
+	ctx context.Context,
+	event whatsapplive.LifecycleEvent,
+	sink bridge.PairSink,
+) (bridge.PairResult, error, bool) {
+	if event.PersistenceError != nil {
+		failure, _ := a.classifyEvent(event)
+		return bridge.PairResult{}, failure, true
+	}
+	switch raw := event.Raw.(type) {
+	case *waevents.PairSuccess:
+		return bridge.PairResult{
+			RemoteAccountID: raw.ID.String(),
+			RemoteDeviceID:  raw.LID.String(),
+		}, nil, true
+	case *waevents.Connected:
+		if event.Paired {
+			info := a.accountInfo()
+			return bridge.PairResult{RemoteAccountID: info.JID}, nil, true
+		}
+	case *waevents.TemporaryBan:
+		failure, _ := a.classifyEvent(event)
+		if sink != nil {
+			_ = sink.EmitPairEvent(ctx, bridge.PairEvent{
+				Kind:      "blocked",
+				ExpiresAt: failure.RetryAt,
+				Message:   failure.Fingerprint,
+			})
+		}
+		return bridge.PairResult{}, failure, true
+	case *waevents.PairError:
+		return bridge.PairResult{}, pairFailure(a.host, raw.Error, "whatsapp_pair_error"), true
+	case *waevents.PairPasskeyRequest:
+		return bridge.PairResult{}, pairFailure(a.host, nil, "whatsapp_pair_passkey_required"), true
+	case *waevents.PairPasskeyError:
+		return bridge.PairResult{}, pairFailure(a.host, raw.Error, "whatsapp_pair_passkey_error"), true
+	case *waevents.QRScannedWithoutMultidevice:
+		return bridge.PairResult{}, pairFailure(a.host, nil, "whatsapp_qr_multidevice_required"), true
+	case *waevents.LoggedOut, *waevents.ClientOutdated, *waevents.ConnectFailure:
+		failure, _ := a.classifyEvent(event)
+		return bridge.PairResult{}, failure, true
+	case *waevents.Disconnected, *waevents.StreamReplaced, *waevents.StreamError, *waevents.CATRefreshError:
+		failure, _ := a.classifyEvent(event)
+		failure.Operation = "pair"
+		return bridge.PairResult{}, failure, true
+	case *waevents.ManualLoginReconnect:
+		// PairSuccess is dispatched before the pairing 515 handoff. Ignore the
+		// handoff here; the successful result disconnects this transport and the
+		// command control asks Supervisor to Start the paired lifecycle.
+	}
+	return bridge.PairResult{}, nil, false
+}
+
+func pairFailure(host *whatsapplive.Bridge, cause error, fingerprint string) bridge.OpError {
+	if host != nil {
+		if message := strings.TrimSpace(host.Status().LastError); message != "" {
+			cause = errors.New(message)
+		}
+	}
+	if cause == nil {
+		cause = errors.New("WhatsApp pairing failed")
+	}
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "pair",
+		Fingerprint: fingerprint,
+		Cause:       cause,
+	}
+}
+
+func (a *Adapter) Unpair(ctx context.Context, accountID string) error {
+	if ctx == nil {
+		return errors.New("whatsapp unpair: nil context")
+	}
+	if accountID != "" && accountID != a.accountID {
+		return fmt.Errorf("whatsapp unpair: account %q does not match %q", accountID, a.accountID)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	a.mu.Lock()
+	busy := a.current != nil || a.starting || a.pairing != nil
+	a.mu.Unlock()
+	if busy {
+		return bridge.ErrSupervisorBusy
+	}
+	if a.unpair == nil {
+		return bridge.ErrPairerUnavailable
+	}
+	return a.unpair()
+}
+
+var (
+	_ bridge.Adapter            = (*Adapter)(nil)
+	_ bridge.CapabilityDeclarer = (*Adapter)(nil)
+	_ bridge.Pairer             = (*Adapter)(nil)
+	_ bridge.Run                = (*run)(nil)
+)

--- a/internal/bridgeadapters/whatsapp/whatsapp_test.go
+++ b/internal/bridgeadapters/whatsapp/whatsapp_test.go
@@ -1,0 +1,896 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	waevents "go.mau.fi/whatsmeow/types/events"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/whatsapplive"
+)
+
+const whatsappAdapterTestTimeout = 2 * time.Second
+
+var whatsappAdapterTestEpoch = time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+
+func TestEventFailureClassification(t *testing.T) {
+	a := &Adapter{}
+	retryAt := whatsappAdapterTestEpoch.Add(30 * time.Minute)
+
+	tests := []struct {
+		name        string
+		event       whatsapplive.LifecycleEvent
+		terminal    bool
+		wantClass   bridge.FailureClass
+		wantRetryAt time.Time
+	}{
+		{
+			name: "connected is non-terminal",
+			event: whatsapplive.LifecycleEvent{
+				Raw:    &waevents.Connected{},
+				Paired: true,
+				At:     whatsappAdapterTestEpoch,
+			},
+			terminal: false,
+		},
+		{
+			name: "disconnected is transient",
+			event: whatsapplive.LifecycleEvent{
+				Raw: &waevents.Disconnected{},
+				At:  whatsappAdapterTestEpoch,
+			},
+			terminal:  true,
+			wantClass: bridge.FailureTransient,
+		},
+		{
+			name: "unknown connect failure is transient",
+			event: whatsapplive.LifecycleEvent{
+				Raw: &waevents.ConnectFailure{
+					Reason:  waevents.ConnectFailureGeneric,
+					Message: "unknown connection failure",
+				},
+				At: whatsappAdapterTestEpoch,
+			},
+			terminal:  true,
+			wantClass: bridge.FailureTransient,
+		},
+		{
+			name: "logged out requires reauth",
+			event: whatsapplive.LifecycleEvent{
+				Raw: &waevents.LoggedOut{
+					OnConnect: true,
+					Reason:    waevents.ConnectFailureLoggedOut,
+				},
+				At: whatsappAdapterTestEpoch,
+			},
+			terminal:  true,
+			wantClass: bridge.FailureReauthRequired,
+		},
+		{
+			name: "temporary ban uses supplied retry deadline",
+			event: whatsapplive.LifecycleEvent{
+				Raw: &waevents.TemporaryBan{
+					Code:   waevents.TempBanSentTooManySameMessage,
+					Expire: 30 * time.Minute,
+				},
+				At:      whatsappAdapterTestEpoch,
+				RetryAt: retryAt,
+			},
+			terminal:    true,
+			wantClass:   bridge.FailureRateLimited,
+			wantRetryAt: retryAt,
+		},
+		{
+			name: "temporary ban derives retry deadline from expiry",
+			event: whatsapplive.LifecycleEvent{
+				Raw: &waevents.TemporaryBan{
+					Code:   waevents.TempBanSentTooManySameMessage,
+					Expire: 30 * time.Minute,
+				},
+				At: whatsappAdapterTestEpoch,
+			},
+			terminal:    true,
+			wantClass:   bridge.FailureRateLimited,
+			wantRetryAt: retryAt,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			failure, terminal := a.classifyEvent(test.event)
+			if terminal != test.terminal {
+				t.Fatalf("terminal = %v, want %v", terminal, test.terminal)
+			}
+			if failure.Class != test.wantClass {
+				t.Fatalf("class = %q, want %q", failure.Class, test.wantClass)
+			}
+			if !failure.RetryAt.Equal(test.wantRetryAt) {
+				t.Fatalf("RetryAt = %s, want %s", failure.RetryAt, test.wantRetryAt)
+			}
+		})
+	}
+
+	t.Run("reported temporary operation error is transient", func(t *testing.T) {
+		failure := a.classifyError(
+			errors.New("temporary send failure"),
+			"operation",
+			"whatsapp_operation_failed",
+		)
+		if failure.Class != bridge.FailureTransient {
+			t.Fatalf("class = %q, want %q", failure.Class, bridge.FailureTransient)
+		}
+	})
+}
+
+func TestReadyRequiresRealPairedConnectedEvent(t *testing.T) {
+	client := newFakeLifecycleClient()
+	a := newTestAdapter(t, client, func() time.Time { return whatsappAdapterTestEpoch })
+	sink := &recordingSink{}
+
+	lifecycleRun, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "whatsapp-primary",
+		Generation: 7,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, lifecycleRun) })
+
+	awaitCondition(t, "successful fake Connect return", func() bool {
+		return client.stats().connectCompleted == 1
+	})
+	concreteRun, ok := lifecycleRun.(*run)
+	if !ok {
+		t.Fatalf("Start() Run type = %T, want *run", lifecycleRun)
+	}
+	concreteRun.workers.Wait()
+	assertNotClosed(t, lifecycleRun.Ready(), "successful Connect return and paired account boolean")
+
+	client.emit(a, whatsapplive.LifecycleEvent{
+		Raw:    &waevents.Connected{},
+		Paired: false,
+		At:     whatsappAdapterTestEpoch,
+	})
+	assertNotClosed(t, lifecycleRun.Ready(), "unpaired Connected pairing transport event")
+	if got := sink.beatsSnapshot(); len(got) != 0 {
+		t.Fatalf("liveness beats after unpaired Connected = %+v, want none", got)
+	}
+
+	connectedAt := whatsappAdapterTestEpoch.Add(time.Second)
+	client.emit(a, whatsapplive.LifecycleEvent{
+		Raw:    &waevents.Connected{},
+		Paired: true,
+		At:     connectedAt,
+	})
+	select {
+	case <-lifecycleRun.Ready():
+	case <-time.After(whatsappAdapterTestTimeout):
+		t.Fatal("Ready did not close after paired Connected event")
+	}
+
+	beats := sink.beatsSnapshot()
+	if len(beats) != 1 {
+		t.Fatalf("liveness beats = %+v, want exactly one", beats)
+	}
+	if beats[0].generation != 7 || !beats[0].at.Equal(connectedAt) ||
+		beats[0].detail != "event:whatsapp.connected" {
+		t.Fatalf("Connected beat = %+v, want generation 7 at %s", beats[0], connectedAt)
+	}
+}
+
+func TestLifecycleEventsDriveSupervisorState(t *testing.T) {
+	tests := []struct {
+		name        string
+		event       func(time.Time) whatsapplive.LifecycleEvent
+		wantState   bridge.State
+		wantClass   bridge.FailureClass
+		wantRetryAt func(time.Time) time.Time
+	}{
+		{
+			name: "paired Connected becomes online",
+			event: func(at time.Time) whatsapplive.LifecycleEvent {
+				return whatsapplive.LifecycleEvent{
+					Raw:    &waevents.Connected{},
+					Paired: true,
+					At:     at,
+				}
+			},
+			wantState: bridge.StateOnline,
+		},
+		{
+			name: "Disconnected enters transient backoff",
+			event: func(at time.Time) whatsapplive.LifecycleEvent {
+				return whatsapplive.LifecycleEvent{Raw: &waevents.Disconnected{}, Paired: true, At: at}
+			},
+			wantState: bridge.StateBackoff,
+			wantClass: bridge.FailureTransient,
+		},
+		{
+			name: "unknown connect failure enters transient backoff",
+			event: func(at time.Time) whatsapplive.LifecycleEvent {
+				return whatsapplive.LifecycleEvent{
+					Raw: &waevents.ConnectFailure{
+						Reason:  waevents.ConnectFailureGeneric,
+						Message: "unknown connection failure",
+					},
+					Paired: true,
+					At:     at,
+				}
+			},
+			wantState: bridge.StateBackoff,
+			wantClass: bridge.FailureTransient,
+		},
+		{
+			name: "LoggedOut blocks for reauth",
+			event: func(at time.Time) whatsapplive.LifecycleEvent {
+				return whatsapplive.LifecycleEvent{
+					Raw: &waevents.LoggedOut{
+						OnConnect: true,
+						Reason:    waevents.ConnectFailureLoggedOut,
+					},
+					At: at,
+				}
+			},
+			wantState: bridge.StateBlocked,
+			wantClass: bridge.FailureReauthRequired,
+		},
+		{
+			name: "TemporaryBan enters rate-limited backoff",
+			event: func(at time.Time) whatsapplive.LifecycleEvent {
+				return whatsapplive.LifecycleEvent{
+					Raw: &waevents.TemporaryBan{
+						Code:   waevents.TempBanSentTooManySameMessage,
+						Expire: 30 * time.Minute,
+					},
+					Paired:  true,
+					At:      at,
+					RetryAt: at.Add(30 * time.Minute),
+				}
+			},
+			wantState: bridge.StateBackoff,
+			wantClass: bridge.FailureRateLimited,
+			wantRetryAt: func(at time.Time) time.Time {
+				return at.Add(30 * time.Minute)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := newManualClock(whatsappAdapterTestEpoch)
+			client := newFakeLifecycleClient()
+			a := newTestAdapter(t, client, clock.Now)
+			supervisor := newTestSupervisor(t, a, clock)
+
+			startSupervisor(t, supervisor)
+			awaitCondition(t, "first WhatsApp connect", func() bool {
+				return client.stats().connectCompleted == 1
+			})
+			at := clock.Now()
+			client.emit(a, test.event(at))
+
+			snapshot := awaitSnapshot(t, supervisor, test.name, func(snapshot bridge.Snapshot) bool {
+				if snapshot.State != test.wantState || snapshot.ErrorClass != test.wantClass {
+					return false
+				}
+				if test.wantState == bridge.StateOnline {
+					return snapshot.LastProbeOKAt.Equal(at)
+				}
+				return true
+			})
+			if test.wantRetryAt != nil {
+				want := test.wantRetryAt(at)
+				if !snapshot.RetryAt.Equal(want) {
+					t.Fatalf("RetryAt = %s, want %s", snapshot.RetryAt, want)
+				}
+			}
+		})
+	}
+}
+
+func TestReportedTemporaryErrorDrivesSupervisorBackoff(t *testing.T) {
+	clock := newManualClock(whatsappAdapterTestEpoch)
+	client := newFakeLifecycleClient()
+	a := newTestAdapter(t, client, clock.Now)
+	supervisor := newTestSupervisor(t, a, clock)
+
+	startSupervisor(t, supervisor)
+	awaitCondition(t, "initial WhatsApp connect", func() bool {
+		return client.stats().connectCompleted == 1
+	})
+	client.emit(a, whatsapplive.LifecycleEvent{
+		Raw:    &waevents.Connected{},
+		Paired: true,
+		At:     clock.Now(),
+	})
+	awaitSnapshot(t, supervisor, "online before reported error", func(snapshot bridge.Snapshot) bool {
+		return snapshot.State == bridge.StateOnline
+	})
+
+	if !a.ReportError(errors.New("temporary legacy send error")) {
+		t.Fatal("ReportError() did not retire the active generation")
+	}
+	snapshot := awaitSnapshot(t, supervisor, "reported error backoff", func(snapshot bridge.Snapshot) bool {
+		return snapshot.State == bridge.StateBackoff && snapshot.ErrorClass == bridge.FailureTransient
+	})
+	if snapshot.ErrorFingerprint != "whatsapp_operation_failed" {
+		t.Fatalf("error fingerprint = %q, want whatsapp_operation_failed", snapshot.ErrorFingerprint)
+	}
+}
+
+func TestReportedErrorIgnoredUntilCurrentRunIsReady(t *testing.T) {
+	clock := newManualClock(whatsappAdapterTestEpoch)
+	client := newFakeLifecycleClient()
+	a := newTestAdapter(t, client, clock.Now)
+	supervisor := newTestSupervisor(t, a, clock)
+
+	startSupervisor(t, supervisor)
+	awaitCondition(t, "initial WhatsApp connect", func() bool {
+		return client.stats().connectCompleted == 1
+	})
+	awaitSnapshot(t, supervisor, "connecting generation before Ready", func(snapshot bridge.Snapshot) bool {
+		return snapshot.State == bridge.StateConnecting && snapshot.Generation == 1
+	})
+
+	if a.ReportError(whatsmeow.ErrNotConnected) {
+		t.Fatal("ReportError() retired the connecting generation before Ready")
+	}
+	syncSupervisor(t, supervisor)
+	snapshot := supervisor.Snapshot()
+	if snapshot.State != bridge.StateConnecting || snapshot.Generation != 1 {
+		t.Fatalf("snapshot after pre-Ready report = %+v, want connecting generation 1", snapshot)
+	}
+	if snapshot.ErrorClass != "" || snapshot.ErrorFingerprint != "" || !snapshot.RetryAt.IsZero() {
+		t.Fatalf("failure state after pre-Ready report = %+v, want no recorded failure or retry", snapshot)
+	}
+
+	client.emit(a, whatsapplive.LifecycleEvent{
+		Raw:    &waevents.Connected{},
+		Paired: true,
+		At:     clock.Now(),
+	})
+	awaitSnapshot(t, supervisor, "online current generation", func(snapshot bridge.Snapshot) bool {
+		return snapshot.State == bridge.StateOnline && snapshot.Generation == 1
+	})
+
+	if !a.ReportError(whatsmeow.ErrNotConnected) {
+		t.Fatal("ReportError() ignored the ready generation")
+	}
+	snapshot = awaitSnapshot(t, supervisor, "first reported-error backoff", func(snapshot bridge.Snapshot) bool {
+		return snapshot.State == bridge.StateBackoff &&
+			snapshot.Generation == 1 &&
+			snapshot.ErrorClass == bridge.FailureTransient
+	})
+	wantRetryAt := clock.Now().Add(5 * time.Second)
+	if !snapshot.RetryAt.Equal(wantRetryAt) {
+		t.Fatalf("RetryAt = %s, want first-attempt retry at %s", snapshot.RetryAt, wantRetryAt)
+	}
+}
+
+func TestAdapterCooldownRejectsStartsUntilRetryAt(t *testing.T) {
+	clock := newManualClock(whatsappAdapterTestEpoch)
+	client := newFakeLifecycleClient()
+	a := newTestAdapter(t, client, clock.Now)
+	retryAt := clock.Now().Add(30 * time.Second)
+	client.emit(a, whatsapplive.LifecycleEvent{
+		Raw: &waevents.TemporaryBan{
+			Code:   waevents.TempBanSentTooManySameMessage,
+			Expire: 30 * time.Second,
+		},
+		Paired:  true,
+		At:      clock.Now(),
+		RetryAt: retryAt,
+	})
+
+	for attempt, advance := range []time.Duration{0, 29 * time.Second} {
+		clock.Advance(advance)
+		lifecycleRun, err := a.Start(context.Background(), bridge.StartRequest{
+			AccountID:  "whatsapp-primary",
+			Generation: bridge.Generation(attempt + 1),
+		}, nil)
+		if lifecycleRun != nil {
+			stopRun(t, lifecycleRun)
+			t.Fatalf("pre-expiry Start %d returned a Run", attempt+1)
+		}
+		failure, ok := asOpError(err)
+		if !ok || failure.Class != bridge.FailureRateLimited || !failure.RetryAt.Equal(retryAt) {
+			t.Fatalf("pre-expiry Start %d error = %v, want rate limit until %s", attempt+1, err, retryAt)
+		}
+		if got := client.stats().connectCalls; got != 0 {
+			t.Fatalf("connect calls before RetryAt = %d, want zero", got)
+		}
+	}
+
+	clock.Advance(time.Second)
+	lifecycleRun, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "whatsapp-primary",
+		Generation: 3,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() at RetryAt error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, lifecycleRun) })
+	awaitCondition(t, "adapter Connect at RetryAt", func() bool {
+		return client.stats().connectCompleted == 1
+	})
+	if now := clock.Now(); !now.Equal(retryAt) {
+		t.Fatalf("eligible Start time = %s, want %s", now, retryAt)
+	}
+}
+
+func TestTemporaryBanCooldownHonorsRetryAt(t *testing.T) {
+	clock := newManualClock(whatsappAdapterTestEpoch)
+	client := newFakeLifecycleClient()
+	a := newTestAdapter(t, client, clock.Now)
+	supervisor := newTestSupervisor(t, a, clock)
+
+	startSupervisor(t, supervisor)
+	awaitCondition(t, "initial WhatsApp connect", func() bool {
+		return client.stats().connectCompleted == 1
+	})
+
+	retryAt := clock.Now().Add(30 * time.Second)
+	client.emit(a, whatsapplive.LifecycleEvent{
+		Raw: &waevents.TemporaryBan{
+			Code:   waevents.TempBanSentTooManySameMessage,
+			Expire: 30 * time.Second,
+		},
+		Paired:  true,
+		At:      clock.Now(),
+		RetryAt: retryAt,
+	})
+	snapshot := awaitSnapshot(t, supervisor, "temporary-ban backoff", func(snapshot bridge.Snapshot) bool {
+		return snapshot.State == bridge.StateBackoff &&
+			snapshot.ErrorClass == bridge.FailureRateLimited
+	})
+	if !snapshot.RetryAt.Equal(retryAt) {
+		t.Fatalf("RetryAt = %s, want %s", snapshot.RetryAt, retryAt)
+	}
+	if got := client.stats().connectCalls; got != 1 {
+		t.Fatalf("connect Starts immediately after ban = %d, want 1", got)
+	}
+
+	clock.Advance(29 * time.Second)
+	syncSupervisor(t, supervisor)
+	if got := client.stats().connectCalls; got != 1 {
+		t.Fatalf("connect Starts before RetryAt = %d, want 1", got)
+	}
+
+	clock.Advance(time.Second)
+	awaitCondition(t, "connect eligibility at RetryAt", func() bool {
+		return client.stats().connectCalls == 2
+	})
+	if now := clock.Now(); !now.Equal(retryAt) {
+		t.Fatalf("restart time = %s, want RetryAt %s", now, retryAt)
+	}
+}
+
+func TestConcurrentStartsAreSingleFlight(t *testing.T) {
+	client := newFakeLifecycleClient()
+	client.accountInfoGate = make(chan struct{})
+	client.accountInfoEntered = make(chan struct{}, 2)
+	client.connectGate = make(chan struct{})
+	a := newTestAdapter(t, client, func() time.Time { return whatsappAdapterTestEpoch })
+
+	type startResult struct {
+		run bridge.Run
+		err error
+	}
+	results := make(chan startResult, 2)
+	releaseStarts := make(chan struct{})
+	for range 2 {
+		go func() {
+			<-releaseStarts
+			run, err := a.Start(context.Background(), bridge.StartRequest{
+				AccountID:  "whatsapp-primary",
+				Generation: 1,
+			}, nil)
+			results <- startResult{run: run, err: err}
+		}()
+	}
+	close(releaseStarts)
+	receiveValue(t, client.accountInfoEntered, "first Start account check")
+	receiveValue(t, client.accountInfoEntered, "second Start account check")
+	close(client.accountInfoGate)
+
+	got := []startResult{
+		receiveValue(t, results, "first Start result"),
+		receiveValue(t, results, "second Start result"),
+	}
+	var successful []bridge.Run
+	var failures []error
+	for _, result := range got {
+		if result.err == nil {
+			successful = append(successful, result.run)
+		} else {
+			failures = append(failures, result.err)
+		}
+	}
+	for _, run := range successful {
+		defer stopRun(t, run)
+	}
+
+	awaitCondition(t, "single admitted Connect call", func() bool {
+		stats := client.stats()
+		return stats.connectCalls >= 1 && stats.activeConnects >= 1
+	})
+	stats := client.stats()
+	if len(successful) != 1 || len(failures) != 1 {
+		t.Fatalf("Start results = %d successes, %d failures; want one each", len(successful), len(failures))
+	}
+	if successful[0] == nil {
+		t.Fatal("successful Start returned a nil Run")
+	}
+	failure, ok := asOpError(failures[0])
+	if !ok || failure.Class != bridge.FailureMisconfigured ||
+		failure.Fingerprint != "overlapping_whatsapp_generation" {
+		t.Fatalf("overlapping Start error = %v, want overlapping misconfigured failure", failures[0])
+	}
+	if stats.connectCalls != 1 || stats.activeConnects != 1 || stats.maxActiveConnects != 1 {
+		t.Fatalf("Connect concurrency = %+v, want one call and max concurrency one", stats)
+	}
+}
+
+func newTestAdapter(t *testing.T, client *fakeLifecycleClient, now func() time.Time) *Adapter {
+	t.Helper()
+	a := New("whatsapp-primary", &whatsapplive.Bridge{})
+	a.connect = client.Connect
+	a.disconnect = client.Disconnect
+	a.probe = client.Probe
+	a.accountInfo = client.AccountInfo
+	a.cooldown = client.Cooldown
+	a.now = now
+	return a
+}
+
+func newTestSupervisor(t *testing.T, adapter *Adapter, clock *manualClock) *bridge.Supervisor {
+	t.Helper()
+	supervisor, err := bridge.NewSupervisor(
+		"whatsapp-primary",
+		bridge.PlatformWhatsApp,
+		adapter,
+		bridge.Policy{
+			ConnectTimeout:     time.Minute,
+			ProbeEvery:         time.Minute,
+			ProbeTimeout:       time.Minute,
+			LivenessTimeout:    5 * time.Minute,
+			MinBackoff:         10 * time.Second,
+			MaxBackoff:         time.Minute,
+			MaxSameFingerprint: 3,
+		},
+		clock,
+		midpointRandom{},
+	)
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), whatsappAdapterTestTimeout)
+		defer cancel()
+		if err := supervisor.Stop(ctx); err != nil {
+			t.Errorf("Supervisor.Stop() error = %v", err)
+		}
+	})
+	return supervisor
+}
+
+func startSupervisor(t *testing.T, supervisor *bridge.Supervisor) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), whatsappAdapterTestTimeout)
+	defer cancel()
+	if err := supervisor.Start(ctx, bridge.StartRequest{}); err != nil {
+		t.Fatalf("Supervisor.Start() error = %v", err)
+	}
+}
+
+func syncSupervisor(t *testing.T, supervisor *bridge.Supervisor) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), whatsappAdapterTestTimeout)
+	defer cancel()
+	if err := supervisor.Sync(ctx); err != nil {
+		t.Fatalf("Supervisor.Sync() error = %v", err)
+	}
+}
+
+func awaitSnapshot(
+	t *testing.T,
+	supervisor *bridge.Supervisor,
+	description string,
+	predicate func(bridge.Snapshot) bool,
+) bridge.Snapshot {
+	t.Helper()
+	var snapshot bridge.Snapshot
+	awaitCondition(t, description, func() bool {
+		snapshot = supervisor.Snapshot()
+		return predicate(snapshot)
+	})
+	return snapshot
+}
+
+func awaitCondition(t *testing.T, description string, condition func() bool) {
+	t.Helper()
+	timer := time.NewTimer(whatsappAdapterTestTimeout)
+	defer timer.Stop()
+	for !condition() {
+		select {
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %s", description)
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
+func receiveValue[T any](t *testing.T, channel <-chan T, description string) T {
+	t.Helper()
+	select {
+	case value := <-channel:
+		return value
+	case <-time.After(whatsappAdapterTestTimeout):
+		var zero T
+		t.Fatalf("timed out waiting for %s", description)
+		return zero
+	}
+}
+
+func assertNotClosed(t *testing.T, channel <-chan struct{}, after string) {
+	t.Helper()
+	select {
+	case <-channel:
+		t.Fatalf("Ready closed after %s without a paired Connected event", after)
+	default:
+	}
+}
+
+func stopRun(t *testing.T, run bridge.Run) {
+	t.Helper()
+	if run == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), whatsappAdapterTestTimeout)
+	defer cancel()
+	if err := run.Stop(ctx); err != nil {
+		t.Fatalf("Run.Stop() error = %v", err)
+	}
+}
+
+type fakeLifecycleClient struct {
+	mu sync.Mutex
+
+	paired        bool
+	cooldownUntil time.Time
+	connectCalls  int
+	connectDone   int
+	active        int
+	maxActive     int
+	disconnects   int
+
+	accountInfoGate    chan struct{}
+	accountInfoEntered chan struct{}
+	connectGate        chan struct{}
+}
+
+type fakeLifecycleStats struct {
+	connectCalls      int
+	connectCompleted  int
+	activeConnects    int
+	maxActiveConnects int
+	disconnects       int
+}
+
+func newFakeLifecycleClient() *fakeLifecycleClient {
+	return &fakeLifecycleClient{paired: true}
+}
+
+func (f *fakeLifecycleClient) Connect(ctx context.Context) error {
+	f.mu.Lock()
+	f.connectCalls++
+	f.active++
+	if f.active > f.maxActive {
+		f.maxActive = f.active
+	}
+	gate := f.connectGate
+	f.mu.Unlock()
+
+	var err error
+	if gate != nil {
+		select {
+		case <-gate:
+		case <-ctx.Done():
+			err = ctx.Err()
+		}
+	}
+
+	f.mu.Lock()
+	f.active--
+	f.connectDone++
+	f.mu.Unlock()
+	return err
+}
+
+func (f *fakeLifecycleClient) Disconnect() {
+	f.mu.Lock()
+	f.disconnects++
+	f.mu.Unlock()
+}
+
+func (*fakeLifecycleClient) Probe(context.Context) error { return nil }
+
+func (f *fakeLifecycleClient) AccountInfo() whatsapplive.AccountInfo {
+	f.mu.Lock()
+	paired := f.paired
+	gate := f.accountInfoGate
+	entered := f.accountInfoEntered
+	f.mu.Unlock()
+	if gate != nil {
+		if entered != nil {
+			entered <- struct{}{}
+		}
+		<-gate
+	}
+	return whatsapplive.AccountInfo{Paired: paired, JID: "15551234567@s.whatsapp.net"}
+}
+
+func (f *fakeLifecycleClient) Cooldown() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.cooldownUntil
+}
+
+func (f *fakeLifecycleClient) emit(a *Adapter, event whatsapplive.LifecycleEvent) {
+	if ban, ok := event.Raw.(*waevents.TemporaryBan); ok && ban != nil {
+		retryAt := event.RetryAt
+		if retryAt.IsZero() && ban.Expire > 0 {
+			retryAt = event.At.Add(ban.Expire)
+		}
+		f.mu.Lock()
+		if retryAt.After(f.cooldownUntil) {
+			f.cooldownUntil = retryAt
+		}
+		f.mu.Unlock()
+	}
+	a.handleLifecycleEvent(event)
+}
+
+func (f *fakeLifecycleClient) stats() fakeLifecycleStats {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return fakeLifecycleStats{
+		connectCalls:      f.connectCalls,
+		connectCompleted:  f.connectDone,
+		activeConnects:    f.active,
+		maxActiveConnects: f.maxActive,
+		disconnects:       f.disconnects,
+	}
+}
+
+type recordingBeat struct {
+	generation bridge.Generation
+	at         time.Time
+	detail     string
+}
+
+type recordingSink struct {
+	mu    sync.Mutex
+	beats []recordingBeat
+}
+
+func (*recordingSink) AppendIngress(context.Context, bridge.RawIngressRecord) error { return nil }
+
+func (*recordingSink) EmitEphemeral(context.Context, bridge.EphemeralEvent) error { return nil }
+
+func (s *recordingSink) Beat(generation bridge.Generation, at time.Time, detail string) {
+	s.mu.Lock()
+	s.beats = append(s.beats, recordingBeat{generation: generation, at: at, detail: detail})
+	s.mu.Unlock()
+}
+
+func (s *recordingSink) beatsSnapshot() []recordingBeat {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]recordingBeat(nil), s.beats...)
+}
+
+type midpointRandom struct{}
+
+func (midpointRandom) Int63n(n int64) int64 {
+	if n <= 1 {
+		return 0
+	}
+	return n / 2
+}
+
+type manualClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers map[*manualTimer]struct{}
+}
+
+func newManualClock(now time.Time) *manualClock {
+	return &manualClock{now: now, timers: make(map[*manualTimer]struct{})}
+}
+
+func (c *manualClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *manualClock) NewTimer(delay time.Duration) bridge.Timer {
+	if delay < 0 {
+		delay = 0
+	}
+	c.mu.Lock()
+	timer := &manualTimer{
+		clock:    c,
+		deadline: c.now.Add(delay),
+		channel:  make(chan time.Time, 1),
+		active:   true,
+	}
+	due := delay == 0
+	if due {
+		timer.active = false
+	} else {
+		c.timers[timer] = struct{}{}
+	}
+	now := c.now
+	c.mu.Unlock()
+	if due {
+		timer.channel <- now
+	}
+	return timer
+}
+
+func (c *manualClock) Advance(delta time.Duration) {
+	if delta < 0 {
+		panic("manual clock cannot move backward")
+	}
+	c.mu.Lock()
+	c.now = c.now.Add(delta)
+	now := c.now
+	var due []*manualTimer
+	for timer := range c.timers {
+		if !now.Before(timer.deadline) {
+			timer.active = false
+			delete(c.timers, timer)
+			due = append(due, timer)
+		}
+	}
+	c.mu.Unlock()
+	for _, timer := range due {
+		timer.channel <- now
+	}
+}
+
+type manualTimer struct {
+	clock    *manualClock
+	deadline time.Time
+	channel  chan time.Time
+	active   bool
+}
+
+func (t *manualTimer) C() <-chan time.Time { return t.channel }
+
+func (t *manualTimer) Stop() bool {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	if !t.active {
+		return false
+	}
+	t.active = false
+	delete(t.clock.timers, t)
+	return true
+}
+
+var (
+	_ bridge.Clock          = (*manualClock)(nil)
+	_ bridge.Timer          = (*manualTimer)(nil)
+	_ bridge.Random         = midpointRandom{}
+	_ bridge.ConnectionSink = (*recordingSink)(nil)
+)

--- a/internal/whatsapplive/client.go
+++ b/internal/whatsapplive/client.go
@@ -39,8 +39,21 @@ const avatarCacheTTL = 30 * time.Minute
 const unavailablePlaceholderRepairCooldown = 30 * time.Minute
 const maxUnavailablePlaceholderRepairs = 25
 const recentlyLeftGroupTTL = 6 * time.Hour
+const unpairRemoteTimeout = 10 * time.Second
+const unpairStoreTimeout = 10 * time.Second
 
 var ErrProfilePhotoNotFound = errors.New("whatsapp profile photo not found")
+
+var ErrTemporaryBanActive = errors.New("whatsapp temporary ban is still active")
+
+const whatsappRuntimeStateSchema = `
+CREATE TABLE IF NOT EXISTS openmessage_whatsapp_runtime_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    blocked_until_ns INTEGER NOT NULL DEFAULT 0
+);
+INSERT OR IGNORE INTO openmessage_whatsapp_runtime_state (singleton, blocked_until_ns)
+VALUES (1, 0);
+`
 
 var sendTextMessage = func(cli *whatsmeow.Client, ctx context.Context, to watypes.JID, message *waE2E.Message, extra ...whatsmeow.SendRequestExtra) (whatsmeow.SendResponse, error) {
 	return cli.SendMessage(ctx, to, message, extra...)
@@ -56,6 +69,22 @@ var downloadMediaWithPath = func(cli *whatsmeow.Client, ctx context.Context, dir
 
 var connectClient = func(cli *whatsmeow.Client) error {
 	return cli.Connect()
+}
+
+var connectClientContext = func(ctx context.Context, cli *whatsmeow.Client) error {
+	return cli.ConnectContext(ctx)
+}
+
+var logoutClient = func(ctx context.Context, cli *whatsmeow.Client) error {
+	return cli.Logout(ctx)
+}
+
+var deleteClientStore = func(ctx context.Context, cli *whatsmeow.Client) error {
+	return cli.Store.Delete(ctx)
+}
+
+var sendClientKeepAlive = func(ctx context.Context, cli *whatsmeow.Client) (bool, bool) {
+	return cli.DangerousInternals().SendKeepAlive(ctx)
 }
 
 var launchConnect = func(b *Bridge, cli *whatsmeow.Client) {
@@ -110,8 +139,50 @@ type Callbacks struct {
 	OnConversationsChange func()
 	OnIncomingMessage     func(*db.Message)
 	OnMessagesChange      func(string)
+	OnConnectionError     func(error)
 	OnStatusChange        func()
 	OnTypingChange        func(conversationID, senderName, senderNumber string, typing bool)
+}
+
+// TemporaryBanError prevents every connection and pairing entry point from
+// touching the network while a server-provided temporary ban is active.
+// RetryAt is an absolute, durably stored deadline.
+type TemporaryBanError struct {
+	RetryAt time.Time
+}
+
+func (e *TemporaryBanError) Error() string {
+	return fmt.Sprintf("%s until %s", ErrTemporaryBanActive, e.RetryAt.Format(time.RFC3339Nano))
+}
+
+func (e *TemporaryBanError) Is(target error) bool {
+	return target == ErrTemporaryBanActive
+}
+
+// LifecycleEvent is the generation-safe event boundary consumed by the
+// supervisor adapter. Raw is the real whatsmeow event. Paired is captured from
+// the exact client that emitted Raw after the legacy status projection has
+// been updated. PersistenceError is non-nil when a TemporaryBan could not be
+// made durable; callers must park rather than risk an early reconnect.
+type LifecycleEvent struct {
+	Raw              any
+	Paired           bool
+	At               time.Time
+	RetryAt          time.Time
+	PersistenceError error
+}
+
+type lifecycleObservation struct {
+	id       uint64
+	callback func(LifecycleEvent)
+}
+
+// AccountInfo is the paired identity needed to build supervisor start and
+// pairing results without exposing the underlying whatsmeow client.
+type AccountInfo struct {
+	Paired   bool
+	JID      string
+	PushName string
 }
 
 type StatusSnapshot struct {
@@ -171,6 +242,16 @@ type Bridge struct {
 
 	container *sqlstore.Container
 	client    *whatsmeow.Client
+	// clientGeneration changes whenever resetClientLocked installs a new
+	// whatsmeow client. Event handler closures capture it so callbacks from a
+	// retired client can never affect or terminate the replacement generation.
+	clientGeneration uint64
+	observation      lifecycleObservation
+	nextObserverID   uint64
+
+	runtimeMu    sync.Mutex
+	runtimeDB    *sql.DB
+	blockedUntil time.Time
 
 	connected                 bool
 	connecting                bool
@@ -191,6 +272,10 @@ func New(sessionPath string, store *db.Store, logger zerolog.Logger, callbacks C
 		recentlyLeftGroups: make(map[string]time.Time),
 	}
 	if err := bridge.initClientLocked(); err != nil {
+		return nil, err
+	}
+	if err := bridge.initRuntimeState(); err != nil {
+		_ = bridge.Close()
 		return nil, err
 	}
 	return bridge, nil
@@ -214,11 +299,47 @@ func (b *Bridge) initClientLocked() error {
 	// are log-only — with a Noop logger they are invisible and a failed pair
 	// just silently returns to idle.
 	cli := whatsmeow.NewClient(deviceStore, waLog.Zerolog(b.logger.With().Str("component", "whatsmeow").Logger()))
-	cli.EnableAutoReconnect = true
-	cli.InitialAutoReconnect = true
-	cli.AddEventHandler(b.handleEvent)
+	// The bridge Supervisor is the sole reconnect owner. In addition to the
+	// normal reconnect toggles, DisableLoginAutoReconnect prevents whatsmeow's
+	// implicit 515 reconnect after pairing from becoming a second owner.
+	cli.EnableAutoReconnect = false
+	cli.InitialAutoReconnect = false
+	cli.DisableLoginAutoReconnect = true
+	b.clientGeneration++
+	clientGeneration := b.clientGeneration
+	cli.AddEventHandler(func(raw any) {
+		b.handleClientEvent(cli, clientGeneration, raw)
+	})
 	b.container = container
 	b.client = cli
+	return nil
+}
+
+func (b *Bridge) initRuntimeState() error {
+	database, err := sql.Open("sqlite", sessionStoreDSN(b.sessionPath))
+	if err != nil {
+		return fmt.Errorf("open WhatsApp runtime state: %w", err)
+	}
+	database.SetMaxOpenConns(1)
+	if _, err = database.ExecContext(context.Background(), whatsappRuntimeStateSchema); err != nil {
+		_ = database.Close()
+		return fmt.Errorf("initialize WhatsApp runtime state: %w", err)
+	}
+	var blockedUntilNS int64
+	if err = database.QueryRowContext(
+		context.Background(),
+		`SELECT blocked_until_ns FROM openmessage_whatsapp_runtime_state WHERE singleton = 1`,
+	).Scan(&blockedUntilNS); err != nil {
+		_ = database.Close()
+		return fmt.Errorf("load WhatsApp runtime state: %w", err)
+	}
+
+	b.runtimeMu.Lock()
+	b.runtimeDB = database
+	if blockedUntilNS > 0 {
+		b.blockedUntil = time.Unix(0, blockedUntilNS)
+	}
+	b.runtimeMu.Unlock()
 	return nil
 }
 
@@ -252,6 +373,78 @@ func isWindowsAbsolutePath(path string) bool {
 		path[2] == '/'
 }
 
+// TemporaryBanDeadline returns the greatest absolute ban deadline observed by
+// this bridge, including the value loaded from a previous process.
+func (b *Bridge) TemporaryBanDeadline() time.Time {
+	b.runtimeMu.Lock()
+	defer b.runtimeMu.Unlock()
+	return b.blockedUntil
+}
+
+func (b *Bridge) temporaryBanError(now time.Time) error {
+	retryAt := b.TemporaryBanDeadline()
+	if retryAt.IsZero() || !now.Before(retryAt) {
+		return nil
+	}
+	return &TemporaryBanError{RetryAt: retryAt}
+}
+
+func (b *Bridge) persistTemporaryBan(at time.Time, duration time.Duration) (time.Time, error) {
+	b.runtimeMu.Lock()
+	defer b.runtimeMu.Unlock()
+
+	retryAt := b.blockedUntil
+	if duration > 0 {
+		candidate := at.Add(duration)
+		if candidate.After(retryAt) {
+			retryAt = candidate
+			// Update memory before durable storage. If the write fails, every
+			// entry point in this process still stays parked and the observer
+			// receives PersistenceError so the supervisor cannot retry.
+			b.blockedUntil = candidate
+		}
+	}
+	if retryAt.IsZero() || b.runtimeDB == nil {
+		return retryAt, nil
+	}
+	if _, err := b.runtimeDB.ExecContext(
+		context.Background(),
+		`UPDATE openmessage_whatsapp_runtime_state
+		 SET blocked_until_ns = CASE
+		     WHEN blocked_until_ns < ? THEN ?
+		     ELSE blocked_until_ns
+		 END
+		 WHERE singleton = 1`,
+		retryAt.UnixNano(),
+		retryAt.UnixNano(),
+	); err != nil {
+		return retryAt, fmt.Errorf("persist WhatsApp temporary ban deadline: %w", err)
+	}
+	return retryAt, nil
+}
+
+// ObserveLifecycle installs the one active supervisor lifecycle observer and
+// binds it to the current client generation. The returned removal function is
+// idempotent with respect to replacement: it cannot clear a newer observer.
+func (b *Bridge) ObserveLifecycle(callback func(LifecycleEvent)) func() {
+	b.mu.Lock()
+	b.nextObserverID++
+	id := b.nextObserverID
+	b.observation = lifecycleObservation{
+		id:       id,
+		callback: callback,
+	}
+	b.mu.Unlock()
+
+	return func() {
+		b.mu.Lock()
+		if b.observation.id == id {
+			b.observation = lifecycleObservation{}
+		}
+		b.mu.Unlock()
+	}
+}
+
 func (b *Bridge) resetClientLocked() error {
 	if b.client != nil {
 		b.client.Disconnect()
@@ -270,10 +463,22 @@ func (b *Bridge) recoverPersistedSessionLocked() error {
 	if err := b.initClientLocked(); err != nil {
 		return err
 	}
-	if b.client == nil || b.client.Store == nil || b.client.Store.ID != nil {
+	if b.client == nil || b.client.Store == nil {
 		return nil
 	}
-	return b.resetClientLocked()
+	if b.client.Store.Deleted {
+		return b.resetClientLocked()
+	}
+	if b.client.Store.ID != nil {
+		return nil
+	}
+	// A clean unpaired device must keep its identity for the active pairing
+	// observation. Reset only when the database proves a paired identity was
+	// persisted after this in-memory store was created.
+	if deviceStore := b.pairedDeviceStoreLocked(); deviceStore != nil {
+		return b.resetClientLocked()
+	}
+	return nil
 }
 
 func (b *Bridge) pairedDeviceStoreLocked() *wastore.Device {
@@ -295,6 +500,9 @@ func (b *Bridge) pairedDeviceStoreLocked() *wastore.Device {
 }
 
 func (b *Bridge) ConnectIfPaired() error {
+	if err := b.temporaryBanError(time.Now()); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	if err := b.recoverPersistedSessionLocked(); err != nil {
 		b.mu.Unlock()
@@ -314,6 +522,9 @@ func (b *Bridge) ConnectIfPaired() error {
 }
 
 func (b *Bridge) Connect() error {
+	if err := b.temporaryBanError(time.Now()); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	if err := b.recoverPersistedSessionLocked(); err != nil {
 		b.mu.Unlock()
@@ -353,6 +564,250 @@ func (b *Bridge) Connect() error {
 	return nil
 }
 
+// ConnectPaired synchronously starts one paired transport connection using the
+// caller-owned context. It never launches a goroutine; the supervisor adapter
+// is responsible for tracking the worker and joining it during Stop.
+func (b *Bridge) ConnectPaired(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("connect WhatsApp: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := b.temporaryBanError(time.Now()); err != nil {
+		return err
+	}
+
+	b.mu.Lock()
+	if err := b.recoverPersistedSessionLocked(); err != nil {
+		b.mu.Unlock()
+		return err
+	}
+	if b.client == nil || b.client.Store == nil || b.client.Store.ID == nil {
+		b.mu.Unlock()
+		return whatsmeow.ErrNotLoggedIn
+	}
+	if b.pairing || b.connecting {
+		b.mu.Unlock()
+		return errors.New("WhatsApp connection is already in progress")
+	}
+	if clientIsConnected(b.client) {
+		b.mu.Unlock()
+		return whatsmeow.ErrAlreadyConnected
+	}
+	cli := b.client
+	b.connected = false
+	b.connecting = true
+	b.pairing = false
+	b.lastError = ""
+	b.mu.Unlock()
+	b.emitStatusChange()
+
+	if err := connectClientContext(ctx, cli); err != nil {
+		b.finishConnectError(cli, err)
+		return err
+	}
+	return nil
+}
+
+// PrepareQRPairing installs whatsmeow's QR listener before the pairing
+// transport is connected. It changes only pairing status and never calls
+// Connect; ConnectPairing is the sole synchronous network entry point.
+func (b *Bridge) PrepareQRPairing(ctx context.Context) (<-chan whatsmeow.QRChannelItem, error) {
+	if ctx == nil {
+		return nil, errors.New("prepare WhatsApp QR pairing: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := b.temporaryBanError(time.Now()); err != nil {
+		return nil, err
+	}
+
+	b.mu.Lock()
+	if err := b.recoverPersistedSessionLocked(); err != nil {
+		b.mu.Unlock()
+		return nil, err
+	}
+	if b.client == nil || b.client.Store == nil {
+		b.mu.Unlock()
+		return nil, errors.New("WhatsApp client unavailable")
+	}
+	if b.client.Store.ID != nil {
+		b.mu.Unlock()
+		return nil, errors.New("WhatsApp is already paired")
+	}
+	if b.pairing || b.connecting || clientIsConnected(b.client) {
+		b.mu.Unlock()
+		return nil, errors.New("WhatsApp pairing is already in progress")
+	}
+	qrChan, err := b.client.GetQRChannel(ctx)
+	if err != nil {
+		b.lastError = err.Error()
+		b.mu.Unlock()
+		b.emitStatusChange()
+		return nil, fmt.Errorf("start WhatsApp pairing: %w", err)
+	}
+	b.pairing = true
+	b.connecting = true
+	b.lastError = ""
+	b.qr = QRSnapshot{}
+	b.mu.Unlock()
+	b.emitStatusChange()
+	return qrChan, nil
+}
+
+// ConnectPairing synchronously connects a pairing transport prepared by
+// PrepareQRPairing. PairPhoneContext performs the equivalent preparation for
+// phone-code pairing itself.
+func (b *Bridge) ConnectPairing(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("connect WhatsApp pairing transport: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := b.temporaryBanError(time.Now()); err != nil {
+		return err
+	}
+
+	b.mu.RLock()
+	cli := b.client
+	pairing := b.pairing
+	paired := cli != nil && cli.Store != nil && cli.Store.ID != nil
+	b.mu.RUnlock()
+	if cli == nil {
+		return errors.New("WhatsApp client unavailable")
+	}
+	if paired {
+		return errors.New("WhatsApp is already paired")
+	}
+	if !pairing {
+		return errors.New("WhatsApp pairing was not prepared")
+	}
+	if clientIsConnected(cli) {
+		return whatsmeow.ErrAlreadyConnected
+	}
+	if err := connectClientContext(ctx, cli); err != nil {
+		b.finishConnectError(cli, err)
+		return err
+	}
+	return nil
+}
+
+func (b *Bridge) finishConnectError(cli *whatsmeow.Client, err error) {
+	b.logger.Warn().Err(err).Msg("WhatsApp connect failed")
+	b.mu.Lock()
+	if b.client == cli {
+		b.connected = false
+		b.connecting = false
+		b.lastError = err.Error()
+		if b.client.Store == nil || b.client.Store.ID == nil {
+			b.pairing = false
+		}
+	}
+	b.mu.Unlock()
+	b.emitStatusChange()
+}
+
+// ApplyQRItem updates the unchanged legacy QR/status projection for one item
+// consumed by the supervisor-owned pairing worker.
+func (b *Bridge) ApplyQRItem(item whatsmeow.QRChannelItem) QRSnapshot {
+	now := time.Now()
+	snap := QRSnapshot{
+		Event:     item.Event,
+		UpdatedAt: now.UnixMilli(),
+	}
+	if item.Timeout > 0 {
+		snap.ExpiresAt = now.Add(item.Timeout).UnixMilli()
+	}
+	if item.Error != nil {
+		snap.Error = item.Error.Error()
+	}
+	if item.Event == whatsmeow.QRChannelEventCode {
+		snap.Code = item.Code
+	}
+
+	b.mu.Lock()
+	switch item.Event {
+	case whatsmeow.QRChannelEventCode:
+		b.qr = snap
+	default:
+		b.qr = snap
+		b.pairing = false
+		b.connecting = false
+		if snap.Error != "" {
+			b.lastError = snap.Error
+		} else if item.Event != whatsmeow.QRChannelSuccess.Event {
+			b.lastError = item.Event
+		}
+	}
+	b.mu.Unlock()
+	b.emitStatusChange()
+	return snap
+}
+
+// DisconnectTransport disconnects only the current socket. It deliberately
+// leaves the session database and a still-unpaired pairing affordance intact.
+func (b *Bridge) DisconnectTransport() {
+	b.mu.RLock()
+	cli := b.client
+	b.mu.RUnlock()
+	if cli != nil {
+		cli.Disconnect()
+	}
+	b.mu.Lock()
+	if b.client == cli {
+		b.connected = false
+		b.connecting = false
+		if cli == nil || cli.Store == nil || cli.Store.ID != nil {
+			b.pairing = false
+		}
+	}
+	b.mu.Unlock()
+	b.emitStatusChange()
+}
+
+// ProbeKeepAlive performs a real WhatsApp websocket keepalive IQ and waits for
+// the server response. No cached boolean is treated as liveness evidence.
+func (b *Bridge) ProbeKeepAlive(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("probe WhatsApp: nil context")
+	}
+	b.mu.RLock()
+	cli := b.client
+	paired := cli != nil && cli.Store != nil && cli.Store.ID != nil
+	b.mu.RUnlock()
+	if !paired {
+		return whatsmeow.ErrNotLoggedIn
+	}
+	ok, shouldContinue := sendClientKeepAlive(ctx, cli)
+	if ok {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !shouldContinue {
+		return errors.New("WhatsApp keepalive stopped because the transport ended")
+	}
+	return errors.New("WhatsApp keepalive timed out")
+}
+
+func (b *Bridge) PairedAccount() AccountInfo {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	deviceStore := b.pairedDeviceStoreLocked()
+	if deviceStore == nil {
+		return AccountInfo{}
+	}
+	return AccountInfo{
+		Paired:   true,
+		JID:      deviceStore.ID.String(),
+		PushName: strings.TrimSpace(deviceStore.PushName),
+	}
+}
+
 // pairPhoneDisplayName is the linked-device name sent during phone pairing.
 // WhatsApp's server validates this against a `Browser (OS)` allowlist and
 // returns "400 bad-request" for anything it doesn't recognize (e.g. a product
@@ -368,6 +823,9 @@ const pairPhoneDisplayName = "Chrome (macOS)"
 // over the same connection through the normal PairSuccess -> Connected events.
 // phone must be in international format (a leading + is fine; it is stripped).
 func (b *Bridge) PairPhone(phone string) (string, error) {
+	if err := b.temporaryBanError(time.Now()); err != nil {
+		return "", err
+	}
 	b.mu.Lock()
 	if err := b.recoverPersistedSessionLocked(); err != nil {
 		b.mu.Unlock()
@@ -380,6 +838,10 @@ func (b *Bridge) PairPhone(phone string) (string, error) {
 	if b.client.Store.ID != nil {
 		b.mu.Unlock()
 		return "", fmt.Errorf("WhatsApp is already paired")
+	}
+	if b.pairing || b.connecting {
+		b.mu.Unlock()
+		return "", errors.New("WhatsApp pairing is already in progress")
 	}
 	cli := b.client
 	needConnect := !clientIsConnected(cli)
@@ -420,6 +882,74 @@ func (b *Bridge) PairPhone(phone string) (string, error) {
 	return code, nil
 }
 
+// PairPhoneContext is the cancelable supervisor-owned phone-code path. The
+// legacy PairPhone method above intentionally retains its concrete protocol
+// call for the F7 compatibility contract.
+func (b *Bridge) PairPhoneContext(ctx context.Context, phone string) (string, error) {
+	if ctx == nil {
+		return "", errors.New("pair WhatsApp phone: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if err := b.temporaryBanError(time.Now()); err != nil {
+		return "", err
+	}
+
+	b.mu.Lock()
+	if err := b.recoverPersistedSessionLocked(); err != nil {
+		b.mu.Unlock()
+		return "", err
+	}
+	if b.client == nil || b.client.Store == nil {
+		b.mu.Unlock()
+		return "", errors.New("WhatsApp client unavailable")
+	}
+	if b.client.Store.ID != nil {
+		b.mu.Unlock()
+		return "", errors.New("WhatsApp is already paired")
+	}
+	if b.pairing || b.connecting {
+		b.mu.Unlock()
+		return "", errors.New("WhatsApp pairing is already in progress")
+	}
+	cli := b.client
+	needConnect := !clientIsConnected(cli)
+	b.lastError = ""
+	b.pairing = true
+	b.connecting = true
+	b.qr = QRSnapshot{}
+	b.mu.Unlock()
+	b.emitStatusChange()
+
+	clearPairingState := func(message string) {
+		b.mu.Lock()
+		if b.client == cli {
+			b.pairing = false
+			b.connecting = false
+			b.lastError = message
+		}
+		b.mu.Unlock()
+		b.emitStatusChange()
+	}
+
+	if needConnect {
+		if err := connectClientContext(ctx, cli); err != nil && !errors.Is(err, whatsmeow.ErrAlreadyConnected) {
+			clearPairingState(err.Error())
+			return "", fmt.Errorf("connect WhatsApp: %w", err)
+		}
+	}
+
+	pairCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	code, err := cli.PairPhone(pairCtx, phone, true, whatsmeow.PairClientChrome, pairPhoneDisplayName)
+	if err != nil {
+		clearPairingState(err.Error())
+		return "", fmt.Errorf("request WhatsApp pairing code: %w", err)
+	}
+	return code, nil
+}
+
 func (b *Bridge) runConnect(cli *whatsmeow.Client) {
 	if err := connectClient(cli); err != nil {
 		b.logger.Warn().Err(err).Msg("WhatsApp connect failed")
@@ -438,36 +968,7 @@ func (b *Bridge) runConnect(cli *whatsmeow.Client) {
 
 func (b *Bridge) consumeQR(ch <-chan whatsmeow.QRChannelItem) {
 	for item := range ch {
-		snap := QRSnapshot{
-			Event:     item.Event,
-			UpdatedAt: time.Now().UnixMilli(),
-		}
-		if item.Timeout > 0 {
-			snap.ExpiresAt = time.Now().Add(item.Timeout).UnixMilli()
-		}
-		if item.Error != nil {
-			snap.Error = item.Error.Error()
-		}
-		if item.Event == whatsmeow.QRChannelEventCode {
-			snap.Code = item.Code
-		}
-
-		b.mu.Lock()
-		switch item.Event {
-		case whatsmeow.QRChannelEventCode:
-			b.qr = snap
-		default:
-			b.qr = snap
-			b.pairing = false
-			b.connecting = false
-			if snap.Error != "" {
-				b.lastError = snap.Error
-			} else if item.Event != whatsmeow.QRChannelSuccess.Event {
-				b.lastError = item.Event
-			}
-		}
-		b.mu.Unlock()
-		b.emitStatusChange()
+		b.ApplyQRItem(item)
 	}
 }
 
@@ -477,14 +978,33 @@ func (b *Bridge) Unpair() error {
 	b.mu.RUnlock()
 
 	if cli != nil && cli.Store != nil && cli.Store.ID != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if clientIsConnected(cli) {
-			if err := cli.Logout(ctx); err != nil {
+		remoteCtx, cancelRemote := context.WithTimeout(context.Background(), unpairRemoteTimeout)
+		connected := clientIsConnected(cli)
+		if !connected {
+			err := connectClientContext(remoteCtx, cli)
+			if err != nil && !errors.Is(err, whatsmeow.ErrAlreadyConnected) {
+				b.logger.Warn().Err(err).Msg("WhatsApp reconnect for logout failed; clearing local session anyway")
+			} else {
+				connected = true
+			}
+		}
+		if connected {
+			if err := logoutClient(remoteCtx, cli); err != nil {
 				b.logger.Warn().Err(err).Msg("WhatsApp logout failed; clearing local session anyway")
 			}
-		} else if err := cli.Store.Delete(ctx); err != nil {
-			b.logger.Warn().Err(err).Msg("Failed to clear WhatsApp session store")
+		}
+		cancelRemote()
+
+		// Logout clears the device store after the server confirms the unlink.
+		// If reconnect or logout failed, force the documented local fallback so
+		// callers can still re-pair without retaining stale credentials.
+		if cli.Store.ID != nil {
+			cli.Disconnect()
+			storeCtx, cancelStore := context.WithTimeout(context.Background(), unpairStoreTimeout)
+			if err := deleteClientStore(storeCtx, cli); err != nil {
+				b.logger.Warn().Err(err).Msg("Failed to clear WhatsApp session store")
+			}
+			cancelStore()
 		}
 	}
 
@@ -524,14 +1044,13 @@ func (b *Bridge) Status() StatusSnapshot {
 	return status
 }
 
-func (b *Bridge) ensureSendClient(wait time.Duration, reason string) (*whatsmeow.Client, error) {
+func (b *Bridge) ensureSendClient() (*whatsmeow.Client, error) {
 	if cli := b.currentSendClient(); cli != nil {
 		return cli, nil
 	}
-	if err := b.beginReconnect(reason, false); err != nil {
-		return nil, err
-	}
-	return b.waitForConnectedClient(wait)
+	err := whatsmeow.ErrNotConnected
+	b.reportConnectionError(err)
+	return nil, err
 }
 
 func (b *Bridge) currentSendClient() *whatsmeow.Client {
@@ -543,75 +1062,21 @@ func (b *Bridge) currentSendClient() *whatsmeow.Client {
 	return b.client
 }
 
-func (b *Bridge) beginReconnect(reason string, force bool) error {
-	b.mu.Lock()
-	if err := b.recoverPersistedSessionLocked(); err != nil {
-		b.mu.Unlock()
-		return err
-	}
-	if b.client == nil || b.client.Store == nil || b.client.Store.ID == nil {
-		b.mu.Unlock()
-		return errors.New("whatsapp live sync is not connected")
-	}
-	if !force && b.connected && clientIsConnected(b.client) {
-		b.mu.Unlock()
-		return nil
-	}
-	if b.connecting {
-		b.mu.Unlock()
-		return nil
-	}
-	cli := b.client
-	b.connected = false
-	b.connecting = true
-	b.pairing = false
-	if reason != "" {
-		b.lastError = reason
-	}
-	b.mu.Unlock()
-	b.emitStatusChange()
-	launchConnect(b, cli)
-	return nil
-}
-
-func (b *Bridge) waitForConnectedClient(wait time.Duration) (*whatsmeow.Client, error) {
-	deadline := time.Now().Add(wait)
-	for {
-		b.mu.RLock()
-		cli := b.client
-		connected := b.connected && clientIsConnected(cli)
-		connecting := b.connecting
-		lastError := b.lastError
-		paired := cli != nil && cli.Store != nil && cli.Store.ID != nil
-		b.mu.RUnlock()
-
-		if connected && cli != nil {
-			return cli, nil
-		}
-		if !paired {
-			if lastError != "" {
-				return nil, errors.New(lastError)
-			}
-			return nil, errors.New("whatsapp live sync is not connected")
-		}
-		if time.Now().After(deadline) {
-			if lastError != "" {
-				return nil, fmt.Errorf("whatsapp reconnect: %s", lastError)
-			}
-			if connecting {
-				return nil, errors.New("whatsapp reconnect timed out")
-			}
-			return nil, errors.New("whatsapp live sync is not connected")
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-}
-
-func shouldReconnectWhatsAppSend(err error) bool {
+// ShouldReconnect reports whether an operation failure means the active
+// transport generation must be retired. It never performs the reconnect.
+func ShouldReconnect(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, whatsmeow.ErrNotConnected) ||
+		errors.Is(err, whatsmeow.ErrNotLoggedIn) ||
+		errors.Is(err, whatsmeow.ErrMessageTimedOut) ||
+		errors.Is(err, wastore.ErrDeviceDeleted) {
+		return true
+	}
+	var disconnected *whatsmeow.DisconnectedError
+	if errors.As(err, &disconnected) {
 		return true
 	}
 	msg := strings.ToLower(strings.TrimSpace(err.Error()))
@@ -619,6 +1084,14 @@ func shouldReconnectWhatsAppSend(err error) bool {
 		strings.Contains(msg, "connection closed") ||
 		strings.Contains(msg, "websocket") ||
 		strings.Contains(msg, "not connected")
+}
+
+func shouldReconnectWhatsAppSend(err error) bool { return ShouldReconnect(err) }
+
+func (b *Bridge) reportConnectionError(err error) {
+	if err != nil && ShouldReconnect(err) && b.callbacks.OnConnectionError != nil {
+		b.callbacks.OnConnectionError(err)
+	}
 }
 
 func (b *Bridge) QRCode() (QRSnapshot, error) {
@@ -643,7 +1116,6 @@ func (b *Bridge) UsesLiveSession() bool {
 
 func (b *Bridge) Close() error {
 	b.mu.Lock()
-	defer b.mu.Unlock()
 	if b.client != nil {
 		b.client.Disconnect()
 		b.client = nil
@@ -651,12 +1123,21 @@ func (b *Bridge) Close() error {
 	b.connected = false
 	b.connecting = false
 	b.pairing = false
+	var errs []error
 	if b.container != nil {
-		err := b.container.Close()
+		errs = append(errs, b.container.Close())
 		b.container = nil
-		return err
 	}
-	return nil
+	b.observation = lifecycleObservation{}
+	b.mu.Unlock()
+
+	b.runtimeMu.Lock()
+	if b.runtimeDB != nil {
+		errs = append(errs, b.runtimeDB.Close())
+		b.runtimeDB = nil
+	}
+	b.runtimeMu.Unlock()
+	return errors.Join(errs...)
 }
 
 func (b *Bridge) SendText(conversationID, body, replyToID string) (*db.Message, error) {
@@ -670,7 +1151,7 @@ func (b *Bridge) SendText(conversationID, body, replyToID string) (*db.Message, 
 		return nil, err
 	}
 
-	cli, err := b.ensureSendClient(15*time.Second, "reconnecting WhatsApp before send")
+	cli, err := b.ensureSendClient()
 	if err != nil {
 		return nil, err
 	}
@@ -683,11 +1164,7 @@ func (b *Bridge) SendText(conversationID, body, replyToID string) (*db.Message, 
 		ID: reqID,
 	})
 	if err != nil {
-		if shouldReconnectWhatsAppSend(err) {
-			if reconnectErr := b.beginReconnect("WhatsApp send timed out; reconnecting", true); reconnectErr != nil {
-				b.logger.Debug().Err(reconnectErr).Msg("Failed to start WhatsApp reconnect after send error")
-			}
-		}
+		b.reportConnectionError(err)
 		return nil, fmt.Errorf("send WhatsApp message: %w", err)
 	}
 
@@ -741,7 +1218,7 @@ func (b *Bridge) SendMedia(conversationID string, data []byte, filename, mime, c
 		return nil, err
 	}
 
-	cli, err := b.ensureSendClient(30*time.Second, "reconnecting WhatsApp before media send")
+	cli, err := b.ensureSendClient()
 	if err != nil {
 		return nil, err
 	}
@@ -751,11 +1228,7 @@ func (b *Bridge) SendMedia(conversationID string, data []byte, filename, mime, c
 
 	upload, err := uploadMedia(cli, uploadCtx, data, mediaType)
 	if err != nil {
-		if shouldReconnectWhatsAppSend(err) {
-			if reconnectErr := b.beginReconnect("WhatsApp media upload timed out; reconnecting", true); reconnectErr != nil {
-				b.logger.Debug().Err(reconnectErr).Msg("Failed to start WhatsApp reconnect after media upload error")
-			}
-		}
+		b.reportConnectionError(err)
 		return nil, fmt.Errorf("upload WhatsApp media: %w", err)
 	}
 	reqID := cli.GenerateMessageID()
@@ -766,11 +1239,7 @@ func (b *Bridge) SendMedia(conversationID string, data []byte, filename, mime, c
 		ID: reqID,
 	})
 	if err != nil {
-		if shouldReconnectWhatsAppSend(err) {
-			if reconnectErr := b.beginReconnect("WhatsApp media send timed out; reconnecting", true); reconnectErr != nil {
-				b.logger.Debug().Err(reconnectErr).Msg("Failed to start WhatsApp reconnect after media send error")
-			}
-		}
+		b.reportConnectionError(err)
 		return nil, fmt.Errorf("send WhatsApp media: %w", err)
 	}
 
@@ -862,7 +1331,7 @@ func (b *Bridge) SendReaction(conversationID, targetMessageID, emoji, action str
 		return errors.New("whatsapp reaction target id is unavailable")
 	}
 
-	cli, err := b.ensureSendClient(15*time.Second, "reconnecting WhatsApp before reaction")
+	cli, err := b.ensureSendClient()
 	if err != nil {
 		return err
 	}
@@ -879,11 +1348,7 @@ func (b *Bridge) SendReaction(conversationID, targetMessageID, emoji, action str
 		ID: reqID,
 	})
 	if err != nil {
-		if shouldReconnectWhatsAppSend(err) {
-			if reconnectErr := b.beginReconnect("WhatsApp reaction timed out; reconnecting", true); reconnectErr != nil {
-				b.logger.Debug().Err(reconnectErr).Msg("Failed to start WhatsApp reconnect after reaction error")
-			}
-		}
+		b.reportConnectionError(err)
 		return fmt.Errorf("send WhatsApp reaction: %w", err)
 	}
 
@@ -917,7 +1382,7 @@ func (b *Bridge) LeaveGroup(conversationID string) error {
 		return errors.New("conversation is not a WhatsApp group")
 	}
 
-	cli, err := b.ensureSendClient(30*time.Second, "reconnecting WhatsApp before leaving group")
+	cli, err := b.ensureSendClient()
 	if err != nil {
 		return err
 	}
@@ -926,11 +1391,7 @@ func (b *Bridge) LeaveGroup(conversationID string) error {
 	defer cancel()
 
 	if err := leaveGroup(cli, ctx, chatJID); err != nil {
-		if shouldReconnectWhatsAppSend(err) {
-			if reconnectErr := b.beginReconnect("WhatsApp leave group timed out; reconnecting", true); reconnectErr != nil {
-				b.logger.Debug().Err(reconnectErr).Msg("Failed to start WhatsApp reconnect after leave-group error")
-			}
-		}
+		b.reportConnectionError(err)
 		return fmt.Errorf("leave WhatsApp group: %w", err)
 	}
 
@@ -1113,7 +1574,55 @@ func (b *Bridge) ProfilePhoto(conversationID string) ([]byte, string, error) {
 	return data, mime, nil
 }
 
+// handleClientEvent fences callbacks by the concrete whatsmeow client and its
+// local generation. Temporary-ban persistence happens before either the
+// compatibility status projection or the supervisor observer is notified.
+func (b *Bridge) handleClientEvent(source *whatsmeow.Client, generation uint64, raw any) {
+	b.mu.RLock()
+	current := source == nil || (b.client == source && b.clientGeneration == generation)
+	b.mu.RUnlock()
+	if !current {
+		return
+	}
+
+	at := time.Now()
+	var retryAt time.Time
+	var persistenceErr error
+	if event, ok := raw.(*waevents.TemporaryBan); ok && event != nil {
+		retryAt, persistenceErr = b.persistTemporaryBan(at, event.Expire)
+	}
+
+	b.applyEvent(raw)
+
+	b.mu.RLock()
+	// Re-check after applying the event because a concurrent explicit unpair
+	// may have replaced the client while the compatibility handler ran.
+	current = source == nil || (b.client == source && b.clientGeneration == generation)
+	paired := source != nil && source.Store != nil && source.Store.ID != nil
+	if source == nil {
+		paired = b.client != nil && b.client.Store != nil && b.client.Store.ID != nil
+	}
+	observer := b.observation.callback
+	b.mu.RUnlock()
+	if !current || observer == nil {
+		return
+	}
+	observer(LifecycleEvent{
+		Raw:              raw,
+		Paired:           paired,
+		At:               at,
+		RetryAt:          retryAt,
+		PersistenceError: persistenceErr,
+	})
+}
+
+// handleEvent remains the characterization-test entry point. Production
+// whatsmeow callbacks always use handleClientEvent with a source generation.
 func (b *Bridge) handleEvent(raw any) {
+	b.handleClientEvent(nil, 0, raw)
+}
+
+func (b *Bridge) applyEvent(raw any) {
 	switch evt := raw.(type) {
 	case *waevents.Connected:
 		b.handleConnected()
@@ -1121,7 +1630,6 @@ func (b *Bridge) handleEvent(raw any) {
 		b.handleDisconnected("")
 	case *waevents.LoggedOut:
 		b.handleDisconnected(evt.PermanentDisconnectDescription())
-		go b.reinitializeAfterLogout()
 	case *waevents.StreamReplaced:
 		b.handleDisconnected("stream replaced")
 	case *waevents.ClientOutdated:
@@ -1130,6 +1638,11 @@ func (b *Bridge) handleEvent(raw any) {
 		b.handleDisconnected(evt.PermanentDisconnectDescription())
 	case *waevents.TemporaryBan:
 		b.handleDisconnected(evt.PermanentDisconnectDescription())
+	case *waevents.ManualLoginReconnect:
+		// DisableLoginAutoReconnect turns whatsmeow's implicit 515 reconnect
+		// into this event. The adapter decides whether pairing is handing off or
+		// an active lifecycle generation must be retired and retried.
+		b.handleDisconnected("WhatsApp requested a supervised login reconnect")
 	case *waevents.PairSuccess:
 		b.handlePairSuccess(evt)
 	case *waevents.PairError:
@@ -1221,18 +1734,6 @@ func (b *Bridge) handlePairError(err error) {
 	b.qr = QRSnapshot{}
 	if err != nil {
 		b.lastError = err.Error()
-	}
-	b.mu.Unlock()
-	b.emitStatusChange()
-}
-
-func (b *Bridge) reinitializeAfterLogout() {
-	b.mu.Lock()
-	if err := b.resetClientLocked(); err != nil {
-		b.lastError = err.Error()
-		b.mu.Unlock()
-		b.emitStatusChange()
-		return
 	}
 	b.mu.Unlock()
 	b.emitStatusChange()

--- a/internal/whatsapplive/client_test.go
+++ b/internal/whatsapplive/client_test.go
@@ -503,7 +503,7 @@ func TestBridgeSendTextBuildsOutgoingWhatsAppMessage(t *testing.T) {
 	}
 }
 
-func TestBridgeSendTextReconnectsStaleClientBeforeSend(t *testing.T) {
+func TestBridgeSendTextNotifiesSupervisorForStaleClient(t *testing.T) {
 	ownJID := watypes.NewJID("15551230000", watypes.DefaultUserServer)
 	bridge := &Bridge{
 		connected: true,
@@ -515,59 +515,33 @@ func TestBridgeSendTextReconnectsStaleClientBeforeSend(t *testing.T) {
 		},
 	}
 
-	originalSend := sendTextMessage
 	originalConnect := connectClient
 	originalIsConnected := clientIsConnected
-	originalLaunch := launchConnect
 	defer func() {
-		sendTextMessage = originalSend
 		connectClient = originalConnect
 		clientIsConnected = originalIsConnected
-		launchConnect = originalLaunch
 	}()
 
-	var wireConnected bool
 	var connectCalls int
-	var sendCalls int
-	clientIsConnected = func(_ *whatsmeow.Client) bool {
-		return wireConnected
-	}
-	launchConnect = func(b *Bridge, cli *whatsmeow.Client) {
-		b.runConnect(cli)
-	}
+	clientIsConnected = func(_ *whatsmeow.Client) bool { return false }
 	connectClient = func(_ *whatsmeow.Client) error {
 		connectCalls++
-		bridge.mu.Lock()
-		wireConnected = true
-		bridge.connected = true
-		bridge.connecting = false
-		bridge.lastError = ""
-		bridge.mu.Unlock()
 		return nil
 	}
-	sendTextMessage = func(_ *whatsmeow.Client, _ context.Context, _ watypes.JID, _ *waE2E.Message, extra ...whatsmeow.SendRequestExtra) (whatsmeow.SendResponse, error) {
-		sendCalls++
-		return whatsmeow.SendResponse{
-			ID:        watypes.MessageID(extra[0].ID),
-			Timestamp: time.UnixMilli(1700000000999),
-		}, nil
+	var notified error
+	bridge.callbacks.OnConnectionError = func(err error) {
+		notified = err
 	}
 
-	msg, err := bridge.SendText("whatsapp:15551234567@s.whatsapp.net", "hello after reconnect", "")
-	if err != nil {
-		t.Fatalf("SendText(): %v", err)
+	_, err := bridge.SendText("whatsapp:15551234567@s.whatsapp.net", "hello after reconnect", "")
+	if !errors.Is(err, whatsmeow.ErrNotConnected) {
+		t.Fatalf("SendText() error = %v, want ErrNotConnected", err)
 	}
-	if connectCalls != 1 {
-		t.Fatalf("connect calls = %d, want 1", connectCalls)
+	if connectCalls != 0 {
+		t.Fatalf("connect calls = %d, want 0", connectCalls)
 	}
-	if sendCalls != 1 {
-		t.Fatalf("send calls = %d, want 1", sendCalls)
-	}
-	if msg.Body != "hello after reconnect" {
-		t.Fatalf("body = %q, want hello after reconnect", msg.Body)
-	}
-	if !bridge.Status().Connected {
-		t.Fatal("expected bridge status to report connected after reconnect")
+	if !errors.Is(notified, whatsmeow.ErrNotConnected) {
+		t.Fatalf("notified error = %v, want ErrNotConnected", notified)
 	}
 }
 
@@ -803,7 +777,7 @@ func TestHandleGroupInfoOwnJoinClearsSuppressionAndRestoresGroup(t *testing.T) {
 	}
 }
 
-func TestBridgeSendTextTimeoutStartsReconnect(t *testing.T) {
+func TestBridgeSendTextTimeoutNotifiesSupervisorWithoutReconnect(t *testing.T) {
 	ownJID := watypes.NewJID("15551230000", watypes.DefaultUserServer)
 	bridge := &Bridge{
 		connected: true,
@@ -818,29 +792,20 @@ func TestBridgeSendTextTimeoutStartsReconnect(t *testing.T) {
 	originalSend := sendTextMessage
 	originalConnect := connectClient
 	originalIsConnected := clientIsConnected
-	originalLaunch := launchConnect
 	defer func() {
 		sendTextMessage = originalSend
 		connectClient = originalConnect
 		clientIsConnected = originalIsConnected
-		launchConnect = originalLaunch
 	}()
 
-	var wireConnected = true
-	reconnectStarted := make(chan struct{}, 1)
-	clientIsConnected = func(_ *whatsmeow.Client) bool {
-		return wireConnected
-	}
-	launchConnect = func(b *Bridge, cli *whatsmeow.Client) {
-		b.runConnect(cli)
-	}
+	var connectCalls int
+	clientIsConnected = func(_ *whatsmeow.Client) bool { return true }
 	connectClient = func(_ *whatsmeow.Client) error {
-		select {
-		case reconnectStarted <- struct{}{}:
-		default:
-		}
+		connectCalls++
 		return nil
 	}
+	var notified error
+	bridge.callbacks.OnConnectionError = func(err error) { notified = err }
 	sendTextMessage = func(_ *whatsmeow.Client, _ context.Context, _ watypes.JID, _ *waE2E.Message, extra ...whatsmeow.SendRequestExtra) (whatsmeow.SendResponse, error) {
 		_ = extra
 		return whatsmeow.SendResponse{}, context.DeadlineExceeded
@@ -850,21 +815,15 @@ func TestBridgeSendTextTimeoutStartsReconnect(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("SendText() error = %v, want context deadline exceeded", err)
 	}
-	select {
-	case <-reconnectStarted:
-	case <-time.After(time.Second):
-		t.Fatal("expected reconnect to start after send timeout")
+	if connectCalls != 0 {
+		t.Fatalf("connect calls = %d, want 0", connectCalls)
 	}
-	status := bridge.Status()
-	if !status.Connecting {
-		t.Fatal("expected bridge to report reconnecting after send timeout")
-	}
-	if status.Connected {
-		t.Fatal("did not expect bridge to remain connected after send timeout")
+	if !errors.Is(notified, context.DeadlineExceeded) {
+		t.Fatalf("notified error = %v, want context deadline exceeded", notified)
 	}
 }
 
-func TestBridgeSendMediaUploadTimeoutStartsReconnect(t *testing.T) {
+func TestBridgeSendMediaUploadTimeoutNotifiesSupervisorWithoutReconnect(t *testing.T) {
 	ownJID := watypes.NewJID("15551230000", watypes.DefaultUserServer)
 	bridge := &Bridge{
 		connected: true,
@@ -879,26 +838,20 @@ func TestBridgeSendMediaUploadTimeoutStartsReconnect(t *testing.T) {
 	originalUpload := uploadMedia
 	originalConnect := connectClient
 	originalIsConnected := clientIsConnected
-	originalLaunch := launchConnect
 	defer func() {
 		uploadMedia = originalUpload
 		connectClient = originalConnect
 		clientIsConnected = originalIsConnected
-		launchConnect = originalLaunch
 	}()
 
-	reconnectStarted := make(chan struct{}, 1)
+	var connectCalls int
 	clientIsConnected = func(_ *whatsmeow.Client) bool { return true }
-	launchConnect = func(b *Bridge, cli *whatsmeow.Client) {
-		b.runConnect(cli)
-	}
 	connectClient = func(_ *whatsmeow.Client) error {
-		select {
-		case reconnectStarted <- struct{}{}:
-		default:
-		}
+		connectCalls++
 		return nil
 	}
+	var notified error
+	bridge.callbacks.OnConnectionError = func(err error) { notified = err }
 	uploadMedia = func(_ *whatsmeow.Client, _ context.Context, _ []byte, _ whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
 		return whatsmeow.UploadResponse{}, context.DeadlineExceeded
 	}
@@ -907,17 +860,11 @@ func TestBridgeSendMediaUploadTimeoutStartsReconnect(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("SendMedia() error = %v, want context deadline exceeded", err)
 	}
-	select {
-	case <-reconnectStarted:
-	case <-time.After(time.Second):
-		t.Fatal("expected reconnect to start after media upload timeout")
+	if connectCalls != 0 {
+		t.Fatalf("connect calls = %d, want 0", connectCalls)
 	}
-	status := bridge.Status()
-	if !status.Connecting {
-		t.Fatal("expected bridge to report reconnecting after media upload timeout")
-	}
-	if status.Connected {
-		t.Fatal("did not expect bridge to remain connected after media upload timeout")
+	if !errors.Is(notified, context.DeadlineExceeded) {
+		t.Fatalf("notified error = %v, want context deadline exceeded", notified)
 	}
 }
 
@@ -1826,6 +1773,142 @@ func TestConsumeQRRotatesCodesAndTimeoutReturnsToUnpairedState(t *testing.T) {
 	if status.Paired || status.QRAvailable || status.QREvent != "timeout" {
 		t.Fatalf("expired QR did not return to unpaired state: %+v", status)
 	}
+}
+
+func TestUnpairReconnectsBeforeLogout(t *testing.T) {
+	bridge := newPairedBridgeForUnpairTest(t)
+
+	originalConnectContext := connectClientContext
+	originalLogout := logoutClient
+	originalDeleteStore := deleteClientStore
+	originalIsConnected := clientIsConnected
+	defer func() {
+		connectClientContext = originalConnectContext
+		logoutClient = originalLogout
+		deleteClientStore = originalDeleteStore
+		clientIsConnected = originalIsConnected
+	}()
+
+	clientIsConnected = func(*whatsmeow.Client) bool { return false }
+	var calls []string
+	var connectDeadline time.Time
+	connectClientContext = func(ctx context.Context, cli *whatsmeow.Client) error {
+		if cli != bridge.client {
+			t.Fatal("connect received a different client")
+		}
+		var ok bool
+		connectDeadline, ok = ctx.Deadline()
+		if !ok || time.Until(connectDeadline) <= 0 || time.Until(connectDeadline) > unpairRemoteTimeout {
+			t.Fatalf("connect context deadline = %v, want a live %v bound", connectDeadline, unpairRemoteTimeout)
+		}
+		calls = append(calls, "connect")
+		return nil
+	}
+	logoutClient = func(ctx context.Context, cli *whatsmeow.Client) error {
+		if cli != bridge.client {
+			t.Fatal("logout received a different client")
+		}
+		logoutDeadline, ok := ctx.Deadline()
+		if !ok || !logoutDeadline.Equal(connectDeadline) {
+			t.Fatalf("logout deadline = %v, want connect deadline %v", logoutDeadline, connectDeadline)
+		}
+		calls = append(calls, "logout")
+		cli.Store.ID = nil // Match whatsmeow.Logout's successful local cleanup.
+		return nil
+	}
+	deleteClientStore = func(context.Context, *whatsmeow.Client) error {
+		calls = append(calls, "delete")
+		return nil
+	}
+
+	if err := bridge.Unpair(); err != nil {
+		t.Fatalf("Unpair(): %v", err)
+	}
+	if got := strings.Join(calls, ","); got != "connect,logout" {
+		t.Fatalf("calls = %q, want connect,logout", got)
+	}
+	if status := bridge.Status(); status.Paired {
+		t.Fatalf("status after Unpair() = %+v, want unpaired", status)
+	}
+}
+
+func TestUnpairFallsBackToLocalDeleteAfterRemoteFailure(t *testing.T) {
+	originalConnectContext := connectClientContext
+	originalLogout := logoutClient
+	originalDeleteStore := deleteClientStore
+	originalIsConnected := clientIsConnected
+	defer func() {
+		connectClientContext = originalConnectContext
+		logoutClient = originalLogout
+		deleteClientStore = originalDeleteStore
+		clientIsConnected = originalIsConnected
+	}()
+
+	clientIsConnected = func(*whatsmeow.Client) bool { return false }
+	remoteErr := errors.New("remote unavailable")
+	tests := []struct {
+		name       string
+		connectErr error
+		logoutErr  error
+		wantCalls  string
+	}{
+		{
+			name:       "connect fails",
+			connectErr: remoteErr,
+			wantCalls:  "connect,delete",
+		},
+		{
+			name:      "logout fails",
+			logoutErr: remoteErr,
+			wantCalls: "connect,logout,delete",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bridge := newPairedBridgeForUnpairTest(t)
+			var calls []string
+			connectClientContext = func(context.Context, *whatsmeow.Client) error {
+				calls = append(calls, "connect")
+				return tt.connectErr
+			}
+			logoutClient = func(context.Context, *whatsmeow.Client) error {
+				calls = append(calls, "logout")
+				return tt.logoutErr
+			}
+			deleteClientStore = func(ctx context.Context, cli *whatsmeow.Client) error {
+				deadline, ok := ctx.Deadline()
+				if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > unpairStoreTimeout {
+					t.Fatalf("store context deadline = %v, want a live %v bound", deadline, unpairStoreTimeout)
+				}
+				calls = append(calls, "delete")
+				cli.Store.ID = nil
+				return nil
+			}
+
+			if err := bridge.Unpair(); err != nil {
+				t.Fatalf("Unpair(): %v", err)
+			}
+			if got := strings.Join(calls, ","); got != tt.wantCalls {
+				t.Fatalf("calls = %q, want %q", got, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func newPairedBridgeForUnpairTest(t *testing.T) *Bridge {
+	t.Helper()
+	bridge, err := New(filepath.Join(t.TempDir(), "whatsapp-session.db"), nil, zerolog.Nop(), Callbacks{})
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := bridge.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+	jid := watypes.NewJID("15551230000", watypes.DefaultUserServer)
+	bridge.client.Store.ID = &jid
+	return bridge
 }
 
 func TestBridgeSendMediaBuildsOutgoingWhatsAppMessage(t *testing.T) {


### PR DESCRIPTION
Wave 1 / C5 — the second live bridge on the supervisor (after C4/Google). Implemented by Sol; adversarial-reviewed + fixed + live-verified by Claude. Runtime-affecting.

A `bridge.Supervisor` owns the WhatsApp (whatsmeow) connection generation + pairing; whatsmeow's own auto-reconnect **and** the serve.go 5s ticker are removed → exactly one connect/reconnect owner. Send/read/media/pairing paths and the F7/F8 tests are preserved.

- **Adapter** maps **real** whatsmeow events (verified against the pinned module source): `Connected(paired)`→ready+beat (fires on auth, no phone data needed — no C4-style `ClientReady` fiction), Disconnected/temporary→transient (circuit-exempt backoff), LoggedOut→reauth, **TemporaryBan→rate_limited with `RetryAt`=the ban's persisted expiry** (fixes the F7 discarded-expiry bug — zero connect attempts until it lifts). Readiness never a bare boolean. All send paths notify the supervisor (App-level notifier → MCP + web both reach repair/park).

## Reviewed, then fixed before merge
An adversarial review (verified against the real whatsmeow pin) confirmed the core correct but found 4 defects, all fixed:
1. A send during `StateConnecting` no longer aborts the in-flight connect (`ReportError` readiness-guarded).
2. **A WhatsApp store-init failure warns and skips WA wiring instead of taking down SMS/Signal/web/MCP** (fault isolation).
3. Supervised unpair does a bounded server-side `Logout` before local delete (no zombie linked device).
4. A remote `LoggedOut` landing in Blocked-while-unpaired rebuilds to Unpaired so Reconnect/PairPhone lead back to pairing.
Control-layer tests added. `go test -race -count=3` green; F7/F8 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
