### PR TITLE
Wire Signal lifecycle behind the per-account supervisor (rebuild Wave 1 / C6)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,6 +23,7 @@ import (
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/bridge"
 	googleadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/google"
+	signaladapter "github.com/maxghenis/openmessage/internal/bridgeadapters/signal"
 	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
 	"github.com/maxghenis/openmessage/internal/db"
 	"github.com/maxghenis/openmessage/internal/googlecookies"
@@ -120,6 +121,8 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	var googleControl *googleSupervisorControl
 	var whatsappSupervisor *bridge.Supervisor
 	var whatsappControl *whatsappSupervisorControl
+	var signalLifecycle *signaladapter.Adapter
+	var signalControl *signalSupervisorControl
 
 	// Google has one lifecycle owner. Transient retry, liveness probes,
 	// credential repair, and terminal parking all flow through this supervisor;
@@ -248,34 +251,57 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	}
 
 	if !isDemo {
-		if err := a.LoadAndConnectSignal(); err != nil {
+		signalBridge, err := a.EnsureSignal()
+		if err != nil {
 			logger.Warn().Err(err).Msg("Signal live bridge unavailable")
+		} else {
+			signalLifecycle = signaladapter.New(signalAccountID, signalBridge)
+			a.SetSignalLifecycleNotifier(signalLifecycle)
+			newSignalSupervisor := func() (*bridge.Supervisor, error) {
+				return bridge.NewSupervisor(
+					signalAccountID,
+					bridge.PlatformSignal,
+					signalLifecycle,
+					signalSupervisorPolicy(),
+					signalWallClock{},
+					signalRandom{},
+				)
+			}
+			signalSupervisor, err := newSignalSupervisor()
+			if err != nil {
+				return fmt.Errorf("init Signal supervisor: %w", err)
+			}
+			signalControl = newSignalSupervisorControl(
+				signalSupervisor,
+				newSignalSupervisor,
+				signalLifecycle.InputFingerprint,
+			)
+			signalStartupCtx, cancelSignalStartup := context.WithCancel(context.Background())
+			var signalStartupWG sync.WaitGroup
+			defer func() {
+				cancelSignalStartup()
+				ctx, cancel := context.WithTimeout(context.Background(), signalSupervisorStopTimeout)
+				defer cancel()
+				if err := signalControl.Stop(ctx); err != nil {
+					logger.Warn().Err(err).Msg("Failed to stop Signal supervisor cleanly")
+				}
+				signalStartupWG.Wait()
+			}()
+
+			if signalBridge.Status().Paired {
+				signalStartupWG.Add(1)
+				go func() {
+					defer signalStartupWG.Done()
+					if err := signalSupervisor.Start(signalStartupCtx, bridge.StartRequest{}); err != nil &&
+						!errors.Is(err, context.Canceled) &&
+						!errors.Is(err, bridge.ErrSupervisorStopped) {
+						logger.Warn().Err(err).Msg("Signal live bridge unavailable")
+					}
+				}()
+			}
 		}
 	} else {
 		logger.Info().Msg("Demo mode — skipping Signal live bridge")
-	}
-
-	if !isDemo {
-		go func() {
-			ticker := time.NewTicker(5 * time.Second)
-			defer ticker.Stop()
-			for range ticker.C {
-				status := a.SignalStatus()
-				if !status.Paired || status.Connected || status.Pairing || status.Connecting {
-					continue
-				}
-				// Skip terminal states that require manual remediation.
-				// Hammering signal-cli every 5s with a known-bad account or
-				// binary wastes resources and produces noise in the logs. The
-				// status payload tells the UI whether to re-pair or upgrade.
-				if status.NeedsReauth || status.UpgradeRequired {
-					continue
-				}
-				if err := a.StartSignalConnect(); err != nil {
-					logger.Warn().Err(err).Msg("Signal reconnect attempt failed")
-				}
-			}
-		}()
 	}
 
 	// Sync WhatsApp and iMessage periodically (every 30s, incremental)
@@ -441,6 +467,14 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 			return whatsappControl.StopAndUnpair(a.UnpairWhatsApp)
 		}
 	}
+	var connectSignal func() error
+	var unpairSignal func() error
+	if signalControl != nil {
+		connectSignal = signalControl.Connect
+		unpairSignal = func() error {
+			return signalControl.StopAndUnpair(signalLifecycle.Unpair)
+		}
+	}
 
 	// Background loop that sends due scheduled ("send later") messages.
 	a.StartScheduler()
@@ -466,9 +500,9 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				PairWhatsAppPhone:     pairWhatsAppPhone,
 				UnpairWhatsApp:        unpairWhatsApp,
 				SignalStatus:          func() any { return a.SignalStatus() },
-				ConnectSignal:         a.StartSignalConnect,
+				ConnectSignal:         connectSignal,
 				ReplaySignalRecovery:  a.ReplaySignalRecoveryQueue,
-				UnpairSignal:          a.UnpairSignal,
+				UnpairSignal:          unpairSignal,
 				LeaveWhatsAppGroup:    a.LeaveWhatsAppGroup,
 				WhatsAppQRCode: func() (any, error) {
 					return a.WhatsAppQRCode()

--- a/cmd/signal_supervisor.go
+++ b/cmd/signal_supervisor.go
@@ -1,0 +1,267 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+const (
+	signalAccountID                = "signal-primary"
+	signalSupervisorStopTimeout    = 30 * time.Second
+	signalSupervisorCommandTimeout = 30 * time.Second
+)
+
+func signalSupervisorPolicy() bridge.Policy {
+	return bridge.Policy{
+		// An unpaired Start contains the existing interactive QR link flow.
+		// signal-cli normally expires that flow itself; this outer deadline is
+		// only a leak backstop and is intentionally not a reconnect ticker.
+		ConnectTimeout:     30 * time.Minute,
+		ProbeEvery:         30 * time.Second,
+		ProbeTimeout:       30 * time.Second,
+		LivenessTimeout:    2 * time.Minute,
+		MinBackoff:         5 * time.Second,
+		MaxBackoff:         5 * time.Minute,
+		MaxSameFingerprint: 5,
+	}
+}
+
+type signalWallClock struct{}
+
+func (signalWallClock) Now() time.Time { return time.Now() }
+
+func (signalWallClock) NewTimer(delay time.Duration) bridge.Timer {
+	return &signalWallTimer{timer: time.NewTimer(delay)}
+}
+
+type signalWallTimer struct{ timer *time.Timer }
+
+func (t *signalWallTimer) C() <-chan time.Time { return t.timer.C }
+func (t *signalWallTimer) Stop() bool          { return t.timer.Stop() }
+
+type signalRandom struct{}
+
+func (signalRandom) Int63n(n int64) int64 { return rand.Int63n(n) }
+
+type signalSupervisorControl struct {
+	supervisor       *bridge.Supervisor
+	newSupervisor    func() (*bridge.Supervisor, error)
+	inputFingerprint func() string
+
+	mu                sync.Mutex
+	lastFingerprint   string
+	supervisorStopped bool
+	stopping          bool
+	closed            bool
+}
+
+func newSignalSupervisorControl(
+	supervisor *bridge.Supervisor,
+	newSupervisor func() (*bridge.Supervisor, error),
+	inputFingerprint func() string,
+) *signalSupervisorControl {
+	fingerprint := ""
+	if inputFingerprint != nil {
+		fingerprint = inputFingerprint()
+	}
+	return &signalSupervisorControl{
+		supervisor:       supervisor,
+		newSupervisor:    newSupervisor,
+		inputFingerprint: inputFingerprint,
+		lastFingerprint:  fingerprint,
+	}
+}
+
+// Connect admits one user-owned start/retry. All automatic retry remains in
+// Supervisor backoff, and active states make duplicate UI clicks no-ops.
+func (c *signalSupervisorControl) Connect() error {
+	c.mu.Lock()
+	if c.closed || c.stopping {
+		c.mu.Unlock()
+		return bridge.ErrSupervisorStopped
+	}
+	if c.supervisorStopped {
+		if c.newSupervisor == nil {
+			c.mu.Unlock()
+			return errors.New("Signal supervisor cannot be restarted")
+		}
+		supervisor, err := c.newSupervisor()
+		if err != nil {
+			c.mu.Unlock()
+			return fmt.Errorf("rebuild Signal supervisor: %w", err)
+		}
+		c.supervisor = supervisor
+		c.supervisorStopped = false
+		if c.inputFingerprint != nil {
+			c.lastFingerprint = c.inputFingerprint()
+		}
+	}
+	supervisor := c.supervisor
+	lastFingerprint := c.lastFingerprint
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), signalSupervisorCommandTimeout)
+	defer cancel()
+	snapshot := supervisor.Snapshot()
+	switch snapshot.State {
+	case bridge.StateStopped:
+		err := supervisor.Start(ctx, bridge.StartRequest{})
+		if errors.Is(err, bridge.ErrSupervisorBusy) {
+			return nil
+		}
+		return err
+	case bridge.StateBlocked:
+		fingerprint := lastFingerprint
+		if c.inputFingerprint != nil {
+			fingerprint = c.inputFingerprint()
+		}
+		if fingerprint == lastFingerprint {
+			return supervisor.RetryBlocked(ctx)
+		}
+		if err := supervisor.InputsChanged(ctx, fingerprint); err != nil {
+			return err
+		}
+		c.mu.Lock()
+		if c.supervisor == supervisor && !c.supervisorStopped {
+			c.lastFingerprint = fingerprint
+		}
+		c.mu.Unlock()
+		return nil
+	case bridge.StateOnline, bridge.StateConnecting, bridge.StateDegraded,
+		bridge.StateBackoff, bridge.StateRepairingCredentials, bridge.StatePairing:
+		return nil
+	case bridge.StateUnpaired:
+		// QR expiry is deliberately terminal and non-retrying. A new pairing
+		// attempt is admitted only by this explicit user action, on a fresh
+		// supervisor because Stop is terminal.
+		return c.restartUnpaired(supervisor)
+	case bridge.StateStopping:
+		return bridge.ErrSupervisorStopped
+	default:
+		return fmt.Errorf("Signal cannot connect from supervisor state %q", snapshot.State)
+	}
+}
+
+func (c *signalSupervisorControl) restartUnpaired(old *bridge.Supervisor) error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return bridge.ErrSupervisorStopped
+	}
+	if c.stopping || c.supervisor != old {
+		c.mu.Unlock()
+		return nil
+	}
+	c.stopping = true
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), signalSupervisorStopTimeout)
+	defer cancel()
+	if err := old.Stop(ctx); err != nil {
+		go c.awaitStoppedSupervisor(old)
+		return fmt.Errorf("stop expired Signal pairing: %w", err)
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.supervisorStopped = true
+		c.stopping = false
+		c.mu.Unlock()
+		return bridge.ErrSupervisorStopped
+	}
+	if c.newSupervisor == nil {
+		c.supervisorStopped = true
+		c.stopping = false
+		c.mu.Unlock()
+		return errors.New("Signal supervisor cannot be restarted")
+	}
+	supervisor, err := c.newSupervisor()
+	if err != nil {
+		c.supervisorStopped = true
+		c.stopping = false
+		c.mu.Unlock()
+		return fmt.Errorf("rebuild Signal supervisor: %w", err)
+	}
+	c.supervisor = supervisor
+	c.supervisorStopped = false
+	c.stopping = false
+	if c.inputFingerprint != nil {
+		c.lastFingerprint = c.inputFingerprint()
+	}
+	c.mu.Unlock()
+
+	startCtx, startCancel := context.WithTimeout(context.Background(), signalSupervisorCommandTimeout)
+	defer startCancel()
+	return supervisor.Start(startCtx, bridge.StartRequest{})
+}
+
+// StopAndUnpair joins the old poller generation before deleting signal-cli
+// state. The next Connect rebuilds a fresh supervisor because Stop is terminal.
+func (c *signalSupervisorControl) StopAndUnpair(
+	unpair func(context.Context) error,
+) error {
+	c.mu.Lock()
+	if c.closed || c.stopping {
+		c.mu.Unlock()
+		return bridge.ErrSupervisorStopped
+	}
+	c.stopping = true
+	supervisor := c.supervisor
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), signalSupervisorStopTimeout)
+	defer cancel()
+	if err := supervisor.Stop(ctx); err != nil {
+		go c.awaitStoppedSupervisor(supervisor)
+		return fmt.Errorf("stop Signal connection: %w", err)
+	}
+
+	var unpairErr error
+	if unpair != nil {
+		unpairErr = unpair(ctx)
+	}
+	c.mu.Lock()
+	c.supervisorStopped = true
+	c.stopping = false
+	c.mu.Unlock()
+	return unpairErr
+}
+
+func (c *signalSupervisorControl) awaitStoppedSupervisor(supervisor *bridge.Supervisor) {
+	_ = supervisor.Stop(context.Background())
+	c.mu.Lock()
+	if c.supervisor == supervisor && !c.closed {
+		c.supervisorStopped = true
+		c.stopping = false
+	}
+	c.mu.Unlock()
+}
+
+func (c *signalSupervisorControl) Stop(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("Signal supervisor control: nil stop context")
+	}
+	c.mu.Lock()
+	if c.supervisor == nil {
+		c.closed = true
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	c.stopping = true
+	supervisor := c.supervisor
+	c.mu.Unlock()
+
+	err := supervisor.Stop(ctx)
+	c.mu.Lock()
+	c.supervisorStopped = true
+	c.stopping = false
+	c.mu.Unlock()
+	return err
+}

