### PR TITLE
Add media send to MessageService over the durable outbox (rebuild Wave 2 / M2a)

### DIFF
--- a/internal/messaging/dispatch.go
+++ b/internal/messaging/dispatch.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"strings"
 	"time"
 
 	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 )
 
@@ -82,8 +84,20 @@ func (s *MessageService) DispatchDue(ctx context.Context, limit int) (int, error
 			}
 			break
 		}
-		if err := s.dispatchTextLease(ctx, lease); err != nil {
-			return processed, errors.Join(err, s.releaseUntouched(ctx, leases[index+1:]))
+		var dispatchErr error
+		switch lease.Kind {
+		case sqlite.OutboxKindText:
+			dispatchErr = s.dispatchTextLease(ctx, lease)
+		case sqlite.OutboxKindMedia:
+			dispatchErr = s.dispatchMediaLease(ctx, lease)
+		default:
+			dispatchErr = s.releaseUnavailable(ctx, lease.OutboxItem, fmt.Errorf(
+				"message dispatcher does not handle outbox kind %q",
+				lease.Kind,
+			))
+		}
+		if dispatchErr != nil {
+			return processed, errors.Join(dispatchErr, s.releaseUntouched(ctx, leases[index+1:]))
 		}
 		processed++
 	}
@@ -95,13 +109,6 @@ func (s *MessageService) dispatchTextLease(ctx context.Context, outboxLease sqli
 	if item.LeaseToken == nil {
 		return fmt.Errorf("dispatch outbox item %q: storage returned no lease token", item.OutboxID)
 	}
-	if item.Kind != sqlite.OutboxKindText {
-		return s.releaseUnavailable(ctx, item, fmt.Errorf(
-			"text dispatcher does not handle outbox kind %q",
-			item.Kind,
-		))
-	}
-
 	dispatchLease, err := s.bridges.Acquire(ctx, item.AccountID, bridge.CapabilityTextSend)
 	if err != nil {
 		if releaseErr := s.releaseUnavailable(ctx, item, err); releaseErr != nil {
@@ -182,7 +189,182 @@ func (s *MessageService) dispatchTextLease(ctx context.Context, outboxLease sqli
 	mutationCtx, cancel := s.storageMutationContext(ctx)
 	defer cancel()
 	if sendErr != nil {
-		return s.recordSendError(mutationCtx, item, sendErr)
+		return s.recordSendError(mutationCtx, item, sendErr, textOperation)
+	}
+	if strings.TrimSpace(result.RemoteMessageID) == "" {
+		if err := s.outbox.MarkUncertain(
+			mutationCtx,
+			item.OutboxID,
+			*item.LeaseToken,
+			"unknown",
+			"missing_remote_message_id",
+			"transport returned success without a remote message ID",
+		); err != nil {
+			return fmt.Errorf("dispatch outbox item %q: record invalid transport result: %w", item.OutboxID, err)
+		}
+		s.signalChange()
+		return nil
+	}
+
+	confirmation := sqlite.Confirmation{
+		OutboxID:       item.OutboxID,
+		LeaseToken:     *item.LeaseToken,
+		ResultRemoteID: result.RemoteMessageID,
+	}
+	if err := s.outbox.Confirm(mutationCtx, confirmation); err != nil {
+		storeErr := s.outbox.MarkStoreFailed(
+			mutationCtx,
+			item.OutboxID,
+			*item.LeaseToken,
+			result.RemoteMessageID,
+			err.Error(),
+		)
+		if storeErr != nil {
+			return fmt.Errorf(
+				"dispatch outbox item %q: confirm: %w",
+				item.OutboxID,
+				errors.Join(err, storeErr),
+			)
+		}
+	}
+	s.signalChange()
+	return nil
+}
+
+func (s *MessageService) dispatchMediaLease(ctx context.Context, outboxLease sqlite.Lease) error {
+	item := outboxLease.OutboxItem
+	if item.LeaseToken == nil {
+		return fmt.Errorf("dispatch outbox item %q: storage returned no lease token", item.OutboxID)
+	}
+
+	dispatchLease, err := s.bridges.Acquire(ctx, item.AccountID, bridge.CapabilityMediaSend)
+	if err != nil {
+		if errors.Is(err, bridge.ErrCapabilityUnavailable) &&
+			!s.bridges.Capabilities(item.AccountID).MediaSend {
+			return s.rejectPreCall(
+				ctx,
+				item,
+				string(bridge.FailureUnsupported),
+				"media_send_unsupported",
+				err,
+			)
+		}
+		if releaseErr := s.releaseUnavailable(ctx, item, err); releaseErr != nil {
+			return releaseErr
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return nil
+	}
+	if dispatchLease == nil || dispatchLease.Media == nil {
+		if dispatchLease != nil {
+			dispatchLease.Close()
+		}
+		return s.releaseUnavailable(ctx, item, bridge.ErrCapabilityUnavailable)
+	}
+	defer dispatchLease.Close()
+
+	message, err := s.messageForLease(ctx, item)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_message",
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	conversation, err := s.store.GetConversation(item.ConversationID)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_conversation",
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	if conversation.AccountID != item.AccountID {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"cross_account_conversation",
+			fmt.Errorf("conversation %q belongs to account %q", item.ConversationID, conversation.AccountID),
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+
+	attachment, err := s.outbox.GetOutboxAttachment(ctx, item.OutboxID)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_media",
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	reader, err := s.blobs.Open(blob.BlobRef{Hash: attachment.BlobHash})
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return s.rejectPreCall(
+				ctx,
+				item,
+				string(bridge.FailureMisconfigured),
+				"blob_missing",
+				err,
+			)
+		}
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"open_blob",
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	defer reader.Close()
+
+	if err := s.outbox.MarkTransportCalled(ctx, sqlite.Attempt{
+		OutboxID:             item.OutboxID,
+		LeaseToken:           *item.LeaseToken,
+		AttemptToken:         item.OutboxID + ":" + *item.LeaseToken,
+		ConnectionGeneration: uint64(dispatchLease.Generation),
+		StartedAt:            s.clock.Now(),
+	}); err != nil {
+		if ctx.Err() != nil {
+			return errors.Join(ctx.Err(), s.releaseUnavailable(ctx, item, err))
+		}
+		return fmt.Errorf("dispatch outbox item %q: mark transport called: %w", item.OutboxID, err)
+	}
+	s.signalChange()
+
+	request := bridge.MediaRequest{
+		AccountID: item.AccountID,
+		Conversation: bridge.ConversationRef{
+			RemoteID: conversation.RemoteConversationID,
+		},
+		Reader:    reader,
+		Size:      attachment.SizeBytes,
+		Filename:  attachment.Filename,
+		MIME:      attachment.MIME,
+		Caption:   message.Body,
+		RequestID: item.TransportRequestID,
+	}
+	if message.ReplyToRemoteID != nil {
+		request.ReplyTo = &bridge.MessageRef{RemoteID: *message.ReplyToRemoteID}
+	}
+	result, sendErr := dispatchLease.Media.SendMedia(ctx, request)
+	mutationCtx, cancel := s.storageMutationContext(ctx)
+	defer cancel()
+	if sendErr != nil {
+		return s.recordSendError(mutationCtx, item, sendErr, mediaOperation)
 	}
 	if strings.TrimSpace(result.RemoteMessageID) == "" {
 		if err := s.outbox.MarkUncertain(
@@ -290,6 +472,31 @@ func (s *MessageService) markPreCallFailure(
 	return nil
 }
 
+func (s *MessageService) rejectPreCall(
+	ctx context.Context,
+	item sqlite.OutboxItem,
+	class, code string,
+	cause error,
+) error {
+	if item.LeaseToken == nil {
+		return fmt.Errorf("reject outbox item %q: lease token is missing", item.OutboxID)
+	}
+	mutationCtx, cancel := s.storageMutationContext(ctx)
+	defer cancel()
+	if err := s.outbox.Reject(
+		mutationCtx,
+		item.OutboxID,
+		*item.LeaseToken,
+		class,
+		code,
+		cause.Error(),
+	); err != nil {
+		return fmt.Errorf("reject outbox item %q: %w", item.OutboxID, err)
+	}
+	s.signalChange()
+	return nil
+}
+
 func (s *MessageService) releaseUntouched(ctx context.Context, leases []sqlite.Lease) error {
 	if len(leases) == 0 {
 		return nil
@@ -335,10 +542,11 @@ func (s *MessageService) recordSendError(
 	ctx context.Context,
 	item sqlite.OutboxItem,
 	sendErr error,
+	defaultCode string,
 ) error {
 	opErr, classified := asOpError(sendErr)
 	class := "unknown"
-	code := "send_text"
+	code := defaultCode
 	retryAt := s.clock.Now().Add(s.retryDelay)
 	if classified {
 		if opErr.Class != "" {

--- a/internal/messaging/dispatch_media_test.go
+++ b/internal/messaging/dispatch_media_test.go
@@ -1,0 +1,418 @@
+package messaging
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func TestQueuedMediaSurvivesRestartAndMapsRequest(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs := newDispatchTestBlobStore(t)
+	content := []byte("media payload after restart")
+
+	beforeRestart := newScriptedRegistry("media-before-restart", &scriptedTextSender{})
+	beforeRestart.setMediaSender(&scriptedMediaSender{})
+	first := newDispatchTestService(t, store, beforeRestart, blobs, clock)
+	parent := mustSendText(t, first, SendTextCommand{
+		CommonCommand: testCommonCommand("media-reply-parent"),
+		Body:          "reply parent",
+	})
+	parentRow := mustOutboxItem(t, first, parent.OutboxID)
+	if _, err := first.Cancel(context.Background(), parent.OutboxID); err != nil {
+		t.Fatalf("Cancel(parent) error = %v", err)
+	}
+	submission := mustSendDispatchMedia(t, first, SendMediaCommand{
+		CommonCommand:    testCommonCommand("media-restart"),
+		Content:          bytes.NewReader(content),
+		Filename:         "restart.bin",
+		MIME:             "application/x-restart-test",
+		Caption:          "surviving caption",
+		ReplyToMessageID: parent.LocalMessageID,
+	})
+
+	sender := &scriptedMediaSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-media-after-restart"},
+	}}}
+	afterRestart := newScriptedRegistry("media-after-restart", &scriptedTextSender{})
+	afterRestart.setMediaSender(sender)
+	afterRestart.setAvailable(true)
+	restarted := newDispatchTestService(t, store, afterRestart, blobs, clock)
+
+	if before := mustDelivery(t, restarted, submission.OutboxID); before.State != OutboxQueued ||
+		before.LocalMessageID != submission.LocalMessageID {
+		t.Fatalf("restarted delivery = %+v, want original queued IDs", before)
+	}
+	if processed, err := restarted.DispatchDue(context.Background(), 4); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(restarted media) = %d, %v; want 1, nil", processed, err)
+	}
+	if after := mustDelivery(t, restarted, submission.OutboxID); after.State != OutboxConfirmed ||
+		after.RemoteMessageID != "remote-media-after-restart" {
+		t.Fatalf("delivery after restart = %+v", after)
+	}
+
+	requests := sender.snapshotRequests()
+	if len(requests) != 1 {
+		t.Fatalf("media requests = %+v, want one", requests)
+	}
+	request := requests[0]
+	gotContent, err := io.ReadAll(request.Reader)
+	if err != nil {
+		t.Fatalf("read mapped media request: %v", err)
+	}
+	outboxRow := mustOutboxItem(t, restarted, submission.OutboxID)
+	if request.AccountID != "account-1" ||
+		request.Conversation.RemoteID != "remote-conversation" ||
+		!bytes.Equal(gotContent, content) ||
+		request.Size != int64(len(content)) ||
+		request.Filename != "restart.bin" ||
+		request.MIME != "application/x-restart-test" ||
+		request.Caption != "surviving caption" ||
+		request.ReplyTo == nil || request.ReplyTo.RemoteID != parentRow.TransportRequestID ||
+		request.RequestID != outboxRow.TransportRequestID {
+		t.Fatalf("mapped media request = %+v", request)
+	}
+}
+
+func TestDeclaredButUnwiredMediaReturnsToQueuedWithoutAttempt(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs := newDispatchTestBlobStore(t)
+	sender := &scriptedMediaSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-media-available"},
+	}}}
+	registry := newScriptedRegistry("media-unavailable", &scriptedTextSender{})
+	registry.setMediaSender(sender)
+	service := newDispatchTestService(t, store, registry, blobs, clock)
+	submission := mustSendDispatchMedia(t, service, SendMediaCommand{
+		CommonCommand: testCommonCommand("media-unavailable"),
+		Content:       bytes.NewReader([]byte("queued media")),
+		Filename:      "queued.bin",
+		MIME:          "application/octet-stream",
+	})
+	registry.setMediaSender(nil)
+	registry.setMediaSendDeclared(true)
+	registry.setAvailable(true)
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(unwired media) = %d, %v; want 1, nil", processed, err)
+	}
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	if row.State != sqlite.OutboxQueued || row.AttemptCount != 0 || row.NextAttemptAtMS != nil {
+		t.Fatalf("unwired media row = %+v, want queued/attempt=0/no next-attempt", row)
+	}
+	if got := sender.requestCount(); got != 0 {
+		t.Fatalf("unwired media send count = %d, want 0", got)
+	}
+}
+
+func TestUnavailableMediaAccountReturnsToQueuedWithoutAttempt(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs := newDispatchTestBlobStore(t)
+	sender := &scriptedMediaSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-media-available"},
+	}}}
+	registry := newScriptedRegistry("media-account-unavailable", &scriptedTextSender{})
+	registry.setMediaSender(sender)
+	service := newDispatchTestService(t, store, registry, blobs, clock)
+	submission := mustSendDispatchMedia(t, service, SendMediaCommand{
+		CommonCommand: testCommonCommand("media-account-unavailable"),
+		Content:       bytes.NewReader([]byte("queued while account unavailable")),
+		Filename:      "queued.bin",
+		MIME:          "application/octet-stream",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(unavailable media account) = %d, %v; want 1, nil", processed, err)
+	}
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	if row.State != sqlite.OutboxQueued || row.AttemptCount != 0 || row.NextAttemptAtMS != nil {
+		t.Fatalf("unavailable media account row = %+v, want queued/attempt=0/no next-attempt", row)
+	}
+	if got := sender.requestCount(); got != 0 {
+		t.Fatalf("unavailable media account send count = %d, want 0", got)
+	}
+}
+
+func TestMediaLeaseWithoutSenderReturnsToQueuedWithoutAttempt(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs := newDispatchTestBlobStore(t)
+	baseRegistry := newScriptedRegistry("media-nil-lease", &scriptedTextSender{})
+	baseRegistry.setMediaSendDeclared(true)
+	baseRegistry.setAvailable(true)
+	registry := nilMediaLeaseRegistry{scriptedRegistry: baseRegistry}
+	service := newDispatchTestService(t, store, registry, blobs, clock)
+	submission := mustSendDispatchMedia(t, service, SendMediaCommand{
+		CommonCommand: testCommonCommand("media-nil-lease"),
+		Content:       bytes.NewReader([]byte("nil media lease")),
+		Filename:      "nil-lease.bin",
+		MIME:          "application/octet-stream",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(nil media lease) = %d, %v; want 1, nil", processed, err)
+	}
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	if row.State != sqlite.OutboxQueued || row.AttemptCount != 0 || row.NextAttemptAtMS != nil {
+		t.Fatalf("nil media lease row = %+v, want queued/attempt=0/no next-attempt", row)
+	}
+}
+
+func TestUndeclaredMediaCapabilityIsRejected(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs := newDispatchTestBlobStore(t)
+	sender := &scriptedMediaSender{}
+	registry := newScriptedRegistry("media-undeclared", &scriptedTextSender{})
+	registry.setMediaSender(sender)
+	registry.setAvailable(true)
+	service := newDispatchTestService(t, store, registry, blobs, clock)
+	submission := mustSendDispatchMedia(t, service, SendMediaCommand{
+		CommonCommand: testCommonCommand("media-undeclared"),
+		Content:       bytes.NewReader([]byte("unsupported later")),
+		Filename:      "unsupported.bin",
+		MIME:          "application/octet-stream",
+	})
+	registry.setMediaSender(nil)
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(undeclared media) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	if delivery.State != OutboxRejected ||
+		delivery.ErrorClass != string(bridge.FailureUnsupported) ||
+		delivery.ErrorCode != "media_send_unsupported" {
+		t.Fatalf("undeclared media delivery = %+v, want rejected/unsupported", delivery)
+	}
+	if row := mustOutboxItem(t, service, submission.OutboxID); row.AttemptCount != 0 {
+		t.Fatalf("undeclared media attempt count = %d, want 0", row.AttemptCount)
+	}
+	if got := sender.requestCount(); got != 0 {
+		t.Fatalf("undeclared media send count = %d, want 0", got)
+	}
+}
+
+func TestMissingMediaBlobIsRejected(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs := newDispatchTestBlobStore(t)
+	sender := &scriptedMediaSender{}
+	registry := newScriptedRegistry("media-blob-missing", &scriptedTextSender{})
+	registry.setMediaSender(sender)
+	registry.setAvailable(true)
+	service := newDispatchTestService(t, store, registry, blobs, clock)
+	submission := mustSendDispatchMedia(t, service, SendMediaCommand{
+		CommonCommand: testCommonCommand("media-blob-missing"),
+		Content:       bytes.NewReader([]byte("delete me")),
+		Filename:      "missing.bin",
+		MIME:          "application/octet-stream",
+	})
+	attachment, err := service.outbox.GetOutboxAttachment(context.Background(), submission.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxAttachment() error = %v", err)
+	}
+	if err := blobs.Delete(blob.BlobRef{Hash: attachment.BlobHash}); err != nil {
+		t.Fatalf("Delete(blob) error = %v", err)
+	}
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(missing blob) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	if delivery.State != OutboxRejected ||
+		delivery.ErrorClass != string(bridge.FailureMisconfigured) ||
+		delivery.ErrorCode != "blob_missing" {
+		t.Fatalf("missing blob delivery = %+v, want rejected/misconfigured/blob_missing", delivery)
+	}
+	if got := sender.requestCount(); got != 0 {
+		t.Fatalf("missing blob media send count = %d, want 0", got)
+	}
+}
+
+func TestMediaSuccessWithoutRemoteMessageIDBecomesUncertain(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs := newDispatchTestBlobStore(t)
+	sender := &scriptedMediaSender{steps: []sendStep{{}}}
+	registry := newScriptedRegistry("media-missing-result", &scriptedTextSender{})
+	registry.setMediaSender(sender)
+	registry.setAvailable(true)
+	service := newDispatchTestService(t, store, registry, blobs, clock)
+	submission := mustSendDispatchMedia(t, service, SendMediaCommand{
+		CommonCommand: testCommonCommand("media-missing-result"),
+		Content:       bytes.NewReader([]byte("missing result")),
+		Filename:      "missing-result.bin",
+		MIME:          "application/octet-stream",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(missing media result) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	if delivery.State != OutboxUncertain || delivery.ErrorCode != "missing_remote_message_id" {
+		t.Fatalf("missing media result delivery = %+v, want uncertain", delivery)
+	}
+}
+
+func TestPostCallMediaTimeoutBecomesUncertainAndIsNotRedispatched(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs := newDispatchTestBlobStore(t)
+	sender := &scriptedMediaSender{steps: []sendStep{{err: bridge.OpError{
+		Class:    bridge.FailureTransient,
+		Dispatch: bridge.DispatchUncertain,
+		Cause:    context.DeadlineExceeded,
+	}}}}
+	registry := newScriptedRegistry("media-timeout", &scriptedTextSender{})
+	registry.setMediaSender(sender)
+	registry.setAvailable(true)
+	service := newDispatchTestService(t, store, registry, blobs, clock)
+	submission := mustSendDispatchMedia(t, service, SendMediaCommand{
+		CommonCommand: testCommonCommand("media-timeout"),
+		Content:       bytes.NewReader([]byte("ambiguous media")),
+		Filename:      "timeout.bin",
+		MIME:          "application/octet-stream",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(media timeout) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	if delivery.State != OutboxUncertain || delivery.ErrorCode != mediaOperation || delivery.Warning == "" {
+		t.Fatalf("media timeout delivery = %+v, want uncertain with %q code", delivery, mediaOperation)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 0 {
+		t.Fatalf("DispatchDue(after media timeout) = %d, %v; want 0, nil", processed, err)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("media timeout send count = %d, want 1", got)
+	}
+}
+
+func TestMediaRetryOpensFreshReader(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs := newDispatchTestBlobStore(t)
+	content := []byte("read from offset zero every time")
+	sender := &scriptedMediaSender{steps: []sendStep{
+		{err: bridge.OpError{
+			Class:     bridge.FailureTransient,
+			Operation: "prepare_media",
+			Dispatch:  bridge.DispatchNotCalled,
+			Cause:     errors.New("safe retry"),
+		}},
+		{result: bridge.SendResult{RemoteMessageID: "remote-media-retry"}},
+	}}
+	registry := newScriptedRegistry("media-reader-retry", &scriptedTextSender{})
+	registry.setMediaSender(sender)
+	registry.setAvailable(true)
+	service := newDispatchTestService(t, store, registry, blobs, clock)
+	submission := mustSendDispatchMedia(t, service, SendMediaCommand{
+		CommonCommand: testCommonCommand("media-reader-retry"),
+		Content:       bytes.NewReader(content),
+		Filename:      "retry.bin",
+		MIME:          "application/octet-stream",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(first media attempt) = %d, %v; want 1, nil", processed, err)
+	}
+	if first := mustDelivery(t, service, submission.OutboxID); first.State != OutboxNotDispatched {
+		t.Fatalf("first media delivery = %+v, want not_dispatched", first)
+	}
+	if _, err := service.RetryNotDispatched(context.Background(), submission.OutboxID); err != nil {
+		t.Fatalf("RetryNotDispatched(media) error = %v", err)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(second media attempt) = %d, %v; want 1, nil", processed, err)
+	}
+	if final := mustDelivery(t, service, submission.OutboxID); final.State != OutboxConfirmed {
+		t.Fatalf("final media delivery = %+v, want confirmed", final)
+	}
+
+	requests := sender.snapshotRequests()
+	var contents [][]byte
+	for index, request := range requests {
+		content, err := io.ReadAll(request.Reader)
+		if err != nil {
+			t.Fatalf("read media retry request %d: %v", index, err)
+		}
+		contents = append(contents, content)
+	}
+	if len(requests) != 2 ||
+		!bytes.Equal(contents[0], content) ||
+		!bytes.Equal(contents[1], content) ||
+		requests[0].RequestID == "" || requests[0].RequestID != requests[1].RequestID {
+		t.Fatalf("media retry requests = %+v, want two full reads with stable request ID", requests)
+	}
+}
+
+type nilMediaLeaseRegistry struct {
+	*scriptedRegistry
+}
+
+func (r nilMediaLeaseRegistry) Acquire(
+	ctx context.Context,
+	accountID string,
+	capability bridge.Capability,
+) (*bridge.DispatchLease, error) {
+	if capability != bridge.CapabilityMediaSend {
+		return r.scriptedRegistry.Acquire(ctx, accountID, capability)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &bridge.DispatchLease{
+		AccountID:  accountID,
+		Platform:   "media-nil-lease",
+		Generation: 7,
+		Ctx:        ctx,
+	}, nil
+}
+
+func newDispatchTestBlobStore(t *testing.T) *blob.BlobStore {
+	t.Helper()
+	blobs, err := blob.New(filepath.Join(t.TempDir(), "blobs"))
+	if err != nil {
+		t.Fatalf("blob.New(): %v", err)
+	}
+	return blobs
+}
+
+func newDispatchTestService(
+	t *testing.T,
+	store *sqlite.Store,
+	registry bridge.Registry,
+	blobs *blob.BlobStore,
+	clock Clock,
+) *MessageService {
+	t.Helper()
+	service, err := NewMessageService(store, registry, blobs, clock, &sequentialIDs{})
+	if err != nil {
+		t.Fatalf("NewMessageService(): %v", err)
+	}
+	return service
+}
+
+func mustSendDispatchMedia(
+	t *testing.T,
+	service *MessageService,
+	command SendMediaCommand,
+) Submission {
+	t.Helper()
+	submission, err := service.SendMedia(context.Background(), command)
+	if err != nil {
+		t.Fatalf("SendMedia(): %v", err)
+	}
+	return submission
+}

--- a/internal/messaging/service.go
+++ b/internal/messaging/service.go
@@ -12,11 +12,16 @@ import (
 	"time"
 
 	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 )
 
+// DefaultMaxMediaBytes is the default hard cap for one outgoing attachment.
+const DefaultMaxMediaBytes int64 = 128 << 20
+
 const (
 	textOperation       = "send_text"
+	mediaOperation      = "send_media"
 	defaultLeaseTime    = 30 * time.Second
 	defaultFinalizeTime = 5 * time.Second
 	defaultRetryDelay   = 5 * time.Second
@@ -25,20 +30,22 @@ const (
 	workerOwner         = "message-service"
 )
 
-// MessageService owns text intent submission and durable dispatch. Concrete
+// MessageService owns message intent submission and durable dispatch. Concrete
 // platform selection remains behind bridge.Registry.
 type MessageService struct {
 	store    *sqlite.Store
 	outbox   *sqlite.OutboxRepository
 	messages messageRepository
 	bridges  bridge.Registry
+	blobs    *blob.BlobStore
 	clock    Clock
 	ids      IDSource
 
-	leaseTime  time.Duration
-	retryDelay time.Duration
-	pollDelay  time.Duration
-	batchLimit int
+	leaseTime     time.Duration
+	retryDelay    time.Duration
+	pollDelay     time.Duration
+	maxMediaBytes int64
+	batchLimit    int
 
 	wake chan struct{}
 
@@ -46,11 +53,12 @@ type MessageService struct {
 	changed  chan struct{}
 }
 
-// NewMessageService constructs the text service over an existing SQLite
+// NewMessageService constructs the message service over an existing SQLite
 // store. The caller retains ownership of the store and registry.
 func NewMessageService(
 	store *sqlite.Store,
 	bridges bridge.Registry,
+	blobs *blob.BlobStore,
 	clock Clock,
 	ids IDSource,
 ) (*MessageService, error) {
@@ -75,18 +83,20 @@ func NewMessageService(
 		return nil, fmt.Errorf("create message service messages: %w", err)
 	}
 	return &MessageService{
-		store:      store,
-		outbox:     outbox,
-		messages:   messages,
-		bridges:    bridges,
-		clock:      clock,
-		ids:        ids,
-		leaseTime:  defaultLeaseTime,
-		retryDelay: defaultRetryDelay,
-		pollDelay:  defaultPollDelay,
-		batchLimit: defaultBatchLimit,
-		wake:       make(chan struct{}, 1),
-		changed:    make(chan struct{}),
+		store:         store,
+		outbox:        outbox,
+		messages:      messages,
+		bridges:       bridges,
+		blobs:         blobs,
+		clock:         clock,
+		ids:           ids,
+		leaseTime:     defaultLeaseTime,
+		retryDelay:    defaultRetryDelay,
+		pollDelay:     defaultPollDelay,
+		maxMediaBytes: DefaultMaxMediaBytes,
+		batchLimit:    defaultBatchLimit,
+		wake:          make(chan struct{}, 1),
+		changed:       make(chan struct{}),
 	}, nil
 }
 
@@ -173,6 +183,137 @@ func (s *MessageService) SendText(
 	})
 	if err != nil {
 		return Submission{}, fmt.Errorf("send text: %w", err)
+	}
+
+	submission := submissionFromItem(item)
+	if disposition == sqlite.EnqueueInserted {
+		s.signalChange()
+		s.signalWake()
+	}
+	return submission, nil
+}
+
+// SendMedia stores an attachment before atomically creating its optimistic
+// outgoing message, durable outbox intent, and blob metadata reference.
+func (s *MessageService) SendMedia(
+	ctx context.Context,
+	cmd SendMediaCommand,
+) (Submission, error) {
+	if ctx == nil {
+		return Submission{}, fmt.Errorf("send media: context is nil")
+	}
+	if err := validateSendMediaCommand(&cmd); err != nil {
+		return Submission{}, err
+	}
+	if !s.bridges.Capabilities(cmd.AccountID).MediaSend {
+		return Submission{}, ErrUnsupported
+	}
+
+	conversation, err := s.store.GetConversation(cmd.ConversationID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("send media: read conversation: %w", err)
+	}
+	if conversation.AccountID != cmd.AccountID {
+		return Submission{}, fmt.Errorf(
+			"%w: conversation %q belongs to account %q, not %q",
+			ErrInvalidCommand,
+			cmd.ConversationID,
+			conversation.AccountID,
+			cmd.AccountID,
+		)
+	}
+
+	var replyToRemoteID *string
+	if cmd.ReplyToMessageID != "" {
+		reply, err := s.messages.GetMessage(ctx, cmd.ReplyToMessageID)
+		if err != nil {
+			return Submission{}, fmt.Errorf("send media: read reply target: %w", err)
+		}
+		if reply.AccountID != cmd.AccountID || reply.ConversationID != cmd.ConversationID {
+			return Submission{}, fmt.Errorf(
+				"%w: reply target %q is outside conversation %q",
+				ErrInvalidCommand,
+				cmd.ReplyToMessageID,
+				cmd.ConversationID,
+			)
+		}
+		replyToRemoteID = &reply.RemoteMessageID
+	}
+
+	if s.blobs == nil {
+		return Submission{}, fmt.Errorf("send media: blob store is not configured")
+	}
+	ref, err := s.blobs.Put(ctx, cmd.Content, cmd.MIME, s.maxMediaBytes)
+	if err != nil {
+		var tooLarge *blob.ErrTooLarge
+		if errors.As(err, &tooLarge) {
+			return Submission{}, fmt.Errorf(
+				"%w: attachment too large (limit %d MB)",
+				ErrInvalidCommand,
+				tooLarge.Max/(1<<20),
+			)
+		}
+		return Submission{}, fmt.Errorf("send media: store blob: %w", err)
+	}
+	if ref.Size == 0 {
+		// Rejecting after Put is intentional: Content is a stream, so emptiness is
+		// only known once read. The residue is a single constant zero-byte blob
+		// (the empty-content hash) with no durable outbox/message row referencing
+		// it — content-addressed, so all empty attempts converge on that one file,
+		// and it is swept by the unreferenced-blob GC.
+		return Submission{}, fmt.Errorf("%w: attachment is empty", ErrInvalidCommand)
+	}
+
+	outboxID, localMessageID, requestID, err := s.newSubmissionIDs()
+	if err != nil {
+		return Submission{}, err
+	}
+	now := s.clock.Now()
+	scheduledFor := cmd.NotBefore
+	if scheduledFor.IsZero() {
+		scheduledFor = now
+	}
+	payloadHash, err := mediaPayloadHash(
+		ref.Hash,
+		ref.Size,
+		cmd.MIME,
+		cmd.Filename,
+		cmd.Caption,
+		cmd.ReplyToMessageID,
+	)
+	if err != nil {
+		return Submission{}, fmt.Errorf("send media: hash payload: %w", err)
+	}
+
+	item, disposition, err := s.outbox.EnqueueOutgoingMediaMessage(ctx, sqlite.NewOutboxItem{
+		OutboxID:           outboxID,
+		AccountID:          cmd.AccountID,
+		ConversationID:     cmd.ConversationID,
+		Kind:               sqlite.OutboxKindMedia,
+		IdempotencyKey:     cmd.IdempotencyKey,
+		PayloadHash:        payloadHash,
+		Operation:          mediaOperation,
+		LocalMessageID:     localMessageID,
+		TransportRequestID: requestID,
+		ScheduledFor:       scheduledFor,
+	}, sqlite.Message{
+		MessageID:       localMessageID,
+		ConversationID:  cmd.ConversationID,
+		AccountID:       cmd.AccountID,
+		RemoteMessageID: requestID,
+		Direction:       sqlite.MessageDirectionOutgoing,
+		Body:            cmd.Caption,
+		ReplyToRemoteID: replyToRemoteID,
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    now.UnixMilli(),
+	}, sqlite.OutboxAttachment{
+		BlobHash:  ref.Hash,
+		SizeBytes: ref.Size,
+		MIME:      cmd.MIME,
+		Filename:  cmd.Filename,
+	})
+	if err != nil {
+		return Submission{}, fmt.Errorf("send media: %w", err)
 	}
 
 	submission := submissionFromItem(item)
@@ -295,10 +436,10 @@ func (s *MessageService) newSubmissionIDs() (string, string, string, error) {
 	for i := range values {
 		value, err := s.ids.NewID()
 		if err != nil {
-			return "", "", "", fmt.Errorf("send text: generate durable ID: %w", err)
+			return "", "", "", fmt.Errorf("send message: generate durable ID: %w", err)
 		}
 		if strings.TrimSpace(value) == "" {
-			return "", "", "", fmt.Errorf("send text: ID source returned an empty ID")
+			return "", "", "", fmt.Errorf("send message: ID source returned an empty ID")
 		}
 		values[i] = value
 	}
@@ -326,11 +467,71 @@ func validateSendTextCommand(cmd SendTextCommand) error {
 	return nil
 }
 
+func validateSendMediaCommand(cmd *SendMediaCommand) error {
+	if cmd == nil {
+		return fmt.Errorf("%w: media command is nil", ErrInvalidCommand)
+	}
+	checks := []struct {
+		name  string
+		value string
+	}{
+		{name: "account ID", value: cmd.AccountID},
+		{name: "conversation ID", value: cmd.ConversationID},
+		{name: "idempotency key", value: cmd.IdempotencyKey},
+	}
+	for _, check := range checks {
+		if strings.TrimSpace(check.value) == "" {
+			return fmt.Errorf("%w: %s is empty", ErrInvalidCommand, check.name)
+		}
+	}
+	if cmd.Content == nil {
+		return fmt.Errorf("%w: content is nil", ErrInvalidCommand)
+	}
+	cmd.MIME = strings.TrimSpace(cmd.MIME)
+	if cmd.MIME == "" {
+		cmd.MIME = "application/octet-stream"
+	}
+	cmd.Filename = strings.TrimSpace(cmd.Filename)
+	if len(cmd.Filename) > 512 {
+		return fmt.Errorf("%w: filename exceeds 512 bytes", ErrInvalidCommand)
+	}
+	if strings.ContainsRune(cmd.Filename, '\x00') {
+		return fmt.Errorf("%w: filename contains NUL", ErrInvalidCommand)
+	}
+	if !cmd.NotBefore.IsZero() && cmd.NotBefore.UnixMilli() <= 0 {
+		return fmt.Errorf("%w: scheduled Unix time is not positive", ErrInvalidCommand)
+	}
+	return nil
+}
+
 func textPayloadHash(body, replyToMessageID string) (string, error) {
 	payload, err := json.Marshal(struct {
 		Body             string `json:"body"`
 		ReplyToMessageID string `json:"reply_to_message_id,omitempty"`
 	}{Body: body, ReplyToMessageID: replyToMessageID})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func mediaPayloadHash(
+	blobHash string,
+	size int64,
+	mime string,
+	filename string,
+	caption string,
+	replyToMessageID string,
+) (string, error) {
+	payload, err := json.Marshal(struct {
+		BlobHash         string `json:"blob_hash"`
+		Size             int64  `json:"size"`
+		MIME             string `json:"mime"`
+		Filename         string `json:"filename"`
+		Caption          string `json:"caption,omitempty"`
+		ReplyToMessageID string `json:"reply_to_message_id,omitempty"`
+	}{blobHash, size, mime, filename, caption, replyToMessageID})
 	if err != nil {
 		return "", err
 	}

--- a/internal/messaging/service_test.go
+++ b/internal/messaging/service_test.go
@@ -1,15 +1,20 @@
 package messaging
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 )
 
@@ -361,6 +366,291 @@ func TestDuplicateSendTextReturnsSameSubmissionAndDispatchesOnce(t *testing.T) {
 	}
 }
 
+func TestSendMediaWritesBlobAndDurableRows(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs, blobRoot := newMessagingTestBlobStore(t)
+	registry := newScriptedRegistry("media-platform", nil)
+	registry.setMediaSender(&scriptedMediaSender{})
+	service := newMessagingTestServiceWithBlobs(t, store, registry, blobs, clock)
+	content := []byte("durable media content")
+
+	submission := mustSendMedia(t, service, SendMediaCommand{
+		CommonCommand: testCommonCommand("key-media-happy"),
+		Content:       bytes.NewReader(content),
+		Filename:      "  photo.test  ",
+		MIME:          "  application/x-openmessage-test  ",
+		Caption:       "a durable caption",
+	})
+
+	item := mustOutboxItem(t, service, submission.OutboxID)
+	if item.Kind != sqlite.OutboxKindMedia || item.Operation != mediaOperation ||
+		item.LocalMessageID == nil || *item.LocalMessageID != submission.LocalMessageID {
+		t.Fatalf("media outbox item = %+v", item)
+	}
+	message, err := service.messages.GetMessage(context.Background(), submission.LocalMessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(): %v", err)
+	}
+	if message.Body != "a durable caption" || message.Direction != sqlite.MessageDirectionOutgoing ||
+		message.RemoteMessageID != item.TransportRequestID || message.ReplyToRemoteID != nil {
+		t.Fatalf("optimistic media message = %+v", message)
+	}
+	attachment, err := service.outbox.GetOutboxAttachment(context.Background(), submission.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxAttachment(): %v", err)
+	}
+	wantHash := fmt.Sprintf("%x", sha256.Sum256(content))
+	if attachment.OutboxID != submission.OutboxID || attachment.Ordinal != 0 ||
+		attachment.BlobHash != wantHash || attachment.SizeBytes != int64(len(content)) ||
+		attachment.MIME != "application/x-openmessage-test" || attachment.Filename != "photo.test" {
+		t.Fatalf("outbox attachment = %+v", attachment)
+	}
+	reader, err := blobs.Open(blob.BlobRef{Hash: attachment.BlobHash})
+	if err != nil {
+		t.Fatalf("Open(blob): %v", err)
+	}
+	gotContent, readErr := io.ReadAll(reader)
+	closeErr := reader.Close()
+	if readErr != nil || closeErr != nil {
+		t.Fatalf("read blob = %v, close = %v", readErr, closeErr)
+	}
+	if !bytes.Equal(gotContent, content) {
+		t.Fatalf("blob content = %q, want %q", gotContent, content)
+	}
+	if files := messagingBlobFiles(t, blobRoot); len(files) != 1 {
+		t.Fatalf("blob files = %v, want one", files)
+	}
+}
+
+func TestDuplicateSendMediaReturnsSameSubmissionAndOneDurableSet(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs, blobRoot := newMessagingTestBlobStore(t)
+	registry := newScriptedRegistry("media-deduplicate", nil)
+	registry.setMediaSender(&scriptedMediaSender{})
+	service := newMessagingTestServiceWithBlobs(t, store, registry, blobs, clock)
+	content := []byte("deduplicate this attachment")
+	command := func(mime, filename string) SendMediaCommand {
+		return SendMediaCommand{
+			CommonCommand: testCommonCommand("key-media-same"),
+			Content:       bytes.NewReader(content),
+			Filename:      filename,
+			MIME:          mime,
+			Caption:       "same caption",
+		}
+	}
+
+	first := mustSendMedia(t, service, command(" image/test ", " image.bin "))
+	second := mustSendMedia(t, service, command("image/test", "image.bin"))
+	if first != second {
+		t.Fatalf("duplicate media submissions differ: first=%+v second=%+v", first, second)
+	}
+	if files := messagingBlobFiles(t, blobRoot); len(files) != 1 {
+		t.Fatalf("duplicate media left blob files %v, want one", files)
+	}
+	if _, err := service.outbox.FindByID(context.Background(), "id-004"); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("duplicate candidate outbox error = %v, want ErrNotFound", err)
+	}
+	if _, err := service.messages.GetMessage(context.Background(), "id-005"); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("duplicate candidate message error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSendMediaIdempotencyConflictCoversCaptionAndFilename(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*SendMediaCommand)
+	}{
+		{name: "caption", mutate: func(cmd *SendMediaCommand) { cmd.Caption = "changed caption" }},
+		{name: "filename", mutate: func(cmd *SendMediaCommand) { cmd.Filename = "changed.bin" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := newManualClock(messagingTestTime)
+			store := openMessagingTestStore(t, clock.Now())
+			blobs, _ := newMessagingTestBlobStore(t)
+			registry := newScriptedRegistry("media-conflict", nil)
+			registry.setMediaSender(&scriptedMediaSender{})
+			service := newMessagingTestServiceWithBlobs(t, store, registry, blobs, clock)
+			content := []byte("same content")
+			command := SendMediaCommand{
+				CommonCommand: testCommonCommand("key-media-conflict"),
+				Content:       bytes.NewReader(content),
+				Filename:      "original.bin",
+				MIME:          "application/test",
+				Caption:       "original caption",
+			}
+			mustSendMedia(t, service, command)
+
+			test.mutate(&command)
+			command.Content = bytes.NewReader(content)
+			if _, err := service.SendMedia(context.Background(), command); !errors.Is(err, ErrIdempotencyConflict) {
+				t.Fatalf("SendMedia(changed %s) error = %v, want ErrIdempotencyConflict", test.name, err)
+			}
+		})
+	}
+}
+
+func TestSendMediaRejectsTooLargeAndEmptyContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		max     int64
+	}{
+		{name: "too large", content: []byte("12345"), max: 4},
+		{name: "empty", content: nil, max: 4},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := newManualClock(messagingTestTime)
+			store := openMessagingTestStore(t, clock.Now())
+			blobs, blobRoot := newMessagingTestBlobStore(t)
+			registry := newScriptedRegistry("media-size", nil)
+			registry.setMediaSender(&scriptedMediaSender{})
+			service := newMessagingTestServiceWithBlobs(t, store, registry, blobs, clock)
+			service.maxMediaBytes = test.max
+
+			_, err := service.SendMedia(context.Background(), SendMediaCommand{
+				CommonCommand: testCommonCommand("key-media-size"),
+				Content:       bytes.NewReader(test.content),
+				MIME:          "application/test",
+			})
+			if !errors.Is(err, ErrInvalidCommand) {
+				t.Fatalf("SendMedia() error = %v, want ErrInvalidCommand", err)
+			}
+			if _, err := service.outbox.FindByID(context.Background(), "id-001"); !errors.Is(err, sqlite.ErrNotFound) {
+				t.Fatalf("invalid media outbox error = %v, want ErrNotFound", err)
+			}
+			if test.name == "too large" {
+				if files := messagingBlobFiles(t, blobRoot); len(files) != 0 {
+					t.Fatalf("oversize media left blob files: %v", files)
+				}
+			}
+		})
+	}
+}
+
+func TestSendMediaCapabilityGatePrecedesBlobAndConversationWork(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs, blobRoot := newMessagingTestBlobStore(t)
+	service := newMessagingTestServiceWithBlobs(
+		t,
+		store,
+		newScriptedRegistry("media-unsupported", nil),
+		blobs,
+		clock,
+	)
+	content := []byte("must not be consumed")
+	reader := bytes.NewReader(content)
+	command := SendMediaCommand{
+		CommonCommand: CommonCommand{
+			AccountID:      "account-1",
+			ConversationID: "missing-conversation",
+			IdempotencyKey: "key-media-unsupported",
+		},
+		Content: reader,
+		MIME:    "application/test",
+	}
+
+	if _, err := service.SendMedia(context.Background(), command); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("SendMedia(unsupported) error = %v, want ErrUnsupported", err)
+	}
+	if reader.Len() != len(content) {
+		t.Fatalf("unsupported SendMedia consumed %d bytes, want 0", len(content)-reader.Len())
+	}
+	if files := messagingBlobFiles(t, blobRoot); len(files) != 0 {
+		t.Fatalf("unsupported SendMedia left blob files: %v", files)
+	}
+	if _, err := service.outbox.FindByID(context.Background(), "id-001"); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("unsupported media outbox error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSendMediaDefaultsMIMEAndAllowsEmptyCaption(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	blobs, _ := newMessagingTestBlobStore(t)
+	registry := newScriptedRegistry("media-defaults", nil)
+	registry.setMediaSender(&scriptedMediaSender{})
+	service := newMessagingTestServiceWithBlobs(t, store, registry, blobs, clock)
+
+	submission := mustSendMedia(t, service, SendMediaCommand{
+		CommonCommand: testCommonCommand("key-media-defaults"),
+		Content:       bytes.NewReader([]byte("content")),
+		Filename:      "  no-caption.bin  ",
+		MIME:          " \t ",
+	})
+	attachment, err := service.outbox.GetOutboxAttachment(context.Background(), submission.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxAttachment(): %v", err)
+	}
+	if attachment.MIME != "application/octet-stream" || attachment.Filename != "no-caption.bin" {
+		t.Fatalf("normalized attachment = %+v", attachment)
+	}
+	message, err := service.messages.GetMessage(context.Background(), submission.LocalMessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(): %v", err)
+	}
+	if message.Body != "" {
+		t.Fatalf("empty caption body = %q, want empty", message.Body)
+	}
+}
+
+func TestSendMediaValidatesContentAndFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  io.Reader
+		filename string
+	}{
+		{name: "nil content", content: nil},
+		{name: "filename too long", content: bytes.NewReader([]byte("x")), filename: strings.Repeat("x", 513)},
+		{name: "filename contains NUL", content: bytes.NewReader([]byte("x")), filename: "bad\x00name"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := newManualClock(messagingTestTime)
+			store := openMessagingTestStore(t, clock.Now())
+			blobs, blobRoot := newMessagingTestBlobStore(t)
+			registry := newScriptedRegistry("media-validation", nil)
+			registry.setMediaSender(&scriptedMediaSender{})
+			service := newMessagingTestServiceWithBlobs(t, store, registry, blobs, clock)
+
+			_, err := service.SendMedia(context.Background(), SendMediaCommand{
+				CommonCommand: testCommonCommand("key-media-validation"),
+				Content:       test.content,
+				Filename:      test.filename,
+			})
+			if !errors.Is(err, ErrInvalidCommand) {
+				t.Fatalf("SendMedia() error = %v, want ErrInvalidCommand", err)
+			}
+			if files := messagingBlobFiles(t, blobRoot); len(files) != 0 {
+				t.Fatalf("invalid command left blob files: %v", files)
+			}
+		})
+	}
+}
+
+func TestSendMediaWithoutBlobStoreReturnsConfigurationError(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	registry := newScriptedRegistry("media-no-blob-store", nil)
+	registry.setMediaSender(&scriptedMediaSender{})
+	service, err := NewMessageService(store, registry, nil, clock, &sequentialIDs{})
+	if err != nil {
+		t.Fatalf("NewMessageService(nil blobs): %v", err)
+	}
+
+	_, err = service.SendMedia(context.Background(), SendMediaCommand{
+		CommonCommand: testCommonCommand("key-media-no-blob-store"),
+		Content:       bytes.NewReader([]byte("content")),
+	})
+	if err == nil || !strings.Contains(err.Error(), "blob store is not configured") {
+		t.Fatalf("SendMedia(nil blobs) error = %v, want configuration error", err)
+	}
+}
+
 func TestCancelAndDeferredAPIs(t *testing.T) {
 	clock := newManualClock(messagingTestTime)
 	store := openMessagingTestStore(t, clock.Now())
@@ -443,11 +733,57 @@ func (s *scriptedTextSender) snapshotRequests() []bridge.TextRequest {
 	return append([]bridge.TextRequest(nil), s.requests...)
 }
 
+type scriptedMediaSender struct {
+	mu       sync.Mutex
+	steps    []sendStep
+	requests []bridge.MediaRequest
+	onSend   func()
+}
+
+func (s *scriptedMediaSender) SendMedia(
+	_ context.Context,
+	request bridge.MediaRequest,
+) (bridge.SendResult, error) {
+	content, readErr := io.ReadAll(request.Reader)
+	request.Reader = bytes.NewReader(content)
+
+	s.mu.Lock()
+	s.requests = append(s.requests, request)
+	var step sendStep
+	if len(s.steps) > 0 {
+		step = s.steps[0]
+		s.steps = s.steps[1:]
+	}
+	onSend := s.onSend
+	s.mu.Unlock()
+	if onSend != nil {
+		onSend()
+	}
+	if readErr != nil {
+		return bridge.SendResult{}, readErr
+	}
+	return step.result, step.err
+}
+
+func (s *scriptedMediaSender) requestCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.requests)
+}
+
+func (s *scriptedMediaSender) snapshotRequests() []bridge.MediaRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]bridge.MediaRequest(nil), s.requests...)
+}
+
 type scriptedRegistry struct {
-	mu        sync.Mutex
-	platform  bridge.Platform
-	sender    bridge.TextSender
-	available bool
+	mu                sync.Mutex
+	platform          bridge.Platform
+	sender            bridge.TextSender
+	media             bridge.MediaSender
+	mediaSendDeclared bool
+	available         bool
 }
 
 func newScriptedRegistry(platform bridge.Platform, sender bridge.TextSender) *scriptedRegistry {
@@ -457,6 +793,19 @@ func newScriptedRegistry(platform bridge.Platform, sender bridge.TextSender) *sc
 func (r *scriptedRegistry) setAvailable(available bool) {
 	r.mu.Lock()
 	r.available = available
+	r.mu.Unlock()
+}
+
+func (r *scriptedRegistry) setMediaSender(sender bridge.MediaSender) {
+	r.mu.Lock()
+	r.media = sender
+	r.mediaSendDeclared = sender != nil
+	r.mu.Unlock()
+}
+
+func (r *scriptedRegistry) setMediaSendDeclared(declared bool) {
+	r.mu.Lock()
+	r.mediaSendDeclared = declared
 	r.mu.Unlock()
 }
 
@@ -486,22 +835,36 @@ func (r *scriptedRegistry) Acquire(
 	if accountID != "account-1" || !r.available {
 		return nil, fmt.Errorf("%w: %s", bridge.ErrAccountNotRegistered, accountID)
 	}
-	if capability != bridge.CapabilityTextSend || r.sender == nil {
-		return nil, bridge.ErrCapabilityUnavailable
-	}
-	return &bridge.DispatchLease{
+	lease := &bridge.DispatchLease{
 		AccountID:  accountID,
 		Platform:   r.platform,
 		Generation: 7,
 		Ctx:        ctx,
-		Text:       r.sender,
-	}, nil
+	}
+	switch capability {
+	case bridge.CapabilityTextSend:
+		if r.sender == nil {
+			return nil, bridge.ErrCapabilityUnavailable
+		}
+		lease.Text = r.sender
+	case bridge.CapabilityMediaSend:
+		if r.media == nil {
+			return nil, bridge.ErrCapabilityUnavailable
+		}
+		lease.Media = r.media
+	default:
+		return nil, bridge.ErrCapabilityUnavailable
+	}
+	return lease, nil
 }
 
 func (r *scriptedRegistry) Capabilities(accountID string) bridge.CapabilitySet {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return bridge.CapabilitySet{TextSend: accountID == "account-1" && r.sender != nil}
+	return bridge.CapabilitySet{
+		TextSend:  accountID == "account-1" && r.sender != nil,
+		MediaSend: accountID == "account-1" && r.mediaSendDeclared,
+	}
 }
 
 type sequentialIDs struct {
@@ -546,11 +909,42 @@ func newMessagingTestService(
 	clock Clock,
 ) *MessageService {
 	t.Helper()
-	service, err := NewMessageService(store, registry, clock, &sequentialIDs{})
+	blobs, _ := newMessagingTestBlobStore(t)
+	return newMessagingTestServiceWithBlobs(t, store, registry, blobs, clock)
+}
+
+func newMessagingTestServiceWithBlobs(
+	t *testing.T,
+	store *sqlite.Store,
+	registry bridge.Registry,
+	blobs *blob.BlobStore,
+	clock Clock,
+) *MessageService {
+	t.Helper()
+	service, err := NewMessageService(store, registry, blobs, clock, &sequentialIDs{})
 	if err != nil {
 		t.Fatalf("NewMessageService(): %v", err)
 	}
 	return service
+}
+
+func newMessagingTestBlobStore(t *testing.T) (*blob.BlobStore, string) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "blobs")
+	store, err := blob.New(root)
+	if err != nil {
+		t.Fatalf("blob.New(): %v", err)
+	}
+	return store, root
+}
+
+func messagingBlobFiles(t *testing.T, root string) []string {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join(root, "*", "*"))
+	if err != nil {
+		t.Fatalf("Glob(blob files): %v", err)
+	}
+	return files
 }
 
 func openMessagingTestStore(t *testing.T, now time.Time) *sqlite.Store {
@@ -607,6 +1001,15 @@ func mustSendText(t *testing.T, service *MessageService, command SendTextCommand
 	submission, err := service.SendText(context.Background(), command)
 	if err != nil {
 		t.Fatalf("SendText(): %v", err)
+	}
+	return submission
+}
+
+func mustSendMedia(t *testing.T, service *MessageService, command SendMediaCommand) Submission {
+	t.Helper()
+	submission, err := service.SendMedia(context.Background(), command)
+	if err != nil {
+		t.Fatalf("SendMedia(): %v", err)
 	}
 	return submission
 }

--- a/internal/messaging/types.go
+++ b/internal/messaging/types.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
@@ -38,6 +39,10 @@ var (
 	// the intent's current state.
 	ErrInvalidState = errors.New("messaging: invalid outbox state")
 
+	// ErrUnsupported means the account bridge does not support the requested
+	// messaging operation.
+	ErrUnsupported = errors.New("messaging: operation unsupported by account bridge")
+
 	// ErrNotImplemented marks API seams reserved for later rebuild items.
 	ErrNotImplemented = errors.New("messaging: not implemented")
 )
@@ -52,6 +57,15 @@ type CommonCommand struct {
 type SendTextCommand struct {
 	CommonCommand
 	Body             string
+	ReplyToMessageID string
+}
+
+type SendMediaCommand struct {
+	CommonCommand
+	Content          io.Reader
+	Filename         string
+	MIME             string
+	Caption          string
 	ReplyToMessageID string
 }
 

--- a/internal/storage/sqlite/attachments.go
+++ b/internal/storage/sqlite/attachments.go
@@ -145,8 +145,13 @@ func (r *AttachmentRepository) ListUnreferencedBlobHashes(
 		}
 
 		rows, err := r.store.db.QueryContext(ctx, `
-			SELECT DISTINCT blob_hash
-			FROM attachments
+			WITH referenced (blob_hash) AS (
+				SELECT blob_hash FROM attachments
+				UNION
+				SELECT blob_hash FROM outbox_attachments
+			)
+			SELECT blob_hash
+			FROM referenced
 			WHERE blob_hash IN (`+placeholders+`)
 		`, arguments...)
 		if err != nil {

--- a/internal/storage/sqlite/attachments_test.go
+++ b/internal/storage/sqlite/attachments_test.go
@@ -90,6 +90,45 @@ func TestAttachmentRepositoryListsUnreferencedCandidates(t *testing.T) {
 	}
 }
 
+func TestAttachmentRepositoryTreatsQueuedOutboxBlobAsReferenced(t *testing.T) {
+	store, repository := openAttachmentTestRepository(t)
+	seedMessageAccount(t, store, "account-a", "test")
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	outbox, err := NewOutboxRepository(
+		store,
+		func() time.Time { return time.UnixMilli(attachmentTestTimeMS) },
+	)
+	if err != nil {
+		t.Fatalf("NewOutboxRepository(): %v", err)
+	}
+
+	queuedHash := strings.Repeat("4d", 32)
+	unreferencedHash := strings.Repeat("5e", 32)
+	item := outboxTestMediaItem("gc-reference")
+	attachment := outboxTestAttachment()
+	attachment.BlobHash = queuedHash
+	if _, _, err := outbox.EnqueueOutgoingMediaMessage(
+		context.Background(),
+		item,
+		outboxTestOutgoingMessage(item, "caption"),
+		attachment,
+	); err != nil {
+		t.Fatalf("EnqueueOutgoingMediaMessage(): %v", err)
+	}
+
+	got, err := repository.ListUnreferencedBlobHashes(
+		context.Background(),
+		[]string{queuedHash, unreferencedHash},
+	)
+	if err != nil {
+		t.Fatalf("ListUnreferencedBlobHashes(): %v", err)
+	}
+	if want := []string{unreferencedHash}; !slices.Equal(got, want) {
+		t.Fatalf("ListUnreferencedBlobHashes() = %v, want %v", got, want)
+	}
+}
+
 func TestAttachmentRepositoryMissingRowPreservesSentinel(t *testing.T) {
 	_, repository := openAttachmentTestRepository(t)
 
@@ -233,8 +272,8 @@ func openAttachmentTestRepository(t *testing.T) (*Store, *AttachmentRepository) 
 		}
 	})
 
