### PR TITLE
Add reactions and read receipts over the durable outbox (rebuild Wave 2 / M3)

### DIFF
--- a/internal/messaging/dispatch.go
+++ b/internal/messaging/dispatch.go
@@ -90,6 +90,10 @@ func (s *MessageService) DispatchDue(ctx context.Context, limit int) (int, error
 			dispatchErr = s.dispatchTextLease(ctx, lease)
 		case sqlite.OutboxKindMedia:
 			dispatchErr = s.dispatchMediaLease(ctx, lease)
+		case sqlite.OutboxKindReaction:
+			dispatchErr = s.dispatchReactionLease(ctx, lease)
+		case sqlite.OutboxKindRead:
+			dispatchErr = s.dispatchReadLease(ctx, lease)
 		default:
 			dispatchErr = s.releaseUnavailable(ctx, lease.OutboxItem, fmt.Errorf(
 				"message dispatcher does not handle outbox kind %q",
@@ -404,6 +408,317 @@ func (s *MessageService) dispatchMediaLease(ctx context.Context, outboxLease sql
 	}
 	s.signalChange()
 	return nil
+}
+
+func (s *MessageService) dispatchReactionLease(ctx context.Context, outboxLease sqlite.Lease) error {
+	item := outboxLease.OutboxItem
+	if item.LeaseToken == nil {
+		return fmt.Errorf("dispatch outbox item %q: storage returned no lease token", item.OutboxID)
+	}
+
+	dispatchLease, err := s.bridges.Acquire(ctx, item.AccountID, bridge.CapabilityReactions)
+	if err != nil {
+		if errors.Is(err, bridge.ErrCapabilityUnavailable) &&
+			!s.bridges.Capabilities(item.AccountID).Reactions {
+			return s.rejectPreCall(
+				ctx,
+				item,
+				string(bridge.FailureUnsupported),
+				"reactions_unsupported",
+				err,
+			)
+		}
+		if releaseErr := s.releaseUnavailable(ctx, item, err); releaseErr != nil {
+			return releaseErr
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return nil
+	}
+	if dispatchLease == nil || dispatchLease.Reaction == nil {
+		if dispatchLease != nil {
+			dispatchLease.Close()
+		}
+		return s.releaseUnavailable(ctx, item, bridge.ErrCapabilityUnavailable)
+	}
+	defer dispatchLease.Close()
+
+	reaction, err := s.outbox.GetOutboxReaction(ctx, item.OutboxID)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_reaction",
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	target, code, err := s.targetRefForLease(ctx, item, reaction.TargetMessageID)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			code,
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	conversation, err := s.store.GetConversation(item.ConversationID)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_conversation",
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	if conversation.AccountID != item.AccountID {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_conversation",
+			fmt.Errorf("conversation %q belongs to account %q", item.ConversationID, conversation.AccountID),
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+
+	if err := s.outbox.MarkTransportCalled(ctx, sqlite.Attempt{
+		OutboxID:             item.OutboxID,
+		LeaseToken:           *item.LeaseToken,
+		AttemptToken:         item.OutboxID + ":" + *item.LeaseToken,
+		ConnectionGeneration: uint64(dispatchLease.Generation),
+		StartedAt:            s.clock.Now(),
+	}); err != nil {
+		if ctx.Err() != nil {
+			return errors.Join(ctx.Err(), s.releaseUnavailable(ctx, item, err))
+		}
+		return fmt.Errorf("dispatch outbox item %q: mark transport called: %w", item.OutboxID, err)
+	}
+	s.signalChange()
+
+	result, sendErr := dispatchLease.Reaction.SendReaction(ctx, bridge.ReactionRequest{
+		AccountID: item.AccountID,
+		Conversation: bridge.ConversationRef{
+			RemoteID: conversation.RemoteConversationID,
+		},
+		Target:    target,
+		Emoji:     reaction.Emoji,
+		Action:    bridge.ReactionAction(reaction.Action),
+		RequestID: item.TransportRequestID,
+	})
+	mutationCtx, cancel := s.storageMutationContext(ctx)
+	defer cancel()
+	if sendErr != nil {
+		return s.recordSendError(mutationCtx, item, sendErr, reactionOperation)
+	}
+	if strings.TrimSpace(result.RemoteMessageID) == "" {
+		// Legacy web/api.go reaction dispatch returns only a success boolean, so
+		// an empty remote result is a valid confirmation for this operation.
+		if err := s.outbox.ConfirmWithoutResult(
+			mutationCtx,
+			item.OutboxID,
+			*item.LeaseToken,
+		); err != nil {
+			return fmt.Errorf(
+				"dispatch outbox item %q: confirm reaction without result: %w",
+				item.OutboxID,
+				err,
+			)
+		}
+		s.signalChange()
+		return nil
+	}
+
+	confirmation := sqlite.Confirmation{
+		OutboxID:       item.OutboxID,
+		LeaseToken:     *item.LeaseToken,
+		ResultRemoteID: result.RemoteMessageID,
+	}
+	if err := s.outbox.Confirm(mutationCtx, confirmation); err != nil {
+		storeErr := s.outbox.MarkStoreFailed(
+			mutationCtx,
+			item.OutboxID,
+			*item.LeaseToken,
+			result.RemoteMessageID,
+			err.Error(),
+		)
+		if storeErr != nil {
+			return fmt.Errorf(
+				"dispatch outbox item %q: confirm: %w",
+				item.OutboxID,
+				errors.Join(err, storeErr),
+			)
+		}
+	}
+	s.signalChange()
+	return nil
+}
+
+func (s *MessageService) dispatchReadLease(ctx context.Context, outboxLease sqlite.Lease) error {
+	item := outboxLease.OutboxItem
+	if item.LeaseToken == nil {
+		return fmt.Errorf("dispatch outbox item %q: storage returned no lease token", item.OutboxID)
+	}
+
+	dispatchLease, err := s.bridges.Acquire(ctx, item.AccountID, bridge.CapabilityReadReceipts)
+	if err != nil {
+		if errors.Is(err, bridge.ErrCapabilityUnavailable) &&
+			!s.bridges.Capabilities(item.AccountID).ReadReceipts {
+			return s.rejectPreCall(
+				ctx,
+				item,
+				string(bridge.FailureUnsupported),
+				"read_receipts_unsupported",
+				err,
+			)
+		}
+		if releaseErr := s.releaseUnavailable(ctx, item, err); releaseErr != nil {
+			return releaseErr
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return nil
+	}
+	if dispatchLease == nil || dispatchLease.ReadReceipt == nil {
+		if dispatchLease != nil {
+			dispatchLease.Close()
+		}
+		return s.releaseUnavailable(ctx, item, bridge.ErrCapabilityUnavailable)
+	}
+	defer dispatchLease.Close()
+
+	receipt, err := s.outbox.GetOutboxReadReceipt(ctx, item.OutboxID)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_read_receipt",
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	target, code, err := s.targetRefForLease(ctx, item, receipt.LastReadMessageID)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			code,
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	conversation, err := s.store.GetConversation(item.ConversationID)
+	if err != nil {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_conversation",
+			err,
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+	if conversation.AccountID != item.AccountID {
+		return s.markPreCallFailure(
+			ctx,
+			item,
+			string(bridge.FailureTransient),
+			"load_conversation",
+			fmt.Errorf("conversation %q belongs to account %q", item.ConversationID, conversation.AccountID),
+			s.clock.Now().Add(s.retryDelay),
+		)
+	}
+
+	if err := s.outbox.MarkTransportCalled(ctx, sqlite.Attempt{
+		OutboxID:             item.OutboxID,
+		LeaseToken:           *item.LeaseToken,
+		AttemptToken:         item.OutboxID + ":" + *item.LeaseToken,
+		ConnectionGeneration: uint64(dispatchLease.Generation),
+		StartedAt:            s.clock.Now(),
+	}); err != nil {
+		if ctx.Err() != nil {
+			return errors.Join(ctx.Err(), s.releaseUnavailable(ctx, item, err))
+		}
+		return fmt.Errorf("dispatch outbox item %q: mark transport called: %w", item.OutboxID, err)
+	}
+	s.signalChange()
+
+	sendErr := dispatchLease.ReadReceipt.MarkRead(ctx, bridge.ReadReceiptRequest{
+		AccountID: item.AccountID,
+		Conversation: bridge.ConversationRef{
+			RemoteID: conversation.RemoteConversationID,
+		},
+		Messages: []bridge.MessageRef{target},
+		ReadAt:   time.UnixMilli(receipt.ReadAtMS),
+	})
+	mutationCtx, cancel := s.storageMutationContext(ctx)
+	defer cancel()
+	if sendErr != nil {
+		return s.recordSendError(mutationCtx, item, sendErr, readOperation)
+	}
+	if err := s.outbox.ConfirmWithoutResult(
+		mutationCtx,
+		item.OutboxID,
+		*item.LeaseToken,
+	); err != nil {
+		return fmt.Errorf(
+			"dispatch outbox item %q: confirm read without result: %w",
+			item.OutboxID,
+			err,
+		)
+	}
+	s.signalChange()
+	return nil
+}
+
+func (s *MessageService) targetRefForLease(
+	ctx context.Context,
+	item sqlite.OutboxItem,
+	targetMessageID string,
+) (bridge.MessageRef, string, error) {
+	target, err := s.messages.GetMessage(ctx, targetMessageID)
+	if err != nil {
+		return bridge.MessageRef{}, "load_target", err
+	}
+	if target.AccountID != item.AccountID || target.ConversationID != item.ConversationID {
+		return bridge.MessageRef{}, "load_target", fmt.Errorf(
+			"target message does not match outbox account/conversation",
+		)
+	}
+
+	authorID := ""
+	if target.SenderIdentityID != nil {
+		identity, err := s.store.GetIdentity(*target.SenderIdentityID)
+		if err != nil {
+			return bridge.MessageRef{}, "load_target_author", err
+		}
+		if identity.AccountID != item.AccountID {
+			return bridge.MessageRef{}, "load_target_author", fmt.Errorf(
+				"target author %q belongs to account %q",
+				identity.IdentityID,
+				identity.AccountID,
+			)
+		}
+		authorID = identity.CanonicalValue
+	}
+	// A nil sender marks an outgoing message authored by self, so an empty
+	// transport-neutral AuthorID preserves that distinction for adapter shims.
+	// Until echo reconciliation, an outgoing target's RemoteID remains its
+	// stable transport request ID.
+	return bridge.MessageRef{
+		RemoteID: target.RemoteMessageID,
+		AuthorID: authorID,
+		SentAt:   time.UnixMilli(target.OccurredAtMS),
+	}, "", nil
 }
 
 func (s *MessageService) messageForLease(

--- a/internal/messaging/dispatch_reaction_test.go
+++ b/internal/messaging/dispatch_reaction_test.go
@@ -1,0 +1,482 @@
+package messaging
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func TestQueuedReactionSurvivesRestartAndMapsRequest(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	identityID := "identity-reaction-author"
+	seedDispatchIdentity(t, store, identityID, "author@example.test", clock.Now())
+	target := mustProjectDispatchMessage(t, store, clock, sqlite.Message{
+		MessageID:        "message-reaction-target",
+		ConversationID:   "conversation-1",
+		AccountID:        "account-1",
+		RemoteMessageID:  "remote-reaction-target",
+		SenderIdentityID: &identityID,
+		Direction:        sqlite.MessageDirectionIncoming,
+		Body:             "target body is not copied",
+		State:            sqlite.MessageStateActive,
+		OccurredAtMS:     clock.Now().Add(-2 * time.Minute).UnixMilli(),
+	})
+
+	beforeRestart := newScriptedRegistry("reaction-before-restart", &scriptedTextSender{})
+	beforeRestart.setReactionSender(&scriptedReactionSender{})
+	first := newMessagingTestService(t, store, beforeRestart, clock)
+	submission := mustSendDispatchReaction(t, first, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-restart"),
+		TargetMessageID: target.MessageID,
+		Emoji:           "🎉",
+		Action:          bridge.ReactionSwitch,
+	})
+
+	sender := &scriptedReactionSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-reaction-result"},
+	}}}
+	afterRestart := newScriptedRegistry("reaction-after-restart", &scriptedTextSender{})
+	afterRestart.setReactionSender(sender)
+	afterRestart.setAvailable(true)
+	restarted := newMessagingTestService(t, store, afterRestart, clock)
+
+	if before := mustDelivery(t, restarted, submission.OutboxID); before.State != OutboxQueued ||
+		before.LocalMessageID != "" {
+		t.Fatalf("restarted reaction delivery = %+v, want queued without local message", before)
+	}
+	if processed, err := restarted.DispatchDue(context.Background(), 4); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(restarted reaction) = %d, %v; want 1, nil", processed, err)
+	}
+	if after := mustDelivery(t, restarted, submission.OutboxID); after.State != OutboxConfirmed ||
+		after.RemoteMessageID != "remote-reaction-result" {
+		t.Fatalf("reaction delivery after restart = %+v", after)
+	}
+
+	requests := sender.snapshotRequests()
+	if len(requests) != 1 {
+		t.Fatalf("reaction requests = %+v, want one", requests)
+	}
+	request := requests[0]
+	outboxRow := mustOutboxItem(t, restarted, submission.OutboxID)
+	if request.AccountID != "account-1" ||
+		request.Conversation.RemoteID != "remote-conversation" ||
+		request.Target.RemoteID != target.RemoteMessageID ||
+		request.Target.AuthorID != "author@example.test" ||
+		!request.Target.SentAt.Equal(time.UnixMilli(target.OccurredAtMS)) ||
+		request.Target.Text != "" ||
+		request.Emoji != "🎉" ||
+		request.Action != bridge.ReactionSwitch ||
+		request.RequestID != outboxRow.TransportRequestID {
+		t.Fatalf("mapped reaction request = %+v", request)
+	}
+}
+
+func TestReactionToOwnOutgoingMessageMapsEmptyAuthor(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedReactionSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-own-reaction"},
+	}}}
+	registry := newScriptedRegistry("reaction-own-target", &scriptedTextSender{})
+	registry.setReactionSender(sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "reaction-own-target")
+	targetRow := mustOutboxItem(t, service, target.OutboxID)
+	mustSendDispatchReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-own"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(own reaction) = %d, %v; want 1, nil", processed, err)
+	}
+	requests := sender.snapshotRequests()
+	if len(requests) != 1 || requests[0].Target.RemoteID != targetRow.TransportRequestID ||
+		requests[0].Target.AuthorID != "" {
+		t.Fatalf("own-target reaction request = %+v, want request ID target and empty author", requests)
+	}
+}
+
+func TestDeclaredButUnwiredReactionReturnsToQueuedWithoutAttempt(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	registry := newScriptedRegistry("reaction-unwired", &scriptedTextSender{})
+	registry.setReactionSender(&scriptedReactionSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "reaction-unwired-target")
+	submission := mustSendDispatchReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-unwired"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+	})
+	registry.setReactionSender(nil)
+	registry.setReactionsDeclared(true)
+	registry.setAvailable(true)
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(unwired reaction) = %d, %v; want 1, nil", processed, err)
+	}
+	assertQueuedWithoutAttempt(t, service, submission.OutboxID)
+}
+
+func TestUnavailableReactionAccountReturnsToQueuedWithoutAttempt(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedReactionSender{}
+	registry := newScriptedRegistry("reaction-account-unavailable", &scriptedTextSender{})
+	registry.setReactionSender(sender)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "reaction-unavailable-target")
+	submission := mustSendDispatchReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-account-unavailable"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(unavailable reaction account) = %d, %v; want 1, nil", processed, err)
+	}
+	assertQueuedWithoutAttempt(t, service, submission.OutboxID)
+	if got := sender.requestCount(); got != 0 {
+		t.Fatalf("unavailable reaction send count = %d, want 0", got)
+	}
+}
+
+func TestReactionLeaseWithoutSenderReturnsToQueuedWithoutAttempt(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	baseRegistry := newScriptedRegistry("reaction-nil-lease", &scriptedTextSender{})
+	baseRegistry.setReactionSender(&scriptedReactionSender{})
+	baseRegistry.setAvailable(true)
+	service := newMessagingTestService(
+		t,
+		store,
+		nilCapabilityLeaseRegistry{scriptedRegistry: baseRegistry, capability: bridge.CapabilityReactions},
+		clock,
+	)
+	target := mustCanceledDispatchTarget(t, service, "reaction-nil-target")
+	submission := mustSendDispatchReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-nil-lease"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(nil reaction sender) = %d, %v; want 1, nil", processed, err)
+	}
+	assertQueuedWithoutAttempt(t, service, submission.OutboxID)
+}
+
+func TestUndeclaredReactionCapabilityIsRejected(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedReactionSender{}
+	registry := newScriptedRegistry("reaction-undeclared", &scriptedTextSender{})
+	registry.setReactionSender(sender)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "reaction-undeclared-target")
+	submission := mustSendDispatchReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-undeclared"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+	})
+	registry.setReactionSender(nil)
+	registry.setReactionsDeclared(false)
+	registry.setAvailable(true)
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(undeclared reaction) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	if delivery.State != OutboxRejected ||
+		delivery.ErrorClass != string(bridge.FailureUnsupported) ||
+		delivery.ErrorCode != "reactions_unsupported" {
+		t.Fatalf("undeclared reaction delivery = %+v, want rejected/unsupported", delivery)
+	}
+	if row := mustOutboxItem(t, service, submission.OutboxID); row.AttemptCount != 0 {
+		t.Fatalf("undeclared reaction attempt count = %d, want 0", row.AttemptCount)
+	}
+	if got := sender.requestCount(); got != 0 {
+		t.Fatalf("undeclared reaction send count = %d, want 0", got)
+	}
+}
+
+func TestDuplicateReactionReturnsSameSubmissionAndDispatchesOnce(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedReactionSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-deduplicated-reaction"},
+	}}}
+	registry := newScriptedRegistry("reaction-dedup", &scriptedTextSender{})
+	registry.setReactionSender(sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "reaction-dedup-target")
+	command := SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-dedup"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+		Action:          bridge.ReactionAdd,
+	}
+
+	first := mustSendDispatchReaction(t, service, command)
+	second := mustSendDispatchReaction(t, service, command)
+	if first != second {
+		t.Fatalf("duplicate reaction submissions differ: first=%+v second=%+v", first, second)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 4); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(duplicate reaction) = %d, %v; want 1, nil", processed, err)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("duplicate reaction send count = %d, want 1", got)
+	}
+}
+
+func TestReactionToggleDispatchesAddThenRemove(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedReactionSender{steps: []sendStep{
+		{result: bridge.SendResult{RemoteMessageID: "remote-reaction-add"}},
+		{result: bridge.SendResult{RemoteMessageID: "remote-reaction-remove"}},
+	}}
+	registry := newScriptedRegistry("reaction-toggle", &scriptedTextSender{})
+	registry.setReactionSender(sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "reaction-toggle-target")
+	mustSendDispatchReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-toggle-add"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+		Action:          bridge.ReactionAdd,
+	})
+	clock.Advance(time.Millisecond)
+	mustSendDispatchReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-toggle-remove"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+		Action:          bridge.ReactionRemove,
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 2); err != nil || processed != 2 {
+		t.Fatalf("DispatchDue(reaction toggle) = %d, %v; want 2, nil", processed, err)
+	}
+	requests := sender.snapshotRequests()
+	if len(requests) != 2 || requests[0].Action != bridge.ReactionAdd ||
+		requests[1].Action != bridge.ReactionRemove {
+		t.Fatalf("reaction toggle requests = %+v, want add then remove", requests)
+	}
+}
+
+func TestReactionSuccessWithoutRemoteMessageIDConfirms(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedReactionSender{steps: []sendStep{{}}}
+	registry := newScriptedRegistry("reaction-idless-success", &scriptedTextSender{})
+	registry.setReactionSender(sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "reaction-idless-target")
+	submission := mustSendDispatchReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-idless-success"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(id-less reaction) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	if delivery.State != OutboxConfirmed || delivery.RemoteMessageID != "" ||
+		row.ResultRemoteID != nil {
+		t.Fatalf("id-less reaction delivery/row = %+v / %+v, want confirmed with NULL result", delivery, row)
+	}
+}
+
+func TestReactionSuccessWithRemoteMessageIDConfirms(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedReactionSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-reaction-confirmed"},
+	}}}
+	registry := newScriptedRegistry("reaction-id-success", &scriptedTextSender{})
+	registry.setReactionSender(sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "reaction-id-target")
+	submission := mustSendDispatchReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-id-success"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(reaction with ID) = %d, %v; want 1, nil", processed, err)
+	}
+	if delivery := mustDelivery(t, service, submission.OutboxID); delivery.State != OutboxConfirmed ||
+		delivery.RemoteMessageID != "remote-reaction-confirmed" {
+		t.Fatalf("reaction delivery = %+v, want confirmed with remote ID", delivery)
+	}
+}
+
+func TestPostCallReactionTimeoutBecomesUncertainAndIsNotRedispatched(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedReactionSender{steps: []sendStep{{err: bridge.OpError{
+		Class:     bridge.FailureTransient,
+		Operation: reactionOperation,
+		Dispatch:  bridge.DispatchUncertain,
+		Cause:     context.DeadlineExceeded,
+	}}}}
+	registry := newScriptedRegistry("reaction-timeout", &scriptedTextSender{})
+	registry.setReactionSender(sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "reaction-timeout-target")
+	submission := mustSendDispatchReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("reaction-timeout"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(reaction timeout) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	if delivery.State != OutboxUncertain || delivery.ErrorCode != reactionOperation ||
+		delivery.Warning == "" {
+		t.Fatalf("reaction timeout delivery = %+v, want uncertain", delivery)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 0 {
+		t.Fatalf("DispatchDue(after reaction timeout) = %d, %v; want 0, nil", processed, err)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("reaction timeout send count = %d, want 1", got)
+	}
+}
+
+type nilCapabilityLeaseRegistry struct {
+	*scriptedRegistry
+	capability bridge.Capability
+}
+
+func (r nilCapabilityLeaseRegistry) Acquire(
+	ctx context.Context,
+	accountID string,
+	capability bridge.Capability,
+) (*bridge.DispatchLease, error) {
+	if capability != r.capability {
+		return r.scriptedRegistry.Acquire(ctx, accountID, capability)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &bridge.DispatchLease{
+		AccountID:  accountID,
+		Platform:   "nil-capability-lease",
+		Generation: 7,
+		Ctx:        ctx,
+	}, nil
+}
+
+func mustCanceledDispatchTarget(
+	t *testing.T,
+	service *MessageService,
+	key string,
+) Submission {
+	t.Helper()
+	target := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand(key),
+		Body:          "dispatch target",
+	})
+	if _, err := service.Cancel(context.Background(), target.OutboxID); err != nil {
+		t.Fatalf("Cancel(dispatch target): %v", err)
+	}
+	return target
+}
+
+func mustSendDispatchReaction(
+	t *testing.T,
+	service *MessageService,
+	command SendReactionCommand,
+) Submission {
+	t.Helper()
+	submission, err := service.SendReaction(context.Background(), command)
+	if err != nil {
+		t.Fatalf("SendReaction(): %v", err)
+	}
+	return submission
+}
+
+func assertQueuedWithoutAttempt(t *testing.T, service *MessageService, outboxID string) {
+	t.Helper()
+	row := mustOutboxItem(t, service, outboxID)
+	if row.State != sqlite.OutboxQueued || row.AttemptCount != 0 || row.NextAttemptAtMS != nil {
+		t.Fatalf("outbox row = %+v, want queued/attempt=0/no next-attempt", row)
+	}
+}
+
+func seedDispatchIdentity(
+	t *testing.T,
+	store *sqlite.Store,
+	identityID, canonicalValue string,
+	now time.Time,
+) {
+	t.Helper()
+	if err := store.UpsertIdentity(sqlite.Identity{
+		IdentityID:     identityID,
+		AccountID:      "account-1",
+		Kind:           sqlite.IdentityKind("test_address"),
+		CanonicalValue: canonicalValue,
+		RawValue:       canonicalValue,
+		DisplayName:    "Dispatch Author",
+		MetadataJSON:   `{}`,
+		CreatedAtMS:    now.UnixMilli(),
+		UpdatedAtMS:    now.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("UpsertIdentity(dispatch author): %v", err)
+	}
+}
+
+func mustProjectDispatchMessage(
+	t *testing.T,
+	store *sqlite.Store,
+	clock Clock,
+	message sqlite.Message,
+) sqlite.Message {
+	t.Helper()
+	repository, err := sqlite.NewMessageRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(dispatch target): %v", err)
+	}
+	inboxID := "inbox-" + message.MessageID
+	if _, err := repository.AppendInbox(context.Background(), sqlite.InboxRecord{
+		InboxID:      inboxID,
+		AccountID:    message.AccountID,
+		Generation:   1,
+		DedupeKey:    "event-" + message.MessageID,
+		Codec:        "dispatch-test",
+		CodecVersion: 1,
+		Payload:      []byte("dispatch target"),
+	}); err != nil {
+		t.Fatalf("AppendInbox(dispatch target): %v", err)
+	}
+	if err := repository.ProjectMessage(context.Background(), sqlite.MessageProjection{
+		InboxID: inboxID,
+		Message: message,
+	}); err != nil {
+		t.Fatalf("ProjectMessage(dispatch target): %v", err)
+	}
+	projected, err := repository.GetMessage(context.Background(), message.MessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(dispatch target): %v", err)
+	}
+	return projected
+}

--- a/internal/messaging/dispatch_read_test.go
+++ b/internal/messaging/dispatch_read_test.go
@@ -1,0 +1,457 @@
+package messaging
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func TestQueuedReadSurvivesRestartAndMapsRequest(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedDispatchDevice(t, store, "device-read-restart", clock.Now())
+	identityID := "identity-read-author"
+	seedDispatchIdentity(t, store, identityID, "reader-target-author@example.test", clock.Now())
+	target := mustProjectDispatchMessage(t, store, clock, sqlite.Message{
+		MessageID:        "message-read-target",
+		ConversationID:   "conversation-1",
+		AccountID:        "account-1",
+		RemoteMessageID:  "remote-read-target",
+		SenderIdentityID: &identityID,
+		Direction:        sqlite.MessageDirectionIncoming,
+		Body:             "read target body is not copied",
+		State:            sqlite.MessageStateActive,
+		OccurredAtMS:     clock.Now().Add(-3 * time.Minute).UnixMilli(),
+	})
+	readAt := clock.Now().Add(-time.Minute)
+
+	beforeRestart := newScriptedRegistry("read-before-restart", &scriptedTextSender{})
+	beforeRestart.setReadReceiptSender(&scriptedReadReceiptSender{})
+	first := newMessagingTestService(t, store, beforeRestart, clock)
+	submission := mustMarkDispatchRead(t, first, MarkReadCommand{
+		CommonCommand:     testCommonCommand("read-restart"),
+		DeviceID:          "device-read-restart",
+		LastReadMessageID: target.MessageID,
+		LastReadAt:        readAt,
+	})
+
+	sender := &scriptedReadReceiptSender{steps: []readReceiptStep{{}}}
+	afterRestart := newScriptedRegistry("read-after-restart", &scriptedTextSender{})
+	afterRestart.setReadReceiptSender(sender)
+	afterRestart.setAvailable(true)
+	restarted := newMessagingTestService(t, store, afterRestart, clock)
+
+	if before := mustDelivery(t, restarted, submission.OutboxID); before.State != OutboxQueued ||
+		before.LocalMessageID != "" {
+		t.Fatalf("restarted read delivery = %+v, want queued without local message", before)
+	}
+	if processed, err := restarted.DispatchDue(context.Background(), 4); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(restarted read) = %d, %v; want 1, nil", processed, err)
+	}
+	if after := mustDelivery(t, restarted, submission.OutboxID); after.State != OutboxConfirmed ||
+		after.RemoteMessageID != "" {
+		t.Fatalf("read delivery after restart = %+v", after)
+	}
+
+	requests := sender.snapshotRequests()
+	if len(requests) != 1 {
+		t.Fatalf("read requests = %+v, want one", requests)
+	}
+	request := requests[0]
+	if request.AccountID != "account-1" ||
+		request.Conversation.RemoteID != "remote-conversation" ||
+		len(request.Messages) != 1 ||
+		request.Messages[0].RemoteID != target.RemoteMessageID ||
+		request.Messages[0].AuthorID != "reader-target-author@example.test" ||
+		!request.Messages[0].SentAt.Equal(time.UnixMilli(target.OccurredAtMS)) ||
+		request.Messages[0].Text != "" ||
+		!request.ReadAt.Equal(readAt) {
+		t.Fatalf("mapped read request = %+v", request)
+	}
+}
+
+func TestDeclaredButUnwiredReadReturnsToQueuedWithoutAttempt(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedDispatchDevice(t, store, "device-read-unwired", clock.Now())
+	registry := newScriptedRegistry("read-unwired", &scriptedTextSender{})
+	registry.setReadReceiptSender(&scriptedReadReceiptSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "read-unwired-target")
+	submission := mustMarkDispatchRead(t, service, MarkReadCommand{
+		CommonCommand:     testCommonCommand("read-unwired"),
+		DeviceID:          "device-read-unwired",
+		LastReadMessageID: target.LocalMessageID,
+	})
+	registry.setReadReceiptSender(nil)
+	registry.setReadReceiptsDeclared(true)
+	registry.setAvailable(true)
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(unwired read) = %d, %v; want 1, nil", processed, err)
+	}
+	assertQueuedWithoutAttempt(t, service, submission.OutboxID)
+}
+
+func TestUnavailableReadAccountReturnsToQueuedWithoutAttempt(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedDispatchDevice(t, store, "device-read-unavailable", clock.Now())
+	sender := &scriptedReadReceiptSender{}
+	registry := newScriptedRegistry("read-account-unavailable", &scriptedTextSender{})
+	registry.setReadReceiptSender(sender)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "read-unavailable-target")
+	submission := mustMarkDispatchRead(t, service, MarkReadCommand{
+		CommonCommand:     testCommonCommand("read-account-unavailable"),
+		DeviceID:          "device-read-unavailable",
+		LastReadMessageID: target.LocalMessageID,
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(unavailable read account) = %d, %v; want 1, nil", processed, err)
+	}
+	assertQueuedWithoutAttempt(t, service, submission.OutboxID)
+	if got := sender.requestCount(); got != 0 {
+		t.Fatalf("unavailable read send count = %d, want 0", got)
+	}
+}
+
+func TestReadLeaseWithoutSenderReturnsToQueuedWithoutAttempt(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedDispatchDevice(t, store, "device-read-nil-lease", clock.Now())
+	baseRegistry := newScriptedRegistry("read-nil-lease", &scriptedTextSender{})
+	baseRegistry.setReadReceiptSender(&scriptedReadReceiptSender{})
+	baseRegistry.setAvailable(true)
+	service := newMessagingTestService(
+		t,
+		store,
+		nilCapabilityLeaseRegistry{
+			scriptedRegistry: baseRegistry,
+			capability:       bridge.CapabilityReadReceipts,
+		},
+		clock,
+	)
+	target := mustCanceledDispatchTarget(t, service, "read-nil-target")
+	submission := mustMarkDispatchRead(t, service, MarkReadCommand{
+		CommonCommand:     testCommonCommand("read-nil-lease"),
+		DeviceID:          "device-read-nil-lease",
+		LastReadMessageID: target.LocalMessageID,
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(nil read sender) = %d, %v; want 1, nil", processed, err)
+	}
+	assertQueuedWithoutAttempt(t, service, submission.OutboxID)
+}
+
+func TestUndeclaredReadCapabilityIsRejected(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedDispatchDevice(t, store, "device-read-undeclared", clock.Now())
+	sender := &scriptedReadReceiptSender{}
+	registry := newScriptedRegistry("read-undeclared", &scriptedTextSender{})
+	registry.setReadReceiptSender(sender)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "read-undeclared-target")
+	submission := mustMarkDispatchRead(t, service, MarkReadCommand{
+		CommonCommand:     testCommonCommand("read-undeclared"),
+		DeviceID:          "device-read-undeclared",
+		LastReadMessageID: target.LocalMessageID,
+	})
+	registry.setReadReceiptSender(nil)
+	registry.setReadReceiptsDeclared(false)
+	registry.setAvailable(true)
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(undeclared read) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	if delivery.State != OutboxRejected ||
+		delivery.ErrorClass != string(bridge.FailureUnsupported) ||
+		delivery.ErrorCode != "read_receipts_unsupported" {
+		t.Fatalf("undeclared read delivery = %+v, want rejected/unsupported", delivery)
+	}
+	if row := mustOutboxItem(t, service, submission.OutboxID); row.AttemptCount != 0 {
+		t.Fatalf("undeclared read attempt count = %d, want 0", row.AttemptCount)
+	}
+	if got := sender.requestCount(); got != 0 {
+		t.Fatalf("undeclared read send count = %d, want 0", got)
+	}
+}
+
+func TestDuplicateReadReturnsSameSubmissionAndDispatchesOnce(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedDispatchDevice(t, store, "device-read-dedup", clock.Now())
+	sender := &scriptedReadReceiptSender{}
+	registry := newScriptedRegistry("read-dedup", &scriptedTextSender{})
+	registry.setReadReceiptSender(sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "read-dedup-target")
+	command := MarkReadCommand{
+		CommonCommand:     testCommonCommand("read-dedup"),
+		DeviceID:          "device-read-dedup",
+		LastReadMessageID: target.LocalMessageID,
+		LastReadAt:        clock.Now(),
+	}
+
+	first := mustMarkDispatchRead(t, service, command)
+	command.LastReadAt = clock.Now().Add(time.Minute)
+	second := mustMarkDispatchRead(t, service, command)
+	if first != second {
+		t.Fatalf("duplicate read submissions differ: first=%+v second=%+v", first, second)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 4); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(duplicate read) = %d, %v; want 1, nil", processed, err)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("duplicate read send count = %d, want 1", got)
+	}
+	requests := sender.snapshotRequests()
+	if len(requests) != 1 || !requests[0].ReadAt.Equal(messagingTestTime) {
+		t.Fatalf("deduplicated read request = %+v, want original ReadAt", requests)
+	}
+}
+
+func TestReadConfirmHasNoRemoteMessageID(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedDispatchDevice(t, store, "device-read-confirm", clock.Now())
+	sender := &scriptedReadReceiptSender{}
+	registry := newScriptedRegistry("read-confirm", &scriptedTextSender{})
+	registry.setReadReceiptSender(sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "read-confirm-target")
+	submission := mustMarkDispatchRead(t, service, MarkReadCommand{
+		CommonCommand:     testCommonCommand("read-confirm"),
+		DeviceID:          "device-read-confirm",
+		LastReadMessageID: target.LocalMessageID,
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(read confirm) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery, err := service.Wait(context.Background(), submission.OutboxID)
+	if err != nil {
+		t.Fatalf("Wait(confirmed read): %v", err)
+	}
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	if delivery.State != OutboxConfirmed || delivery.RemoteMessageID != "" ||
+		row.ResultRemoteID != nil {
+		t.Fatalf("confirmed read delivery/row = %+v / %+v, want confirmed with NULL result", delivery, row)
+	}
+}
+
+func TestPostCallReadTimeoutBecomesUncertainAndIsNotRedispatched(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedDispatchDevice(t, store, "device-read-timeout", clock.Now())
+	sender := &scriptedReadReceiptSender{steps: []readReceiptStep{{err: bridge.OpError{
+		Class:     bridge.FailureTransient,
+		Operation: readOperation,
+		Dispatch:  bridge.DispatchUncertain,
+		Cause:     context.DeadlineExceeded,
+	}}}}
+	registry := newScriptedRegistry("read-timeout", &scriptedTextSender{})
+	registry.setReadReceiptSender(sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "read-timeout-target")
+	submission := mustMarkDispatchRead(t, service, MarkReadCommand{
+		CommonCommand:     testCommonCommand("read-timeout"),
+		DeviceID:          "device-read-timeout",
+		LastReadMessageID: target.LocalMessageID,
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(read timeout) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	if delivery.State != OutboxUncertain || delivery.ErrorCode != readOperation || delivery.Warning == "" {
+		t.Fatalf("read timeout delivery = %+v, want uncertain", delivery)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 0 {
+		t.Fatalf("DispatchDue(after read timeout) = %d, %v; want 0, nil", processed, err)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("read timeout send count = %d, want 1", got)
+	}
+}
+
+func TestReadCursorPersistsThroughTerminalDispatchFailure(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedDispatchDevice(t, store, "device-read-terminal", clock.Now())
+	sender := &scriptedReadReceiptSender{steps: []readReceiptStep{{err: bridge.OpError{
+		Class:     bridge.FailureUnsupported,
+		Operation: readOperation,
+		Dispatch:  bridge.DispatchNotCalled,
+		Cause:     context.Canceled,
+	}}}}
+	registry := newScriptedRegistry("read-terminal", &scriptedTextSender{})
+	registry.setReadReceiptSender(sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustCanceledDispatchTarget(t, service, "read-terminal-target")
+	readAt := clock.Now().Add(-time.Second)
+	submission := mustMarkDispatchRead(t, service, MarkReadCommand{
+		CommonCommand:     testCommonCommand("read-terminal"),
+		DeviceID:          "device-read-terminal",
+		LastReadMessageID: target.LocalMessageID,
+		LastReadAt:        readAt,
+	})
+
+	before, err := store.GetReadCursor("device-read-terminal", "conversation-1")
+	if err != nil {
+		t.Fatalf("GetReadCursor(before dispatch): %v", err)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(terminal read) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	after, err := store.GetReadCursor("device-read-terminal", "conversation-1")
+	if err != nil {
+		t.Fatalf("GetReadCursor(after dispatch): %v", err)
+	}
+	if delivery.State != OutboxRejected || before.LastReadMessageID == nil ||
+		after.LastReadMessageID == nil || *before.LastReadMessageID != target.LocalMessageID ||
+		*after.LastReadMessageID != target.LocalMessageID ||
+		before.LastReadAtMS != readAt.UnixMilli() || after.LastReadAtMS != readAt.UnixMilli() {
+		t.Fatalf("terminal read delivery/cursors = %+v / %+v / %+v", delivery, before, after)
+	}
+}
+
+func TestReactionAndReadExpiredLeaseRecoveryClassifiesPreAndPostCall(t *testing.T) {
+	t.Run("reaction", func(t *testing.T) {
+		clock := newManualClock(messagingTestTime)
+		store := openMessagingTestStore(t, clock.Now())
+		registry := newScriptedRegistry("reaction-recovery", &scriptedTextSender{})
+		registry.setReactionSender(&scriptedReactionSender{})
+		service := newMessagingTestService(t, store, registry, clock)
+		target := mustCanceledDispatchTarget(t, service, "reaction-recovery-target")
+		first := mustSendDispatchReaction(t, service, SendReactionCommand{
+			CommonCommand:   testCommonCommand("reaction-recovery-pre"),
+			TargetMessageID: target.LocalMessageID,
+			Emoji:           "👍",
+		})
+		clock.Advance(time.Millisecond)
+		second := mustSendDispatchReaction(t, service, SendReactionCommand{
+			CommonCommand:   testCommonCommand("reaction-recovery-post"),
+			TargetMessageID: target.LocalMessageID,
+			Emoji:           "👎",
+		})
+		assertExpiredDispatchLeaseRecovery(t, service, clock, first.OutboxID, second.OutboxID)
+	})
+
+	t.Run("read", func(t *testing.T) {
+		clock := newManualClock(messagingTestTime)
+		store := openMessagingTestStore(t, clock.Now())
+		seedDispatchDevice(t, store, "device-read-recovery", clock.Now())
+		registry := newScriptedRegistry("read-recovery", &scriptedTextSender{})
+		registry.setReadReceiptSender(&scriptedReadReceiptSender{})
+		service := newMessagingTestService(t, store, registry, clock)
+		target := mustCanceledDispatchTarget(t, service, "read-recovery-target")
+		first := mustMarkDispatchRead(t, service, MarkReadCommand{
+			CommonCommand:     testCommonCommand("read-recovery-pre"),
+			DeviceID:          "device-read-recovery",
+			LastReadMessageID: target.LocalMessageID,
+		})
+		clock.Advance(time.Millisecond)
+		second := mustMarkDispatchRead(t, service, MarkReadCommand{
+			CommonCommand:     testCommonCommand("read-recovery-post"),
+			DeviceID:          "device-read-recovery",
+			LastReadMessageID: target.LocalMessageID,
+		})
+		assertExpiredDispatchLeaseRecovery(t, service, clock, first.OutboxID, second.OutboxID)
+	})
+}
+
+func assertExpiredDispatchLeaseRecovery(
+	t *testing.T,
+	service *MessageService,
+	clock *manualClock,
+	preCallID, postCallID string,
+) {
+	t.Helper()
+	leases, err := service.outbox.LeaseDue(context.Background(), sqlite.LeaseRequest{
+		Owner:    "dispatch-recovery-test",
+		Now:      clock.Now(),
+		Duration: defaultLeaseTime,
+		Limit:    2,
+	})
+	if err != nil {
+		t.Fatalf("LeaseDue(recovery): %v", err)
+	}
+	if len(leases) != 2 {
+		t.Fatalf("recovery leases = %d, want 2", len(leases))
+	}
+	var postCallLease *sqlite.Lease
+	for index := range leases {
+		if leases[index].OutboxID == postCallID {
+			postCallLease = &leases[index]
+		}
+	}
+	if postCallLease == nil || postCallLease.LeaseToken == nil {
+		t.Fatalf("post-call lease = %+v, want active lease", postCallLease)
+	}
+	if err := service.outbox.MarkTransportCalled(context.Background(), sqlite.Attempt{
+		OutboxID:             postCallID,
+		LeaseToken:           *postCallLease.LeaseToken,
+		AttemptToken:         "dispatch-recovery-attempt",
+		ConnectionGeneration: 7,
+		StartedAt:            clock.Now(),
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(recovery): %v", err)
+	}
+
+	clock.Advance(defaultLeaseTime + time.Second)
+	recovered, err := service.outbox.RecoverExpiredLeases(context.Background(), clock.Now())
+	if err != nil {
+		t.Fatalf("RecoverExpiredLeases(): %v", err)
+	}
+	if recovered.NotDispatched != 1 || recovered.Uncertain != 1 {
+		t.Fatalf("RecoverExpiredLeases() = %+v, want one pre-call and one post-call", recovered)
+	}
+	preCall := mustOutboxItem(t, service, preCallID)
+	postCall := mustOutboxItem(t, service, postCallID)
+	if preCall.State != sqlite.OutboxNotDispatched || preCall.AttemptCount != 0 ||
+		postCall.State != sqlite.OutboxUncertain || postCall.AttemptCount != 1 {
+		t.Fatalf("recovered pre/post rows = %+v / %+v", preCall, postCall)
+	}
+}
+
+func seedDispatchDevice(t *testing.T, store *sqlite.Store, deviceID string, now time.Time) {
+	t.Helper()
+	if err := store.UpsertDevice(sqlite.Device{
+		DeviceID:    deviceID,
+		AccountID:   "account-1",
+		Kind:        sqlite.DeviceKindLocalInstallation,
+		DisplayName: "Dispatch test device",
+		State:       sqlite.DeviceStateActive,
+		IsCurrent:   true,
+		CreatedAtMS: now.UnixMilli(),
+		UpdatedAtMS: now.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("UpsertDevice(dispatch): %v", err)
+	}
+}
+
+func mustMarkDispatchRead(
+	t *testing.T,
+	service *MessageService,
+	command MarkReadCommand,
+) Submission {
+	t.Helper()
+	submission, err := service.MarkRead(context.Background(), command)
+	if err != nil {
+		t.Fatalf("MarkRead(): %v", err)
+	}
+	return submission
+}

--- a/internal/messaging/service.go
+++ b/internal/messaging/service.go
@@ -22,6 +22,8 @@ const DefaultMaxMediaBytes int64 = 128 << 20
 const (
 	textOperation       = "send_text"
 	mediaOperation      = "send_media"
+	reactionOperation   = "reaction"
+	readOperation       = "read_receipt"
 	defaultLeaseTime    = 30 * time.Second
 	defaultFinalizeTime = 5 * time.Second
 	defaultRetryDelay   = 5 * time.Second
@@ -324,6 +326,211 @@ func (s *MessageService) SendMedia(
 	return submission, nil
 }
 
+// SendReaction creates a durable reaction intent without projecting a local
+// message row. An identical account-scoped idempotent submission returns the
+// original durable identity.
+func (s *MessageService) SendReaction(
+	ctx context.Context,
+	cmd SendReactionCommand,
+) (Submission, error) {
+	if ctx == nil {
+		return Submission{}, fmt.Errorf("send reaction: context is nil")
+	}
+	if err := validateSendReactionCommand(&cmd); err != nil {
+		return Submission{}, err
+	}
+	if !s.bridges.Capabilities(cmd.AccountID).Reactions {
+		return Submission{}, ErrUnsupported
+	}
+
+	conversation, err := s.store.GetConversation(cmd.ConversationID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("send reaction: read conversation: %w", err)
+	}
+	if conversation.AccountID != cmd.AccountID {
+		return Submission{}, fmt.Errorf(
+			"%w: conversation %q belongs to account %q, not %q",
+			ErrInvalidCommand,
+			cmd.ConversationID,
+			conversation.AccountID,
+			cmd.AccountID,
+		)
+	}
+
+	target, err := s.messages.GetMessage(ctx, cmd.TargetMessageID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("send reaction: read target: %w", err)
+	}
+	if target.AccountID != cmd.AccountID || target.ConversationID != cmd.ConversationID {
+		return Submission{}, fmt.Errorf(
+			"%w: reaction target %q is outside conversation %q",
+			ErrInvalidCommand,
+			cmd.TargetMessageID,
+			cmd.ConversationID,
+		)
+	}
+	// Reactions cannot target a deleted message. MarkRead deliberately permits
+	// deleted cursor targets because deletion does not undo that the user read it.
+	if target.State == sqlite.MessageStateDeleted {
+		return Submission{}, fmt.Errorf(
+			"%w: reaction target %q is deleted",
+			ErrInvalidCommand,
+			cmd.TargetMessageID,
+		)
+	}
+
+	outboxID, _, requestID, err := s.newSubmissionIDs()
+	if err != nil {
+		return Submission{}, err
+	}
+	now := s.clock.Now()
+	scheduledFor := cmd.NotBefore
+	if scheduledFor.IsZero() {
+		scheduledFor = now
+	}
+	payloadHash, err := reactionPayloadHash(cmd.TargetMessageID, cmd.Emoji, cmd.Action)
+	if err != nil {
+		return Submission{}, fmt.Errorf("send reaction: hash payload: %w", err)
+	}
+
+	item, disposition, err := s.outbox.EnqueueReaction(ctx, sqlite.NewOutboxItem{
+		OutboxID:           outboxID,
+		AccountID:          cmd.AccountID,
+		ConversationID:     cmd.ConversationID,
+		Kind:               sqlite.OutboxKindReaction,
+		IdempotencyKey:     cmd.IdempotencyKey,
+		PayloadHash:        payloadHash,
+		Operation:          reactionOperation,
+		TransportRequestID: requestID,
+		ScheduledFor:       scheduledFor,
+	}, sqlite.OutboxReaction{
+		TargetMessageID: cmd.TargetMessageID,
+		Emoji:           cmd.Emoji,
+		Action:          string(cmd.Action),
+	})
+	if err != nil {
+		return Submission{}, fmt.Errorf("send reaction: %w", err)
+	}
+
+	submission := submissionFromItem(item)
+	if disposition == sqlite.EnqueueInserted {
+		s.signalChange()
+		s.signalWake()
+	}
+	return submission, nil
+}
+
+// MarkRead atomically records the device cursor and creates its durable
+// outbound receipt intent. The cursor remains advanced even if dispatch later
+// reaches a terminal failure.
+func (s *MessageService) MarkRead(
+	ctx context.Context,
+	cmd MarkReadCommand,
+) (Submission, error) {
+	if ctx == nil {
+		return Submission{}, fmt.Errorf("mark read: context is nil")
+	}
+	if err := validateMarkReadCommand(cmd); err != nil {
+		return Submission{}, err
+	}
+	if !s.bridges.Capabilities(cmd.AccountID).ReadReceipts {
+		return Submission{}, ErrUnsupported
+	}
+
+	conversation, err := s.store.GetConversation(cmd.ConversationID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("mark read: read conversation: %w", err)
+	}
+	if conversation.AccountID != cmd.AccountID {
+		return Submission{}, fmt.Errorf(
+			"%w: conversation %q belongs to account %q, not %q",
+			ErrInvalidCommand,
+			cmd.ConversationID,
+			conversation.AccountID,
+			cmd.AccountID,
+		)
+	}
+
+	target, err := s.messages.GetMessage(ctx, cmd.LastReadMessageID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("mark read: read cursor target: %w", err)
+	}
+	if target.AccountID != cmd.AccountID || target.ConversationID != cmd.ConversationID {
+		return Submission{}, fmt.Errorf(
+			"%w: read cursor target %q is outside conversation %q",
+			ErrInvalidCommand,
+			cmd.LastReadMessageID,
+			cmd.ConversationID,
+		)
+	}
+	// Unlike reactions, a read cursor may name a deleted message: deletion does
+	// not regress the user's durable read position.
+	device, err := s.store.GetDevice(cmd.DeviceID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("mark read: read device: %w", err)
+	}
+	if device.AccountID != cmd.AccountID {
+		return Submission{}, fmt.Errorf(
+			"%w: device %q belongs to account %q, not %q",
+			ErrInvalidCommand,
+			cmd.DeviceID,
+			device.AccountID,
+			cmd.AccountID,
+		)
+	}
+
+	outboxID, _, requestID, err := s.newSubmissionIDs()
+	if err != nil {
+		return Submission{}, err
+	}
+	now := s.clock.Now()
+	if cmd.LastReadAt.IsZero() {
+		cmd.LastReadAt = now
+	}
+	scheduledFor := cmd.NotBefore
+	if scheduledFor.IsZero() {
+		scheduledFor = now
+	}
+	payloadHash, err := readPayloadHash(cmd.DeviceID, cmd.LastReadMessageID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("mark read: hash payload: %w", err)
+	}
+	lastReadMessageID := cmd.LastReadMessageID
+
+	item, disposition, err := s.outbox.EnqueueReadReceipt(ctx, sqlite.NewOutboxItem{
+		OutboxID:           outboxID,
+		AccountID:          cmd.AccountID,
+		ConversationID:     cmd.ConversationID,
+		Kind:               sqlite.OutboxKindRead,
+		IdempotencyKey:     cmd.IdempotencyKey,
+		PayloadHash:        payloadHash,
+		Operation:          readOperation,
+		TransportRequestID: requestID,
+		ScheduledFor:       scheduledFor,
+	}, sqlite.OutboxReadReceipt{
+		DeviceID:          cmd.DeviceID,
+		LastReadMessageID: cmd.LastReadMessageID,
+		ReadAtMS:          cmd.LastReadAt.UnixMilli(),
+	}, sqlite.ReadCursor{
+		AccountID:         cmd.AccountID,
+		DeviceID:          cmd.DeviceID,
+		ConversationID:    cmd.ConversationID,
+		LastReadMessageID: &lastReadMessageID,
+		LastReadAtMS:      cmd.LastReadAt.UnixMilli(),
+		UpdatedAtMS:       now.UnixMilli(),
+	})
+	if err != nil {
+		return Submission{}, fmt.Errorf("mark read: %w", err)
+	}
+
+	submission := submissionFromItem(item)
+	if disposition == sqlite.EnqueueInserted {
+		s.signalChange()
+		s.signalWake()
+	}
+	return submission, nil
+}
+
 // Get returns the current durable delivery state.
 func (s *MessageService) Get(ctx context.Context, outboxID string) (Delivery, error) {
 	if ctx == nil {
@@ -504,6 +711,70 @@ func validateSendMediaCommand(cmd *SendMediaCommand) error {
 	return nil
 }
 
+func validateSendReactionCommand(cmd *SendReactionCommand) error {
+	if cmd == nil {
+		return fmt.Errorf("%w: reaction command is nil", ErrInvalidCommand)
+	}
+	checks := []struct {
+		name  string
+		value string
+	}{
+		{name: "account ID", value: cmd.AccountID},
+		{name: "conversation ID", value: cmd.ConversationID},
+		{name: "idempotency key", value: cmd.IdempotencyKey},
+		{name: "target message ID", value: cmd.TargetMessageID},
+	}
+	for _, check := range checks {
+		if strings.TrimSpace(check.value) == "" {
+			return fmt.Errorf("%w: %s is empty", ErrInvalidCommand, check.name)
+		}
+	}
+	cmd.Emoji = strings.TrimSpace(cmd.Emoji)
+	if cmd.Emoji == "" {
+		return fmt.Errorf("%w: emoji is empty", ErrInvalidCommand)
+	}
+	if len(cmd.Emoji) > 64 {
+		return fmt.Errorf("%w: emoji exceeds 64 bytes", ErrInvalidCommand)
+	}
+	if cmd.Action == "" {
+		cmd.Action = bridge.ReactionAdd
+	}
+	switch cmd.Action {
+	case bridge.ReactionAdd, bridge.ReactionRemove, bridge.ReactionSwitch:
+	default:
+		return fmt.Errorf("%w: reaction action %q is invalid", ErrInvalidCommand, cmd.Action)
+	}
+	if !cmd.NotBefore.IsZero() && cmd.NotBefore.UnixMilli() <= 0 {
+		return fmt.Errorf("%w: scheduled Unix time is not positive", ErrInvalidCommand)
+	}
+	return nil
+}
+
+func validateMarkReadCommand(cmd MarkReadCommand) error {
+	checks := []struct {
+		name  string
+		value string
+	}{
+		{name: "account ID", value: cmd.AccountID},
+		{name: "conversation ID", value: cmd.ConversationID},
+		{name: "idempotency key", value: cmd.IdempotencyKey},
+		{name: "device ID", value: cmd.DeviceID},
+		{name: "last read message ID", value: cmd.LastReadMessageID},
+	}
+	for _, check := range checks {
+		if strings.TrimSpace(check.value) == "" {
+			return fmt.Errorf("%w: %s is empty", ErrInvalidCommand, check.name)
+		}
+	}
+	if !cmd.LastReadAt.IsZero() && cmd.LastReadAt.UnixMilli() <= 0 {
+		return fmt.Errorf("%w: last-read Unix time is not positive", ErrInvalidCommand)
+	}
+	if !cmd.NotBefore.IsZero() && cmd.NotBefore.UnixMilli() <= 0 {
+		return fmt.Errorf("%w: scheduled Unix time is not positive", ErrInvalidCommand)
+	}
+	return nil
+}
+
 func textPayloadHash(body, replyToMessageID string) (string, error) {
 	payload, err := json.Marshal(struct {
 		Body             string `json:"body"`
@@ -532,6 +803,44 @@ func mediaPayloadHash(
 		Caption          string `json:"caption,omitempty"`
 		ReplyToMessageID string `json:"reply_to_message_id,omitempty"`
 	}{blobHash, size, mime, filename, caption, replyToMessageID})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func reactionPayloadHash(
+	targetMessageID string,
+	emoji string,
+	action bridge.ReactionAction,
+) (string, error) {
+	payload, err := json.Marshal(struct {
+		TargetMessageID string                `json:"target_message_id"`
+		Emoji           string                `json:"emoji"`
+		Action          bridge.ReactionAction `json:"action"`
+	}{
+		TargetMessageID: targetMessageID,
+		Emoji:           emoji,
+		Action:          action,
+	})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func readPayloadHash(deviceID, lastReadMessageID string) (string, error) {
+	// ReadAt is intentionally excluded: the idempotent intent is the device's
+	// cursor position, so a replay at a later wall-clock time remains identical.
+	payload, err := json.Marshal(struct {
+		DeviceID          string `json:"device_id"`
+		LastReadMessageID string `json:"last_read_message_id"`
+	}{
+		DeviceID:          deviceID,
+		LastReadMessageID: lastReadMessageID,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/internal/messaging/service_test.go
+++ b/internal/messaging/service_test.go
@@ -651,6 +651,473 @@ func TestSendMediaWithoutBlobStoreReturnsConfigurationError(t *testing.T) {
 	}
 }
 
+func TestSendReactionValidatesCommand(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	registry := newScriptedRegistry("reaction-validation", nil)
+	registry.setReactionSender(&scriptedReactionSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+
+	tests := []struct {
+		name   string
+		mutate func(*SendReactionCommand)
+	}{
+		{name: "empty emoji", mutate: func(cmd *SendReactionCommand) { cmd.Emoji = " \t " }},
+		{name: "emoji too long", mutate: func(cmd *SendReactionCommand) { cmd.Emoji = strings.Repeat("x", 65) }},
+		{name: "bad action", mutate: func(cmd *SendReactionCommand) { cmd.Action = bridge.ReactionAction("toggle") }},
+		{name: "empty target", mutate: func(cmd *SendReactionCommand) { cmd.TargetMessageID = " " }},
+		{name: "invalid schedule", mutate: func(cmd *SendReactionCommand) { cmd.NotBefore = time.UnixMilli(0) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := SendReactionCommand{
+				CommonCommand:   testCommonCommand("key-reaction-validation-" + test.name),
+				TargetMessageID: "target-message",
+				Emoji:           "👍",
+				Action:          bridge.ReactionAdd,
+			}
+			test.mutate(&command)
+
+			if _, err := service.SendReaction(context.Background(), command); !errors.Is(err, ErrInvalidCommand) {
+				t.Fatalf("SendReaction() error = %v, want ErrInvalidCommand", err)
+			}
+		})
+	}
+}
+
+func TestMarkReadValidatesCommand(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	registry := newScriptedRegistry("read-validation", nil)
+	registry.setReadReceiptSender(&scriptedReadReceiptSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+
+	tests := []struct {
+		name   string
+		mutate func(*MarkReadCommand)
+	}{
+		{name: "empty device", mutate: func(cmd *MarkReadCommand) { cmd.DeviceID = " " }},
+		{name: "empty target", mutate: func(cmd *MarkReadCommand) { cmd.LastReadMessageID = "\t" }},
+		{name: "invalid read time", mutate: func(cmd *MarkReadCommand) { cmd.LastReadAt = time.UnixMilli(0) }},
+		{name: "invalid schedule", mutate: func(cmd *MarkReadCommand) { cmd.NotBefore = time.UnixMilli(0) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := MarkReadCommand{
+				CommonCommand:     testCommonCommand("key-read-validation-" + test.name),
+				DeviceID:          "device-1",
+				LastReadMessageID: "target-message",
+				LastReadAt:        clock.Now(),
+			}
+			test.mutate(&command)
+
+			if _, err := service.MarkRead(context.Background(), command); !errors.Is(err, ErrInvalidCommand) {
+				t.Fatalf("MarkRead() error = %v, want ErrInvalidCommand", err)
+			}
+		})
+	}
+}
+
+func TestReactionAndReadCapabilityGatesPrecedeGraphWork(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	service := newMessagingTestService(
+		t,
+		store,
+		newScriptedRegistry("unsupported-intents", nil),
+		clock,
+	)
+
+	if _, err := service.SendReaction(context.Background(), SendReactionCommand{
+		CommonCommand: CommonCommand{
+			AccountID:      "account-1",
+			ConversationID: "missing-conversation",
+			IdempotencyKey: "key-reaction-unsupported",
+		},
+		TargetMessageID: "missing-message",
+		Emoji:           "👍",
+	}); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("SendReaction(unsupported) error = %v, want ErrUnsupported", err)
+	}
+	if _, err := service.MarkRead(context.Background(), MarkReadCommand{
+		CommonCommand: CommonCommand{
+			AccountID:      "account-1",
+			ConversationID: "missing-conversation",
+			IdempotencyKey: "key-read-unsupported",
+		},
+		DeviceID:          "missing-device",
+		LastReadMessageID: "missing-message",
+	}); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("MarkRead(unsupported) error = %v, want ErrUnsupported", err)
+	}
+}
+
+func TestMarkReadChecksTargetBeforeDevice(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	registry := newScriptedRegistry("read-check-order", nil)
+	registry.setReadReceiptSender(&scriptedReadReceiptSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+
+	_, err := service.MarkRead(context.Background(), MarkReadCommand{
+		CommonCommand:     testCommonCommand("key-read-check-order"),
+		DeviceID:          "missing-device",
+		LastReadMessageID: "missing-message",
+	})
+	if !errors.Is(err, sqlite.ErrNotFound) || !strings.Contains(err.Error(), "read cursor target") {
+		t.Fatalf("MarkRead(missing target and device) error = %v, want target not-found first", err)
+	}
+}
+
+func TestReactionAndReadPayloadHashesCoverIntentFields(t *testing.T) {
+	reaction, err := reactionPayloadHash("target-a", "👍", bridge.ReactionAdd)
+	if err != nil {
+		t.Fatalf("reactionPayloadHash(): %v", err)
+	}
+	for _, candidate := range []struct {
+		target string
+		emoji  string
+		action bridge.ReactionAction
+	}{
+		{target: "target-b", emoji: "👍", action: bridge.ReactionAdd},
+		{target: "target-a", emoji: "🔥", action: bridge.ReactionAdd},
+		{target: "target-a", emoji: "👍", action: bridge.ReactionRemove},
+	} {
+		got, hashErr := reactionPayloadHash(candidate.target, candidate.emoji, candidate.action)
+		if hashErr != nil {
+			t.Fatalf("reactionPayloadHash(candidate): %v", hashErr)
+		}
+		if got == reaction {
+			t.Fatalf("reaction hash did not cover candidate %+v", candidate)
+		}
+	}
+
+	read, err := readPayloadHash("device-a", "message-a")
+	if err != nil {
+		t.Fatalf("readPayloadHash(): %v", err)
+	}
+	for _, candidate := range [][2]string{{"device-b", "message-a"}, {"device-a", "message-b"}} {
+		got, hashErr := readPayloadHash(candidate[0], candidate[1])
+		if hashErr != nil {
+			t.Fatalf("readPayloadHash(candidate): %v", hashErr)
+		}
+		if got == read {
+			t.Fatalf("read hash did not cover device/message %q/%q", candidate[0], candidate[1])
+		}
+	}
+}
+
+func TestSendReactionWritesDurableIntentWithoutMessageProjection(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	registry := newScriptedRegistry("reaction-submit", nil)
+	registry.setReactionSender(&scriptedReactionSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-reaction-target"),
+		Body:          "react to me",
+	})
+
+	submission := mustSendReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("key-reaction-submit"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "  👍  ",
+	})
+	item := mustOutboxItem(t, service, submission.OutboxID)
+	if item.Kind != sqlite.OutboxKindReaction || item.Operation != reactionOperation ||
+		item.LocalMessageID != nil || submission.LocalMessageID != "" {
+		t.Fatalf("reaction outbox item = %+v, submission = %+v", item, submission)
+	}
+	reaction, err := service.outbox.GetOutboxReaction(context.Background(), submission.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxReaction(): %v", err)
+	}
+	if reaction.TargetMessageID != target.LocalMessageID || reaction.Emoji != "👍" ||
+		reaction.Action != string(bridge.ReactionAdd) || reaction.CreatedAtMS != clock.Now().UnixMilli() {
+		t.Fatalf("outbox reaction = %+v", reaction)
+	}
+	if _, err := service.messages.GetMessage(context.Background(), "id-005"); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("reaction candidate message error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSendReactionDeduplicatesAndHashesEmojiAndAction(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	registry := newScriptedRegistry("reaction-dedup", nil)
+	registry.setReactionSender(&scriptedReactionSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-reaction-dedup-target"),
+		Body:          "target",
+	})
+	command := SendReactionCommand{
+		CommonCommand:   testCommonCommand("key-reaction-dedup"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "🔥",
+		Action:          bridge.ReactionAdd,
+	}
+
+	first := mustSendReaction(t, service, command)
+	second := mustSendReaction(t, service, command)
+	if first != second {
+		t.Fatalf("duplicate reaction submissions differ: first=%+v second=%+v", first, second)
+	}
+	if _, err := service.outbox.FindByID(context.Background(), "id-007"); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("duplicate candidate reaction error = %v, want ErrNotFound", err)
+	}
+
+	for _, mutate := range []func(*SendReactionCommand){
+		func(cmd *SendReactionCommand) { cmd.Emoji = "👍" },
+		func(cmd *SendReactionCommand) { cmd.Action = bridge.ReactionRemove },
+	} {
+		conflict := command
+		mutate(&conflict)
+		if _, err := service.SendReaction(context.Background(), conflict); !errors.Is(err, ErrIdempotencyConflict) {
+			t.Fatalf("SendReaction(conflict) error = %v, want ErrIdempotencyConflict", err)
+		}
+	}
+}
+
+func TestSendReactionKeepsRapidToggleAsTwoOrderedIntents(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	registry := newScriptedRegistry("reaction-toggle", nil)
+	registry.setReactionSender(&scriptedReactionSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-reaction-toggle-target"),
+		Body:          "target",
+	})
+
+	add := mustSendReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("key-reaction-add"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+		Action:          bridge.ReactionAdd,
+	})
+	clock.Advance(time.Millisecond)
+	remove := mustSendReaction(t, service, SendReactionCommand{
+		CommonCommand:   testCommonCommand("key-reaction-remove"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+		Action:          bridge.ReactionRemove,
+	})
+	addItem := mustOutboxItem(t, service, add.OutboxID)
+	removeItem := mustOutboxItem(t, service, remove.OutboxID)
+	if add.OutboxID == remove.OutboxID || addItem.CreatedAtMS >= removeItem.CreatedAtMS ||
+		addItem.State != sqlite.OutboxQueued || removeItem.State != sqlite.OutboxQueued {
+		t.Fatalf("toggle intents = (%+v, %+v), want two ordered queued rows", addItem, removeItem)
+	}
+}
+
+func TestSendReactionRejectsConversationAndTargetOwnershipViolations(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedSecondMessagingAccount(t, store, clock.Now())
+	registry := newScriptedRegistry("reaction-ownership", nil)
+	registry.setReactionSender(&scriptedReactionSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+	foreignTarget := seedMessagingMessage(t, store, clock, sqlite.Message{
+		MessageID:       "foreign-message",
+		ConversationID:  "conversation-2",
+		AccountID:       "account-2",
+		RemoteMessageID: "remote-foreign-message",
+		Direction:       sqlite.MessageDirectionIncoming,
+		Body:            "foreign",
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    clock.Now().UnixMilli(),
+	})
+
+	_, err := service.SendReaction(context.Background(), SendReactionCommand{
+		CommonCommand: CommonCommand{
+			AccountID:      "account-1",
+			ConversationID: "conversation-2",
+			IdempotencyKey: "key-reaction-foreign-conversation",
+		},
+		TargetMessageID: foreignTarget,
+		Emoji:           "👍",
+	})
+	if !errors.Is(err, ErrInvalidCommand) {
+		t.Fatalf("SendReaction(foreign conversation) error = %v, want ErrInvalidCommand", err)
+	}
+
+	_, err = service.SendReaction(context.Background(), SendReactionCommand{
+		CommonCommand:   testCommonCommand("key-reaction-foreign-target"),
+		TargetMessageID: foreignTarget,
+		Emoji:           "👍",
+	})
+	if !errors.Is(err, ErrInvalidCommand) {
+		t.Fatalf("SendReaction(foreign target) error = %v, want ErrInvalidCommand", err)
+	}
+}
+
+func TestReactionRejectsDeletedTargetButReadAllowsDeletedCursorTarget(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	registry := newScriptedRegistry("deleted-target", nil)
+	registry.setReactionSender(&scriptedReactionSender{})
+	registry.setReadReceiptSender(&scriptedReadReceiptSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-deleted-target"),
+		Body:          "delete me",
+	})
+	markMessagingMessageDeleted(t, store, clock, target.LocalMessageID)
+	seedMessagingDevice(t, store, "device-1", "account-1", clock.Now())
+
+	if _, err := service.SendReaction(context.Background(), SendReactionCommand{
+		CommonCommand:   testCommonCommand("key-deleted-reaction"),
+		TargetMessageID: target.LocalMessageID,
+		Emoji:           "👍",
+	}); !errors.Is(err, ErrInvalidCommand) {
+		t.Fatalf("SendReaction(deleted target) error = %v, want ErrInvalidCommand", err)
+	}
+	read := mustMarkRead(t, service, MarkReadCommand{
+		CommonCommand:     testCommonCommand("key-deleted-read"),
+		DeviceID:          "device-1",
+		LastReadMessageID: target.LocalMessageID,
+	})
+	if read.State != OutboxQueued {
+		t.Fatalf("MarkRead(deleted target) = %+v, want queued", read)
+	}
+}
+
+func TestMarkReadWritesReceiptAndMonotoneCursorWithoutMessageProjection(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedMessagingDevice(t, store, "device-1", "account-1", clock.Now())
+	registry := newScriptedRegistry("read-submit", nil)
+	registry.setReadReceiptSender(&scriptedReadReceiptSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-read-target"),
+		Body:          "read me",
+	})
+
+	submission := mustMarkRead(t, service, MarkReadCommand{
+		CommonCommand:     testCommonCommand("key-read-submit"),
+		DeviceID:          "device-1",
+		LastReadMessageID: target.LocalMessageID,
+	})
+	item := mustOutboxItem(t, service, submission.OutboxID)
+	if item.Kind != sqlite.OutboxKindRead || item.Operation != readOperation ||
+		item.LocalMessageID != nil || submission.LocalMessageID != "" {
+		t.Fatalf("read outbox item = %+v, submission = %+v", item, submission)
+	}
+	receipt, err := service.outbox.GetOutboxReadReceipt(context.Background(), submission.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxReadReceipt(): %v", err)
+	}
+	if receipt.DeviceID != "device-1" || receipt.LastReadMessageID != target.LocalMessageID ||
+		receipt.ReadAtMS != clock.Now().UnixMilli() || receipt.CreatedAtMS != clock.Now().UnixMilli() {
+		t.Fatalf("outbox read receipt = %+v", receipt)
+	}
+	cursor, err := store.GetReadCursor("device-1", "conversation-1")
+	if err != nil {
+		t.Fatalf("GetReadCursor(): %v", err)
+	}
+	if cursor.AccountID != "account-1" || cursor.LastReadMessageID == nil ||
+		*cursor.LastReadMessageID != target.LocalMessageID || cursor.LastReadAtMS != clock.Now().UnixMilli() ||
+		cursor.UpdatedAtMS != clock.Now().UnixMilli() {
+		t.Fatalf("read cursor = %+v", cursor)
+	}
+	if _, err := service.messages.GetMessage(context.Background(), "id-005"); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("read candidate message error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMarkReadDeduplicatesSameCursorWithReadAtExcluded(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedMessagingDevice(t, store, "device-1", "account-1", clock.Now())
+	registry := newScriptedRegistry("read-dedup", nil)
+	registry.setReadReceiptSender(&scriptedReadReceiptSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+	target := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-read-dedup-target"),
+		Body:          "target",
+	})
+	command := MarkReadCommand{
+		CommonCommand:     testCommonCommand("key-read-dedup"),
+		DeviceID:          "device-1",
+		LastReadMessageID: target.LocalMessageID,
+		LastReadAt:        clock.Now(),
+	}
+
+	first := mustMarkRead(t, service, command)
+	clock.Advance(time.Minute)
+	command.LastReadAt = clock.Now()
+	second := mustMarkRead(t, service, command)
+	if first != second {
+		t.Fatalf("duplicate read submissions differ: first=%+v second=%+v", first, second)
+	}
+	receipt, err := service.outbox.GetOutboxReadReceipt(context.Background(), first.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxReadReceipt(): %v", err)
+	}
+	if receipt.ReadAtMS != messagingTestTime.UnixMilli() {
+		t.Fatalf("deduplicated receipt read_at_ms = %d, want original %d", receipt.ReadAtMS, messagingTestTime.UnixMilli())
+	}
+	cursor, err := store.GetReadCursor("device-1", "conversation-1")
+	if err != nil {
+		t.Fatalf("GetReadCursor(): %v", err)
+	}
+	if cursor.LastReadAtMS != messagingTestTime.UnixMilli() || cursor.UpdatedAtMS != messagingTestTime.UnixMilli() {
+		t.Fatalf("deduplicated cursor changed = %+v, want original timestamps", cursor)
+	}
+}
+
+func TestMarkReadRejectsMissingAndCrossAccountDeviceAndForeignTarget(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	seedSecondMessagingAccount(t, store, clock.Now())
+	seedMessagingDevice(t, store, "device-1", "account-1", clock.Now())
+	seedMessagingDevice(t, store, "device-2", "account-2", clock.Now())
+	registry := newScriptedRegistry("read-ownership", nil)
+	registry.setReadReceiptSender(&scriptedReadReceiptSender{})
+	service := newMessagingTestService(t, store, registry, clock)
+	localTarget := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-read-local-target"),
+		Body:          "local",
+	})
+	foreignTarget := seedMessagingMessage(t, store, clock, sqlite.Message{
+		MessageID:       "foreign-read-message",
+		ConversationID:  "conversation-2",
+		AccountID:       "account-2",
+		RemoteMessageID: "remote-foreign-read-message",
+		Direction:       sqlite.MessageDirectionIncoming,
+		Body:            "foreign",
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    clock.Now().UnixMilli(),
+	})
+
+	tests := []struct {
+		name     string
+		deviceID string
+		targetID string
+	}{
+		{name: "missing device", deviceID: "missing-device", targetID: localTarget.LocalMessageID},
+		{name: "cross-account device", deviceID: "device-2", targetID: localTarget.LocalMessageID},
+		{name: "foreign target", deviceID: "device-1", targetID: foreignTarget},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := service.MarkRead(context.Background(), MarkReadCommand{
+				CommonCommand:     testCommonCommand("key-read-ownership-" + test.name),
+				DeviceID:          test.deviceID,
+				LastReadMessageID: test.targetID,
+			})
+			if err == nil {
+				t.Fatal("MarkRead() succeeded, want ownership/not-found error")
+			}
+			if test.name != "missing device" && !errors.Is(err, ErrInvalidCommand) {
+				t.Fatalf("MarkRead() error = %v, want ErrInvalidCommand", err)
+			}
+		})
+	}
+}
+
 func TestCancelAndDeferredAPIs(t *testing.T) {
 	clock := newManualClock(messagingTestTime)
 	store := openMessagingTestStore(t, clock.Now())
@@ -777,13 +1244,97 @@ func (s *scriptedMediaSender) snapshotRequests() []bridge.MediaRequest {
 	return append([]bridge.MediaRequest(nil), s.requests...)
 }
 
+type scriptedReactionSender struct {
+	mu       sync.Mutex
+	steps    []sendStep
+	requests []bridge.ReactionRequest
+	onSend   func()
+}
+
+func (s *scriptedReactionSender) SendReaction(
+	_ context.Context,
+	request bridge.ReactionRequest,
+) (bridge.SendResult, error) {
+	s.mu.Lock()
+	s.requests = append(s.requests, request)
+	var step sendStep
+	if len(s.steps) > 0 {
+		step = s.steps[0]
+		s.steps = s.steps[1:]
+	}
+	onSend := s.onSend
+	s.mu.Unlock()
+	if onSend != nil {
+		onSend()
+	}
+	return step.result, step.err
+}
+
+func (s *scriptedReactionSender) requestCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.requests)
+}
+
+func (s *scriptedReactionSender) snapshotRequests() []bridge.ReactionRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]bridge.ReactionRequest(nil), s.requests...)
+}
+
+type readReceiptStep struct {
+	err error
+}
+
+type scriptedReadReceiptSender struct {
+	mu       sync.Mutex
+	steps    []readReceiptStep
+	requests []bridge.ReadReceiptRequest
+	onSend   func()
+}
+
+func (s *scriptedReadReceiptSender) MarkRead(
+	_ context.Context,
+	request bridge.ReadReceiptRequest,
+) error {
+	s.mu.Lock()
+	s.requests = append(s.requests, request)
+	var step readReceiptStep
+	if len(s.steps) > 0 {
+		step = s.steps[0]
+		s.steps = s.steps[1:]
+	}
+	onSend := s.onSend
+	s.mu.Unlock()
+	if onSend != nil {
+		onSend()
+	}
+	return step.err
+}
+
+func (s *scriptedReadReceiptSender) requestCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.requests)
+}
+
+func (s *scriptedReadReceiptSender) snapshotRequests() []bridge.ReadReceiptRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]bridge.ReadReceiptRequest(nil), s.requests...)
+}
+
 type scriptedRegistry struct {
-	mu                sync.Mutex
-	platform          bridge.Platform
-	sender            bridge.TextSender
-	media             bridge.MediaSender
-	mediaSendDeclared bool
-	available         bool
+	mu                   sync.Mutex
+	platform             bridge.Platform
+	sender               bridge.TextSender
+	media                bridge.MediaSender
+	reaction             bridge.ReactionSender
+	readReceipt          bridge.ReadReceiptSender
+	mediaSendDeclared    bool
+	reactionsDeclared    bool
+	readReceiptsDeclared bool
+	available            bool
 }
 
 func newScriptedRegistry(platform bridge.Platform, sender bridge.TextSender) *scriptedRegistry {
@@ -806,6 +1357,32 @@ func (r *scriptedRegistry) setMediaSender(sender bridge.MediaSender) {
 func (r *scriptedRegistry) setMediaSendDeclared(declared bool) {
 	r.mu.Lock()
 	r.mediaSendDeclared = declared
+	r.mu.Unlock()
+}
+
+func (r *scriptedRegistry) setReactionSender(sender bridge.ReactionSender) {
+	r.mu.Lock()
+	r.reaction = sender
+	r.reactionsDeclared = sender != nil
+	r.mu.Unlock()
+}
+
+func (r *scriptedRegistry) setReactionsDeclared(declared bool) {
+	r.mu.Lock()
+	r.reactionsDeclared = declared
+	r.mu.Unlock()
+}
+
+func (r *scriptedRegistry) setReadReceiptSender(sender bridge.ReadReceiptSender) {
+	r.mu.Lock()
+	r.readReceipt = sender
+	r.readReceiptsDeclared = sender != nil
+	r.mu.Unlock()
+}
+
+func (r *scriptedRegistry) setReadReceiptsDeclared(declared bool) {
+	r.mu.Lock()
+	r.readReceiptsDeclared = declared
 	r.mu.Unlock()
 }
 
@@ -852,6 +1429,16 @@ func (r *scriptedRegistry) Acquire(
 			return nil, bridge.ErrCapabilityUnavailable
 		}
 		lease.Media = r.media
+	case bridge.CapabilityReactions:
+		if r.reaction == nil {
+			return nil, bridge.ErrCapabilityUnavailable
+		}
+		lease.Reaction = r.reaction
+	case bridge.CapabilityReadReceipts:
+		if r.readReceipt == nil {
+			return nil, bridge.ErrCapabilityUnavailable
+		}
+		lease.ReadReceipt = r.readReceipt
 	default:
 		return nil, bridge.ErrCapabilityUnavailable
 	}
@@ -862,8 +1449,10 @@ func (r *scriptedRegistry) Capabilities(accountID string) bridge.CapabilitySet {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return bridge.CapabilitySet{
-		TextSend:  accountID == "account-1" && r.sender != nil,
-		MediaSend: accountID == "account-1" && r.mediaSendDeclared,
+		TextSend:     accountID == "account-1" && r.sender != nil,
+		MediaSend:    accountID == "account-1" && r.mediaSendDeclared,
+		Reactions:    accountID == "account-1" && r.reactionsDeclared,
+		ReadReceipts: accountID == "account-1" && r.readReceiptsDeclared,
 	}
 }
 
@@ -1014,6 +1603,24 @@ func mustSendMedia(t *testing.T, service *MessageService, command SendMediaComma
 	return submission
 }
 
+func mustSendReaction(t *testing.T, service *MessageService, command SendReactionCommand) Submission {
+	t.Helper()
+	submission, err := service.SendReaction(context.Background(), command)
+	if err != nil {
+		t.Fatalf("SendReaction(): %v", err)
+	}
+	return submission
+}
+
+func mustMarkRead(t *testing.T, service *MessageService, command MarkReadCommand) Submission {
+	t.Helper()
+	submission, err := service.MarkRead(context.Background(), command)
+	if err != nil {
+		t.Fatalf("MarkRead(): %v", err)
+	}
+	return submission
+}
+
 func mustDelivery(t *testing.T, service *MessageService, outboxID string) Delivery {
 	t.Helper()
 	delivery, err := service.Get(context.Background(), outboxID)
@@ -1030,4 +1637,107 @@ func mustOutboxItem(t *testing.T, service *MessageService, outboxID string) sqli
 		t.Fatalf("FindByID(%q): %v", outboxID, err)
 	}
 	return item
+}
+
+func seedMessagingDevice(
+	t *testing.T,
+	store *sqlite.Store,
+	deviceID string,
+	accountID string,
+	now time.Time,
+) {
+	t.Helper()
+	if err := store.UpsertDevice(sqlite.Device{
+		DeviceID:    deviceID,
+		AccountID:   accountID,
+		Kind:        sqlite.DeviceKindLocalInstallation,
+		DisplayName: "Test device",
+		State:       sqlite.DeviceStateActive,
+		IsCurrent:   true,
+		CreatedAtMS: now.UnixMilli(),
+		UpdatedAtMS: now.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("UpsertDevice(%q): %v", deviceID, err)
+	}
+}
+
+func seedSecondMessagingAccount(t *testing.T, store *sqlite.Store, now time.Time) {
+	t.Helper()
+	nowMS := now.UnixMilli()
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   "account-2",
+		BridgeKey:   "scripted",
+		DisplayName: "Second account",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: nowMS,
+		UpdatedAtMS: nowMS,
+	}); err != nil {
+		t.Fatalf("UpsertAccount(account-2): %v", err)
+	}
+	if err := store.UpsertConversation(sqlite.Conversation{
+		ConversationID:       "conversation-2",
+		AccountID:            "account-2",
+		RemoteConversationID: "remote-conversation-2",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Second conversation",
+		NotificationMode:     sqlite.NotificationModeAll,
+		MetadataJSON:         `{}`,
+		CreatedAtMS:          nowMS,
+		UpdatedAtMS:          nowMS,
+	}); err != nil {
+		t.Fatalf("UpsertConversation(conversation-2): %v", err)
+	}
+}
+
+func seedMessagingMessage(
+	t *testing.T,
+	store *sqlite.Store,
+	clock Clock,
+	message sqlite.Message,
+) string {
+	t.Helper()
+	repository, err := sqlite.NewMessageRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	inboxID := "inbox-" + message.MessageID + "-" + string(message.State)
+	if _, err := repository.AppendInbox(context.Background(), sqlite.InboxRecord{
+		InboxID:      inboxID,
+		AccountID:    message.AccountID,
+		Generation:   1,
+		DedupeKey:    inboxID,
+		Codec:        "test.frame",
+		CodecVersion: 1,
+		Payload:      []byte("frame"),
+	}); err != nil {
+		t.Fatalf("AppendInbox(%q): %v", inboxID, err)
+	}
+	if err := repository.ProjectMessage(context.Background(), sqlite.MessageProjection{
+		InboxID: inboxID,
+		Message: message,
+	}); err != nil {
+		t.Fatalf("ProjectMessage(%q): %v", message.MessageID, err)
+	}
+	return message.MessageID
+}
+
+func markMessagingMessageDeleted(
+	t *testing.T,
+	store *sqlite.Store,
+	clock Clock,
+	messageID string,
+) {
+	t.Helper()
+	repository, err := sqlite.NewMessageRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	message, err := repository.GetMessage(context.Background(), messageID)
+	if err != nil {
+		t.Fatalf("GetMessage(%q): %v", messageID, err)
+	}
+	message.State = sqlite.MessageStateDeleted
+	seedMessagingMessage(t, store, clock, message)
 }