--- a/cmd/signal_supervisor_test.go
+++ b/cmd/signal_supervisor_test.go
@@ -1,0 +1,436 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+func TestSignalSupervisorControlConnectStartsOnceAndActiveDuplicateIsNoop(t *testing.T) {
+	lifecycle := &signalControlTestLifecycle{}
+	supervisor := newSignalControlTestSupervisor(t, lifecycle)
+	control := newSignalSupervisorControl(supervisor, nil, func() string { return "signal-input-v1" })
+	t.Cleanup(func() { stopSignalControlForTest(t, control) })
+
+	const callers = 8
+	start := make(chan struct{})
+	errorsByCaller := make(chan error, callers)
+	var callersDone sync.WaitGroup
+	callersDone.Add(callers)
+	for range callers {
+		go func() {
+			defer callersDone.Done()
+			<-start
+			errorsByCaller <- control.Connect()
+		}()
+	}
+	close(start)
+	callersDone.Wait()
+	close(errorsByCaller)
+	for err := range errorsByCaller {
+		if err != nil {
+			t.Fatalf("concurrent Connect() error = %v", err)
+		}
+	}
+
+	awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateOnline, 1)
+	if got := lifecycle.StartCount(); got != 1 {
+		t.Fatalf("lifecycle starts after concurrent Connect() = %d, want 1", got)
+	}
+
+	if err := control.Connect(); err != nil {
+		t.Fatalf("Connect() while active error = %v", err)
+	}
+	if got := lifecycle.StartCount(); got != 1 {
+		t.Fatalf("lifecycle starts after active duplicate = %d, want 1", got)
+	}
+}
+
+func TestSignalSupervisorControlBlockedCommandsRetryAndAcceptChangedInputs(t *testing.T) {
+	lifecycle := &signalControlTestLifecycle{}
+	supervisor := newSignalControlTestSupervisor(t, lifecycle)
+	var inputFingerprint atomic.Value
+	inputFingerprint.Store("signal-input-v1")
+	control := newSignalSupervisorControl(
+		supervisor,
+		nil,
+		func() string { return inputFingerprint.Load().(string) },
+	)
+	t.Cleanup(func() { stopSignalControlForTest(t, control) })
+
+	if err := control.Connect(); err != nil {
+		t.Fatalf("initial Connect() error = %v", err)
+	}
+	awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateOnline, 1)
+
+	lifecycle.Run(0).Fail(bridge.OpError{
+		Class:       bridge.FailureUpgradeRequired,
+		Operation:   "receive",
+		Fingerprint: "signal-cli-too-old",
+		Cause:       errors.New("upgrade signal-cli"),
+	})
+	awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateBlocked, 1)
+
+	// An ordinary Start is forbidden from StateBlocked. Connect must use the
+	// supervisor-owned RetryBlocked command when inputs have not changed.
+	if err := control.Connect(); err != nil {
+		t.Fatalf("Connect() via RetryBlocked error = %v", err)
+	}
+	awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateOnline, 2)
+
+	lifecycle.Run(1).Fail(bridge.OpError{
+		Class:       bridge.FailureUpgradeRequired,
+		Operation:   "receive",
+		Fingerprint: "signal-cli-too-old",
+		Cause:       errors.New("upgrade signal-cli"),
+	})
+	awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateBlocked, 2)
+
+	inputFingerprint.Store("signal-input-v2")
+	if err := control.Connect(); err != nil {
+		t.Fatalf("Connect() via InputsChanged error = %v", err)
+	}
+	awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateOnline, 3)
+	if got := lifecycle.StartCount(); got != 3 {
+		t.Fatalf("lifecycle starts = %d, want 3", got)
+	}
+	control.mu.Lock()
+	gotFingerprint := control.lastFingerprint
+	control.mu.Unlock()
+	if gotFingerprint != "signal-input-v2" {
+		t.Fatalf("remembered input fingerprint = %q, want %q", gotFingerprint, "signal-input-v2")
+	}
+}
+
+func TestSignalSupervisorControlStopAndUnpairJoinsThenRebuilds(t *testing.T) {
+	firstStopRelease := make(chan struct{})
+	lifecycle := &signalControlTestLifecycle{firstStopRelease: firstStopRelease}
+	var supervisorCount atomic.Int32
+	newSupervisor := func() (*bridge.Supervisor, error) {
+		supervisorCount.Add(1)
+		return bridge.NewSupervisor(
+			signalAccountID,
+			bridge.PlatformSignal,
+			lifecycle,
+			signalSupervisorPolicy(),
+			signalWallClock{},
+			signalRandom{},
+		)
+	}
+	firstSupervisor, err := newSupervisor()
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	control := newSignalSupervisorControl(
+		firstSupervisor,
+		newSupervisor,
+		func() string { return "signal-input-v1" },
+	)
+	t.Cleanup(func() { stopSignalControlForTest(t, control) })
+
+	if err := control.Connect(); err != nil {
+		t.Fatalf("initial Connect() error = %v", err)
+	}
+	awaitSignalSupervisorGenerationState(t, firstSupervisor, bridge.StateOnline, 1)
+	firstRun := lifecycle.Run(0)
+
+	unpairCalled := make(chan struct{})
+	stopResult := make(chan error, 1)
+	go func() {
+		stopResult <- control.StopAndUnpair(func(context.Context) error {
+			if !firstRun.Joined() {
+				return errors.New("unpair ran before the Signal generation joined")
+			}
+			close(unpairCalled)
+			return nil
+		})
+	}()
+
+	select {
+	case <-firstRun.StopEntered():
+	case <-time.After(time.Second):
+		t.Fatal("old Signal generation did not begin stopping")
+	}
+	select {
+	case <-unpairCalled:
+		t.Fatal("unpair ran while the old Signal generation was still stopping")
+	default:
+	}
+	close(firstStopRelease)
+	select {
+	case err := <-stopResult:
+		if err != nil {
+			t.Fatalf("StopAndUnpair() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StopAndUnpair() did not return after the old generation joined")
+	}
+
+	if err := control.Connect(); err != nil {
+		t.Fatalf("Connect() after re-pair error = %v", err)
+	}
+	control.mu.Lock()
+	secondSupervisor := control.supervisor
+	control.mu.Unlock()
+	if secondSupervisor == firstSupervisor {
+		t.Fatal("Connect() reused the terminal supervisor after unpair")
+	}
+	awaitSignalSupervisorGenerationState(t, secondSupervisor, bridge.StateOnline, 1)
+	if got := lifecycle.StartCount(); got != 2 {
+		t.Fatalf("lifecycle starts = %d, want 2", got)
+	}
+	if lifecycle.Run(1) == firstRun {
+		t.Fatal("Connect() reused the stopped Signal run after unpair")
+	}
+	if got := supervisorCount.Load(); got != 2 {
+		t.Fatalf("supervisors constructed = %d, want 2", got)
+	}
+}
+
+func TestSignalSupervisorControlExpiredPairingRequiresExplicitFreshConnect(t *testing.T) {
+	lifecycle := &signalControlTestLifecycle{}
+	var supervisorCount atomic.Int32
+	newSupervisor := func() (*bridge.Supervisor, error) {
+		supervisorCount.Add(1)
+		return bridge.NewSupervisor(
+			signalAccountID,
+			bridge.PlatformSignal,
+			lifecycle,
+			signalSupervisorPolicy(),
+			signalWallClock{},
+			signalRandom{},
+		)
+	}
+	firstSupervisor, err := newSupervisor()
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	control := newSignalSupervisorControl(
+		firstSupervisor,
+		newSupervisor,
+		func() string { return "signal-input-v1" },
+	)
+	t.Cleanup(func() { stopSignalControlForTest(t, control) })
+
+	if err := control.Connect(); err != nil {
+		t.Fatalf("initial Connect() error = %v", err)
+	}
+	awaitSignalSupervisorGenerationState(t, firstSupervisor, bridge.StateOnline, 1)
+	lifecycle.Run(0).Fail(bridge.OpError{
+		Class:       bridge.FailureUnpaired,
+		Operation:   "pair",
+		Fingerprint: "signal_pairing_incomplete",
+		Cause:       errors.New("Signal link QR expired"),
+	})
+	awaitSignalSupervisorGenerationState(t, firstSupervisor, bridge.StateUnpaired, 1)
+
+	time.Sleep(20 * time.Millisecond)
+	if got := lifecycle.StartCount(); got != 1 {
+		t.Fatalf("lifecycle starts without explicit reconnect = %d, want 1", got)
+	}
+	if err := control.Connect(); err != nil {
+		t.Fatalf("explicit Connect() after pairing expiry error = %v", err)
+	}
+	control.mu.Lock()
+	secondSupervisor := control.supervisor
+	control.mu.Unlock()
+	if secondSupervisor == firstSupervisor {
+		t.Fatal("explicit Connect() reused the supervisor left unpaired")
+	}
+	awaitSignalSupervisorGenerationState(t, secondSupervisor, bridge.StateOnline, 1)
+	if got := lifecycle.StartCount(); got != 2 {
+		t.Fatalf("lifecycle starts after explicit reconnect = %d, want 2", got)
+	}
+	if got := supervisorCount.Load(); got != 2 {
+		t.Fatalf("supervisors constructed = %d, want 2", got)
+	}
+}
+
+func TestSignalSupervisorControlTerminalStopPreventsRebuild(t *testing.T) {
+	lifecycle := &signalControlTestLifecycle{}
+	var supervisorCount atomic.Int32
+	newSupervisor := func() (*bridge.Supervisor, error) {
+		supervisorCount.Add(1)
+		return bridge.NewSupervisor(
+			signalAccountID,
+			bridge.PlatformSignal,
+			lifecycle,
+			signalSupervisorPolicy(),
+			signalWallClock{},
+			signalRandom{},
+		)
+	}
+	supervisor, err := newSupervisor()
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	control := newSignalSupervisorControl(
+		supervisor,
+		newSupervisor,
+		func() string { return "signal-input-v1" },
+	)
+
+	if err := control.Connect(); err != nil {
+		t.Fatalf("initial Connect() error = %v", err)
+	}
+	awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateOnline, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	if err := control.Stop(ctx); err != nil {
+		cancel()
+		t.Fatalf("Stop() error = %v", err)
+	}
+	cancel()
+
+	if err := control.Connect(); !errors.Is(err, bridge.ErrSupervisorStopped) {
+		t.Fatalf("Connect() after terminal Stop error = %v, want ErrSupervisorStopped", err)
+	}
+	if got := supervisorCount.Load(); got != 1 {
+		t.Fatalf("supervisors after terminal Stop = %d, want 1", got)
+	}
+}
+
+func newSignalControlTestSupervisor(
+	t *testing.T,
+	lifecycle bridge.Lifecycle,
+) *bridge.Supervisor {
+	t.Helper()
+	supervisor, err := bridge.NewSupervisor(
+		signalAccountID,
+		bridge.PlatformSignal,
+		lifecycle,
+		signalSupervisorPolicy(),
+		signalWallClock{},
+		signalRandom{},
+	)
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	return supervisor
+}
+
+func stopSignalControlForTest(t *testing.T, control *signalSupervisorControl) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := control.Stop(ctx); err != nil {
+		t.Errorf("signal control Stop() error = %v", err)
+	}
+}
+
+func awaitSignalSupervisorGenerationState(
+	t *testing.T,
+	supervisor *bridge.Supervisor,
+	want bridge.State,
+	wantGeneration bridge.Generation,
+) bridge.Snapshot {
+	t.Helper()
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		snapshot := supervisor.Snapshot()
+		if snapshot.State == want && snapshot.Generation == wantGeneration {
+			return snapshot
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf(
+				"supervisor state/generation = %q/%d, want %q/%d (snapshot %+v)",
+				snapshot.State,
+				snapshot.Generation,
+				want,
+				wantGeneration,
+				snapshot,
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+type signalControlTestLifecycle struct {
+	mu               sync.Mutex
+	runs             []*signalControlTestRun
+	firstStopRelease <-chan struct{}
+}
+
+func (l *signalControlTestLifecycle) Start(
+	_ context.Context,
+	_ bridge.StartRequest,
+	_ bridge.ConnectionSink,
+) (bridge.Run, error) {
+	l.mu.Lock()
+	stopRelease := (<-chan struct{})(nil)
+	if len(l.runs) == 0 {
+		stopRelease = l.firstStopRelease
+	}
+	run := &signalControlTestRun{
+		ready:       make(chan struct{}),
+		done:        make(chan error, 1),
+		stopEntered: make(chan struct{}),
+		stopRelease: stopRelease,
+	}
+	l.runs = append(l.runs, run)
+	l.mu.Unlock()
+	close(run.ready)
+	return run, nil
+}
+
+func (l *signalControlTestLifecycle) StartCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.runs)
+}
+
+func (l *signalControlTestLifecycle) Run(index int) *signalControlTestRun {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.runs[index]
+}
+
+type signalControlTestRun struct {
+	ready       chan struct{}
+	done        chan error
+	stopEntered chan struct{}
+	stopRelease <-chan struct{}
+
+	doneOnce sync.Once
+	stopOnce sync.Once
+	joined   atomic.Bool
+}
+
+func (r *signalControlTestRun) Ready() <-chan struct{} { return r.ready }
+func (r *signalControlTestRun) Done() <-chan error     { return r.done }
+func (r *signalControlTestRun) Probe(context.Context) (bridge.Liveness, error) {
+	return bridge.Liveness{AliveAt: time.Now(), Detail: "test"}, nil
+}
+func (r *signalControlTestRun) Stop(ctx context.Context) error {
+	var stopErr error
+	r.stopOnce.Do(func() {
+		close(r.stopEntered)
+		if r.stopRelease != nil {
+			select {
+			case <-r.stopRelease:
+			case <-ctx.Done():
+				stopErr = ctx.Err()
+				return
+			}
+		}
+		r.joined.Store(true)
+		r.doneOnce.Do(func() { close(r.done) })
+	})
+	return stopErr
+}
+func (r *signalControlTestRun) Fail(err error) {
+	r.doneOnce.Do(func() {
+		r.done <- err
+		close(r.done)
+	})
+}
+func (r *signalControlTestRun) Joined() bool                 { return r.joined.Load() }
+func (r *signalControlTestRun) StopEntered() <-chan struct{} { return r.stopEntered }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -166,6 +166,8 @@ type App struct {
 	googlePhoneRespondingSeen atomic.Bool
 	googleLifecycleMu         sync.RWMutex
 	googleLifecycleNotifier   GoogleLifecycleNotifier
+	signalLifecycleMu         sync.RWMutex
+	signalLifecycleNotifier   SignalLifecycleNotifier
 	tempDataDir               string
 	pendingMediaMu            sync.Mutex
 	pendingMedia              map[string]struct{}

--- a/internal/app/signal.go
+++ b/internal/app/signal.go
@@ -34,43 +34,17 @@ func (a *App) ensureSignal() (*signallive.Bridge, error) {
 	return bridge, nil
 }
 
+// EnsureSignal initializes the retained Signal bridge without starting its
+// receive poller. Production connection ownership belongs to the Signal
+// bridge.Supervisor adapter.
+func (a *App) EnsureSignal() (*signallive.Bridge, error) {
+	return a.ensureSignal()
+}
+
 func (a *App) GetSignal() *signallive.Bridge {
 	a.signalMu.Lock()
 	defer a.signalMu.Unlock()
 	return a.Signal
-}
-
-func (a *App) LoadAndConnectSignal() error {
-	bridge, err := a.ensureSignal()
-	if err != nil {
-		return fmt.Errorf("init Signal bridge: %w", err)
-	}
-	if err := bridge.ConnectIfPaired(); err != nil {
-		return fmt.Errorf("connect Signal bridge: %w", err)
-	}
-	return nil
-}
-
-func (a *App) StartSignalConnect() error {
-	bridge, err := a.ensureSignal()
-	if err != nil {
-		return fmt.Errorf("init Signal bridge: %w", err)
-	}
-	if err := bridge.Connect(); err != nil {
-		return fmt.Errorf("connect Signal bridge: %w", err)
-	}
-	return nil
-}
-
-func (a *App) UnpairSignal() error {
-	bridge, err := a.ensureSignal()
-	if err != nil {
-		return fmt.Errorf("init Signal bridge: %w", err)
-	}
-	if err := bridge.Unpair(); err != nil {
-		return fmt.Errorf("unpair Signal bridge: %w", err)
-	}
-	return nil
 }
 
 func (a *App) SignalStatus() signallive.StatusSnapshot {
@@ -106,7 +80,11 @@ func (a *App) SendSignalText(conversationID, body, replyToID string) (*db.Messag
 	if err != nil {
 		return nil, fmt.Errorf("init Signal bridge: %w", err)
 	}
-	return bridge.SendText(conversationID, body, replyToID)
+	message, err := bridge.SendText(conversationID, body, replyToID)
+	if err != nil {
+		a.reportSignalLifecycleError(err)
+	}
+	return message, err
 }
 
 func (a *App) SendSignalMedia(conversationID string, data []byte, filename, mime, caption, replyToID string) (*db.Message, error) {
@@ -114,7 +92,11 @@ func (a *App) SendSignalMedia(conversationID string, data []byte, filename, mime
 	if err != nil {
 		return nil, fmt.Errorf("init Signal bridge: %w", err)
 	}
-	return bridge.SendMedia(conversationID, data, filename, mime, caption, replyToID)
+	message, err := bridge.SendMedia(conversationID, data, filename, mime, caption, replyToID)
+	if err != nil {
+		a.reportSignalLifecycleError(err)
+	}
+	return message, err
 }
 
 func (a *App) SendSignalReaction(conversationID, messageID, emoji, action string) error {
@@ -122,7 +104,11 @@ func (a *App) SendSignalReaction(conversationID, messageID, emoji, action string
 	if err != nil {
 		return fmt.Errorf("init Signal bridge: %w", err)
 	}
-	return bridge.SendReaction(conversationID, messageID, emoji, action)
+	err = bridge.SendReaction(conversationID, messageID, emoji, action)
+	if err != nil {
+		a.reportSignalLifecycleError(err)
+	}
+	return err
 }
 
 func (a *App) DownloadSignalMedia(msg *db.Message) ([]byte, string, error) {

--- a/internal/app/signal_lifecycle_notify.go
+++ b/internal/app/signal_lifecycle_notify.go
@@ -1,0 +1,29 @@
+package app
+
+// SignalLifecycleNotifier lets legacy App send paths report signal-cli
+// transport failures without owning receive-loop reconnect or parking.
+type SignalLifecycleNotifier interface {
+	ReportError(error) bool
+}
+
+// SetSignalLifecycleNotifier installs the sole lifecycle owner notified by
+// Signal send/media/reaction paths. It is safe to replace or clear while an
+// operation is in flight.
+func (a *App) SetSignalLifecycleNotifier(notifier SignalLifecycleNotifier) {
+	a.signalLifecycleMu.Lock()
+	a.signalLifecycleNotifier = notifier
+	a.signalLifecycleMu.Unlock()
+}
+
+func (a *App) signalLifecycle() SignalLifecycleNotifier {
+	a.signalLifecycleMu.RLock()
+	notifier := a.signalLifecycleNotifier
+	a.signalLifecycleMu.RUnlock()
+	return notifier
+}
+
+func (a *App) reportSignalLifecycleError(err error) {
+	if notifier := a.signalLifecycle(); notifier != nil {
+		notifier.ReportError(err)
+	}
+}

--- a/internal/app/signal_lifecycle_notify_test.go
+++ b/internal/app/signal_lifecycle_notify_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/signallive"
+)
+
+type recordingSignalLifecycleNotifier struct {
+	reported []error
+}
+
+func (n *recordingSignalLifecycleNotifier) ReportError(err error) bool {
+	n.reported = append(n.reported, err)
+	return true
+}
+
+func TestSignalLifecycleNotifierCoversCentralSendPaths(t *testing.T) {
+	live, err := signallive.New(t.TempDir(), nil, zerolog.Nop(), signallive.Callbacks{})
+	if err != nil {
+		t.Fatalf("signallive.New(): %v", err)
+	}
+	t.Cleanup(func() { _ = live.Close() })
+
+	a := &App{Signal: live, Logger: zerolog.Nop()}
+	notifier := &recordingSignalLifecycleNotifier{}
+	a.SetSignalLifecycleNotifier(notifier)
+
+	_, _ = a.SendSignalText("signal:+15551234567", "", "")
+	_, _ = a.SendSignalMedia("signal:+15551234567", nil, "", "", "", "")
+	_ = a.SendSignalReaction("signal:+15551234567", "", "👍", "add")
+
+	if got := len(notifier.reported); got != 3 {
+		t.Fatalf("Signal send-path notifications = %d, want 3", got)
+	}
+}
+
+func TestSignalLifecycleNotifierCanBeCleared(t *testing.T) {
+	a := &App{}
+	notifier := &recordingSignalLifecycleNotifier{}
+	a.SetSignalLifecycleNotifier(notifier)
+	a.SetSignalLifecycleNotifier(nil)
+	a.reportSignalLifecycleError(assertSignalNotifierError{})
+	if len(notifier.reported) != 0 {
+		t.Fatalf("cleared Signal notifier was invoked: %v", notifier.reported)
+	}
+}
+
+type assertSignalNotifierError struct{}
+
+func (assertSignalNotifierError) Error() string { return "test Signal failure" }

--- a/internal/bridge/supervisor.go
+++ b/internal/bridge/supervisor.go
@@ -1124,7 +1124,7 @@ func (l *supervisorLoop) handlePairResult(result pairingResult) {
 
 func (l *supervisorLoop) routeFailure(failure OpError) {
 	switch failure.Class {
-	case FailureTransient, FailureRateLimited, FailureCredentialsExpired,
+	case FailureTransient, FailureRateLimited, FailureCredentialsExpired, FailureUnpaired,
 		FailureReauthRequired, FailureUpgradeRequired, FailureMisconfigured,
 		FailureUnsupported:
 	default:
@@ -1135,6 +1135,18 @@ func (l *supervisorLoop) routeFailure(failure OpError) {
 	l.snapshot.ErrorFingerprint = failure.Fingerprint
 	l.snapshot.RetryAt = time.Time{}
 	l.snapshot.LivenessDeadline = time.Time{}
+	if failure.Class == FailureUnpaired {
+		// A lifecycle can discover that no linked account exists (notably an
+		// expired QR attempt). This is intentionally idle until an explicit
+		// user action; it is neither reconnect backoff nor a blocked circuit.
+		l.resetFailureHistory()
+		l.lastFailure = failure
+		l.snapshot.ErrorClass = failure.Class
+		l.snapshot.ErrorFingerprint = failure.Fingerprint
+		l.snapshot.State = StateUnpaired
+		l.publish()
+		return
+	}
 
 	if l.recordFingerprint(failure.Class, failure.Fingerprint) {
 		l.snapshot.State = StateBlocked

--- a/internal/bridge/supervisor_test.go
+++ b/internal/bridge/supervisor_test.go
@@ -590,6 +590,44 @@ func TestSupervisorTerminalFailuresRequireExplicitExit(t *testing.T) {
 	})
 }
 
+func TestSupervisorUnpairedFailureIdlesWithoutAutomaticRetry(t *testing.T) {
+	clock := newSupervisorManualClock(supervisorTestEpoch)
+	lifecycle := &supervisorTestLifecycle{scripts: []supervisorStartScript{{
+		err: OpError{
+			Class:       FailureUnpaired,
+			Operation:   "pair",
+			Fingerprint: "pairing_expired",
+			Cause:       errors.New("pairing expired"),
+		},
+	}}}
+	supervisor := newTestSupervisor(
+		t,
+		lifecycle,
+		supervisorTestPolicy(),
+		clock,
+		&supervisorScriptedRandom{},
+	)
+
+	if err := supervisorStart(t, supervisor, StartRequest{}); err == nil {
+		t.Fatal("Start() error = nil, want unpaired failure")
+	}
+	snapshot := supervisor.Snapshot()
+	if snapshot.State != StateUnpaired ||
+		snapshot.ErrorClass != FailureUnpaired ||
+		snapshot.ErrorFingerprint != "pairing_expired" ||
+		!snapshot.RetryAt.IsZero() {
+		t.Fatalf("unpaired snapshot = %+v", snapshot)
+	}
+	clock.Advance(24 * time.Hour)
+	supervisorSync(t, supervisor)
+	if got := lifecycle.CallCount(); got != 1 {
+		t.Fatalf("automatic starts while unpaired = %d, want 1", got)
+	}
+	if err := supervisorStart(t, supervisor, StartRequest{}); !errors.Is(err, ErrPairingNotAllowed) {
+		t.Fatalf("Start() while unpaired error = %v, want ErrPairingNotAllowed", err)
+	}
+}
+
 func TestSupervisorPairingIsSingleFlightAndExpiryDoesNotAutoPair(t *testing.T) {
 	clock := newSupervisorManualClock(supervisorTestEpoch)
 	lifecycle := &supervisorTestLifecycle{}

--- a/internal/bridge/types.go
+++ b/internal/bridge/types.go
@@ -136,6 +136,7 @@ const (
 	FailureTransient          FailureClass = "transient"
 	FailureRateLimited        FailureClass = "rate_limited"
 	FailureCredentialsExpired FailureClass = "credentials_expired"
+	FailureUnpaired           FailureClass = "unpaired"
 	FailureReauthRequired     FailureClass = "reauth_required"
 	FailureUpgradeRequired    FailureClass = "upgrade_required"
 	FailureMisconfigured      FailureClass = "misconfigured"

--- a/internal/bridgeadapters/signal/signal.go
+++ b/internal/bridgeadapters/signal/signal.go
@@ -1,0 +1,489 @@
+// Package signal adapts one retained signallive signal-cli poller lifecycle to
+// bridge.Run. Legacy send, media, reaction, recovery, and QR/status paths stay
+// on signallive.Bridge; this adapter owns only connect/reconnect/park.
+package signal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/signallive"
+)
+
+type poller interface {
+	StartPoller(context.Context) (signallive.PollerRun, error)
+	Status() signallive.StatusSnapshot
+	ApplyPollerFailure(signallive.PollerExit)
+	InputFingerprint() string
+	UnpairContext(context.Context) error
+}
+
+// Adapter owns Signal connection generations while retaining signallive's
+// existing signal-cli receive loop and all legacy operation paths.
+type Adapter struct {
+	accountID string
+	poller    poller
+
+	mu       sync.Mutex
+	current  *run
+	starting bool
+}
+
+func New(accountID string, live *signallive.Bridge) *Adapter {
+	adapter := &Adapter{accountID: accountID}
+	if live != nil {
+		adapter.poller = live
+	}
+	return adapter
+}
+
+func (a *Adapter) AccountID() string { return a.accountID }
+
+func (a *Adapter) Platform() bridge.Platform { return bridge.PlatformSignal }
+
+func (a *Adapter) DeclaredCapabilities() bridge.CapabilitySet {
+	return bridge.CapabilitySet{
+		TextSend:      true,
+		MediaSend:     true,
+		Reactions:     true,
+		PairQR:        true,
+		MediaDownload: true,
+	}
+}
+
+func (a *Adapter) Start(
+	ctx context.Context,
+	req bridge.StartRequest,
+	sink bridge.ConnectionSink,
+) (bridge.Run, error) {
+	if ctx == nil {
+		return nil, errors.New("signal lifecycle: nil start context")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if a == nil || a.poller == nil {
+		return nil, bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "signal_adapter_unconfigured",
+			Cause:       errors.New("Signal lifecycle adapter is not configured"),
+		}
+	}
+	if req.AccountID != a.accountID {
+		return nil, fmt.Errorf("signal lifecycle: account %q does not match %q", req.AccountID, a.accountID)
+	}
+
+	a.mu.Lock()
+	if a.current != nil || a.starting {
+		a.mu.Unlock()
+		return nil, bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "overlapping_signal_generation",
+			Cause:       errors.New("a Signal generation is already active"),
+		}
+	}
+	a.starting = true
+	a.mu.Unlock()
+	installed := false
+	defer func() {
+		if installed {
+			return
+		}
+		a.mu.Lock()
+		a.starting = false
+		a.mu.Unlock()
+	}()
+
+	pollerRun, err := a.poller.StartPoller(ctx)
+	if err != nil {
+		return nil, classifyStartError(err)
+	}
+	if pollerRun == nil {
+		return nil, bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "signal_poller_nil_run",
+			Cause:       errors.New("Signal poller returned a nil run"),
+		}
+	}
+
+	r := &run{
+		adapter:      a,
+		request:      req,
+		sink:         sink,
+		poller:       pollerRun,
+		ready:        pollerRun.Ready(),
+		done:         make(chan error, 1),
+		stopped:      make(chan struct{}),
+		finish:       make(chan struct{}, 1),
+		activityWait: make(chan struct{}),
+		admitting:    true,
+	}
+	a.mu.Lock()
+	a.current = r
+	a.starting = false
+	installed = true
+	a.mu.Unlock()
+
+	go r.coordinate(ctx)
+	return r, nil
+}
+
+// ReportError lets unchanged App-level signal-cli send paths surface a local
+// account fault to the receive lifecycle. It deliberately ignores everything a
+// send can fail on that does NOT indict the local account — an unregistered
+// *recipient* (whose "not registered" text is indistinguishable from an
+// unregistered local account), untrusted-identity changes, group-permission
+// denials, rate/proof challenges, and transient network blips — because none of
+// those should disturb a healthy receive loop, and the account-scoped receive
+// probe (probe_account -> PollerFailureReauth) is the authoritative detector for
+// a genuinely invalid account. Even for an unambiguous local-account send
+// failure the generation is retired only as *transient*: the next generation's
+// probe, not this send's text, is what parks reauth, so a send can never by
+// itself drive the bridge to Blocked/needs-reauth. Local validation/database
+// errors (non-CommandError) are ignored entirely.
+func (a *Adapter) ReportError(err error) bool {
+	if a == nil || a.poller == nil || err == nil || !signallive.IsCommandError(err) {
+		return false
+	}
+	if !signallive.IsSendAccountInvalidError(err) {
+		// Not a local-account fault (recipient error, untrusted identity, group
+		// perms, rate limit, network). The healthy receive generation stays.
+		return false
+	}
+	status := a.poller.Status()
+	if status.UpgradeRequired || status.NeedsReauth {
+		// The poller has already established a stronger terminal state. Its Done
+		// result owns the exact fingerprint and must win over this send failure.
+		return false
+	}
+	r := a.currentRun()
+	if r == nil || !r.admitCallback() {
+		return false
+	}
+	defer r.callbacks.Done()
+
+	// Retire as transient (circuit-exempt): the next generation's account-scoped
+	// probe authoritatively parks reauth iff the account is really invalid.
+	exit := signallive.PollerExit{
+		Kind:        signallive.PollerFailureTransient,
+		Operation:   "send",
+		Fingerprint: "signal_send_account_check",
+		Err:         err,
+	}
+	r.requestFinish(terminalCandidate{
+		err:      classifyPollerExit(exit),
+		sendExit: &exit,
+	})
+	return true
+}
+
+func (a *Adapter) InputFingerprint() string {
+	if a == nil || a.poller == nil {
+		return ""
+	}
+	return a.poller.InputFingerprint()
+}
+
+func (a *Adapter) Unpair(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("signal unpair: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if a == nil || a.poller == nil {
+		return errors.New("Signal lifecycle adapter is not configured")
+	}
+	a.mu.Lock()
+	active := a.current != nil || a.starting
+	a.mu.Unlock()
+	if active {
+		return errors.New("cannot unpair Signal while a lifecycle generation is active")
+	}
+	return a.poller.UnpairContext(ctx)
+}
+
+func (a *Adapter) currentRun() *run {
+	a.mu.Lock()
+	r := a.current
+	a.mu.Unlock()
+	return r
+}
+
+func (a *Adapter) clearCurrent(candidate *run) {
+	a.mu.Lock()
+	if a.current == candidate {
+		a.current = nil
+	}
+	a.mu.Unlock()
+}
+
+func classifyStartError(err error) bridge.OpError {
+	var failure bridge.OpError
+	if errors.As(err, &failure) {
+		return failure
+	}
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "connect",
+		Fingerprint: "signal_start_failed",
+		Cause:       err,
+	}
+}
+
+func classifyPollerExit(exit signallive.PollerExit) error {
+	if exit.Kind == "" {
+		if errors.Is(exit.Err, context.Canceled) {
+			return nil
+		}
+		return exit.Err
+	}
+	class := bridge.FailureTransient
+	switch exit.Kind {
+	case signallive.PollerFailureReauth:
+		class = bridge.FailureReauthRequired
+	case signallive.PollerFailureUnpaired:
+		class = bridge.FailureUnpaired
+	case signallive.PollerFailureUpgrade:
+		class = bridge.FailureUpgradeRequired
+	}
+	operation := exit.Operation
+	if operation == "" {
+		operation = "receive"
+	}
+	fingerprint := exit.Fingerprint
+	if fingerprint == "" {
+		fingerprint = "signal_poller_stopped"
+	}
+	cause := exit.Err
+	if cause == nil {
+		cause = errors.New("Signal poller stopped")
+	}
+	return bridge.OpError{
+		Class:       class,
+		Operation:   operation,
+		Fingerprint: fingerprint,
+		Cause:       cause,
+	}
+}
+
+type run struct {
+	adapter *Adapter
+	request bridge.StartRequest
+	sink    bridge.ConnectionSink
+	poller  signallive.PollerRun
+	ready   <-chan struct{}
+	done    chan error
+	stopped chan struct{}
+	finish  chan struct{}
+
+	finishOnce sync.Once
+	terminalMu sync.Mutex
+	requested  terminalCandidate
+
+	admissionMu sync.Mutex
+	admitting   bool
+	callbacks   sync.WaitGroup
+
+	activityMu   sync.Mutex
+	lastActivity bridge.Liveness
+	activityWait chan struct{}
+}
+
+func (r *run) Ready() <-chan struct{} { return r.ready }
+
+func (r *run) Done() <-chan error { return r.done }
+
+func (r *run) Probe(ctx context.Context) (bridge.Liveness, error) {
+	if ctx == nil {
+		return bridge.Liveness{}, errors.New("signal probe: nil context")
+	}
+	started := time.Now()
+	for {
+		r.activityMu.Lock()
+		liveness := r.lastActivity
+		wait := r.activityWait
+		r.activityMu.Unlock()
+		if !liveness.AliveAt.Before(started) {
+			return liveness, nil
+		}
+		select {
+		case <-wait:
+		case <-r.stopped:
+			return bridge.Liveness{}, errors.New("Signal generation ended during liveness probe")
+		case <-ctx.Done():
+			return bridge.Liveness{}, ctx.Err()
+		}
+	}
+}
+
+func (r *run) Stop(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("signal run: nil stop context")
+	}
+	r.requestFinish(terminalCandidate{})
+	select {
+	case <-r.stopped:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *run) coordinate(ctx context.Context) {
+	activities := r.poller.Activity()
+	pollerDone := r.poller.Done()
+	var terminal terminalCandidate
+	selected := false
+	pollerResolved := false
+	for !selected {
+		select {
+		case activity, ok := <-activities:
+			if !ok {
+				activities = nil
+				continue
+			}
+			r.recordActivity(activity)
+			if r.sink != nil {
+				r.sink.Beat(r.request.Generation, activity.At, activity.Detail)
+			}
+		case exit, ok := <-pollerDone:
+			pollerResolved = true
+			if !ok {
+				exit = signallive.PollerExit{
+					Kind:        signallive.PollerFailureTransient,
+					Operation:   "receive",
+					Fingerprint: "signal_poller_done_closed",
+					Err:         errors.New("Signal poller completion closed without a result"),
+				}
+			}
+			terminal.err = classifyPollerExit(exit)
+			selected = true
+		case <-r.finish:
+			terminal = r.requestedTerminal()
+			selected = true
+		case <-ctx.Done():
+			terminal.err = context.Canceled
+			selected = true
+		}
+	}
+
+	r.closeAdmission()
+	// Poller.Done reports the retained receive/link loop's exit. Stop is its
+	// token-bound join; host-scoped metadata remains joined by Bridge.Close.
+	_ = r.poller.Stop(context.Background())
+	r.callbacks.Wait()
+	// A receive terminal and an already-admitted send callback can become
+	// ready together. Drain both sources after the poller join and keep the
+	// stronger class so upgrade/reauth can never be downgraded to transient.
+	if !pollerResolved {
+		select {
+		case exit, ok := <-pollerDone:
+			if ok {
+				terminal = preferTerminal(
+					terminal,
+					terminalCandidate{err: classifyPollerExit(exit)},
+				)
+			}
+		default:
+		}
+	}
+	terminal = preferTerminal(terminal, r.requestedTerminal())
+	if terminal.sendExit != nil {
+		r.adapter.poller.ApplyPollerFailure(*terminal.sendExit)
+	}
+	r.adapter.clearCurrent(r)
+	if errors.Is(terminal.err, context.Canceled) {
+		terminal.err = nil
+	}
+	r.done <- terminal.err
+	close(r.done)
+	close(r.stopped)
+}
+
+type terminalCandidate struct {
+	err      error
+	sendExit *signallive.PollerExit
+}
+
+func preferTerminal(current, candidate terminalCandidate) terminalCandidate {
+	if candidate.err == nil {
+		return current
+	}
+	if current.err == nil || terminalRank(candidate.err) > terminalRank(current.err) {
+		return candidate
+	}
+	return current
+}
+
+func terminalRank(err error) int {
+	var failure bridge.OpError
+	if !errors.As(err, &failure) {
+		return 0
+	}
+	switch failure.Class {
+	case bridge.FailureUpgradeRequired:
+		return 4
+	case bridge.FailureReauthRequired:
+		return 3
+	case bridge.FailureUnpaired:
+		return 2
+	case bridge.FailureTransient:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func (r *run) requestFinish(candidate terminalCandidate) {
+	r.closeAdmission()
+	r.terminalMu.Lock()
+	r.requested = preferTerminal(r.requested, candidate)
+	r.terminalMu.Unlock()
+	r.finishOnce.Do(func() {
+		r.finish <- struct{}{}
+	})
+}
+
+func (r *run) requestedTerminal() terminalCandidate {
+	r.terminalMu.Lock()
+	defer r.terminalMu.Unlock()
+	return r.requested
+}
+
+func (r *run) closeAdmission() {
+	r.admissionMu.Lock()
+	r.admitting = false
+	r.admissionMu.Unlock()
+}
+
+func (r *run) admitCallback() bool {
+	r.admissionMu.Lock()
+	defer r.admissionMu.Unlock()
+	if !r.admitting {
+		return false
+	}
+	r.callbacks.Add(1)
+	return true
+}
+
+func (r *run) recordActivity(activity signallive.PollerActivity) {
+	r.activityMu.Lock()
+	r.lastActivity = bridge.Liveness{AliveAt: activity.At, Detail: activity.Detail}
+	close(r.activityWait)
+	r.activityWait = make(chan struct{})
+	r.activityMu.Unlock()
+}
+
+var (
+	_ bridge.Adapter            = (*Adapter)(nil)
+	_ bridge.CapabilityDeclarer = (*Adapter)(nil)
+	_ bridge.Run                = (*run)(nil)
+)

--- a/internal/bridgeadapters/signal/signal_test.go
+++ b/internal/bridgeadapters/signal/signal_test.go
@@ -1,0 +1,891 @@
+package signal
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/signallive"
+)
+
+const signalAdapterTestTimeout = 2 * time.Second
+
+var signalAdapterTestEpoch = time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+
+func TestRunTranslatesRetainedPollerSignals(t *testing.T) {
+	poller := newFakePoller()
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	sink := &recordingSink{beats: make(chan recordedBeat, 1)}
+
+	run, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "signal-primary",
+		Generation: 7,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopAdapterRun(t, run) })
+	retained := receiveValue(t, poller.started, "retained poller start")
+
+	assertChannelOpen(t, run.Ready(), "before retained poller readiness")
+	retained.markReady()
+	select {
+	case <-run.Ready():
+	case <-time.After(signalAdapterTestTimeout):
+		t.Fatal("adapter Ready did not follow retained poller Ready")
+	}
+
+	activity := signallive.PollerActivity{
+		At:     time.Now().Add(time.Hour),
+		Detail: "receive_batch",
+	}
+	retained.emitActivity(activity)
+	beat := receiveValue(t, sink.beats, "retained poller activity beat")
+	if beat.generation != 7 || !beat.at.Equal(activity.At) || beat.detail != activity.Detail {
+		t.Fatalf("Beat = %+v, want generation 7 and activity %+v", beat, activity)
+	}
+
+	probeContext, probeCancel := context.WithTimeout(context.Background(), signalAdapterTestTimeout)
+	defer probeCancel()
+	liveness, err := run.Probe(probeContext)
+	if err != nil {
+		t.Fatalf("Probe() error = %v", err)
+	}
+	if !liveness.AliveAt.Equal(activity.At) || liveness.Detail != activity.Detail {
+		t.Fatalf("Probe() = %+v, want activity %+v", liveness, activity)
+	}
+
+	retained.complete(signallive.PollerExit{
+		Kind:        signallive.PollerFailureTransient,
+		Operation:   "receive",
+		Fingerprint: signallive.SignalReceiveFailureFingerprint,
+		Err:         errors.New("receive failed repeatedly"),
+	})
+	terminal := receiveValue(t, run.Done(), "adapter terminal result")
+	assertOpError(t, terminal, bridge.FailureTransient, signallive.SignalReceiveFailureFingerprint)
+	if _, ok := <-run.Done(); ok {
+		t.Fatal("adapter Done remained open after its one terminal result")
+	}
+	if got := retained.stopCount(); got != 1 {
+		t.Fatalf("retained poller join calls after natural exit = %d, want 1", got)
+	}
+}
+
+func TestAdapterStartIsSingleFlight(t *testing.T) {
+	poller := newFakePoller()
+	poller.startEntered = make(chan struct{}, 1)
+	poller.startRelease = make(chan struct{})
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+	type startResult struct {
+		run bridge.Run
+		err error
+	}
+	firstResult := make(chan startResult, 1)
+	go func() {
+		run, err := adapter.Start(context.Background(), bridge.StartRequest{
+			AccountID:  "signal-primary",
+			Generation: 1,
+		}, nil)
+		firstResult <- startResult{run: run, err: err}
+	}()
+	receiveValue(t, poller.startEntered, "first StartPoller admission")
+
+	second, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "signal-primary",
+		Generation: 2,
+	}, nil)
+	if second != nil {
+		t.Fatalf("overlapping Start() run = %T, want nil", second)
+	}
+	assertOpError(t, err, bridge.FailureMisconfigured, "overlapping_signal_generation")
+	if got := poller.startCount(); got != 1 {
+		t.Fatalf("StartPoller calls while first start is admitted = %d, want 1", got)
+	}
+
+	close(poller.startRelease)
+	first := receiveValue(t, firstResult, "first adapter Start result")
+	if first.err != nil {
+		t.Fatalf("first Start() error = %v", first.err)
+	}
+	if first.run == nil {
+		t.Fatal("first Start() run = nil")
+	}
+	stopAdapterRun(t, first.run)
+}
+
+func TestAdapterStartDoesNotWaitForReady(t *testing.T) {
+	poller := newFakePoller()
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+	returned := make(chan bridge.Run, 1)
+	errorsReturned := make(chan error, 1)
+	go func() {
+		run, err := adapter.Start(context.Background(), bridge.StartRequest{
+			AccountID:  "signal-primary",
+			Generation: 1,
+		}, nil)
+		if err != nil {
+			errorsReturned <- err
+			return
+		}
+		returned <- run
+	}()
+
+	var run bridge.Run
+	select {
+	case err := <-errorsReturned:
+		t.Fatalf("Start() error = %v", err)
+	case run = <-returned:
+	case <-time.After(signalAdapterTestTimeout):
+		t.Fatal("Start blocked waiting for retained poller Ready")
+	}
+	assertChannelOpen(t, run.Ready(), "after non-blocking Start return")
+	stopAdapterRun(t, run)
+}
+
+func TestPollerTerminalOutranksRacingTransientSendFailure(t *testing.T) {
+	poller := newFakePoller()
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	run, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "signal-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	retained := receiveValue(t, poller.started, "retained poller start")
+	retained.setStopExit(signallive.PollerExit{
+		Kind:        signallive.PollerFailureUpgrade,
+		Operation:   "receive",
+		Fingerprint: "incoming_message_get_sender_content_null",
+		Err:         errors.New("signal-cli poison envelope"),
+	})
+
+	if reported := adapter.ReportError(signallive.NewCommandError("send failed: authorization failed")); !reported {
+		t.Fatal("ReportError() rejected an admitted local-account send failure")
+	}
+	terminal := receiveValue(t, run.Done(), "arbitrated terminal result")
+	assertOpError(
+		t,
+		terminal,
+		bridge.FailureUpgradeRequired,
+		"incoming_message_get_sender_content_null",
+	)
+	if got := poller.appliedCount(); got != 0 {
+		t.Fatalf("send failure status projections after poller terminal won = %d, want 0", got)
+	}
+}
+
+func TestStrongestAlreadyAdmittedSendFailureWins(t *testing.T) {
+	poller := newFakePoller()
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	started, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "signal-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	receiveValue(t, poller.started, "retained poller start")
+	r := started.(*run)
+	if !r.admitCallback() || !r.admitCallback() {
+		t.Fatal("failed to admit send callbacks before terminal selection")
+	}
+	transientExit := signallive.PollerExit{
+		Kind:        signallive.PollerFailureTransient,
+		Operation:   "send",
+		Fingerprint: "signal_send_failed",
+		Err:         errors.New("temporary send failure"),
+	}
+	reauthExit := signallive.PollerExit{
+		Kind:        signallive.PollerFailureReauth,
+		Operation:   "send",
+		Fingerprint: signallive.SignalAccountInvalidFingerprint,
+		Err:         errors.New("account is not registered"),
+	}
+	r.requestFinish(terminalCandidate{
+		err:      classifyPollerExit(transientExit),
+		sendExit: &transientExit,
+	})
+	r.requestFinish(terminalCandidate{
+		err:      classifyPollerExit(reauthExit),
+		sendExit: &reauthExit,
+	})
+	r.callbacks.Done()
+	r.callbacks.Done()
+
+	terminal := receiveValue(t, started.Done(), "strongest send terminal result")
+	assertOpError(
+		t,
+		terminal,
+		bridge.FailureReauthRequired,
+		signallive.SignalAccountInvalidFingerprint,
+	)
+	if got := poller.appliedCount(); got != 1 {
+		t.Fatalf("winning send status projections = %d, want 1", got)
+	}
+}
+
+// A send can fail for many reasons that do NOT indict the local Signal account:
+// an unregistered *recipient* (whose "not registered" text is identical to an
+// unregistered local account), an untrusted-identity change, a group-permission
+// denial, a rate/proof challenge, or a plain network blip. None of these may
+// retire the healthy receive generation — the account-scoped receive probe owns
+// account validity. Regression for the C6 D1/D2 send-classification defect.
+func TestReportErrorIgnoresRecipientAndNonAccountSendFailures(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"unregistered recipient", "send failed: Untrusted or not registered: user +15551230000 is not registered"},
+		{"untrusted identity", "send failed: Untrusted identity key for +15551230000"},
+		{"group permission", "send failed: User is not authorized to send to this group"},
+		{"rate limited", "send failed: Rate limit challenge required (proof of work)"},
+		{"network blip", "send failed: Connection reset by peer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := newFakePoller()
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+			run, err := adapter.Start(context.Background(), bridge.StartRequest{
+				AccountID:  "signal-primary",
+				Generation: 1,
+			}, nil)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			receiveValue(t, poller.started, "retained poller start")
+			t.Cleanup(func() { stopAdapterRun(t, run) })
+
+			if reported := adapter.ReportError(signallive.NewCommandError(tc.text)); reported {
+				t.Fatalf("ReportError(%q) acted on a non-account send failure", tc.text)
+			}
+			select {
+			case terminal := <-run.Done():
+				t.Fatalf("ignored send failure produced terminal %v", terminal)
+			default:
+			}
+			if got := poller.appliedCount(); got != 0 {
+				t.Fatalf("status projections after ignored send failure = %d, want 0", got)
+			}
+		})
+	}
+}
+
+// An unambiguous local-account send failure ("authorization failed" / "invalid
+// account") is worth a nudge, but only as a *transient* bounce — never reauth.
+// The next generation's account-scoped probe, not this send's text, is what
+// parks reauth, so a send can never by itself drive the bridge to Blocked.
+func TestReportErrorTransientlyReportsLocalAccountSendFailure(t *testing.T) {
+	for _, text := range []string{
+		"send failed: authorization failed",
+		"send failed: invalid account",
+	} {
+		t.Run(text, func(t *testing.T) {
+			poller := newFakePoller()
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+			run, err := adapter.Start(context.Background(), bridge.StartRequest{
+				AccountID:  "signal-primary",
+				Generation: 1,
+			}, nil)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			receiveValue(t, poller.started, "retained poller start")
+			t.Cleanup(func() { stopAdapterRun(t, run) })
+
+			if reported := adapter.ReportError(signallive.NewCommandError(text)); !reported {
+				t.Fatalf("ReportError(%q) ignored a local-account send failure", text)
+			}
+			// FailureTransient + signal_send_account_check IS the proof it is not
+			// reauth/signal_account_invalid — the probe, not the send, owns reauth.
+			terminal := receiveValue(t, run.Done(), "local-account send terminal")
+			assertOpError(t, terminal, bridge.FailureTransient, "signal_send_account_check")
+		})
+	}
+}
+
+// End to end: texting a number that is not on Signal must not disturb the live
+// receive loop. The supervised generation stays Online — no reconnect, no
+// projection, and never Blocked or needs-reauth.
+func TestSupervisorKeepsReceivingThroughUnregisteredRecipientSend(t *testing.T) {
+	poller := newFakePoller()
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	clock := newManualClock(signalAdapterTestEpoch)
+	supervisor := newSignalTestSupervisor(t, adapter, signalSupervisorTestPolicy(), clock)
+
+	startSupervisor(t, supervisor)
+	readyNextGeneration(t, supervisor, poller, 1)
+
+	if reported := adapter.ReportError(signallive.NewCommandError(
+		"send failed: user +15551230000 is not registered",
+	)); reported {
+		t.Fatal("ReportError() acted on an unregistered-recipient send failure")
+	}
+
+	syncSupervisor(t, supervisor)
+	if got := poller.startCount(); got != 1 {
+		t.Fatalf("StartPoller calls after recipient send failure = %d, want 1", got)
+	}
+	if got := poller.appliedCount(); got != 0 {
+		t.Fatalf("status projections after recipient send failure = %d, want 0", got)
+	}
+	snapshot := supervisor.Snapshot()
+	if snapshot.State != bridge.StateOnline || snapshot.Generation != 1 {
+		t.Fatalf("snapshot after recipient send failure = %+v, want online generation 1", snapshot)
+	}
+	if snapshot.ErrorClass == bridge.FailureReauthRequired ||
+		snapshot.ErrorFingerprint == signallive.SignalAccountInvalidFingerprint {
+		t.Fatalf("recipient send failure produced reauth: %+v", snapshot)
+	}
+}
+
+func TestSupervisorReceiveFailureRetriesBeyondFingerprintThreshold(t *testing.T) {
+	poller := newFakePoller()
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	clock := newManualClock(signalAdapterTestEpoch)
+	policy := signalSupervisorTestPolicy()
+	policy.MaxSameFingerprint = 2
+	supervisor := newSignalTestSupervisor(t, adapter, policy, clock)
+
+	startSupervisor(t, supervisor)
+	retained := readyNextGeneration(t, supervisor, poller, 1)
+	for generation := bridge.Generation(1); generation <= 3; generation++ {
+		retained.complete(signallive.PollerExit{
+			Kind:        signallive.PollerFailureTransient,
+			Operation:   "receive",
+			Fingerprint: signallive.SignalReceiveFailureFingerprint,
+			Err:         errors.New("signal-cli receive failed repeatedly"),
+		})
+		backoff := awaitSnapshot(t, supervisor, "transient receive backoff", func(snapshot bridge.Snapshot) bool {
+			return snapshot.Generation == generation && snapshot.State == bridge.StateBackoff
+		})
+		if backoff.ErrorClass != bridge.FailureTransient ||
+			backoff.ErrorFingerprint != signallive.SignalReceiveFailureFingerprint {
+			t.Fatalf("generation %d backoff = %+v", generation, backoff)
+		}
+		clock.Advance(backoff.RetryAt.Sub(clock.Now()))
+		retained = readyNextGeneration(t, supervisor, poller, generation+1)
+	}
+
+	if got := poller.startCount(); got != 4 {
+		t.Fatalf("StartPoller calls after three identical transient failures = %d, want 4", got)
+	}
+	if snapshot := supervisor.Snapshot(); snapshot.State != bridge.StateOnline || snapshot.Generation != 4 {
+		t.Fatalf("snapshot after transient retries = %+v, want online generation 4", snapshot)
+	}
+}
+
+func TestSupervisorParksTerminalSignalFailuresWithoutReconnectChurn(t *testing.T) {
+	tests := []struct {
+		name        string
+		exit        signallive.PollerExit
+		wantClass   bridge.FailureClass
+		fingerprint string
+	}{
+		{
+			name: "account invalid requires re-pair",
+			exit: signallive.PollerExit{
+				Kind:        signallive.PollerFailureReauth,
+				Operation:   "probe_account",
+				Fingerprint: signallive.SignalAccountInvalidFingerprint,
+				Err:         errors.New("account is not registered"),
+			},
+			wantClass:   bridge.FailureReauthRequired,
+			fingerprint: signallive.SignalAccountInvalidFingerprint,
+		},
+		{
+			name: "old signal-cli version",
+			exit: signallive.PollerExit{
+				Kind:        signallive.PollerFailureUpgrade,
+				Operation:   "version_gate",
+				Fingerprint: signallive.SignalCLIVersionFingerprint,
+				Err:         errors.New("signal-cli is below the minimum version"),
+			},
+			wantClass:   bridge.FailureUpgradeRequired,
+			fingerprint: signallive.SignalCLIVersionFingerprint,
+		},
+		{
+			name: "getSender poison circuit",
+			exit: signallive.PollerExit{
+				Kind:        signallive.PollerFailureUpgrade,
+				Operation:   "receive",
+				Fingerprint: "incoming_message_get_sender_content_null",
+				Err:         errors.New("IncomingMessageHandler.getSender content is null"),
+			},
+			wantClass:   bridge.FailureUpgradeRequired,
+			fingerprint: "incoming_message_get_sender_content_null",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			poller := newFakePoller()
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+			clock := newManualClock(signalAdapterTestEpoch)
+			supervisor := newSignalTestSupervisor(t, adapter, signalSupervisorTestPolicy(), clock)
+
+			startSupervisor(t, supervisor)
+			retained := readyNextGeneration(t, supervisor, poller, 1)
+			retained.complete(test.exit)
+			blocked := awaitSnapshot(t, supervisor, "blocked terminal failure", func(snapshot bridge.Snapshot) bool {
+				return snapshot.State == bridge.StateBlocked
+			})
+			if blocked.ErrorClass != test.wantClass || blocked.ErrorFingerprint != test.fingerprint {
+				t.Fatalf("blocked snapshot = %+v, want class %q fingerprint %q", blocked, test.wantClass, test.fingerprint)
+			}
+
+			clock.Advance(7 * 24 * time.Hour)
+			syncSupervisor(t, supervisor)
+			if got := poller.startCount(); got != 1 {
+				t.Fatalf("StartPoller calls after a week parked = %d, want 1", got)
+			}
+			if snapshot := supervisor.Snapshot(); snapshot.State != bridge.StateBlocked || snapshot.Generation != 1 {
+				t.Fatalf("snapshot after parked clock advance = %+v", snapshot)
+			}
+		})
+	}
+}
+
+func TestSupervisorLeavesExpiredPairingUnpairedWithoutReconnectChurn(t *testing.T) {
+	poller := newFakePoller()
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	clock := newManualClock(signalAdapterTestEpoch)
+	supervisor := newSignalTestSupervisor(t, adapter, signalSupervisorTestPolicy(), clock)
+
+	startSupervisor(t, supervisor)
+	retained := receiveValue(t, poller.started, "pairing poller start")
+	retained.complete(signallive.PollerExit{
+		Kind:        signallive.PollerFailureUnpaired,
+		Operation:   "pair",
+		Fingerprint: signallive.SignalPairingIncompleteFingerprint,
+		Err:         errors.New("Signal link QR expired"),
+	})
+	unpaired := awaitSnapshot(t, supervisor, "unpaired pairing expiry", func(snapshot bridge.Snapshot) bool {
+		return snapshot.State == bridge.StateUnpaired
+	})
+	if unpaired.ErrorClass != bridge.FailureUnpaired ||
+		unpaired.ErrorFingerprint != signallive.SignalPairingIncompleteFingerprint ||
+		!unpaired.RetryAt.IsZero() {
+		t.Fatalf("unpaired snapshot = %+v", unpaired)
+	}
+
+	clock.Advance(7 * 24 * time.Hour)
+	syncSupervisor(t, supervisor)
+	if got := poller.startCount(); got != 1 {
+		t.Fatalf("StartPoller calls after a week unpaired = %d, want 1", got)
+	}
+	if snapshot := supervisor.Snapshot(); snapshot.State != bridge.StateUnpaired {
+		t.Fatalf("snapshot after unpaired clock advance = %+v", snapshot)
+	}
+}
+
+type fakePoller struct {
+	mu           sync.Mutex
+	starts       int
+	runs         []*fakePollerRun
+	started      chan *fakePollerRun
+	startEntered chan struct{}
+	startRelease chan struct{}
+	applied      []signallive.PollerExit
+	fingerprint  string
+}
+
+func newFakePoller() *fakePoller {
+	return &fakePoller{started: make(chan *fakePollerRun, 16)}
+}
+
+func (p *fakePoller) StartPoller(ctx context.Context) (signallive.PollerRun, error) {
+	p.mu.Lock()
+	p.starts++
+	entered := p.startEntered
+	release := p.startRelease
+	p.mu.Unlock()
+	if entered != nil {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+	}
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	run := newFakePollerRun()
+	p.mu.Lock()
+	p.runs = append(p.runs, run)
+	p.mu.Unlock()
+	select {
+	case p.started <- run:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return run, nil
+}
+
+func (*fakePoller) Status() signallive.StatusSnapshot { return signallive.StatusSnapshot{} }
+
+func (p *fakePoller) ApplyPollerFailure(exit signallive.PollerExit) {
+	p.mu.Lock()
+	p.applied = append(p.applied, exit)
+	p.mu.Unlock()
+}
+
+func (p *fakePoller) appliedCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.applied)
+}
+
+func (p *fakePoller) InputFingerprint() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.fingerprint
+}
+
+func (*fakePoller) UnpairContext(context.Context) error { return nil }
+
+func (p *fakePoller) startCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.starts
+}
+
+type fakePollerRun struct {
+	ready      chan struct{}
+	activity   chan signallive.PollerActivity
+	done       chan signallive.PollerExit
+	stopped    chan struct{}
+	readyOnce  sync.Once
+	finishOnce sync.Once
+	mu         sync.Mutex
+	stops      int
+	stopExit   signallive.PollerExit
+}
+
+func newFakePollerRun() *fakePollerRun {
+	return &fakePollerRun{
+		ready:    make(chan struct{}),
+		activity: make(chan signallive.PollerActivity, 4),
+		done:     make(chan signallive.PollerExit, 1),
+		stopped:  make(chan struct{}),
+	}
+}
+
+func (r *fakePollerRun) Ready() <-chan struct{} { return r.ready }
+
+func (r *fakePollerRun) Activity() <-chan signallive.PollerActivity { return r.activity }
+
+func (r *fakePollerRun) Done() <-chan signallive.PollerExit { return r.done }
+
+func (r *fakePollerRun) Stop(ctx context.Context) error {
+	r.mu.Lock()
+	r.stops++
+	exit := r.stopExit
+	r.mu.Unlock()
+	r.complete(exit)
+	select {
+	case <-r.stopped:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *fakePollerRun) setStopExit(exit signallive.PollerExit) {
+	r.mu.Lock()
+	r.stopExit = exit
+	r.mu.Unlock()
+}
+
+func (r *fakePollerRun) markReady() {
+	r.readyOnce.Do(func() { close(r.ready) })
+}
+
+func (r *fakePollerRun) emitActivity(activity signallive.PollerActivity) {
+	r.activity <- activity
+}
+
+func (r *fakePollerRun) complete(exit signallive.PollerExit) {
+	r.finishOnce.Do(func() {
+		r.done <- exit
+		close(r.done)
+		close(r.activity)
+		close(r.stopped)
+	})
+}
+
+func (r *fakePollerRun) stopCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stops
+}
+
+type recordedBeat struct {
+	generation bridge.Generation
+	at         time.Time
+	detail     string
+}
+
+type recordingSink struct {
+	beats chan recordedBeat
+}
+
+func (*recordingSink) AppendIngress(context.Context, bridge.RawIngressRecord) error { return nil }
+
+func (*recordingSink) EmitEphemeral(context.Context, bridge.EphemeralEvent) error { return nil }
+
+func (s *recordingSink) Beat(generation bridge.Generation, at time.Time, detail string) {
+	s.beats <- recordedBeat{generation: generation, at: at, detail: detail}
+}
+
+type manualClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers map[*manualTimer]struct{}
+}
+
+func newManualClock(now time.Time) *manualClock {
+	return &manualClock{now: now, timers: make(map[*manualTimer]struct{})}
+}
+
+func (c *manualClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *manualClock) NewTimer(delay time.Duration) bridge.Timer {
+	if delay < 0 {
+		delay = 0
+	}
+	c.mu.Lock()
+	timer := &manualTimer{
+		clock:    c,
+		deadline: c.now.Add(delay),
+		channel:  make(chan time.Time, 1),
+		active:   delay != 0,
+	}
+	if timer.active {
+		c.timers[timer] = struct{}{}
+	}
+	now := c.now
+	c.mu.Unlock()
+	if delay == 0 {
+		timer.channel <- now
+	}
+	return timer
+}
+
+func (c *manualClock) Advance(delta time.Duration) {
+	if delta < 0 {
+		panic("manual clock cannot move backward")
+	}
+	c.mu.Lock()
+	c.now = c.now.Add(delta)
+	now := c.now
+	var due []*manualTimer
+	for timer := range c.timers {
+		if !now.Before(timer.deadline) {
+			timer.active = false
+			delete(c.timers, timer)
+			due = append(due, timer)
+		}
+	}
+	c.mu.Unlock()
+	for _, timer := range due {
+		timer.channel <- now
+	}
+}
+
+type manualTimer struct {
+	clock    *manualClock
+	deadline time.Time
+	channel  chan time.Time
+	active   bool
+}
+
+func (t *manualTimer) C() <-chan time.Time { return t.channel }
+
+func (t *manualTimer) Stop() bool {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	if !t.active {
+		return false
+	}
+	t.active = false
+	delete(t.clock.timers, t)
+	return true
+}
+
+type midpointRandom struct{}
+
+func (midpointRandom) Int63n(bound int64) int64 { return bound / 2 }
+
+func signalSupervisorTestPolicy() bridge.Policy {
+	return bridge.Policy{
+		ConnectTimeout:     time.Hour,
+		ProbeEvery:         time.Hour,
+		ProbeTimeout:       time.Hour,
+		LivenessTimeout:    time.Hour,
+		MinBackoff:         10 * time.Second,
+		MaxBackoff:         time.Minute,
+		MaxSameFingerprint: 3,
+	}
+}
+
+func newSignalTestSupervisor(
+	t *testing.T,
+	adapter *Adapter,
+	policy bridge.Policy,
+	clock *manualClock,
+) *bridge.Supervisor {
+	t.Helper()
+	supervisor, err := bridge.NewSupervisor(
+		"signal-primary",
+		bridge.PlatformSignal,
+		adapter,
+		policy,
+		clock,
+		midpointRandom{},
+	)
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), signalAdapterTestTimeout)
+		defer cancel()
+		if err := supervisor.Stop(ctx); err != nil {
+			t.Errorf("Supervisor.Stop() cleanup error = %v", err)
+		}
+	})
+	return supervisor
+}
+
+func startSupervisor(t *testing.T, supervisor *bridge.Supervisor) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), signalAdapterTestTimeout)
+	defer cancel()
+	if err := supervisor.Start(ctx, bridge.StartRequest{}); err != nil {
+		t.Fatalf("Supervisor.Start() error = %v", err)
+	}
+}
+
+func syncSupervisor(t *testing.T, supervisor *bridge.Supervisor) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), signalAdapterTestTimeout)
+	defer cancel()
+	if err := supervisor.Sync(ctx); err != nil {
+		t.Fatalf("Supervisor.Sync() error = %v", err)
+	}
+}
+
+func readyNextGeneration(
+	t *testing.T,
+	supervisor *bridge.Supervisor,
+	poller *fakePoller,
+	generation bridge.Generation,
+) *fakePollerRun {
+	t.Helper()
+	retained := receiveValue(t, poller.started, "retained poller generation start")
+	retained.markReady()
+	awaitSnapshot(t, supervisor, "online generation", func(snapshot bridge.Snapshot) bool {
+		return snapshot.State == bridge.StateOnline && snapshot.Generation == generation
+	})
+	return retained
+}
+
+func awaitSnapshot(
+	t *testing.T,
+	supervisor *bridge.Supervisor,
+	description string,
+	predicate func(bridge.Snapshot) bool,
+) bridge.Snapshot {
+	t.Helper()
+	deadline := time.NewTimer(signalAdapterTestTimeout)
+	defer deadline.Stop()
+	for {
+		snapshot := supervisor.Snapshot()
+		if predicate(snapshot) {
+			return snapshot
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for %s; last snapshot: %+v", description, snapshot)
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
+func assertChannelOpen(t *testing.T, channel <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-channel:
+		t.Fatalf("channel closed %s", description)
+	default:
+	}
+}
+
+func assertOpError(
+	t *testing.T,
+	err error,
+	wantClass bridge.FailureClass,
+	wantFingerprint string,
+) {
+	t.Helper()
+	var operationError bridge.OpError
+	if !errors.As(err, &operationError) {
+		t.Fatalf("error = %v (%T), want bridge.OpError", err, err)
+	}
+	if operationError.Class != wantClass || operationError.Fingerprint != wantFingerprint {
+		t.Fatalf("OpError = %+v, want class %q fingerprint %q", operationError, wantClass, wantFingerprint)
+	}
+}
+
+func stopAdapterRun(t *testing.T, run bridge.Run) {
+	t.Helper()
+	if run == nil {
+		return
+	}
+	select {
+	case <-run.Done():
+		return
+	default:
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), signalAdapterTestTimeout)
+	defer cancel()
+	if err := run.Stop(ctx); err != nil {
+		t.Fatalf("Run.Stop() error = %v", err)
+	}
+}
+
+func receiveValue[T any](t *testing.T, channel <-chan T, description string) T {
+	t.Helper()
+	select {
+	case value := <-channel:
+		return value
+	case <-time.After(signalAdapterTestTimeout):
+		var zero T
+		t.Fatalf("timed out waiting for %s", description)
+		return zero
+	}
+}
+
+var (
+	_ poller                = (*fakePoller)(nil)
+	_ signallive.PollerRun  = (*fakePollerRun)(nil)
+	_ bridge.ConnectionSink = (*recordingSink)(nil)
+	_ bridge.Clock          = (*manualClock)(nil)
+	_ bridge.Timer          = (*manualTimer)(nil)
+	_ bridge.Random         = midpointRandom{}
+)

--- a/internal/messaging/dispatch.go
+++ b/internal/messaging/dispatch.go
@@ -431,7 +431,8 @@ func retryableFailure(class bridge.FailureClass) bool {
 
 func terminalFailure(class bridge.FailureClass) bool {
 	switch class {
-	case bridge.FailureReauthRequired,
+	case bridge.FailureUnpaired,
+		bridge.FailureReauthRequired,
 		bridge.FailureUpgradeRequired,
 		bridge.FailureMisconfigured,
 		bridge.FailureUnsupported:

--- a/internal/messaging/service_test.go
+++ b/internal/messaging/service_test.go
@@ -256,6 +256,7 @@ func TestPostCallTimeoutBecomesUncertainAndIsNotRedispatched(t *testing.T) {
 
 func TestTerminalFailuresAreRejected(t *testing.T) {
 	classes := []bridge.FailureClass{
+		bridge.FailureUnpaired,
 		bridge.FailureReauthRequired,
 		bridge.FailureUpgradeRequired,
 		bridge.FailureMisconfigured,

--- a/internal/signallive/client.go
+++ b/internal/signallive/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -175,6 +176,128 @@ type Callbacks struct {
 	OnTypingChange        func(conversationID, senderName, senderNumber string, typing bool)
 }
 
+// PollerFailureKind is the transport-local terminal classification emitted by
+// the retained signal-cli receive poller. The bridge adapter translates these
+// values to bridge.FailureClass without making signallive depend on the generic
+// bridge package.
+type PollerFailureKind string
+
+const (
+	PollerFailureTransient PollerFailureKind = "transient"
+	PollerFailureReauth    PollerFailureKind = "reauth_required"
+	PollerFailureUpgrade   PollerFailureKind = "upgrade_required"
+	PollerFailureUnpaired  PollerFailureKind = "unpaired"
+)
+
+const (
+	SignalCLIVersionFingerprint        = "signal_cli_too_old"
+	SignalAccountInvalidFingerprint    = "signal_account_invalid"
+	SignalReceiveFailureFingerprint    = "signal_receive_failed"
+	SignalAccountProbeFingerprint      = "signal_account_probe_failed"
+	SignalReceivePanicFingerprint      = "signal_receive_panic"
+	SignalPairingIncompleteFingerprint = "signal_pairing_incomplete"
+)
+
+// PollerExit is the terminal result of exactly one retained poller lifecycle.
+// A zero Kind is a caller-requested stop.
+type PollerExit struct {
+	Kind        PollerFailureKind
+	Operation   string
+	Fingerprint string
+	Err         error
+}
+
+// PollerActivity is evidence that the retained receive machinery advanced.
+// Expected idle completions count: they prove signal-cli returned control to
+// the poller even when the account had no incoming messages.
+type PollerActivity struct {
+	At     time.Time
+	Detail string
+}
+
+// PollerRun is a token-bound view of one link/probe/receive generation. Done
+// resolves only after the existing link/receive goroutine has returned.
+type PollerRun interface {
+	Ready() <-chan struct{}
+	Activity() <-chan PollerActivity
+	Done() <-chan PollerExit
+	Stop(context.Context) error
+}
+
+type pollerRun struct {
+	ready       chan struct{}
+	activity    chan PollerActivity
+	done        chan PollerExit
+	stopped     chan struct{}
+	cancel      context.CancelFunc
+	readyOnce   sync.Once
+	finishOnce  sync.Once
+	stoppedOnce sync.Once
+}
+
+func newPollerRun(parent context.Context) (*pollerRun, context.Context) {
+	ctx, cancel := context.WithCancel(parent)
+	return &pollerRun{
+		ready:    make(chan struct{}),
+		activity: make(chan PollerActivity, 1),
+		done:     make(chan PollerExit, 1),
+		stopped:  make(chan struct{}),
+		cancel:   cancel,
+	}, ctx
+}
+
+func (r *pollerRun) Ready() <-chan struct{} { return r.ready }
+
+func (r *pollerRun) Activity() <-chan PollerActivity { return r.activity }
+
+func (r *pollerRun) Done() <-chan PollerExit { return r.done }
+
+func (r *pollerRun) Stop(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("signal poller: nil stop context")
+	}
+	r.cancel()
+	select {
+	case <-r.stopped:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *pollerRun) markReady() {
+	r.readyOnce.Do(func() { close(r.ready) })
+}
+
+func (r *pollerRun) beat(detail string) {
+	activity := PollerActivity{At: now(), Detail: detail}
+	select {
+	case r.activity <- activity:
+		return
+	default:
+	}
+	select {
+	case <-r.activity:
+	default:
+	}
+	select {
+	case r.activity <- activity:
+	default:
+	}
+}
+
+func (r *pollerRun) finish(exit PollerExit) {
+	r.finishOnce.Do(func() {
+		r.done <- exit
+		close(r.done)
+		close(r.activity)
+	})
+}
+
+func (r *pollerRun) markStopped() {
+	r.stoppedOnce.Do(func() { close(r.stopped) })
+}
+
 type StatusSnapshot struct {
 	Connected       bool   `json:"connected"`
 	Connecting      bool   `json:"connecting"`
@@ -247,8 +370,8 @@ type Bridge struct {
 	qr         QRSnapshot
 	// needsReauth is set when signal-cli reports the stored account is no
 	// longer registered / authorized. Cleared on successful pair or
-	// reconnect. While set, the reconnect ticker skips this bridge so we
-	// don't hammer signal-cli with a known-bad account every 5 seconds.
+	// reconnect. While set, the lifecycle reports reauth_required so the
+	// supervisor parks instead of retrying a known-bad account.
 	needsReauth bool
 	// upgradeRequired is a terminal receive state for an unsupported
 	// signal-cli version or its known poison-envelope crash. Automatic
@@ -535,12 +658,85 @@ func (b *Bridge) Connect() error {
 	return nil
 }
 
+// StartPoller starts one manual Signal lifecycle for bridge.Supervisor. It
+// preserves Connect's behavior: an existing account re-runs the version gate
+// and retained receive poller, while an unpaired account runs the existing QR
+// link flow and hands directly into that same poller after a successful scan.
+// The method returns after the tracked goroutine is admitted; signal-cli work
+// remains asynchronous.
+func (b *Bridge) StartPoller(ctx context.Context) (PollerRun, error) {
+	if ctx == nil {
+		return nil, errors.New("signal poller: nil start context")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	b.mu.Lock()
+	if b.account == "" {
+		b.account = b.firstStoredAccount()
+	}
+	if b.pairing || b.connecting || b.connected {
+		b.mu.Unlock()
+		return nil, errors.New("signal poller lifecycle is already active")
+	}
+
+	run, runCtx := newPollerRun(ctx)
+	account := b.account
+	b.connecting = true
+	b.needsReauth = false
+	b.upgradeRequired = false
+	b.lastError = ""
+	if account == "" {
+		b.pairing = true
+		b.pairCancel = run.cancel
+		b.qr = QRSnapshot{}
+	}
+	b.mu.Unlock()
+	b.emitStatusChange()
+
+	b.wg.Add(1)
+	go func() {
+		var exit PollerExit
+		if account == "" {
+			exit = b.runLinkPoller(runCtx, run)
+		} else {
+			exit = b.runReceiveLoop(runCtx, account, false, run)
+		}
+		// Done is the retained link/receive loop's terminal result. Metadata/WAL
+		// replay remains host-scoped, as before, and Bridge.Close joins it before
+		// App closes the store.
+		run.finish(exit)
+		b.wg.Done()
+		run.markStopped()
+	}()
+	return run, nil
+}
+
 func (b *Bridge) Unpair() error {
+	return b.UnpairContext(context.Background())
+}
+
+// UnpairContext bounds the join before signal-cli state is removed. The
+// context-free Unpair method remains for legacy callers.
+func (b *Bridge) UnpairContext(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("signal unpair: nil context")
+	}
 	b.cancelBackgroundWork(true)
 	// Wait for in-flight loops before removing the config dir: a draining
 	// receive poll may still be writing WAL/recovery files inside it, and
 	// RemoveAll on a directory that's being written to fails part-way.
-	b.wg.Wait()
+	joined := make(chan struct{})
+	go func() {
+		b.wg.Wait()
+		close(joined)
+	}()
+	select {
+	case <-joined:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 	if err := os.RemoveAll(b.configDir); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove Signal config dir: %w", err)
 	}
@@ -587,6 +783,71 @@ func (b *Bridge) Status() StatusSnapshot {
 	b.mu.RUnlock()
 	snapshot.ReceiveRecovery = b.receiveRecoveryStatus()
 	return snapshot
+}
+
+// InputFingerprint captures the paired account and signal-cli executable
+// identity used by a blocked generation. It is intentionally cheap and does
+// not execute signal-cli; a manual reconnect can therefore notice an upgraded
+// binary without creating a second lifecycle owner.
+func (b *Bridge) InputFingerprint() string {
+	hash := sha256.New()
+	_, _ = fmt.Fprintf(hash, "config=%s\n", b.configDir)
+	accountsPath := filepath.Join(b.configDir, "data", "accounts.json")
+	if data, err := os.ReadFile(accountsPath); err == nil {
+		_, _ = hash.Write(data)
+	} else {
+		_, _ = fmt.Fprintf(hash, "accounts_error=%v\n", err)
+	}
+	executable := signalCLIExecutable()
+	_, _ = fmt.Fprintf(hash, "executable=%s\n", executable)
+	if info, err := os.Stat(executable); err == nil {
+		_, _ = fmt.Fprintf(
+			hash,
+			"mode=%s\nsize=%d\nmtime=%d\n",
+			info.Mode(),
+			info.Size(),
+			info.ModTime().UnixNano(),
+		)
+	} else {
+		_, _ = fmt.Fprintf(hash, "executable_error=%v\n", err)
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
+}
+
+// ApplyPollerFailure keeps the legacy Signal status projection aligned when a
+// send path, rather than the receive loop, terminates the active generation.
+// Cancellation/join remains the adapter's responsibility.
+func (b *Bridge) ApplyPollerFailure(exit PollerExit) {
+	if exit.Err == nil {
+		return
+	}
+	b.mu.Lock()
+	// Once the receive loop has established a terminal condition, a racing
+	// ordinary send failure cannot downgrade it and accidentally resume churn.
+	if b.upgradeRequired && exit.Kind != PollerFailureUpgrade {
+		b.mu.Unlock()
+		return
+	}
+	if b.needsReauth && exit.Kind == PollerFailureTransient {
+		b.mu.Unlock()
+		return
+	}
+	b.connected = false
+	b.connecting = false
+	b.lastError = exit.Err.Error()
+	switch exit.Kind {
+	case PollerFailureReauth:
+		b.needsReauth = true
+		b.upgradeRequired = false
+	case PollerFailureUpgrade:
+		b.needsReauth = false
+		b.upgradeRequired = true
+	case PollerFailureTransient:
+		b.needsReauth = false
+		b.upgradeRequired = false
+	}
+	b.mu.Unlock()
+	b.emitStatusChange()
 }
 
 func (b *Bridge) ReplayReceiveRecoveryQueue() error {
@@ -830,6 +1091,10 @@ func (b *Bridge) Close() error {
 }
 
 func (b *Bridge) runLink(ctx context.Context) {
+	_ = b.runLinkPoller(ctx, nil)
+}
+
+func (b *Bridge) runLinkPoller(ctx context.Context, run *pollerRun) PollerExit {
 	reader, wait, err := startSignalLink(ctx, b.configDir)
 	if err != nil {
 		b.mu.Lock()
@@ -839,7 +1104,12 @@ func (b *Bridge) runLink(ctx context.Context) {
 		b.pairCancel = nil
 		b.mu.Unlock()
 		b.emitStatusChange()
-		return
+		return PollerExit{
+			Kind:        PollerFailureUnpaired,
+			Operation:   "pair",
+			Fingerprint: SignalPairingIncompleteFingerprint,
+			Err:         err,
+		}
 	}
 	defer reader.Close()
 
@@ -856,6 +1126,9 @@ func (b *Bridge) runLink(ctx context.Context) {
 			}
 			b.mu.Unlock()
 			b.emitStatusChange()
+			if run != nil {
+				run.beat("pairing_qr")
+			}
 			continue
 		}
 		if strings.TrimSpace(line) != "" {
@@ -897,29 +1170,41 @@ func (b *Bridge) runLink(ctx context.Context) {
 	b.mu.Unlock()
 	b.emitStatusChange()
 	if account != "" {
-		b.startReceiveLoop(account, true)
+		return b.runReceiveLoop(ctx, account, true, run)
+	}
+	if ctx.Err() != nil {
+		return PollerExit{Err: ctx.Err()}
+	}
+	detail := strings.TrimSpace(b.Status().LastError)
+	if detail == "" {
+		detail = "Signal pairing did not produce a linked account"
+	}
+	return PollerExit{
+		Kind:        PollerFailureUnpaired,
+		Operation:   "pair",
+		Fingerprint: SignalPairingIncompleteFingerprint,
+		Err:         errors.New(detail),
 	}
 }
 
 func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
+	_ = b.runReceiveLoop(context.Background(), account, requestSync, nil)
+}
+
+func (b *Bridge) runReceiveLoop(
+	parent context.Context,
+	account string,
+	requestSync bool,
+	run *pollerRun,
+) (exit PollerExit) {
 	// A panic while parsing an attacker-influenced envelope (unchecked indexes
 	// into attachments/reactions/quotes) would otherwise kill this goroutine
-	// and leave connected=true — Signal silently freezes. Recover, reset the
-	// connection state, and let the reconnect watchdog re-spawn the loop.
-	defer func() {
-		if r := recover(); r != nil {
-			b.logger.Error().
-				Interface("panic", r).
-				Bytes("stack", debug.Stack()).
-				Msg("Recovered from panic in Signal receive loop")
-			b.mu.Lock()
-			b.connected = false
-			b.connecting = false
-			b.mu.Unlock()
-			b.emitStatusChange()
-		}
-	}()
-	ctx, cancel := context.WithCancel(context.Background())
+	// and leave connected=true — Signal silently freezes. Recover and report a
+	// typed transient exit so the supervisor owns the eventual retry.
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
 	b.mu.Lock()
 	if b.receiveCancel != nil {
@@ -929,6 +1214,32 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 	token := b.receiveToken
 	b.receiveCancel = cancel
 	b.mu.Unlock()
+
+	defer func() {
+		if r := recover(); r != nil {
+			b.logger.Error().
+				Interface("panic", r).
+				Bytes("stack", debug.Stack()).
+				Msg("Recovered from panic in Signal receive loop")
+			b.mu.Lock()
+			b.connected = false
+			b.connecting = false
+			b.lastError = fmt.Sprintf("panic in Signal receive loop: %v", r)
+			b.mu.Unlock()
+			b.emitStatusChange()
+			exit = PollerExit{
+				Kind:        PollerFailureTransient,
+				Operation:   "receive",
+				Fingerprint: SignalReceivePanicFingerprint,
+				Err:         fmt.Errorf("panic in Signal receive loop: %v", r),
+			}
+		}
+		b.mu.Lock()
+		if b.receiveToken == token {
+			b.receiveCancel = nil
+		}
+		b.mu.Unlock()
+	}()
 
 	versionCtx, versionCancel := context.WithTimeout(ctx, versionProbeTimeout)
 	versionOutput, versionErr := probeSignalCLIVersion(versionCtx)
@@ -941,15 +1252,21 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 			b.connecting = false
 		}
 		b.mu.Unlock()
-		return
+		return PollerExit{Err: ctx.Err()}
 	}
 	version, versionDetected := parseSignalCLIVersion(versionOutput)
 	if versionDetected && version.less(minimumSignalCLIVersion) {
-		b.parkUpgradeRequired(token, fmt.Sprintf(
+		detail := fmt.Sprintf(
 			"signal-cli %s is below the required minimum %s; upgrade signal-cli to continue receiving messages",
 			version, minimumSignalCLIVersion,
-		))
-		return
+		)
+		b.parkUpgradeRequired(token, detail)
+		return PollerExit{
+			Kind:        PollerFailureUpgrade,
+			Operation:   "version_gate",
+			Fingerprint: SignalCLIVersionFingerprint,
+			Err:         errors.New(detail),
+		}
 	}
 	if !versionDetected {
 		event := b.logger.Warn()
@@ -964,9 +1281,12 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 
 	probedAccount, err := b.probeAccount(ctx, account)
 	if err != nil || probedAccount == "" {
+		accountInvalid := (err == nil && probedAccount == "") || isSignalAccountInvalid(err, nil)
 		b.mu.Lock()
 		b.connected = false
 		b.connecting = false
+		b.needsReauth = accountInvalid
+		b.upgradeRequired = false
 		if err != nil {
 			b.lastError = err.Error()
 		} else {
@@ -977,7 +1297,20 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 		}
 		b.mu.Unlock()
 		b.emitStatusChange()
-		return
+		if accountInvalid {
+			return PollerExit{
+				Kind:        PollerFailureReauth,
+				Operation:   "probe_account",
+				Fingerprint: SignalAccountInvalidFingerprint,
+				Err:         errors.New(b.Status().LastError),
+			}
+		}
+		return PollerExit{
+			Kind:        PollerFailureTransient,
+			Operation:   "probe_account",
+			Fingerprint: SignalAccountProbeFingerprint,
+			Err:         err,
+		}
 	}
 
 	b.mu.Lock()
@@ -989,6 +1322,10 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 	b.lastError = ""
 	b.mu.Unlock()
 	b.emitStatusChange()
+	if run != nil {
+		run.beat("account_probe")
+		run.markReady()
+	}
 	b.goTracked(func() { b.refreshMetadataAndReplay(probedAccount) })
 	if requestSync {
 		b.beginHistorySync()
@@ -1013,7 +1350,7 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 			}
 			b.mu.Unlock()
 			b.emitStatusChange()
-			return
+			return PollerExit{Err: ctx.Err()}
 		default:
 		}
 
@@ -1033,14 +1370,17 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 				consecutiveFailures = 0
 				consecutivePoisonFailures = 0
 				lastPoisonFingerprint = ""
+				if run != nil {
+					run.beat("receive_idle")
+				}
 				continue
 			}
 			if isSignalAccountInvalid(err, output) {
 				// Signal-side says the account is no longer registered /
 				// authorized. Don't clear b.account — we want the UI to
 				// know *which* account needs re-pairing. Instead flip
-				// needsReauth so the reconnect ticker stops retrying and
-				// the UI surfaces a clear "re-pair Signal" banner.
+				// needsReauth so the supervisor parks and the UI surfaces a
+				// clear "re-pair Signal" banner.
 				b.mu.Lock()
 				if b.receiveToken == token {
 					b.receiveCancel = nil
@@ -1052,7 +1392,12 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 				b.logger.Warn().Str("account", b.account).Msg("Signal account needs re-pairing (signal-cli reports unregistered/unauthorized)")
 				b.mu.Unlock()
 				b.emitStatusChange()
-				return
+				return PollerExit{
+					Kind:        PollerFailureReauth,
+					Operation:   "receive",
+					Fingerprint: SignalAccountInvalidFingerprint,
+					Err:         commandError("receive Signal messages", err, output),
+				}
 			}
 			poisonFingerprint := signalReceivePoisonFingerprint(err, output)
 			if poisonFingerprint == "" {
@@ -1067,11 +1412,17 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 			consecutiveFailures++
 			receiveErr := commandError("receive Signal messages", err, output)
 			if consecutivePoisonFailures >= receivePoisonLimit {
-				b.parkUpgradeRequired(token, fmt.Sprintf(
+				detail := fmt.Sprintf(
 					"signal-cli repeatedly failed in IncomingMessageHandler.getSender() because content is null; upgrade signal-cli to %s or newer",
 					minimumSignalCLIVersion,
-				))
-				return
+				)
+				b.parkUpgradeRequired(token, detail)
+				return PollerExit{
+					Kind:        PollerFailureUpgrade,
+					Operation:   "receive",
+					Fingerprint: signalGetSenderPoisonFingerprint,
+					Err:         errors.New(detail),
+				}
 			}
 			if consecutiveFailures >= receiveFailureLimit {
 				b.logger.Warn().Err(receiveErr).Int("failures", consecutiveFailures).Msg("Signal receive polling repeatedly failed; forcing reconnect")
@@ -1084,7 +1435,12 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 				b.lastError = cleanSignalCommandOutput(err, output)
 				b.mu.Unlock()
 				b.emitStatusChange()
-				return
+				return PollerExit{
+					Kind:        PollerFailureTransient,
+					Operation:   "receive",
+					Fingerprint: SignalReceiveFailureFingerprint,
+					Err:         receiveErr,
+				}
 			}
 			b.logger.Debug().Err(receiveErr).Int("failures", consecutiveFailures).Msg("Signal receive polling failed")
 			time.Sleep(500 * time.Millisecond)
@@ -1093,6 +1449,13 @@ func (b *Bridge) startReceiveLoop(account string, requestSync bool) {
 		consecutiveFailures = 0
 		consecutivePoisonFailures = 0
 		lastPoisonFingerprint = ""
+		if run != nil {
+			detail := "receive_poll"
+			if len(bytes.TrimSpace(output)) != 0 {
+				detail = "receive_batch"
+			}
+			run.beat(detail)
+		}
 		if len(bytes.TrimSpace(output)) == 0 {
 			continue
 		}
@@ -2280,16 +2643,12 @@ func (b *Bridge) cancelBackgroundWork(clearPairQR bool) {
 func (b *Bridge) usableAccount() (string, error) {
 	b.mu.RLock()
 	account := b.account
-	connected := b.connected
 	b.mu.RUnlock()
 	if account == "" {
 		account = b.firstStoredAccount()
 	}
 	if account == "" {
 		return "", errors.New("signal is not paired")
-	}
-	if !connected {
-		_ = b.ConnectIfPaired()
 	}
 	return account, nil
 }
@@ -3274,8 +3633,48 @@ func extractSignalLinkURI(line string) string {
 	return strings.TrimSpace(line[idx:])
 }
 
+// CommandError identifies a signal-cli subprocess failure. App-level send
+// wrappers use this marker to notify the lifecycle owner without turning local
+// validation, file, or database errors into reconnects.
+type CommandError struct {
+	message string
+}
+
+func (e *CommandError) Error() string { return e.message }
+
 func commandError(prefix string, err error, output []byte) error {
-	return fmt.Errorf("%s: %s", prefix, cleanSignalCommandOutput(err, output))
+	return &CommandError{message: fmt.Sprintf("%s: %s", prefix, cleanSignalCommandOutput(err, output))}
+}
+
+// NewCommandError builds a signal-cli command-failure marker carrying message as
+// its text. Production send paths use the internal commandError constructor;
+// this exported form lets callers and tests synthesize the exact marker that App
+// send wrappers hand to the lifecycle owner via ReportError.
+func NewCommandError(message string) *CommandError {
+	return &CommandError{message: message}
+}
+
+func IsCommandError(err error) bool {
+	var commandErr *CommandError
+	return errors.As(err, &commandErr)
+}
+
+func IsAccountInvalidError(err error) bool {
+	return isSignalAccountInvalid(err, nil)
+}
+
+// IsSendAccountInvalidError reports whether a signal-cli *send* failure
+// unambiguously indicts the local account's own credentials rather than the
+// message recipient. signal-cli reports an unregistered recipient with the same
+// "not registered" phrasing it uses for an unregistered local account, so send
+// paths must NOT treat that phrase as a local-account fault: the account-scoped
+// receive probe (probe_account -> PollerFailureReauth) is the authoritative
+// detector and parks reauth on its own within seconds. "authorization failed"
+// and "invalid account" name the local account/credentials and never a
+// recipient, so they stay safe to act on from a send. See isSignalAccountInvalid
+// for the broader receive/probe matcher that also accepts "not registered".
+func IsSendAccountInvalidError(err error) bool {
+	return isSignalSendAccountInvalid(err, nil)
 }
 
 func cleanSignalCommandOutput(err error, output []byte) string {
@@ -3297,6 +3696,16 @@ func isSignalAccountInvalid(err error, output []byte) bool {
 	text := strings.ToLower(cleanSignalCommandOutput(err, output))
 	return strings.Contains(text, "not registered") ||
 		strings.Contains(text, "authorization failed") ||
+		strings.Contains(text, "invalid account")
+}
+
+// isSignalSendAccountInvalid is the send-context subset of isSignalAccountInvalid:
+// it matches only the phrases that unambiguously indict the local account and
+// omits "not registered", which a send commonly reports for an unregistered
+// *recipient*. Keep this list a strict subset of isSignalAccountInvalid.
+func isSignalSendAccountInvalid(err error, output []byte) bool {
+	text := strings.ToLower(cleanSignalCommandOutput(err, output))
+	return strings.Contains(text, "authorization failed") ||
 		strings.Contains(text, "invalid account")
 }
 

--- a/internal/signallive/gate_test.go
+++ b/internal/signallive/gate_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -435,6 +436,156 @@ func TestSignalReceivePoisonConsecutiveCountResetsAfterIdlePoll(t *testing.T) {
 	})
 	if got := receiveCalls.Load(); got != 4 {
 		t.Fatalf("receive calls = %d, want 4 (poison, idle, poison, poison)", got)
+	}
+}
+
+func TestStartPollerPublishesRealReadyActivityAndJoinedDone(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+	var receiveCalls atomic.Int32
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			return []byte("signal-cli 0.14.5\n"), nil
+		},
+		func(ctx context.Context, _ string, args ...string) ([]byte, error) {
+			switch {
+			case hasSignalCLIArg(args, "listAccounts"):
+				return []byte(`[{"number":"+15551230000"}]`), nil
+			case hasSignalCLIArg(args, "receive"):
+				if receiveCalls.Add(1) == 1 {
+					return nil, context.DeadlineExceeded
+				}
+				<-ctx.Done()
+				return nil, ctx.Err()
+			default:
+				return []byte("[]"), nil
+			}
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	run, err := bridge.StartPoller(ctx)
+	if err != nil {
+		cancel()
+		t.Fatalf("StartPoller(): %v", err)
+	}
+	select {
+	case <-run.Ready():
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("poller did not become ready after account probe")
+	}
+
+	seenIdle := false
+	deadline := time.After(2 * time.Second)
+	for !seenIdle {
+		select {
+		case activity := <-run.Activity():
+			seenIdle = activity.Detail == "receive_idle"
+		case <-deadline:
+			cancel()
+			t.Fatal("poller did not publish completed receive activity")
+		}
+	}
+	cancel()
+	select {
+	case exit := <-run.Done():
+		if exit.Kind != "" || !errors.Is(exit.Err, context.Canceled) {
+			t.Fatalf("controlled poller exit = %+v, want canceled without failure class", exit)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("poller Done did not resolve after receive loop exit")
+	}
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+	defer stopCancel()
+	if err := run.Stop(stopCtx); err != nil {
+		t.Fatalf("PollerRun.Stop() after Done: %v", err)
+	}
+}
+
+func TestStartPollerClassifiesAccountInvalidAtInitialProbe(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			return []byte("signal-cli 0.14.5\n"), nil
+		},
+		func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			if hasSignalCLIArg(args, "listAccounts") {
+				return []byte("User +15551230000 is not registered."), errors.New("exit status 1")
+			}
+			return nil, nil
+		},
+	)
+
+	run, err := bridge.StartPoller(context.Background())
+	if err != nil {
+		t.Fatalf("StartPoller(): %v", err)
+	}
+	select {
+	case exit := <-run.Done():
+		if exit.Kind != PollerFailureReauth || exit.Fingerprint != SignalAccountInvalidFingerprint {
+			t.Fatalf("initial account-invalid exit = %+v, want reauth/%s", exit, SignalAccountInvalidFingerprint)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("account-invalid poller did not exit")
+	}
+	if status := bridge.Status(); !status.NeedsReauth || status.Connected || status.Connecting {
+		t.Fatalf("account-invalid status = %+v, want parked reauth", status)
+	}
+}
+
+func TestStartPollerClassifiesExpiredLinkAsUnpaired(t *testing.T) {
+	bridge := &Bridge{
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+	originalStartLink := startSignalLink
+	originalRunSignalCLI := runSignalCLI
+	startSignalLink = func(context.Context, string) (io.ReadCloser, func() error, error) {
+		return io.NopCloser(strings.NewReader("sgnl://linkdevice?uuid=expired\n")), func() error {
+			return errors.New("Signal link QR expired")
+		}, nil
+	}
+	runSignalCLI = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("[]"), nil
+	}
+	t.Cleanup(func() {
+		_ = bridge.Close()
+		startSignalLink = originalStartLink
+		bridge.commandMu.Lock()
+		runSignalCLI = originalRunSignalCLI
+		bridge.commandMu.Unlock()
+	})
+
+	run, err := bridge.StartPoller(context.Background())
+	if err != nil {
+		t.Fatalf("StartPoller(): %v", err)
+	}
+	select {
+	case exit := <-run.Done():
+		if exit.Kind != PollerFailureUnpaired ||
+			exit.Operation != "pair" ||
+			exit.Fingerprint != SignalPairingIncompleteFingerprint {
+			t.Fatalf("expired pairing exit = %+v, want unpaired/%s", exit, SignalPairingIncompleteFingerprint)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expired pairing did not resolve poller Done")
+	}
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+	defer stopCancel()
+	if err := run.Stop(stopCtx); err != nil {
+		t.Fatalf("PollerRun.Stop() after expired pairing: %v", err)
+	}
+	status := bridge.Status()
+	if status.Paired || status.Pairing || status.Connecting || status.QRAvailable {
+		t.Fatalf("expired pairing status = %+v, want idle unpaired", status)
 	}
 }
 


### PR DESCRIPTION
## Rebuild Wave 1 / C6 — wire Signal lifecycle behind the per-account supervisor

Last of the three live bridges to move off scattered watchdogs onto the
generation-aware `bridge.Supervisor`. Completes Wave 1: Google (C4), WhatsApp
(C5), and now Signal all share one reconnect owner.

### What it does
- **Retains the proven signal-cli receive poller** (the full daemon rewrite is a
  later phase) and wraps it behind the supervisor. Readiness = account probe +
  live poll loop; `Done` resolves on loop exit; `Stop` cancels and joins the
  poller (no leaked goroutine, no orphaned signal-cli JVM). Liveness beats on
  real received activity, not a bare `connected` bool.
- **Removes the serve.go 5s Signal reconnect ticker** — the supervisor is now the
  sole reconnect owner (no double-reconnect).
- **Preserves the F8 guards**: signal-cli ≥0.14.5 version gate and the
  `getSender`/content-is-null poison circuit-breaker both surface as
  `upgrade_required` → Blocked with zero reconnect churn.
- **Adds a shared `FailureUnpaired` class** (idle `StateUnpaired`, no
  backoff/circuit) for QR-expiry / incomplete-pair. Purely additive for Google
  and WhatsApp, which never emit it.

### Send-path classification hardening (adversarial review D1/D2)
App send failures no longer classify the **receive** lifecycle by their
frequently recipient-scoped text. signal-cli reports an unregistered *recipient*
with the same "not registered" phrasing as an unregistered local account, so a
routine text to a non-Signal number previously false-parked the whole bridge as
needs-reauth and tore down a healthy receive loop. `ReportError` now:
- acts only on **unambiguous local-account** failures (`authorization failed` /
  `invalid account`), and
- even then retires the generation as **transient** — the next generation's
  account-scoped probe is the sole authority for reauth.

Everything else (recipient errors, untrusted identity, group perms, rate limits,
network blips) leaves the receive loop untouched.

### Tests
- New regressions: the ignored send-failure classes; the transient local-account
  nudge (never reauth); and an end-to-end "texting a non-Signal number keeps
  receiving" supervisor test.
- Full repo `go test -race ./...` green (×3 on the touched packages).

### Live-verified on a signed build
Deployed to `/Applications`, sampled `/api/status` over 40s + SSE flap over 13s:
- **Signal** stays connected/paired/fresh under the new supervisor (the exact
  bridge this PR rewraps).
- **Google** unaffected (connected/paired/phone-responding/fresh).
- **WhatsApp** (unpaired) stays cleanly down — does not brick the daemon.
- **1** status event in 13s (initial handshake only), **0** disconnect
  transitions — zero reconnect flapping, confirming single-ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