-	if len(embeddedMigrations) != 5 {
-		t.Fatalf("embedded migrations = %d, want 5", len(embeddedMigrations))
+	if len(embeddedMigrations) != 6 {
+		t.Fatalf("embedded migrations = %d, want 6", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 3)

--- a/internal/storage/sqlite/identity_graph_test.go
+++ b/internal/storage/sqlite/identity_graph_test.go
@@ -162,8 +162,8 @@ func openIdentityGraphTestStore(t *testing.T) *Store {
 		}
 	})
 
-	if len(embeddedMigrations) != 5 {
-		t.Fatalf("embedded migrations = %d, want 5", len(embeddedMigrations))
+	if len(embeddedMigrations) != 6 {
+		t.Fatalf("embedded migrations = %d, want 6", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 2)

--- a/internal/storage/sqlite/messages_test.go
+++ b/internal/storage/sqlite/messages_test.go
@@ -542,8 +542,8 @@ func TestMessagesInboxMigrationIsChecksummedAndStrict(t *testing.T) {
 		t,
 		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
 	)
-	if len(embeddedMigrations) != 5 {
-		t.Fatalf("embedded migrations = %d, want 5", len(embeddedMigrations))
+	if len(embeddedMigrations) != 6 {
+		t.Fatalf("embedded migrations = %d, want 6", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 4)

--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -51,12 +51,16 @@ var migration0004SQL string
 //go:embed migrations/0005_outbox.sql
 var migration0005SQL string
 
+//go:embed migrations/0006_outbox_attachments.sql
+var migration0006SQL string
+
 var embeddedMigrations = []migration{
 	newMigration(1, "storage_shell", migration0001SQL, newStorageShellArguments),
 	newMigration(2, "identity_graph", migration0002SQL, nil),
 	newMigration(3, "attachments", migration0003SQL, nil),
 	newMigration(4, "messages_inbox", migration0004SQL, nil),
 	newMigration(5, "outbox", migration0005SQL, nil),
+	newMigration(6, "outbox_attachments", migration0006SQL, nil),
 }
 
 func newMigration(

--- a/internal/storage/sqlite/migrations/0006_outbox_attachments.sql
+++ b/internal/storage/sqlite/migrations/0006_outbox_attachments.sql
@@ -1,0 +1,23 @@
+-- Media metadata for outbox intents of kind 'media'. Caption and reply-to ride
+-- the optimistic outgoing message row, exactly as text bodies do. blob_hash
+-- references a content-addressed file under the private BlobStore root; blob
+-- existence is filesystem-owned, so there is no SQL FK for it.
+CREATE TABLE outbox_attachments (
+    outbox_id      TEXT NOT NULL,
+    ordinal        INTEGER NOT NULL CHECK (ordinal >= 0),
+    blob_hash      TEXT NOT NULL CHECK (
+        length(blob_hash) = 64
+        AND blob_hash = lower(blob_hash)
+        AND blob_hash NOT GLOB '*[^0-9a-f]*'
+    ),
+    size_bytes     INTEGER NOT NULL CHECK (size_bytes > 0),
+    mime           TEXT NOT NULL CHECK (trim(mime) <> ''),
+    filename       TEXT NOT NULL DEFAULT '',
+    created_at_ms  INTEGER NOT NULL CHECK (created_at_ms > 0),
+    PRIMARY KEY (outbox_id, ordinal),
+    FOREIGN KEY (outbox_id)
+        REFERENCES outbox(outbox_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE INDEX outbox_attachments_blob_hash_idx
+    ON outbox_attachments(blob_hash);

--- a/internal/storage/sqlite/outbox.go
+++ b/internal/storage/sqlite/outbox.go
@@ -92,6 +92,19 @@ type OutboxItem struct {
 	UpdatedAtMS         int64
 }
 
+// OutboxAttachment is the persisted blob metadata for one media outbox intent.
+// M2 stores exactly one attachment at ordinal zero. Enqueue stamps OutboxID,
+// Ordinal, and CreatedAtMS; GetOutboxAttachment populates every field.
+type OutboxAttachment struct {
+	OutboxID    string
+	BlobHash    string
+	MIME        string
+	Filename    string
+	Ordinal     int64
+	SizeBytes   int64
+	CreatedAtMS int64
+}
+
 // LeaseRequest controls one atomic due-row claim.
 type LeaseRequest struct {
 	Owner    string
@@ -159,7 +172,7 @@ func (r *OutboxRepository) Enqueue(
 	ctx context.Context,
 	item NewOutboxItem,
 ) (OutboxItem, EnqueueDisposition, error) {
-	return r.enqueue(ctx, item, nil)
+	return r.enqueue(ctx, item, nil, nil)
 }
 
 // EnqueueOutgoingMessage atomically inserts an outbound intent and its
@@ -171,16 +184,61 @@ func (r *OutboxRepository) EnqueueOutgoingMessage(
 	item NewOutboxItem,
 	message Message,
 ) (OutboxItem, EnqueueDisposition, error) {
-	return r.enqueue(ctx, item, &message)
+	return r.enqueue(ctx, item, &message, nil)
+}
+
+// EnqueueOutgoingMediaMessage atomically inserts a media intent, its
+// optimistic outgoing message, and its blob metadata. An idempotent replay
+// returns the existing intent only when its complete persisted pair exists.
+func (r *OutboxRepository) EnqueueOutgoingMediaMessage(
+	ctx context.Context,
+	item NewOutboxItem,
+	message Message,
+	attachment OutboxAttachment,
+) (OutboxItem, EnqueueDisposition, error) {
+	return r.enqueue(ctx, item, &message, &attachment)
+}
+
+// GetOutboxAttachment returns the ordinal-zero attachment for outboxID. A
+// missing row wraps database/sql.ErrNoRows so callers can use errors.Is.
+func (r *OutboxRepository) GetOutboxAttachment(
+	ctx context.Context,
+	outboxID string,
+) (OutboxAttachment, error) {
+	if strings.TrimSpace(outboxID) == "" {
+		return OutboxAttachment{}, fmt.Errorf("get outbox attachment: outbox ID is empty")
+	}
+
+	var attachment OutboxAttachment
+	if err := r.store.db.QueryRowContext(ctx, `
+		SELECT outbox_id, ordinal, blob_hash, size_bytes, mime, filename, created_at_ms
+		FROM outbox_attachments
+		WHERE outbox_id = ? AND ordinal = 0
+	`, outboxID).Scan(
+		&attachment.OutboxID,
+		&attachment.Ordinal,
+		&attachment.BlobHash,
+		&attachment.SizeBytes,
+		&attachment.MIME,
+		&attachment.Filename,
+		&attachment.CreatedAtMS,
+	); err != nil {
+		return OutboxAttachment{}, fmt.Errorf("get outbox attachment for outbox item %q: %w", outboxID, err)
+	}
+	return attachment, nil
 }
 
 func (r *OutboxRepository) enqueue(
 	ctx context.Context,
 	item NewOutboxItem,
 	message *Message,
+	attachment *OutboxAttachment,
 ) (OutboxItem, EnqueueDisposition, error) {
 	if err := validateNewOutboxItem(item); err != nil {
 		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item: %w", err)
+	}
+	if err := validateOutboxAttachmentPair(item, attachment); err != nil {
+		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item %q: %w", item.OutboxID, err)
 	}
 	nowMS, err := r.nowMS("enqueue outbox item")
 	if err != nil {
@@ -283,8 +341,18 @@ func (r *OutboxRepository) enqueue(
 			return OutboxItem{}, "", err
 		}
 	}
+	if disposition == EnqueueExisting && row.Kind == OutboxKindMedia {
+		if err := validateExistingOutboxAttachment(ctx, tx, row.OutboxID); err != nil {
+			return OutboxItem{}, "", err
+		}
+	}
 	if disposition == EnqueueInserted && message != nil {
 		if err := r.insertOutgoingMessage(ctx, tx, item, *message, nowMS); err != nil {
+			return OutboxItem{}, "", err
+		}
+	}
+	if disposition == EnqueueInserted && attachment != nil {
+		if err := r.insertOutboxAttachment(ctx, tx, item.OutboxID, *attachment, nowMS); err != nil {
 			return OutboxItem{}, "", err
 		}
 	}
@@ -292,6 +360,94 @@ func (r *OutboxRepository) enqueue(
 		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item %q: commit: %w", item.OutboxID, err)
 	}
 	return row, disposition, nil
+}
+
+func (r *OutboxRepository) insertOutboxAttachment(
+	ctx context.Context,
+	tx *sql.Tx,
+	outboxID string,
+	attachment OutboxAttachment,
+	nowMS int64,
+) error {
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO outbox_attachments (
+			outbox_id,
+			ordinal,
+			blob_hash,
+			size_bytes,
+			mime,
+			filename,
+			created_at_ms
+		) VALUES (?, 0, ?, ?, ?, ?, ?)
+	`,
+		outboxID,
+		attachment.BlobHash,
+		attachment.SizeBytes,
+		attachment.MIME,
+		attachment.Filename,
+		nowMS,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"enqueue outbox attachment for outbox item %q: %w",
+			outboxID,
+			mapConstraintError(err),
+		)
+	}
+	return nil
+}
+
+func validateOutboxAttachmentPair(
+	item NewOutboxItem,
+	attachment *OutboxAttachment,
+) error {
+	if item.Kind == OutboxKindMedia && attachment == nil {
+		return fmt.Errorf("media kind requires an attachment")
+	}
+	if item.Kind != OutboxKindMedia && attachment != nil {
+		return fmt.Errorf("kind %q does not accept an attachment", item.Kind)
+	}
+	if attachment == nil {
+		return nil
+	}
+	if err := validateBlobHash(attachment.BlobHash); err != nil {
+		return err
+	}
+	if attachment.SizeBytes <= 0 {
+		return fmt.Errorf("outbox attachment size must be positive")
+	}
+	if strings.TrimSpace(attachment.MIME) == "" {
+		return fmt.Errorf("outbox attachment MIME type is empty")
+	}
+	return nil
+}
+
+func validateExistingOutboxAttachment(
+	ctx context.Context,
+	tx *sql.Tx,
+	outboxID string,
+) error {
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM outbox_attachments
+			WHERE outbox_id = ? AND ordinal = 0
+		)
+	`, outboxID).Scan(&exists); err != nil {
+		return fmt.Errorf(
+			"enqueue outgoing media message for existing outbox item %q: inspect attachment: %w",
+			outboxID,
+			err,
+		)
+	}
+	if !exists {
+		return fmt.Errorf(
+			"enqueue outgoing media message for existing outbox item %q: attachment is missing",
+			outboxID,
+		)
+	}
+	return nil
 }
 
 func (r *OutboxRepository) insertOutgoingMessage(

--- a/internal/storage/sqlite/outbox_test.go
+++ b/internal/storage/sqlite/outbox_test.go
@@ -2,9 +2,11 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -168,6 +170,231 @@ func TestOutboxEnqueueOutgoingMessageIsAtomicAndDeduplicated(t *testing.T) {
 	}
 	assertRowCount(t, store.db, "outbox", 4)
 	assertRowCount(t, store.db, "messages", 2)
+}
+
+func TestOutboxEnqueueOutgoingMediaMessageRoundTripAndDeduplicates(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	ctx := context.Background()
+
+	item := outboxTestMediaItem("media")
+	message := outboxTestOutgoingMessage(item, "photo caption")
+	attachment := outboxTestAttachment()
+	row, disposition, err := repository.EnqueueOutgoingMediaMessage(ctx, item, message, attachment)
+	if err != nil {
+		t.Fatalf("EnqueueOutgoingMediaMessage(): %v", err)
+	}
+	if disposition != EnqueueInserted || row.OutboxID != item.OutboxID {
+		t.Fatalf("EnqueueOutgoingMediaMessage() = (%+v, %q), want inserted", row, disposition)
+	}
+
+	got, err := repository.GetOutboxAttachment(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxAttachment(): %v", err)
+	}
+	want := attachment
+	want.OutboxID = item.OutboxID
+	want.Ordinal = 0
+	want.CreatedAtMS = outboxTestTimeMS
+	if got != want {
+		t.Fatalf("GetOutboxAttachment() = %+v, want %+v", got, want)
+	}
+
+	messageRepository, err := NewMessageRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	gotMessage, err := messageRepository.GetMessage(ctx, item.LocalMessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(): %v", err)
+	}
+	if gotMessage.Body != message.Body {
+		t.Fatalf("optimistic media message body = %q, want caption %q", gotMessage.Body, message.Body)
+	}
+
+	clock.Set(outboxTestTimeMS + 500)
+	duplicate := item
+	duplicate.OutboxID = "outbox-unused-media-duplicate"
+	duplicate.LocalMessageID = "message-unused-media-duplicate"
+	duplicate.TransportRequestID = "request-unused-media-duplicate"
+	duplicateRow, disposition, err := repository.EnqueueOutgoingMediaMessage(
+		ctx,
+		duplicate,
+		Message{},
+		attachment,
+	)
+	if err != nil {
+		t.Fatalf("EnqueueOutgoingMediaMessage(duplicate): %v", err)
+	}
+	if disposition != EnqueueExisting || duplicateRow.OutboxID != item.OutboxID {
+		t.Fatalf("duplicate result = (%+v, %q), want original", duplicateRow, disposition)
+	}
+	assertRowCount(t, store.db, "outbox", 1)
+	assertRowCount(t, store.db, "messages", 1)
+	assertRowCount(t, store.db, "outbox_attachments", 1)
+
+	if _, err := repository.GetOutboxAttachment(ctx, "missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetOutboxAttachment(missing) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestOutboxEnqueueOutgoingMediaMessageRollsBackAttachmentInsertFailure(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	mustExec(t, store.db, `
+		CREATE TRIGGER fail_outbox_attachment_insert
+		BEFORE INSERT ON outbox_attachments
+		BEGIN
+			SELECT RAISE(ABORT, 'injected outbox attachment failure');
+		END
+	`)
+
+	item := outboxTestMediaItem("atomic-failure")
+	_, _, err := repository.EnqueueOutgoingMediaMessage(
+		context.Background(),
+		item,
+		outboxTestOutgoingMessage(item, "must roll back"),
+		outboxTestAttachment(),
+	)
+	if err == nil {
+		t.Fatal("EnqueueOutgoingMediaMessage() succeeded, want injected attachment failure")
+	}
+	assertRowCount(t, store.db, "outbox", 0)
+	assertRowCount(t, store.db, "messages", 0)
+	assertRowCount(t, store.db, "outbox_attachments", 0)
+}
+
+func TestOutboxEnqueueValidatesMediaAttachmentPair(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		enqueue func() error
+	}{
+		{
+			name: "media without attachment",
+			enqueue: func() error {
+				item := outboxTestMediaItem("missing-attachment")
+				_, _, err := repository.EnqueueOutgoingMessage(
+					ctx,
+					item,
+					outboxTestOutgoingMessage(item, "caption"),
+				)
+				return err
+			},
+		},
+		{
+			name: "text with attachment",
+			enqueue: func() error {
+				item := outboxTestItem("text-attachment")
+				_, _, err := repository.EnqueueOutgoingMediaMessage(
+					ctx,
+					item,
+					outboxTestOutgoingMessage(item, "body"),
+					outboxTestAttachment(),
+				)
+				return err
+			},
+		},
+		{
+			name: "invalid blob hash",
+			enqueue: func() error {
+				item := outboxTestMediaItem("invalid-hash")
+				attachment := outboxTestAttachment()
+				attachment.BlobHash = "not-a-sha256"
+				_, _, err := repository.EnqueueOutgoingMediaMessage(
+					ctx, item, outboxTestOutgoingMessage(item, "caption"), attachment,
+				)
+				return err
+			},
+		},
+		{
+			name: "nonpositive size",
+			enqueue: func() error {
+				item := outboxTestMediaItem("invalid-size")
+				attachment := outboxTestAttachment()
+				attachment.SizeBytes = 0
+				_, _, err := repository.EnqueueOutgoingMediaMessage(
+					ctx, item, outboxTestOutgoingMessage(item, "caption"), attachment,
+				)
+				return err
+			},
+		},
+		{
+			name: "empty MIME",
+			enqueue: func() error {
+				item := outboxTestMediaItem("invalid-mime")
+				attachment := outboxTestAttachment()
+				attachment.MIME = " \t"
+				_, _, err := repository.EnqueueOutgoingMediaMessage(
+					ctx, item, outboxTestOutgoingMessage(item, "caption"), attachment,
+				)
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.enqueue(); err == nil {
+				t.Fatal("enqueue succeeded, want validation error")
+			}
+		})
+	}
+	assertRowCount(t, store.db, "outbox", 0)
+	assertRowCount(t, store.db, "messages", 0)
+	assertRowCount(t, store.db, "outbox_attachments", 0)
+}
+
+func TestOutboxAttachmentCascadesAndExistingMediaRequiresAttachment(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	ctx := context.Background()
+
+	item := outboxTestMediaItem("cascade")
+	if _, _, err := repository.EnqueueOutgoingMediaMessage(
+		ctx,
+		item,
+		outboxTestOutgoingMessage(item, "caption"),
+		outboxTestAttachment(),
+	); err != nil {
+		t.Fatalf("EnqueueOutgoingMediaMessage(): %v", err)
+	}
+	assertRowCount(t, store.db, "outbox_attachments", 1)
+	mustExec(t, store.db, `DELETE FROM outbox WHERE outbox_id = ?`, item.OutboxID)
+	assertRowCount(t, store.db, "outbox_attachments", 0)
+
+	item = outboxTestMediaItem("missing-existing-attachment")
+	if _, _, err := repository.EnqueueOutgoingMediaMessage(
+		ctx,
+		item,
+		outboxTestOutgoingMessage(item, "caption"),
+		outboxTestAttachment(),
+	); err != nil {
+		t.Fatalf("EnqueueOutgoingMediaMessage(second): %v", err)
+	}
+	mustExec(t, store.db, `DELETE FROM outbox_attachments WHERE outbox_id = ?`, item.OutboxID)
+	duplicate := item
+	duplicate.OutboxID = "outbox-unused-missing-existing-attachment"
+	duplicate.LocalMessageID = "message-unused-missing-existing-attachment"
+	duplicate.TransportRequestID = "request-unused-missing-existing-attachment"
+	if _, _, err := repository.EnqueueOutgoingMediaMessage(
+		ctx,
+		duplicate,
+		Message{},
+		outboxTestAttachment(),
+	); err == nil {
+		t.Fatal("EnqueueOutgoingMediaMessage(existing without attachment) succeeded")
+	}
 }
 
 func TestOutboxLeaseDueRespectsScheduleRetryAndLiveLease(t *testing.T) {
@@ -689,10 +916,10 @@ func TestOutboxMigrationIsChecksummedAndStrict(t *testing.T) {
 	store, _ := openOutboxTestRepository(t, func() time.Time {
 		return time.UnixMilli(outboxTestTimeMS)
 	})
-	if len(embeddedMigrations) != 5 {
-		t.Fatalf("embedded migrations = %d, want 5", len(embeddedMigrations))
+	if len(embeddedMigrations) != 6 {
+		t.Fatalf("embedded migrations = %d, want 6", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 5)
+	assertPragmaInt(t, store.db, "user_version", 6)
 	ledger := readLedgerRow(t, store.db, 5)
 	if ledger.name != "outbox" {
 		t.Fatalf("migration 0005 name = %q, want outbox", ledger.name)
@@ -710,6 +937,98 @@ func TestOutboxMigrationIsChecksummedAndStrict(t *testing.T) {
 	}
 	if strict != 1 {
 		t.Fatalf("outbox strict = %d, want 1", strict)
+	}
+}
+
+func TestOutboxAttachmentsMigrationAppliesToBlankAndExistingV5Database(t *testing.T) {
+	t.Run("blank", func(t *testing.T) {
+		store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+		if err != nil {
+			t.Fatalf("Open(): %v", err)
+		}
+		t.Cleanup(func() {
+			if err := store.Close(); err != nil {
+				t.Errorf("Close(): %v", err)
+			}
+		})
+		assertOutboxAttachmentsMigration(t, store)
+	})
+
+	t.Run("existing v5", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "store.sqlite3")
+		db, err := sql.Open("sqlite", storeDSN(path))
+		if err != nil {
+			t.Fatalf("sql.Open(): %v", err)
+		}
+		if err := db.Ping(); err != nil {
+			_ = db.Close()
+			t.Fatalf("Ping(): %v", err)
+		}
+		if err := enableWAL(context.Background(), db); err != nil {
+			_ = db.Close()
+			t.Fatalf("enableWAL(): %v", err)
+		}
+		if err := verifyConnectionPragmas(context.Background(), db); err != nil {
+			_ = db.Close()
+			t.Fatalf("verifyConnectionPragmas(): %v", err)
+		}
+		if err := runMigrations(context.Background(), db, embeddedMigrations[:5]); err != nil {
+			_ = db.Close()
+			t.Fatalf("runMigrations(v5): %v", err)
+		}
+		before := readLedgerRows(t, db)
+		if len(before) != 5 {
+			_ = db.Close()
+			t.Fatalf("v5 ledger rows = %d, want 5", len(before))
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close v5 database: %v", err)
+		}
+
+		store, err := Open(path)
+		if err != nil {
+			t.Fatalf("Open(v5): %v", err)
+		}
+		t.Cleanup(func() {
+			if err := store.Close(); err != nil {
+				t.Errorf("Close(): %v", err)
+			}
+		})
+		after := readLedgerRows(t, store.db)
+		if len(after) != 6 {
+			t.Fatalf("migrated ledger rows = %d, want 6", len(after))
+		}
+		if !slices.Equal(after[:5], before) {
+			t.Fatalf("migrations 0001-0005 changed:\nbefore: %+v\nafter:  %+v", before, after[:5])
+		}
+		assertOutboxAttachmentsMigration(t, store)
+	})
+}
+
+func assertOutboxAttachmentsMigration(t *testing.T, store *Store) {
+	t.Helper()
+	assertPragmaInt(t, store.db, "user_version", 6)
+	ledger := readLedgerRow(t, store.db, 6)
+	if ledger.name != "outbox_attachments" {
+		t.Fatalf("migration 0006 name = %q, want outbox_attachments", ledger.name)
+	}
+	if ledger.checksum != embeddedMigrations[5].checksumSHA256 {
+		t.Fatalf(
+			"migration 0006 checksum = %q, want %q",
+			ledger.checksum,
+			embeddedMigrations[5].checksumSHA256,
+		)
+	}
+	var strict int
+	if err := store.db.QueryRow(`
+		SELECT strict
+		FROM pragma_table_list
+		WHERE schema = 'main' AND name = 'outbox_attachments'
+	`).Scan(&strict); err != nil {
+		t.Fatalf("read outbox_attachments STRICT flag: %v", err)
+	}
+	if strict != 1 {
+		t.Fatalf("outbox_attachments strict = %d, want 1", strict)
 	}
 }
 
@@ -767,6 +1086,22 @@ func outboxTestItem(id string) NewOutboxItem {
 		Operation:          "send_text",
 		LocalMessageID:     "message-" + id,
 		TransportRequestID: "request-" + id,
+	}
+}
+
+func outboxTestMediaItem(id string) NewOutboxItem {
+	item := outboxTestItem(id)
+	item.Kind = OutboxKindMedia
+	item.Operation = "send_media"
+	return item
+}
+
+func outboxTestAttachment() OutboxAttachment {
+	return OutboxAttachment{
+		BlobHash:  "abababababababababababababababababababababababababababababababab",
+		SizeBytes: 42,
+		MIME:      "image/png",
+		Filename:  "photo.png",
 	}
 }
 

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -81,6 +81,7 @@ func TestOpenInitializesBlankDatabase(t *testing.T) {
 		"inbox",
 		"messages",
 		"outbox",
+		"outbox_attachments",
 		"people",
 		"person_identities",
 		"schema_migrations",

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -27,6 +27,7 @@ import (
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/client"
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/messaging"
 	"github.com/maxghenis/openmessage/internal/story"
 	"github.com/maxghenis/openmessage/internal/whatsapplive"
 )
@@ -39,7 +40,7 @@ var staticFS embed.FS
 // ~64MB, MMS ~1MB) while keeping a runaway POST from exhausting memory. It is a
 // var (not a const) only so tests can shrink it; it is never mutated in
 // production.
-var maxUploadBytes int64 = 128 << 20
+var maxUploadBytes int64 = messaging.DefaultMaxMediaBytes
 
 const maxTranscriptRequestBytes = db.MaxTranscriptBytes + db.MaxTranscriptModelBytes + 4096
 


### PR DESCRIPTION
## Rebuild Wave 2 / M2a — media send through MessageService → outbox → blob

Extends the M1 text-send pipeline to media. **Storage + service + dispatch only** — the three adapter `MediaSender` shims (the live half) are M2b. The v2 send pipeline has no production callers yet, so this changes no live send/receive path.

### What it does
- `MessageService.SendMedia` streams the attachment into the content-addressed blob store, then **atomically** creates the optimistic message + a durable media outbox item in one transaction.
- Dispatch gains a media path parallel to text, mapping transport results through the **same** outbox state machine (uncertain/terminal/retry) as text.

### Design (per the Fable-designed spec, adversarially reviewed)
- **Migration 0006** — additive `outbox_attachments` side table (`blob_hash`/`size`/`mime`/`filename`, FK to `outbox` `ON DELETE CASCADE`). Caption and reply-to ride the optimistic message row exactly as text bodies do. `0005` untouched (checksum ledger).
- **Crash-safety** — blob is written *before* the enqueue transaction; the only crash residue is an orphan blob, swept by the unreferenced-blob GC — which now **unions** `outbox_attachments` so queued-media blobs can't be collected.
- **Idempotency** — the media payload hash covers blob digest + size + mime + filename + caption + reply-to (content bytes hashed once, in the blob store). A changed caption under the same idempotency key **conflicts** rather than silently re-sending.
- **Dispatch mapping** — undeclared capability → terminal `unsupported`; missing blob → terminal `blob_missing` (no retry spin); transport-called committed *before* the send, so a crash recovers as `uncertain`, never an auto-resend; fresh blob reader per attempt.

### Verification
- Full `go test -race ./...` green (24 packages) in a real environment.
- Adversarially reviewed against the real SQL on a scratch sqlite DB (STRICT flag, every CHECK/PK/FK/CASCADE) and the GC union; verdict **mergeable**. Two review nits folded in (generic submission-ID error text; documented the empty-content zero-byte orphan). A third (nil-BlobStore fail-fast) is recorded as an M2b wiring requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