--- a/internal/messaging/types.go
+++ b/internal/messaging/types.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/maxghenis/openmessage/internal/bridge"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 )
 
@@ -67,6 +68,20 @@ type SendMediaCommand struct {
 	MIME             string
 	Caption          string
 	ReplyToMessageID string
+}
+
+type SendReactionCommand struct {
+	CommonCommand
+	TargetMessageID string
+	Emoji           string
+	Action          bridge.ReactionAction // empty means ReactionAdd
+}
+
+type MarkReadCommand struct {
+	CommonCommand
+	DeviceID          string
+	LastReadMessageID string
+	LastReadAt        time.Time // zero means clock.Now()
 }
 
 type Submission struct {

--- a/internal/storage/sqlite/attachments_test.go
+++ b/internal/storage/sqlite/attachments_test.go
@@ -272,8 +272,8 @@ func openAttachmentTestRepository(t *testing.T) (*Store, *AttachmentRepository) 
 		}
 	})
 
-	if len(embeddedMigrations) != 6 {
-		t.Fatalf("embedded migrations = %d, want 6", len(embeddedMigrations))
+	if len(embeddedMigrations) != 7 {
+		t.Fatalf("embedded migrations = %d, want 7", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 3)

--- a/internal/storage/sqlite/identity_graph_test.go
+++ b/internal/storage/sqlite/identity_graph_test.go
@@ -162,8 +162,8 @@ func openIdentityGraphTestStore(t *testing.T) *Store {
 		}
 	})
 
-	if len(embeddedMigrations) != 6 {
-		t.Fatalf("embedded migrations = %d, want 6", len(embeddedMigrations))
+	if len(embeddedMigrations) != 7 {
+		t.Fatalf("embedded migrations = %d, want 7", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 2)

--- a/internal/storage/sqlite/messages_test.go
+++ b/internal/storage/sqlite/messages_test.go
@@ -542,8 +542,8 @@ func TestMessagesInboxMigrationIsChecksummedAndStrict(t *testing.T) {
 		t,
 		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
 	)
-	if len(embeddedMigrations) != 6 {
-		t.Fatalf("embedded migrations = %d, want 6", len(embeddedMigrations))
+	if len(embeddedMigrations) != 7 {
+		t.Fatalf("embedded migrations = %d, want 7", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 4)

--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -54,6 +54,9 @@ var migration0005SQL string
 //go:embed migrations/0006_outbox_attachments.sql
 var migration0006SQL string
 
+//go:embed migrations/0007_reactions_read.sql
+var migration0007SQL string
+
 var embeddedMigrations = []migration{
 	newMigration(1, "storage_shell", migration0001SQL, newStorageShellArguments),
 	newMigration(2, "identity_graph", migration0002SQL, nil),
@@ -61,6 +64,7 @@ var embeddedMigrations = []migration{
 	newMigration(4, "messages_inbox", migration0004SQL, nil),
 	newMigration(5, "outbox", migration0005SQL, nil),
 	newMigration(6, "outbox_attachments", migration0006SQL, nil),
+	newMigration(7, "reactions_read", migration0007SQL, nil),
 }
 
 func newMigration(

--- a/internal/storage/sqlite/migrations/0007_reactions_read.sql
+++ b/internal/storage/sqlite/migrations/0007_reactions_read.sql
@@ -1,0 +1,61 @@
+-- Reaction intent payload for outbox rows of kind 'reaction'. The target is a
+-- local message; its remote identity is resolved at dispatch time.
+CREATE TABLE outbox_reactions (
+    outbox_id          TEXT NOT NULL,
+    target_message_id  TEXT NOT NULL,
+    emoji              TEXT NOT NULL CHECK (trim(emoji) <> '' AND length(emoji) <= 64),
+    action             TEXT NOT NULL CHECK (action IN ('add', 'remove', 'switch')),
+    created_at_ms      INTEGER NOT NULL CHECK (created_at_ms > 0),
+    PRIMARY KEY (outbox_id),
+    FOREIGN KEY (outbox_id) REFERENCES outbox(outbox_id) ON DELETE CASCADE,
+    FOREIGN KEY (target_message_id) REFERENCES messages(message_id)
+) STRICT;
+
+CREATE INDEX outbox_reactions_target_idx ON outbox_reactions(target_message_id);
+
+-- Read-receipt intent payload for outbox rows of kind 'read'.
+CREATE TABLE outbox_read_receipts (
+    outbox_id             TEXT NOT NULL,
+    device_id             TEXT NOT NULL,
+    last_read_message_id  TEXT NOT NULL,
+    read_at_ms            INTEGER NOT NULL CHECK (read_at_ms > 0),
+    created_at_ms         INTEGER NOT NULL CHECK (created_at_ms > 0),
+    PRIMARY KEY (outbox_id),
+    FOREIGN KEY (outbox_id) REFERENCES outbox(outbox_id) ON DELETE CASCADE,
+    FOREIGN KEY (device_id) REFERENCES devices(device_id),
+    FOREIGN KEY (last_read_message_id) REFERENCES messages(message_id)
+) STRICT;
+
+CREATE INDEX outbox_read_receipts_message_idx
+    ON outbox_read_receipts(last_read_message_id);
+
+-- S5b partial absorption: device-scoped monotone read cursors (plan §2.4).
+-- The derived FTS migration and unread-derivation queries remain S5b/S8 scope.
+-- The unique index makes the composite cursor FK legal against the merged 0004
+-- messages table (which has only PK message_id and
+-- UNIQUE(account_id, conversation_id, remote_message_id)).
+CREATE UNIQUE INDEX messages_conversation_message_uq
+    ON messages(conversation_id, message_id);
+
+CREATE TABLE read_cursors (
+    account_id            TEXT NOT NULL,
+    device_id             TEXT NOT NULL,
+    conversation_id       TEXT NOT NULL,
+    last_read_message_id  TEXT,
+    last_read_at_ms       INTEGER NOT NULL DEFAULT 0 CHECK (last_read_at_ms >= 0),
+    source_updated_at_ms  INTEGER CHECK (
+        source_updated_at_ms IS NULL OR source_updated_at_ms >= 0
+    ),
+    updated_at_ms         INTEGER NOT NULL CHECK (updated_at_ms > 0),
+    PRIMARY KEY (device_id, conversation_id),
+    FOREIGN KEY (account_id, device_id)
+        REFERENCES devices(account_id, device_id) ON DELETE CASCADE,
+    FOREIGN KEY (account_id, conversation_id)
+        REFERENCES conversations(account_id, conversation_id) ON DELETE CASCADE,
+    FOREIGN KEY (conversation_id, last_read_message_id)
+        REFERENCES messages(conversation_id, message_id),
+    CHECK (last_read_message_id IS NULL OR last_read_at_ms > 0)
+) STRICT;
+
+CREATE INDEX read_cursors_conversation_idx
+    ON read_cursors(conversation_id, last_read_at_ms DESC);

--- a/internal/storage/sqlite/outbox.go
+++ b/internal/storage/sqlite/outbox.go
@@ -105,6 +105,27 @@ type OutboxAttachment struct {
 	CreatedAtMS int64
 }
 
+// OutboxReaction is the persisted payload for one reaction intent. Enqueue
+// stamps OutboxID and CreatedAtMS; GetOutboxReaction populates every field.
+type OutboxReaction struct {
+	OutboxID        string
+	TargetMessageID string
+	Emoji           string
+	Action          string
+	CreatedAtMS     int64
+}
+
+// OutboxReadReceipt is the persisted payload for one read-receipt intent.
+// Enqueue stamps OutboxID and CreatedAtMS; GetOutboxReadReceipt populates every
+// field.
+type OutboxReadReceipt struct {
+	OutboxID          string
+	DeviceID          string
+	LastReadMessageID string
+	ReadAtMS          int64
+	CreatedAtMS       int64
+}
+
 // LeaseRequest controls one atomic due-row claim.
 type LeaseRequest struct {
 	Owner    string
@@ -150,6 +171,13 @@ type OutboxRepository struct {
 	now   func() time.Time
 }
 
+type enqueueCarriers struct {
+	attachment  *OutboxAttachment
+	reaction    *OutboxReaction
+	readReceipt *OutboxReadReceipt
+	readCursor  *ReadCursor
+}
+
 // NewOutboxRepository creates an outbox repository. The clock is required so
 // all storage-owned timestamps are deterministic in tests.
 func NewOutboxRepository(
@@ -172,7 +200,7 @@ func (r *OutboxRepository) Enqueue(
 	ctx context.Context,
 	item NewOutboxItem,
 ) (OutboxItem, EnqueueDisposition, error) {
-	return r.enqueue(ctx, item, nil, nil)
+	return r.enqueue(ctx, item, nil, enqueueCarriers{})
 }
 
 // EnqueueOutgoingMessage atomically inserts an outbound intent and its
@@ -184,7 +212,7 @@ func (r *OutboxRepository) EnqueueOutgoingMessage(
 	item NewOutboxItem,
 	message Message,
 ) (OutboxItem, EnqueueDisposition, error) {
-	return r.enqueue(ctx, item, &message, nil)
+	return r.enqueue(ctx, item, &message, enqueueCarriers{})
 }
 
 // EnqueueOutgoingMediaMessage atomically inserts a media intent, its
@@ -196,7 +224,33 @@ func (r *OutboxRepository) EnqueueOutgoingMediaMessage(
 	message Message,
 	attachment OutboxAttachment,
 ) (OutboxItem, EnqueueDisposition, error) {
-	return r.enqueue(ctx, item, &message, &attachment)
+	return r.enqueue(ctx, item, &message, enqueueCarriers{attachment: &attachment})
+}
+
+// EnqueueReaction atomically inserts a message-less reaction intent and its
+// typed carrier row. An idempotent replay requires the persisted pair to
+// remain intact.
+func (r *OutboxRepository) EnqueueReaction(
+	ctx context.Context,
+	item NewOutboxItem,
+	reaction OutboxReaction,
+) (OutboxItem, EnqueueDisposition, error) {
+	return r.enqueue(ctx, item, nil, enqueueCarriers{reaction: &reaction})
+}
+
+// EnqueueReadReceipt atomically inserts a message-less read-receipt intent,
+// its typed carrier row, and the monotone local read cursor. An idempotent
+// replay validates the carrier but deliberately does not update the cursor.
+func (r *OutboxRepository) EnqueueReadReceipt(
+	ctx context.Context,
+	item NewOutboxItem,
+	receipt OutboxReadReceipt,
+	cursor ReadCursor,
+) (OutboxItem, EnqueueDisposition, error) {
+	return r.enqueue(ctx, item, nil, enqueueCarriers{
+		readReceipt: &receipt,
+		readCursor:  &cursor,
+	})
 }
 
 // GetOutboxAttachment returns the ordinal-zero attachment for outboxID. A
@@ -228,16 +282,78 @@ func (r *OutboxRepository) GetOutboxAttachment(
 	return attachment, nil
 }
 
+// GetOutboxReaction returns the typed reaction payload for outboxID. A
+// missing row wraps database/sql.ErrNoRows so callers can use errors.Is.
+func (r *OutboxRepository) GetOutboxReaction(
+	ctx context.Context,
+	outboxID string,
+) (OutboxReaction, error) {
+	if strings.TrimSpace(outboxID) == "" {
+		return OutboxReaction{}, fmt.Errorf("get outbox reaction: outbox ID is empty")
+	}
+
+	var reaction OutboxReaction
+	if err := r.store.db.QueryRowContext(ctx, `
+		SELECT outbox_id, target_message_id, emoji, action, created_at_ms
+		FROM outbox_reactions
+		WHERE outbox_id = ?
+	`, outboxID).Scan(
+		&reaction.OutboxID,
+		&reaction.TargetMessageID,
+		&reaction.Emoji,
+		&reaction.Action,
+		&reaction.CreatedAtMS,
+	); err != nil {
+		return OutboxReaction{}, fmt.Errorf(
+			"get outbox reaction for outbox item %q: %w",
+			outboxID,
+			err,
+		)
+	}
+	return reaction, nil
+}
+
+// GetOutboxReadReceipt returns the typed read-receipt payload for outboxID. A
+// missing row wraps database/sql.ErrNoRows so callers can use errors.Is.
+func (r *OutboxRepository) GetOutboxReadReceipt(
+	ctx context.Context,
+	outboxID string,
+) (OutboxReadReceipt, error) {
+	if strings.TrimSpace(outboxID) == "" {
+		return OutboxReadReceipt{}, fmt.Errorf("get outbox read receipt: outbox ID is empty")
+	}
+
+	var receipt OutboxReadReceipt
+	if err := r.store.db.QueryRowContext(ctx, `
+		SELECT outbox_id, device_id, last_read_message_id, read_at_ms, created_at_ms
+		FROM outbox_read_receipts
+		WHERE outbox_id = ?
+	`, outboxID).Scan(
+		&receipt.OutboxID,
+		&receipt.DeviceID,
+		&receipt.LastReadMessageID,
+		&receipt.ReadAtMS,
+		&receipt.CreatedAtMS,
+	); err != nil {
+		return OutboxReadReceipt{}, fmt.Errorf(
+			"get outbox read receipt for outbox item %q: %w",
+			outboxID,
+			err,
+		)
+	}
+	return receipt, nil
+}
+
 func (r *OutboxRepository) enqueue(
 	ctx context.Context,
 	item NewOutboxItem,
 	message *Message,
-	attachment *OutboxAttachment,
+	carriers enqueueCarriers,
 ) (OutboxItem, EnqueueDisposition, error) {
 	if err := validateNewOutboxItem(item); err != nil {
 		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item: %w", err)
 	}
-	if err := validateOutboxAttachmentPair(item, attachment); err != nil {
+	if err := validateOutboxAttachmentPair(item, carriers); err != nil {
 		return OutboxItem{}, "", fmt.Errorf("enqueue outbox item %q: %w", item.OutboxID, err)
 	}
 	nowMS, err := r.nowMS("enqueue outbox item")
@@ -346,13 +462,36 @@ func (r *OutboxRepository) enqueue(
 			return OutboxItem{}, "", err
 		}
 	}
+	if disposition == EnqueueExisting && row.Kind == OutboxKindReaction {
+		if err := validateExistingOutboxReaction(ctx, tx, row.OutboxID); err != nil {
+			return OutboxItem{}, "", err
+		}
+	}
+	if disposition == EnqueueExisting && row.Kind == OutboxKindRead {
+		if err := validateExistingOutboxReadReceipt(ctx, tx, row.OutboxID); err != nil {
+			return OutboxItem{}, "", err
+		}
+	}
 	if disposition == EnqueueInserted && message != nil {
 		if err := r.insertOutgoingMessage(ctx, tx, item, *message, nowMS); err != nil {
 			return OutboxItem{}, "", err
 		}
 	}
-	if disposition == EnqueueInserted && attachment != nil {
-		if err := r.insertOutboxAttachment(ctx, tx, item.OutboxID, *attachment, nowMS); err != nil {
+	if disposition == EnqueueInserted && carriers.attachment != nil {
+		if err := r.insertOutboxAttachment(ctx, tx, item.OutboxID, *carriers.attachment, nowMS); err != nil {
+			return OutboxItem{}, "", err
+		}
+	}
+	if disposition == EnqueueInserted && carriers.reaction != nil {
+		if err := r.insertOutboxReaction(ctx, tx, item.OutboxID, *carriers.reaction, nowMS); err != nil {
+			return OutboxItem{}, "", err
+		}
+	}
+	if disposition == EnqueueInserted && carriers.readReceipt != nil {
+		if err := r.insertOutboxReadReceipt(ctx, tx, item.OutboxID, *carriers.readReceipt, nowMS); err != nil {
+			return OutboxItem{}, "", err
+		}
+		if err := r.store.upsertReadCursorTx(ctx, tx, *carriers.readCursor); err != nil {
 			return OutboxItem{}, "", err
 		}
 	}
@@ -397,27 +536,120 @@ func (r *OutboxRepository) insertOutboxAttachment(
 	return nil
 }
 
+func (r *OutboxRepository) insertOutboxReaction(
+	ctx context.Context,
+	tx *sql.Tx,
+	outboxID string,
+	reaction OutboxReaction,
+	nowMS int64,
+) error {
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO outbox_reactions (
+			outbox_id,
+			target_message_id,
+			emoji,
+			action,
+			created_at_ms
+		) VALUES (?, ?, ?, ?, ?)
+	`,
+		outboxID,
+		reaction.TargetMessageID,
+		reaction.Emoji,
+		reaction.Action,
+		nowMS,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"enqueue outbox reaction for outbox item %q: %w",
+			outboxID,
+			mapConstraintError(err),
+		)
+	}
+	return nil
+}
+
+func (r *OutboxRepository) insertOutboxReadReceipt(
+	ctx context.Context,
+	tx *sql.Tx,
+	outboxID string,
+	receipt OutboxReadReceipt,
+	nowMS int64,
+) error {
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO outbox_read_receipts (
+			outbox_id,
+			device_id,
+			last_read_message_id,
+			read_at_ms,
+			created_at_ms
+		) VALUES (?, ?, ?, ?, ?)
+	`,
+		outboxID,
+		receipt.DeviceID,
+		receipt.LastReadMessageID,
+		receipt.ReadAtMS,
+		nowMS,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"enqueue outbox read receipt for outbox item %q: %w",
+			outboxID,
+			mapConstraintError(err),
+		)
+	}
+	return nil
+}
+
 func validateOutboxAttachmentPair(
 	item NewOutboxItem,
-	attachment *OutboxAttachment,
+	carriers enqueueCarriers,
 ) error {
-	if item.Kind == OutboxKindMedia && attachment == nil {
-		return fmt.Errorf("media kind requires an attachment")
+	switch item.Kind {
+	case OutboxKindMedia:
+		if carriers.attachment == nil {
+			return fmt.Errorf("media kind requires an attachment")
+		}
+		if carriers.reaction != nil || carriers.readReceipt != nil || carriers.readCursor != nil {
+			return fmt.Errorf("media kind accepts only an attachment carrier")
+		}
+	case OutboxKindReaction:
+		if carriers.reaction == nil {
+			return fmt.Errorf("reaction kind requires a reaction carrier")
+		}
+		if carriers.attachment != nil || carriers.readReceipt != nil || carriers.readCursor != nil {
+			return fmt.Errorf("reaction kind accepts only a reaction carrier")
+		}
+	case OutboxKindRead:
+		if carriers.readReceipt == nil {
+			return fmt.Errorf("read kind requires a read-receipt carrier")
+		}
+		if carriers.readCursor == nil {
+			return fmt.Errorf("read kind requires a read cursor")
+		}
+		if carriers.attachment != nil || carriers.reaction != nil {
+			return fmt.Errorf("read kind accepts only a read-receipt carrier")
+		}
+	default:
+		if carriers.attachment != nil {
+			return fmt.Errorf("kind %q does not accept an attachment", item.Kind)
+		}
+		if carriers.reaction != nil {
+			return fmt.Errorf("kind %q does not accept a reaction carrier", item.Kind)
+		}
+		if carriers.readReceipt != nil || carriers.readCursor != nil {
+			return fmt.Errorf("kind %q does not accept a read-receipt carrier", item.Kind)
+		}
 	}
-	if item.Kind != OutboxKindMedia && attachment != nil {
-		return fmt.Errorf("kind %q does not accept an attachment", item.Kind)
-	}
-	if attachment == nil {
-		return nil
-	}
-	if err := validateBlobHash(attachment.BlobHash); err != nil {
-		return err
-	}
-	if attachment.SizeBytes <= 0 {
-		return fmt.Errorf("outbox attachment size must be positive")
-	}
-	if strings.TrimSpace(attachment.MIME) == "" {
-		return fmt.Errorf("outbox attachment MIME type is empty")
+	if carriers.attachment != nil {
+		if err := validateBlobHash(carriers.attachment.BlobHash); err != nil {
+			return err
+		}
+		if carriers.attachment.SizeBytes <= 0 {
+			return fmt.Errorf("outbox attachment size must be positive")
+		}
+		if strings.TrimSpace(carriers.attachment.MIME) == "" {
+			return fmt.Errorf("outbox attachment MIME type is empty")
+		}
 	}
 	return nil
 }
@@ -444,6 +676,62 @@ func validateExistingOutboxAttachment(
 	if !exists {
 		return fmt.Errorf(
 			"enqueue outgoing media message for existing outbox item %q: attachment is missing",
+			outboxID,
+		)
+	}
+	return nil
+}
+
+func validateExistingOutboxReaction(
+	ctx context.Context,
+	tx *sql.Tx,
+	outboxID string,
+) error {
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM outbox_reactions
+			WHERE outbox_id = ?
+		)
+	`, outboxID).Scan(&exists); err != nil {
+		return fmt.Errorf(
+			"enqueue reaction for existing outbox item %q: inspect reaction: %w",
+			outboxID,
+			err,
+		)
+	}
+	if !exists {
+		return fmt.Errorf(
+			"enqueue reaction for existing outbox item %q: reaction is missing",
+			outboxID,
+		)
+	}
+	return nil
+}
+
+func validateExistingOutboxReadReceipt(
+	ctx context.Context,
+	tx *sql.Tx,
+	outboxID string,
+) error {
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM outbox_read_receipts
+			WHERE outbox_id = ?
+		)
+	`, outboxID).Scan(&exists); err != nil {
+		return fmt.Errorf(
+			"enqueue read receipt for existing outbox item %q: inspect receipt: %w",
+			outboxID,
+			err,
+		)
+	}
+	if !exists {
+		return fmt.Errorf(
+			"enqueue read receipt for existing outbox item %q: receipt is missing",
 			outboxID,
 		)
 	}
@@ -941,6 +1229,39 @@ func (r *OutboxRepository) Reject(
 		return fmt.Errorf("reject outbox item %q: %w", outboxID, err)
 	}
 	return r.requireLeaseMutation(ctx, "reject", outboxID, result)
+}
+
+// ConfirmWithoutResult terminally confirms an active called lease whose
+// operation yields no remote result identity.
+func (r *OutboxRepository) ConfirmWithoutResult(
+	ctx context.Context,
+	outboxID, leaseToken string,
+) error {
+	nowMS, err := r.nowMS("confirm outbox item without result")
+	if err != nil {
+		return err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE outbox
+		SET state = 'confirmed',
+			error_class = NULL,
+			error_code = NULL,
+			error_detail = NULL,
+			next_attempt_at_ms = NULL,
+			lease_owner = NULL,
+			lease_token = NULL,
+			lease_expires_at_ms = NULL,
+			transport_called_at_ms = NULL,
+			updated_at_ms = ?
+		WHERE outbox_id = ?
+		  AND state = 'dispatching'
+		  AND lease_token = ?
+		  AND transport_called_at_ms IS NOT NULL
+	`, nowMS, outboxID, leaseToken)
+	if err != nil {
+		return fmt.Errorf("confirm outbox item %q without result: %w", outboxID, err)
+	}
+	return r.requireLeaseMutation(ctx, "confirm without result", outboxID, result)
 }
 
 // Confirm atomically records a known remote result for the active called

--- a/internal/storage/sqlite/outbox_test.go
+++ b/internal/storage/sqlite/outbox_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -394,6 +395,449 @@ func TestOutboxAttachmentCascadesAndExistingMediaRequiresAttachment(t *testing.T
 		outboxTestAttachment(),
 	); err == nil {
 		t.Fatal("EnqueueOutgoingMediaMessage(existing without attachment) succeeded")
+	}
+}
+
+func TestOutboxEnqueueReactionRoundTripsAndDeduplicates(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	seedOutboxTestMessage(t, store, "target-a", "account-a", "conversation-a")
+	ctx := context.Background()
+
+	item := outboxTestReactionItem("reaction")
+	reaction := OutboxReaction{
+		TargetMessageID: "target-a",
+		Emoji:           "👍",
+		Action:          "add",
+	}
+	row, disposition, err := repository.EnqueueReaction(ctx, item, reaction)
+	if err != nil {
+		t.Fatalf("EnqueueReaction(): %v", err)
+	}
+	if disposition != EnqueueInserted || row.OutboxID != item.OutboxID || row.LocalMessageID != nil {
+		t.Fatalf("EnqueueReaction() = (%+v, %q), want message-less inserted row", row, disposition)
+	}
+	got, err := repository.GetOutboxReaction(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxReaction(): %v", err)
+	}
+	want := reaction
+	want.OutboxID = item.OutboxID
+	want.CreatedAtMS = outboxTestTimeMS
+	if got != want {
+		t.Fatalf("GetOutboxReaction() = %+v, want %+v", got, want)
+	}
+	assertRowCount(t, store.db, "messages", 1)
+
+	clock.Set(outboxTestTimeMS + 500)
+	duplicate := item
+	duplicate.OutboxID = "outbox-unused-reaction-duplicate"
+	duplicate.TransportRequestID = "request-unused-reaction-duplicate"
+	duplicateRow, disposition, err := repository.EnqueueReaction(ctx, duplicate, reaction)
+	if err != nil {
+		t.Fatalf("EnqueueReaction(duplicate): %v", err)
+	}
+	if disposition != EnqueueExisting || duplicateRow.OutboxID != item.OutboxID {
+		t.Fatalf("duplicate result = (%+v, %q), want original", duplicateRow, disposition)
+	}
+	assertRowCount(t, store.db, "outbox", 1)
+	assertRowCount(t, store.db, "outbox_reactions", 1)
+
+	conflict := duplicate
+	conflict.OutboxID = "outbox-reaction-conflict"
+	conflict.TransportRequestID = "request-reaction-conflict"
+	conflict.PayloadHash = "different-reaction-hash"
+	if _, _, err := repository.EnqueueReaction(ctx, conflict, reaction); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("EnqueueReaction(conflict) error = %v, want ErrIdempotencyConflict", err)
+	}
+
+	mustExec(t, store.db, `DELETE FROM outbox_reactions WHERE outbox_id = ?`, item.OutboxID)
+	missingPair := duplicate
+	missingPair.OutboxID = "outbox-unused-missing-reaction"
+	missingPair.TransportRequestID = "request-unused-missing-reaction"
+	if _, _, err := repository.EnqueueReaction(ctx, missingPair, reaction); err == nil {
+		t.Fatal("EnqueueReaction(existing without side row) succeeded")
+	}
+	if _, err := repository.GetOutboxReaction(ctx, "missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetOutboxReaction(missing) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestOutboxEnqueueReadReceiptRoundTripsAndSkipsCursorOnReplay(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	seedOutboxTestDevice(t, store, "device-a", "account-a")
+	seedOutboxTestMessage(t, store, "target-a", "account-a", "conversation-a")
+	ctx := context.Background()
+
+	item := outboxTestReadItem("read")
+	receipt := OutboxReadReceipt{
+		DeviceID:          "device-a",
+		LastReadMessageID: "target-a",
+		ReadAtMS:          outboxTestTimeMS - 100,
+	}
+	targetID := "target-a"
+	cursor := ReadCursor{
+		AccountID:         "account-a",
+		DeviceID:          "device-a",
+		ConversationID:    "conversation-a",
+		LastReadMessageID: &targetID,
+		LastReadAtMS:      receipt.ReadAtMS,
+		UpdatedAtMS:       outboxTestTimeMS,
+	}
+	row, disposition, err := repository.EnqueueReadReceipt(ctx, item, receipt, cursor)
+	if err != nil {
+		t.Fatalf("EnqueueReadReceipt(): %v", err)
+	}
+	if disposition != EnqueueInserted || row.OutboxID != item.OutboxID || row.LocalMessageID != nil {
+		t.Fatalf("EnqueueReadReceipt() = (%+v, %q), want message-less inserted row", row, disposition)
+	}
+	gotReceipt, err := repository.GetOutboxReadReceipt(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxReadReceipt(): %v", err)
+	}
+	wantReceipt := receipt
+	wantReceipt.OutboxID = item.OutboxID
+	wantReceipt.CreatedAtMS = outboxTestTimeMS
+	if gotReceipt != wantReceipt {
+		t.Fatalf("GetOutboxReadReceipt() = %+v, want %+v", gotReceipt, wantReceipt)
+	}
+	gotCursor, err := store.GetReadCursor("device-a", "conversation-a")
+	if err != nil {
+		t.Fatalf("GetReadCursor(): %v", err)
+	}
+	if gotCursor.LastReadMessageID == nil || *gotCursor.LastReadMessageID != targetID ||
+		gotCursor.LastReadAtMS != receipt.ReadAtMS || gotCursor.UpdatedAtMS != cursor.UpdatedAtMS {
+		t.Fatalf("GetReadCursor() = %+v, want %+v", gotCursor, cursor)
+	}
+
+	clock.Set(outboxTestTimeMS + 500)
+	duplicate := item
+	duplicate.OutboxID = "outbox-unused-read-duplicate"
+	duplicate.TransportRequestID = "request-unused-read-duplicate"
+	candidateCursor := cursor
+	candidateCursor.LastReadAtMS += 10_000
+	candidateCursor.UpdatedAtMS += 10_000
+	duplicateRow, disposition, err := repository.EnqueueReadReceipt(
+		ctx,
+		duplicate,
+		receipt,
+		candidateCursor,
+	)
+	if err != nil {
+		t.Fatalf("EnqueueReadReceipt(duplicate): %v", err)
+	}
+	if disposition != EnqueueExisting || duplicateRow.OutboxID != item.OutboxID {
+		t.Fatalf("duplicate result = (%+v, %q), want original", duplicateRow, disposition)
+	}
+	unchangedCursor, err := store.GetReadCursor("device-a", "conversation-a")
+	if err != nil {
+		t.Fatalf("GetReadCursor(after replay): %v", err)
+	}
+	if unchangedCursor.LastReadAtMS != cursor.LastReadAtMS || unchangedCursor.UpdatedAtMS != cursor.UpdatedAtMS {
+		t.Fatalf("replay changed cursor: got %+v, want %+v", unchangedCursor, cursor)
+	}
+	assertRowCount(t, store.db, "outbox", 1)
+	assertRowCount(t, store.db, "outbox_read_receipts", 1)
+	assertRowCount(t, store.db, "read_cursors", 1)
+
+	conflict := duplicate
+	conflict.OutboxID = "outbox-read-conflict"
+	conflict.TransportRequestID = "request-read-conflict"
+	conflict.PayloadHash = "different-read-hash"
+	if _, _, err := repository.EnqueueReadReceipt(ctx, conflict, receipt, cursor); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("EnqueueReadReceipt(conflict) error = %v, want ErrIdempotencyConflict", err)
+	}
+
+	mustExec(t, store.db, `DELETE FROM outbox_read_receipts WHERE outbox_id = ?`, item.OutboxID)
+	missingPair := duplicate
+	missingPair.OutboxID = "outbox-unused-missing-read-receipt"
+	missingPair.TransportRequestID = "request-unused-missing-read-receipt"
+	if _, _, err := repository.EnqueueReadReceipt(ctx, missingPair, receipt, cursor); err == nil {
+		t.Fatal("EnqueueReadReceipt(existing without side row) succeeded")
+	}
+	if _, err := repository.GetOutboxReadReceipt(ctx, "missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetOutboxReadReceipt(missing) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestOutboxCarrierInsertsAreAtomic(t *testing.T) {
+	t.Run("reaction side row", func(t *testing.T) {
+		clock := newOutboxTestClock(outboxTestTimeMS)
+		store, repository := openOutboxTestRepository(t, clock.Now)
+		seedMessageConversation(t, store, "conversation-a", "account-a")
+		seedOutboxTestMessage(t, store, "target-a", "account-a", "conversation-a")
+		mustExec(t, store.db, `
+			CREATE TRIGGER fail_outbox_reaction_insert
+			BEFORE INSERT ON outbox_reactions
+			BEGIN
+				SELECT RAISE(ABORT, 'injected reaction carrier failure');
+			END
+		`)
+		_, _, err := repository.EnqueueReaction(
+			context.Background(),
+			outboxTestReactionItem("atomic-reaction"),
+			OutboxReaction{TargetMessageID: "target-a", Emoji: "❤️", Action: "add"},
+		)
+		if err == nil {
+			t.Fatal("EnqueueReaction() succeeded, want injected side-row failure")
+		}
+		assertRowCount(t, store.db, "outbox", 0)
+		assertRowCount(t, store.db, "outbox_reactions", 0)
+		assertRowCount(t, store.db, "messages", 1)
+	})
+
+	t.Run("read cursor", func(t *testing.T) {
+		clock := newOutboxTestClock(outboxTestTimeMS)
+		store, repository := openOutboxTestRepository(t, clock.Now)
+		seedMessageConversation(t, store, "conversation-a", "account-a")
+		seedOutboxTestDevice(t, store, "device-a", "account-a")
+		seedOutboxTestMessage(t, store, "target-a", "account-a", "conversation-a")
+		mustExec(t, store.db, `
+			CREATE TRIGGER fail_read_cursor_insert
+			BEFORE INSERT ON read_cursors
+			BEGIN
+				SELECT RAISE(ABORT, 'injected read cursor failure');
+			END
+		`)
+		targetID := "target-a"
+		_, _, err := repository.EnqueueReadReceipt(
+			context.Background(),
+			outboxTestReadItem("atomic-read"),
+			OutboxReadReceipt{
+				DeviceID: "device-a", LastReadMessageID: targetID, ReadAtMS: outboxTestTimeMS,
+			},
+			ReadCursor{
+				AccountID: "account-a", DeviceID: "device-a", ConversationID: "conversation-a",
+				LastReadMessageID: &targetID, LastReadAtMS: outboxTestTimeMS, UpdatedAtMS: outboxTestTimeMS,
+			},
+		)
+		if err == nil {
+			t.Fatal("EnqueueReadReceipt() succeeded, want injected cursor failure")
+		}
+		assertRowCount(t, store.db, "outbox", 0)
+		assertRowCount(t, store.db, "outbox_read_receipts", 0)
+		assertRowCount(t, store.db, "read_cursors", 0)
+	})
+}
+
+func TestOutboxValidatesReactionAndReadCarrierPairing(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	seedOutboxTestDevice(t, store, "device-a", "account-a")
+	seedOutboxTestMessage(t, store, "target-a", "account-a", "conversation-a")
+	ctx := context.Background()
+	targetID := "target-a"
+	reaction := OutboxReaction{TargetMessageID: targetID, Emoji: "👍", Action: "add"}
+	receipt := OutboxReadReceipt{DeviceID: "device-a", LastReadMessageID: targetID, ReadAtMS: outboxTestTimeMS}
+	cursor := ReadCursor{
+		AccountID: "account-a", DeviceID: "device-a", ConversationID: "conversation-a",
+		LastReadMessageID: &targetID, LastReadAtMS: outboxTestTimeMS, UpdatedAtMS: outboxTestTimeMS,
+	}
+
+	tests := []struct {
+		name    string
+		enqueue func() error
+	}{
+		{
+			name: "reaction without reaction carrier",
+			enqueue: func() error {
+				_, _, err := repository.Enqueue(ctx, outboxTestReactionItem("missing-reaction"))
+				return err
+			},
+		},
+		{
+			name: "text with reaction carrier",
+			enqueue: func() error {
+				_, _, err := repository.EnqueueReaction(ctx, outboxTestItem("text-reaction"), reaction)
+				return err
+			},
+		},
+		{
+			name: "read without receipt carrier",
+			enqueue: func() error {
+				_, _, err := repository.Enqueue(ctx, outboxTestReadItem("missing-receipt"))
+				return err
+			},
+		},
+		{
+			name: "text with receipt carrier",
+			enqueue: func() error {
+				_, _, err := repository.EnqueueReadReceipt(ctx, outboxTestItem("text-receipt"), receipt, cursor)
+				return err
+			},
+		},
+		{
+			name: "reaction with attachment carrier",
+			enqueue: func() error {
+				item := outboxTestReactionItem("reaction-attachment")
+				_, _, err := repository.enqueue(ctx, item, nil, enqueueCarriers{
+					attachment: &OutboxAttachment{
+						BlobHash: strings.Repeat("a", 64), SizeBytes: 1, MIME: "image/png",
+					},
+					reaction: &reaction,
+				})
+				return err
+			},
+		},
+		{
+			name: "read with reaction carrier",
+			enqueue: func() error {
+				item := outboxTestReadItem("read-reaction")
+				_, _, err := repository.enqueue(ctx, item, nil, enqueueCarriers{
+					reaction:    &reaction,
+					readReceipt: &receipt,
+					readCursor:  &cursor,
+				})
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.enqueue(); err == nil {
+				t.Fatal("enqueue succeeded, want carrier-pairing error")
+			}
+		})
+	}
+	assertRowCount(t, store.db, "outbox", 0)
+}
+
+func TestOutboxReactionAndReadReceiptForeignKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		enqueue func(*testing.T, *Store, *OutboxRepository) error
+	}{
+		{
+			name: "unknown reaction target",
+			enqueue: func(t *testing.T, _ *Store, repository *OutboxRepository) error {
+				_, _, err := repository.EnqueueReaction(
+					context.Background(), outboxTestReactionItem("unknown-target"),
+					OutboxReaction{TargetMessageID: "missing", Emoji: "👍", Action: "add"},
+				)
+				return err
+			},
+		},
+		{
+			name: "unknown read target",
+			enqueue: func(t *testing.T, _ *Store, repository *OutboxRepository) error {
+				targetID := "missing"
+				_, _, err := repository.EnqueueReadReceipt(
+					context.Background(), outboxTestReadItem("unknown-read-target"),
+					OutboxReadReceipt{DeviceID: "device-a", LastReadMessageID: targetID, ReadAtMS: outboxTestTimeMS},
+					ReadCursor{
+						AccountID: "account-a", DeviceID: "device-a", ConversationID: "conversation-a",
+						LastReadMessageID: &targetID, LastReadAtMS: outboxTestTimeMS, UpdatedAtMS: outboxTestTimeMS,
+					},
+				)
+				return err
+			},
+		},
+		{
+			name: "unknown device",
+			enqueue: func(t *testing.T, _ *Store, repository *OutboxRepository) error {
+				targetID := "target-a"
+				_, _, err := repository.EnqueueReadReceipt(
+					context.Background(), outboxTestReadItem("unknown-device"),
+					OutboxReadReceipt{DeviceID: "missing", LastReadMessageID: targetID, ReadAtMS: outboxTestTimeMS},
+					ReadCursor{
+						AccountID: "account-a", DeviceID: "missing", ConversationID: "conversation-a",
+						LastReadMessageID: &targetID, LastReadAtMS: outboxTestTimeMS, UpdatedAtMS: outboxTestTimeMS,
+					},
+				)
+				return err
+			},
+		},
+		{
+			name: "cross-conversation cursor target",
+			enqueue: func(t *testing.T, store *Store, repository *OutboxRepository) error {
+				seedMessageConversation(t, store, "conversation-other", "account-a")
+				seedOutboxTestMessage(t, store, "target-other", "account-a", "conversation-other")
+				targetID := "target-other"
+				_, _, err := repository.EnqueueReadReceipt(
+					context.Background(), outboxTestReadItem("cross-conversation"),
+					OutboxReadReceipt{DeviceID: "device-a", LastReadMessageID: targetID, ReadAtMS: outboxTestTimeMS},
+					ReadCursor{
+						AccountID: "account-a", DeviceID: "device-a", ConversationID: "conversation-a",
+						LastReadMessageID: &targetID, LastReadAtMS: outboxTestTimeMS, UpdatedAtMS: outboxTestTimeMS,
+					},
+				)
+				return err
+			},
+		},
+		{
+			name: "cross-account device",
+			enqueue: func(t *testing.T, store *Store, repository *OutboxRepository) error {
+				seedMessageAccount(t, store, "account-b", "test-b")
+				seedOutboxTestDevice(t, store, "device-b", "account-b")
+				targetID := "target-a"
+				_, _, err := repository.EnqueueReadReceipt(
+					context.Background(), outboxTestReadItem("cross-account"),
+					OutboxReadReceipt{DeviceID: "device-b", LastReadMessageID: targetID, ReadAtMS: outboxTestTimeMS},
+					ReadCursor{
+						AccountID: "account-a", DeviceID: "device-b", ConversationID: "conversation-a",
+						LastReadMessageID: &targetID, LastReadAtMS: outboxTestTimeMS, UpdatedAtMS: outboxTestTimeMS,
+					},
+				)
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := newOutboxTestClock(outboxTestTimeMS)
+			store, repository := openOutboxTestRepository(t, clock.Now)
+			seedMessageConversation(t, store, "conversation-a", "account-a")
+			seedOutboxTestDevice(t, store, "device-a", "account-a")
+			seedOutboxTestMessage(t, store, "target-a", "account-a", "conversation-a")
+			if err := test.enqueue(t, store, repository); !errors.Is(err, ErrConstraintViolation) {
+				t.Fatalf("enqueue error = %v, want ErrConstraintViolation", err)
+			}
+			assertRowCount(t, store.db, "outbox", 0)
+			assertRowCount(t, store.db, "outbox_reactions", 0)
+			assertRowCount(t, store.db, "outbox_read_receipts", 0)
+		})
+	}
+}
+
+func TestOutboxConfirmWithoutResultRequiresCalledActiveLease(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	item := mustEnqueueOutbox(t, repository, outboxTestItem("confirm-without-result"))
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	token := mustLeaseToken(t, lease)
+
+	if err := repository.ConfirmWithoutResult(ctx, item.OutboxID, token); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("ConfirmWithoutResult(pre-call) error = %v, want ErrLeaseLost", err)
+	}
+	if err := repository.MarkTransportCalled(ctx, Attempt{OutboxID: item.OutboxID, LeaseToken: token}); err != nil {
+		t.Fatalf("MarkTransportCalled(): %v", err)
+	}
+	if err := repository.Confirm(ctx, Confirmation{OutboxID: item.OutboxID, LeaseToken: token}); err == nil {
+		t.Fatal("Confirm(empty result ID) succeeded")
+	}
+	if err := repository.ConfirmWithoutResult(ctx, item.OutboxID, "stale-token"); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("ConfirmWithoutResult(stale token) error = %v, want ErrLeaseLost", err)
+	}
+	if err := repository.ConfirmWithoutResult(ctx, item.OutboxID, token); err != nil {
+		t.Fatalf("ConfirmWithoutResult(): %v", err)
+	}
+	confirmed, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(): %v", err)
+	}
+	if confirmed.State != OutboxConfirmed || confirmed.ResultRemoteID != nil ||
+		confirmed.LeaseOwner != nil || confirmed.LeaseToken != nil ||
+		confirmed.LeaseExpiresAtMS != nil || confirmed.TransportCalledAtMS != nil ||
+		confirmed.ErrorClass != nil || confirmed.ErrorCode != nil || confirmed.ErrorDetail != nil {
+		t.Fatalf("confirmed without-result row = %+v", confirmed)
 	}
 }
 
@@ -916,10 +1360,10 @@ func TestOutboxMigrationIsChecksummedAndStrict(t *testing.T) {
 	store, _ := openOutboxTestRepository(t, func() time.Time {
 		return time.UnixMilli(outboxTestTimeMS)
 	})
-	if len(embeddedMigrations) != 6 {
-		t.Fatalf("embedded migrations = %d, want 6", len(embeddedMigrations))
+	if len(embeddedMigrations) != 7 {
+		t.Fatalf("embedded migrations = %d, want 7", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 6)
+	assertPragmaInt(t, store.db, "user_version", 7)
 	ledger := readLedgerRow(t, store.db, 5)
 	if ledger.name != "outbox" {
 		t.Fatalf("migration 0005 name = %q, want outbox", ledger.name)
@@ -995,8 +1439,8 @@ func TestOutboxAttachmentsMigrationAppliesToBlankAndExistingV5Database(t *testin
 			}
 		})
 		after := readLedgerRows(t, store.db)
-		if len(after) != 6 {
-			t.Fatalf("migrated ledger rows = %d, want 6", len(after))
+		if len(after) != 7 {
+			t.Fatalf("migrated ledger rows = %d, want 7", len(after))
 		}
 		if !slices.Equal(after[:5], before) {
 			t.Fatalf("migrations 0001-0005 changed:\nbefore: %+v\nafter:  %+v", before, after[:5])
@@ -1007,7 +1451,7 @@ func TestOutboxAttachmentsMigrationAppliesToBlankAndExistingV5Database(t *testin
 
 func assertOutboxAttachmentsMigration(t *testing.T, store *Store) {
 	t.Helper()
-	assertPragmaInt(t, store.db, "user_version", 6)
+	assertPragmaInt(t, store.db, "user_version", 7)
 	ledger := readLedgerRow(t, store.db, 6)
 	if ledger.name != "outbox_attachments" {
 		t.Fatalf("migration 0006 name = %q, want outbox_attachments", ledger.name)
@@ -1029,6 +1473,82 @@ func assertOutboxAttachmentsMigration(t *testing.T, store *Store) {
 	}
 	if strict != 1 {
 		t.Fatalf("outbox_attachments strict = %d, want 1", strict)
+	}
+}
+
+func TestReactionsReadMigrationAppliesToBlankAndReopens(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite3")
+	first, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open(): %v", err)
+	}
+	assertReactionsReadMigration(t, first)
+	firstLedger := readLedgerRows(t, first.db)
+	if err := first.Close(); err != nil {
+		t.Fatalf("first Close(): %v", err)
+	}
+
+	second, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := second.Close(); err != nil {
+			t.Errorf("second Close(): %v", err)
+		}
+	})
+	assertReactionsReadMigration(t, second)
+	secondLedger := readLedgerRows(t, second.db)
+	if !slices.Equal(secondLedger, firstLedger) {
+		t.Fatalf("migration ledger changed on reopen:\nfirst:  %+v\nsecond: %+v", firstLedger, secondLedger)
+	}
+}
+
+func assertReactionsReadMigration(t *testing.T, store *Store) {
+	t.Helper()
+	assertPragmaInt(t, store.db, "user_version", 7)
+	ledger := readLedgerRow(t, store.db, 7)
+	if ledger.name != "reactions_read" {
+		t.Fatalf("migration 0007 name = %q, want reactions_read", ledger.name)
+	}
+	if ledger.checksum != embeddedMigrations[6].checksumSHA256 {
+		t.Fatalf(
+			"migration 0007 checksum = %q, want %q",
+			ledger.checksum,
+			embeddedMigrations[6].checksumSHA256,
+		)
+	}
+	for _, table := range []string{"outbox_reactions", "outbox_read_receipts", "read_cursors"} {
+		var strict int
+		if err := store.db.QueryRow(`
+			SELECT strict
+			FROM pragma_table_list
+			WHERE schema = 'main' AND name = ?
+		`, table).Scan(&strict); err != nil {
+			t.Fatalf("read %s STRICT flag: %v", table, err)
+		}
+		if strict != 1 {
+			t.Fatalf("%s strict = %d, want 1", table, strict)
+		}
+	}
+	for _, index := range []string{
+		"messages_conversation_message_uq",
+		"outbox_reactions_target_idx",
+		"outbox_read_receipts_message_idx",
+		"read_cursors_conversation_idx",
+	} {
+		var exists bool
+		if err := store.db.QueryRow(`
+			SELECT EXISTS (
+				SELECT 1 FROM sqlite_schema
+				WHERE type = 'index' AND name = ?
+			)
+		`, index).Scan(&exists); err != nil {
+			t.Fatalf("inspect migration index %q: %v", index, err)
+		}
+		if !exists {
+			t.Fatalf("migration index %q is missing", index)
+		}
 	}
 }
 
@@ -1096,6 +1616,22 @@ func outboxTestMediaItem(id string) NewOutboxItem {
 	return item
 }
 
+func outboxTestReactionItem(id string) NewOutboxItem {
+	item := outboxTestItem(id)
+	item.Kind = OutboxKindReaction
+	item.Operation = "reaction"
+	item.LocalMessageID = ""
+	return item
+}
+
+func outboxTestReadItem(id string) NewOutboxItem {
+	item := outboxTestItem(id)
+	item.Kind = OutboxKindRead
+	item.Operation = "read_receipt"
+	item.LocalMessageID = ""
+	return item
+}
+
 func outboxTestAttachment() OutboxAttachment {
 	return OutboxAttachment{
 		BlobHash:  "abababababababababababababababababababababababababababababababab",
@@ -1118,6 +1654,50 @@ func outboxTestOutgoingMessage(item NewOutboxItem, body string) Message {
 		State:            MessageStateActive,
 		OccurredAtMS:     outboxTestTimeMS,
 	}
+}
+
+func seedOutboxTestDevice(t *testing.T, store *Store, deviceID, accountID string) {
+	t.Helper()
+	mustRepositoryWrite(t, "seed UpsertDevice", store.UpsertDevice(Device{
+		DeviceID:    deviceID,
+		AccountID:   accountID,
+		Kind:        DeviceKindLocalInstallation,
+		State:       DeviceStateActive,
+		CreatedAtMS: outboxTestTimeMS,
+		UpdatedAtMS: outboxTestTimeMS,
+	}))
+}
+
+func seedOutboxTestMessage(
+	t *testing.T,
+	store *Store,
+	messageID, accountID, conversationID string,
+) {
+	t.Helper()
+	mustExec(t, store.db, `
+		INSERT INTO messages (
+			message_id,
+			conversation_id,
+			account_id,
+			remote_message_id,
+			sender_identity_id,
+			direction,
+			body,
+			reply_to_remote_id,
+			state,
+			occurred_at_ms,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, NULL, 'incoming', '', NULL, 'active', ?, ?, ?)
+	`,
+		messageID,
+		conversationID,
+		accountID,
+		"remote-"+messageID,
+		outboxTestTimeMS-1_000,
+		outboxTestTimeMS,
+		outboxTestTimeMS,
+	)
 }
 
 func mustEnqueueOutbox(

--- a/internal/storage/sqlite/read_cursors.go
+++ b/internal/storage/sqlite/read_cursors.go
@@ -1,0 +1,131 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ReadCursor is the latest device-scoped read position for one conversation.
+// LastReadMessageID may be nil for imported cursors that only approximate a
+// position; M3 read-receipt submissions always provide it.
+type ReadCursor struct {
+	AccountID         string
+	DeviceID          string
+	ConversationID    string
+	LastReadMessageID *string
+	LastReadAtMS      int64
+	SourceUpdatedAtMS *int64
+	UpdatedAtMS       int64
+}
+
+// UpsertReadCursor advances a cursor monotonically by read time. An older
+// write succeeds without changing the stored cursor; an equal time replaces
+// the message position and update timestamp.
+func (s *Store) UpsertReadCursor(cursor ReadCursor) error {
+	if err := upsertReadCursor(
+		context.Background(),
+		s.db,
+		cursor,
+	); err != nil {
+		return fmt.Errorf(
+			"upsert read cursor for device %q and conversation %q: %w",
+			cursor.DeviceID,
+			cursor.ConversationID,
+			err,
+		)
+	}
+	return nil
+}
+
+func (s *Store) upsertReadCursorTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	cursor ReadCursor,
+) error {
+	if err := upsertReadCursor(ctx, tx, cursor); err != nil {
+		return fmt.Errorf(
+			"upsert read cursor for device %q and conversation %q: %w",
+			cursor.DeviceID,
+			cursor.ConversationID,
+			err,
+		)
+	}
+	return nil
+}
+
+type readCursorExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func upsertReadCursor(
+	ctx context.Context,
+	execer readCursorExecer,
+	cursor ReadCursor,
+) error {
+	_, err := execer.ExecContext(ctx, `
+		INSERT INTO read_cursors (
+			account_id,
+			device_id,
+			conversation_id,
+			last_read_message_id,
+			last_read_at_ms,
+			source_updated_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, NULL, ?)
+		ON CONFLICT(device_id, conversation_id) DO UPDATE SET
+			last_read_message_id = excluded.last_read_message_id,
+			last_read_at_ms      = excluded.last_read_at_ms,
+			updated_at_ms        = excluded.updated_at_ms
+		WHERE excluded.last_read_at_ms >= read_cursors.last_read_at_ms
+	`,
+		cursor.AccountID,
+		cursor.DeviceID,
+		cursor.ConversationID,
+		cursor.LastReadMessageID,
+		cursor.LastReadAtMS,
+		cursor.UpdatedAtMS,
+	)
+	if err != nil {
+		return mapConstraintError(err)
+	}
+	return nil
+}
+
+// GetReadCursor returns the cursor for one device and conversation.
+func (s *Store) GetReadCursor(deviceID, conversationID string) (ReadCursor, error) {
+	var cursor ReadCursor
+	err := s.db.QueryRowContext(context.Background(), `
+		SELECT
+			account_id,
+			device_id,
+			conversation_id,
+			last_read_message_id,
+			last_read_at_ms,
+			source_updated_at_ms,
+			updated_at_ms
+		FROM read_cursors
+		WHERE device_id = ? AND conversation_id = ?
+	`, deviceID, conversationID).Scan(
+		&cursor.AccountID,
+		&cursor.DeviceID,
+		&cursor.ConversationID,
+		&cursor.LastReadMessageID,
+		&cursor.LastReadAtMS,
+		&cursor.SourceUpdatedAtMS,
+		&cursor.UpdatedAtMS,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ReadCursor{}, notFound("read cursor", deviceID+"/"+conversationID)
+	}
+	if err != nil {
+		return ReadCursor{}, fmt.Errorf(
+			"get read cursor for device %q and conversation %q: %w",
+			deviceID,
+			conversationID,
+			err,
+		)
+	}
+	return cursor, nil
+}

--- a/internal/storage/sqlite/read_cursors_test.go
+++ b/internal/storage/sqlite/read_cursors_test.go
@@ -1,0 +1,191 @@
+package sqlite
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestReadCursorUpsertIsMonotone(t *testing.T) {
+	store, _ := openOutboxTestRepository(t, func() time.Time {
+		return time.UnixMilli(outboxTestTimeMS)
+	})
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	seedOutboxTestDevice(t, store, "device-a", "account-a")
+	for _, messageID := range []string{"message-first", "message-equal", "message-forward"} {
+		seedOutboxTestMessage(t, store, messageID, "account-a", "conversation-a")
+	}
+
+	firstID := "message-first"
+	first := ReadCursor{
+		AccountID:         "account-a",
+		DeviceID:          "device-a",
+		ConversationID:    "conversation-a",
+		LastReadMessageID: &firstID,
+		LastReadAtMS:      100,
+		UpdatedAtMS:       1_000,
+	}
+	if err := store.UpsertReadCursor(first); err != nil {
+		t.Fatalf("UpsertReadCursor(first): %v", err)
+	}
+	assertReadCursor(t, store, first)
+
+	backwardID := "message-equal"
+	backward := first
+	backward.LastReadMessageID = &backwardID
+	backward.LastReadAtMS = 99
+	backward.UpdatedAtMS = 2_000
+	if err := store.UpsertReadCursor(backward); err != nil {
+		t.Fatalf("UpsertReadCursor(backward): %v", err)
+	}
+	assertReadCursor(t, store, first)
+
+	equal := backward
+	equal.LastReadAtMS = 100
+	equal.UpdatedAtMS = 3_000
+	if err := store.UpsertReadCursor(equal); err != nil {
+		t.Fatalf("UpsertReadCursor(equal): %v", err)
+	}
+	assertReadCursor(t, store, equal)
+
+	forwardID := "message-forward"
+	forward := equal
+	forward.LastReadMessageID = &forwardID
+	forward.LastReadAtMS = 101
+	forward.UpdatedAtMS = 4_000
+	if err := store.UpsertReadCursor(forward); err != nil {
+		t.Fatalf("UpsertReadCursor(forward): %v", err)
+	}
+	assertReadCursor(t, store, forward)
+}
+
+func TestReadCursorAllowsNullMessageAtZero(t *testing.T) {
+	store, _ := openOutboxTestRepository(t, func() time.Time {
+		return time.UnixMilli(outboxTestTimeMS)
+	})
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	seedOutboxTestDevice(t, store, "device-a", "account-a")
+	sourceUpdatedAtMS := int64(500)
+	cursor := ReadCursor{
+		AccountID:         "account-a",
+		DeviceID:          "device-a",
+		ConversationID:    "conversation-a",
+		LastReadAtMS:      0,
+		SourceUpdatedAtMS: &sourceUpdatedAtMS,
+		UpdatedAtMS:       1_000,
+	}
+	if err := store.UpsertReadCursor(cursor); err != nil {
+		t.Fatalf("UpsertReadCursor(): %v", err)
+	}
+	got, err := store.GetReadCursor("device-a", "conversation-a")
+	if err != nil {
+		t.Fatalf("GetReadCursor(): %v", err)
+	}
+	if got.LastReadMessageID != nil || got.LastReadAtMS != 0 || got.SourceUpdatedAtMS != nil {
+		t.Fatalf("GetReadCursor() = %+v, want null message/source and zero time", got)
+	}
+}
+
+func TestReadCursorForeignKeysAndChecksMapConstraintErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		cursor func(*testing.T, *Store) ReadCursor
+	}{
+		{
+			name: "unknown device",
+			cursor: func(_ *testing.T, _ *Store) ReadCursor {
+				messageID := "message-a"
+				return ReadCursor{
+					AccountID: "account-a", DeviceID: "missing", ConversationID: "conversation-a",
+					LastReadMessageID: &messageID, LastReadAtMS: 100, UpdatedAtMS: 1_000,
+				}
+			},
+		},
+		{
+			name: "cross-account device",
+			cursor: func(t *testing.T, store *Store) ReadCursor {
+				seedMessageAccount(t, store, "account-b", "test-b")
+				seedOutboxTestDevice(t, store, "device-b", "account-b")
+				messageID := "message-a"
+				return ReadCursor{
+					AccountID: "account-a", DeviceID: "device-b", ConversationID: "conversation-a",
+					LastReadMessageID: &messageID, LastReadAtMS: 100, UpdatedAtMS: 1_000,
+				}
+			},
+		},
+		{
+			name: "cross-account conversation",
+			cursor: func(t *testing.T, store *Store) ReadCursor {
+				seedMessageAccount(t, store, "account-b", "test-b")
+				seedMessageConversation(t, store, "conversation-b", "account-b")
+				seedOutboxTestMessage(t, store, "message-b", "account-b", "conversation-b")
+				messageID := "message-b"
+				return ReadCursor{
+					AccountID: "account-a", DeviceID: "device-a", ConversationID: "conversation-b",
+					LastReadMessageID: &messageID, LastReadAtMS: 100, UpdatedAtMS: 1_000,
+				}
+			},
+		},
+		{
+			name: "cross-conversation message",
+			cursor: func(t *testing.T, store *Store) ReadCursor {
+				seedMessageConversation(t, store, "conversation-b", "account-a")
+				seedOutboxTestMessage(t, store, "message-b", "account-a", "conversation-b")
+				messageID := "message-b"
+				return ReadCursor{
+					AccountID: "account-a", DeviceID: "device-a", ConversationID: "conversation-a",
+					LastReadMessageID: &messageID, LastReadAtMS: 100, UpdatedAtMS: 1_000,
+				}
+			},
+		},
+		{
+			name: "message requires positive read time",
+			cursor: func(_ *testing.T, _ *Store) ReadCursor {
+				messageID := "message-a"
+				return ReadCursor{
+					AccountID: "account-a", DeviceID: "device-a", ConversationID: "conversation-a",
+					LastReadMessageID: &messageID, LastReadAtMS: 0, UpdatedAtMS: 1_000,
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store, _ := openOutboxTestRepository(t, func() time.Time {
+				return time.UnixMilli(outboxTestTimeMS)
+			})
+			seedMessageConversation(t, store, "conversation-a", "account-a")
+			seedOutboxTestDevice(t, store, "device-a", "account-a")
+			seedOutboxTestMessage(t, store, "message-a", "account-a", "conversation-a")
+			if err := store.UpsertReadCursor(test.cursor(t, store)); !errors.Is(err, ErrConstraintViolation) {
+				t.Fatalf("UpsertReadCursor() error = %v, want ErrConstraintViolation", err)
+			}
+			assertRowCount(t, store.db, "read_cursors", 0)
+		})
+	}
+}
+
+func TestGetReadCursorMissingReturnsNotFound(t *testing.T) {
+	store, _ := openOutboxTestRepository(t, func() time.Time {
+		return time.UnixMilli(outboxTestTimeMS)
+	})
+	if _, err := store.GetReadCursor("missing-device", "missing-conversation"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetReadCursor(missing) error = %v, want ErrNotFound", err)
+	}
+}
+
+func assertReadCursor(t *testing.T, store *Store, want ReadCursor) {
+	t.Helper()
+	got, err := store.GetReadCursor(want.DeviceID, want.ConversationID)
+	if err != nil {
+		t.Fatalf("GetReadCursor(): %v", err)
+	}
+	if got.AccountID != want.AccountID || got.DeviceID != want.DeviceID ||
+		got.ConversationID != want.ConversationID || got.LastReadAtMS != want.LastReadAtMS ||
+		got.UpdatedAtMS != want.UpdatedAtMS || got.SourceUpdatedAtMS != nil ||
+		(got.LastReadMessageID == nil) != (want.LastReadMessageID == nil) ||
+		(got.LastReadMessageID != nil && *got.LastReadMessageID != *want.LastReadMessageID) {
+		t.Fatalf("GetReadCursor() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -82,8 +82,11 @@ func TestOpenInitializesBlankDatabase(t *testing.T) {
 		"messages",
 		"outbox",
 		"outbox_attachments",
+		"outbox_reactions",
+		"outbox_read_receipts",
 		"people",
 		"person_identities",
+		"read_cursors",
 		"schema_migrations",
 		"store_metadata",
 	}


### PR DESCRIPTION
## Rebuild Wave 2 / M3 — reactions and read receipts over the durable outbox

Extends the MessageService pipeline to two message-less intent kinds, **fake capabilities only** — transport adapter shims are T5. The v2 pipeline has no production callers, so this changes no live path.

### What it does
- `MessageService.SendReaction` / `MarkRead` enqueue durable reaction/read intents through the same outbox state machine (uncertain/terminal/retry) as text and media.
- **Reactions** create no message row. **Read receipts** pair the outbox row with a monotone read-cursor upsert in **one transaction** — the cursor is authoritative local state, so a failed receipt send never un-reads a conversation (matching today's local-only mark-read semantics).

### Design (per the Fable-designed spec, Opus-reviewed)
- **Migration 0007** — additive `outbox_reactions` + `outbox_read_receipts` side tables (the 0006 media precedent) and, **absorbing the read-cursor half of the never-merged S5b**, a device-scoped `read_cursors` table whose composite FK enforces *at the DB layer* that a cursor's message belongs to its conversation. `0001–0006` untouched. (S5b's FTS/unread-derivation half stays its own task.)
- **New `ConfirmWithoutResult` outbox arm** — terminally confirms a called lease whose operation returns no remote identity (read receipts; reactions on transports that return acceptance-only, e.g. a success bool). Treating id-less success as "uncertain" — the text/media rule — would wrongly flag every explicit accept.
- **Idempotency** — reaction hash = target+emoji+action; read hash = device+cursor message (ReadAt excluded, so reopening an unchanged conversation dedups rather than conflicts). Rapid toggles are two ordered rows, never a coalesced UPDATE (which would race the lease claim window).
- **Unsupported is explicit at two layers** — service `ErrUnsupported` + dispatch terminal `rejected/unsupported` (e.g. Signal read receipts).

### Verification
- Full `go test -race ./...` green — 23 packages; `-shuffle=on -count=2` on messaging; hermetic (no platform identifiers in service/storage/dispatch).
- Adversarial review verdict **mergeable, no fixes**: migrations applied to a real scratch sqlite DB **including a populated-v6 upgrade**; the cross-conversation-cursor FK rejection, the `ConfirmWithoutResult` guards + stale-lease-token safety, and the shared-enqueue byte-identity for text/media all verified against real SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
