### PR TITLE
Add app-owned media download service (rebuild Wave 2 / M4a)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	go.mau.fi/whatsmeow v0.0.0-20260630180629-b572e5bcb92b
 	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.56.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/term v0.44.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.44.3
@@ -39,7 +40,6 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.mau.fi/libsignal v0.2.2 // indirect
 	golang.org/x/exp v0.0.0-20260611194520-c48552f49976 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/media/policy.go
+++ b/internal/media/policy.go
@@ -1,0 +1,90 @@
+package media
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Disposition controls whether media may render inline or must be downloaded.
+type Disposition string
+
+const (
+	DispositionInline         Disposition = "inline"
+	DispositionForcedDownload Disposition = "attachment"
+)
+
+// ServingDisposition returns inline only for a passive declared media type
+// whose sniffed bytes are not active markup.
+func ServingDisposition(declaredMIME string, sniff []byte) Disposition {
+	if isPassiveInlineMIME(declaredMIME) && !isActiveMIME(http.DetectContentType(sniff)) {
+		return DispositionInline
+	}
+	return DispositionForcedDownload
+}
+
+func normalizeMIME(mimeType string) string {
+	m := strings.ToLower(strings.TrimSpace(mimeType))
+	if i := strings.IndexByte(m, ';'); i >= 0 {
+		m = strings.TrimSpace(m[:i])
+	}
+	return m
+}
+
+// isPassiveInlineMIME reports whether a media type can be rendered inline in a
+// browser with no risk of executing script. SVG and the HTML/XML family are
+// excluded because they can carry <script>; anything not positively recognized
+// is treated as unsafe and downloaded instead.
+func isPassiveInlineMIME(mimeType string) bool {
+	m := normalizeMIME(mimeType)
+	switch {
+	case m == "image/svg+xml":
+		return false
+	case strings.HasPrefix(m, "image/"),
+		strings.HasPrefix(m, "audio/"),
+		strings.HasPrefix(m, "video/"):
+		return true
+	case m == "application/pdf", m == "text/plain":
+		return true
+	default:
+		return false
+	}
+}
+
+// isActiveMIME reports whether a sniffed type could be interpreted as
+// script-bearing markup. It rejects a payload declared as a passive type whose
+// bytes actually sniff as active content (a spoofed image/png that is really
+// HTML).
+func isActiveMIME(mimeType string) bool {
+	switch normalizeMIME(mimeType) {
+	case "text/html", "application/xhtml+xml", "image/svg+xml", "text/xml", "application/xml":
+		return true
+	}
+	return false
+}
+
+// sanitizeMediaFilename strips path components, control characters, and
+// header-breaking characters so a filename can be placed in a quoted
+// Content-Disposition value. Non-ASCII bytes are replaced to keep the header
+// well-formed; the result is never empty.
+func sanitizeMediaFilename(name string) string {
+	name = strings.TrimSpace(name)
+	if i := strings.LastIndexAny(name, "/\\"); i >= 0 {
+		name = name[i+1:]
+	}
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r < 0x20 || r == 0x7f, r == '"' || r == '\\':
+			// drop
+		case r > 0x7f:
+			b.WriteByte('_')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return "attachment"
+	}
+	return out
+}

--- a/internal/media/policy_test.go
+++ b/internal/media/policy_test.go
@@ -1,0 +1,63 @@
+package media
+
+import "testing"
+
+func TestServingDisposition(t *testing.T) {
+	png := append([]byte("\x89PNG\r\n\x1a\n"), make([]byte, 64)...)
+	html := []byte("<html><body><script>alert(1)</script></body></html>")
+	svg := []byte(`<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`)
+	xml := []byte(`<?xml version="1.0"?><root/>`)
+
+	tests := []struct {
+		name     string
+		declared string
+		sniff    []byte
+		want     Disposition
+	}{
+		{name: "PNG image", declared: "image/png", sniff: png, want: DispositionInline},
+		{name: "audio", declared: "audio/mpeg", sniff: []byte("ID3\x04\x00\x00"), want: DispositionInline},
+		{name: "video", declared: "video/mp4", sniff: []byte("\x00\x00\x00\x18ftypmp42"), want: DispositionInline},
+		{name: "PDF", declared: "application/pdf", sniff: []byte("%PDF-1.7\n"), want: DispositionInline},
+		{name: "plain text", declared: "text/plain", sniff: []byte("hello world\n"), want: DispositionInline},
+		{name: "normalized passive MIME", declared: " IMAGE/PNG ; charset=binary ", sniff: png, want: DispositionInline},
+		{name: "SVG", declared: "image/svg+xml", sniff: svg, want: DispositionForcedDownload},
+		{name: "HTML", declared: "text/html", sniff: html, want: DispositionForcedDownload},
+		{name: "XHTML", declared: "application/xhtml+xml", sniff: html, want: DispositionForcedDownload},
+		{name: "text XML", declared: "text/xml", sniff: xml, want: DispositionForcedDownload},
+		{name: "application XML", declared: "application/xml", sniff: xml, want: DispositionForcedDownload},
+		{name: "unknown", declared: "application/x-unknown", sniff: []byte("opaque bytes"), want: DispositionForcedDownload},
+		{name: "empty", declared: "", sniff: []byte("opaque bytes"), want: DispositionForcedDownload},
+		{name: "PNG declared HTML sniffed spoof", declared: "image/png", sniff: html, want: DispositionForcedDownload},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ServingDisposition(tt.declared, tt.sniff); got != tt.want {
+				t.Fatalf("ServingDisposition(%q) = %q, want %q", tt.declared, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeMediaFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain", in: "photo.png", want: "photo.png"},
+		{name: "slash path", in: "  ../../photo.png  ", want: "photo.png"},
+		{name: "backslash path", in: `C:\temp\photo.png`, want: "photo.png"},
+		{name: "controls and quote", in: "bad\x00\r\n\"name.png", want: "badname.png"},
+		{name: "non ASCII", in: "caf\u00e9.png", want: "caf_.png"},
+		{name: "empty after sanitizing", in: "\"\r\n", want: "attachment"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeMediaFilename(tt.in); got != tt.want {
+				t.Fatalf("sanitizeMediaFilename(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/media/service.go
+++ b/internal/media/service.go
@@ -1,0 +1,341 @@
+package media
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"golang.org/x/sync/singleflight"
+)
+
+const failureRecordTimeout = 5 * time.Second
+
+// Clock is the same application clock contract used by MessageService.
+type Clock = messaging.Clock
+
+// Service resolves inbound attachment references and materializes their bytes
+// in the application-owned BlobStore.
+type Service struct {
+	attachments *sqlite.MessageAttachmentRepository
+	bridges     bridge.Registry
+	blobs       *blob.BlobStore
+	clock       Clock
+	maxBytes    int64
+	group       singleflight.Group
+}
+
+// DownloadCommand identifies one message-owned attachment. It deliberately
+// carries neither a transport reference nor a filesystem path.
+type DownloadCommand struct {
+	AccountID string
+	MessageID string
+	Ordinal   int64
+}
+
+// Descriptor is the safe, path-free serving view of a materialized attachment.
+type Descriptor struct {
+	Ref         blob.BlobRef
+	MIME        string
+	Filename    string
+	Size        int64
+	Disposition Disposition
+}
+
+var (
+	ErrUnsupported = errors.New("media: account bridge cannot download media")
+	ErrUnavailable = errors.New("media: download capability unavailable")
+	ErrNotFound    = errors.New("media: attachment not found")
+	ErrTooLarge    = errors.New("media: attachment exceeds size limit")
+)
+
+// NewService constructs the media download service over application-owned
+// storage and transport capabilities. The caller retains ownership of every
+// dependency.
+func NewService(
+	store *sqlite.Store,
+	bridges bridge.Registry,
+	blobs *blob.BlobStore,
+	clock Clock,
+) (*Service, error) {
+	if store == nil {
+		return nil, fmt.Errorf("create media service: store is nil")
+	}
+	if bridges == nil {
+		return nil, fmt.Errorf("create media service: bridge registry is nil")
+	}
+	if blobs == nil {
+		return nil, fmt.Errorf("create media service: blob store is nil")
+	}
+	if clock == nil {
+		return nil, fmt.Errorf("create media service: clock is nil")
+	}
+	attachments, err := sqlite.NewMessageAttachmentRepository(store, clock.Now)
+	if err != nil {
+		return nil, fmt.Errorf("create media service attachments: %w", err)
+	}
+	return &Service{
+		attachments: attachments,
+		bridges:     bridges,
+		blobs:       blobs,
+		clock:       clock,
+		maxBytes:    messaging.DefaultMaxMediaBytes,
+	}, nil
+}
+
+// Resolve returns a safe descriptor for one message attachment, downloading it
+// on demand when the durable row is still pending.
+func (s *Service) Resolve(ctx context.Context, command DownloadCommand) (Descriptor, error) {
+	if ctx == nil {
+		return Descriptor{}, fmt.Errorf("resolve media: context is nil")
+	}
+	if strings.TrimSpace(command.AccountID) == "" {
+		return Descriptor{}, fmt.Errorf("resolve media: account ID is empty")
+	}
+	if strings.TrimSpace(command.MessageID) == "" {
+		return Descriptor{}, fmt.Errorf("resolve media: message ID is empty")
+	}
+	if command.Ordinal < 0 {
+		return Descriptor{}, fmt.Errorf("resolve media: attachment ordinal is negative")
+	}
+
+	row, err := s.attachments.GetForDownload(ctx, command.MessageID, command.Ordinal)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Descriptor{}, ErrNotFound
+	}
+	if err != nil {
+		return Descriptor{}, fmt.Errorf("resolve media: read attachment: %w", err)
+	}
+	if row.AccountID != command.AccountID {
+		return Descriptor{}, ErrNotFound
+	}
+	if row.State == "downloaded" {
+		return s.descriptorForRow(row)
+	}
+
+	key := row.MessageID + "\x00" + strconv.FormatInt(row.Ordinal, 10)
+	_, err, _ = s.group.Do(key, func() (any, error) {
+		return s.download(ctx, row)
+	})
+	if err != nil {
+		return Descriptor{}, err
+	}
+
+	// Re-read after the slot rather than trusting its returned BlobRef. A
+	// concurrent process may have won MarkDownloaded; the durable row is the
+	// authoritative winner in that race and also contains the resolved MIME.
+	row, err = s.attachments.GetForDownload(ctx, command.MessageID, command.Ordinal)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Descriptor{}, ErrNotFound
+	}
+	if err != nil {
+		return Descriptor{}, fmt.Errorf("resolve media: reload attachment: %w", err)
+	}
+	if row.AccountID != command.AccountID {
+		return Descriptor{}, ErrNotFound
+	}
+	return s.descriptorForRow(row)
+}
+
+// Open delegates to the BlobStore's hash-validated, private-root reader.
+func (s *Service) Open(ref blob.BlobRef) (io.ReadCloser, error) {
+	return s.blobs.Open(ref)
+}
+
+func (s *Service) download(
+	ctx context.Context,
+	requested sqlite.MessageAttachment,
+) (blob.BlobRef, error) {
+	row, err := s.attachments.GetForDownload(ctx, requested.MessageID, requested.Ordinal)
+	if errors.Is(err, sql.ErrNoRows) {
+		return blob.BlobRef{}, ErrNotFound
+	}
+	if err != nil {
+		return blob.BlobRef{}, fmt.Errorf("download media: reload attachment: %w", err)
+	}
+	if row.AccountID != requested.AccountID {
+		return blob.BlobRef{}, ErrNotFound
+	}
+	if row.State == "downloaded" {
+		return blobRefForAttachment(row)
+	}
+
+	// Capabilities returns the zero set for both an unsupported adapter and an
+	// unregistered account. Snapshot preserves the routing table's distinction:
+	// unregistered is unavailable, while registered-but-unsupported is terminal.
+	if _, registered := s.bridges.Snapshot(row.AccountID); !registered {
+		return blob.BlobRef{}, ErrUnavailable
+	}
+	if !s.bridges.Capabilities(row.AccountID).MediaDownload {
+		return blob.BlobRef{}, ErrUnsupported
+	}
+
+	lease, err := s.bridges.Acquire(ctx, row.AccountID, bridge.CapabilityMediaDownload)
+	if err != nil {
+		switch {
+		case errors.Is(err, bridge.ErrAccountNotRegistered):
+			return blob.BlobRef{}, fmt.Errorf("%w: %w", ErrUnavailable, err)
+		case errors.Is(err, bridge.ErrCapabilityUnavailable):
+			if _, registered := s.bridges.Snapshot(row.AccountID); !registered {
+				return blob.BlobRef{}, fmt.Errorf("%w: %w", ErrUnavailable, err)
+			}
+			if !s.bridges.Capabilities(row.AccountID).MediaDownload {
+				return blob.BlobRef{}, fmt.Errorf("%w: %w", ErrUnsupported, err)
+			}
+			return blob.BlobRef{}, fmt.Errorf("%w: %w", ErrUnavailable, err)
+		default:
+			return blob.BlobRef{}, err
+		}
+	}
+	if lease == nil || lease.Download == nil {
+		if lease != nil {
+			lease.Close()
+		}
+		return blob.BlobRef{}, ErrUnavailable
+	}
+	defer lease.Close()
+
+	stream, err := lease.Download.DownloadMedia(ctx, row.AccountID, bridge.MediaRef{
+		RemoteID: row.RemoteID,
+		Opaque:   row.RemoteRef,
+		Filename: row.Filename,
+		MIME:     row.MIME,
+	})
+	if err != nil {
+		return blob.BlobRef{}, s.recordFailure(ctx, row, classifyTransportError(err))
+	}
+	if stream.ReadCloser == nil {
+		// A MediaStream value wrapping a nil interface is itself non-nil, so
+		// blob.Put's nil-reader guard cannot catch it and Close would panic.
+		return blob.BlobRef{}, s.recordFailure(ctx, row, errors.New(
+			"download media: transport returned no stream",
+		))
+	}
+	defer stream.Close()
+
+	mime := firstNonEmpty(stream.MIME, row.MIME, "application/octet-stream")
+	ref, err := s.blobs.Put(ctx, stream, mime, s.maxBytes)
+	if err != nil {
+		var tooLarge *blob.ErrTooLarge
+		if errors.As(err, &tooLarge) {
+			failure := fmt.Errorf("%w: %v", ErrTooLarge, tooLarge)
+			return blob.BlobRef{}, s.recordFailure(ctx, row, failure)
+		}
+		return blob.BlobRef{}, s.recordFailure(ctx, row, err)
+	}
+	if err := s.attachments.MarkDownloaded(
+		ctx,
+		row.MessageID,
+		row.Ordinal,
+		ref.Hash,
+		ref.Size,
+		mime,
+	); err != nil {
+		return blob.BlobRef{}, fmt.Errorf("download media: mark downloaded: %w", err)
+	}
+	return ref, nil
+}
+
+func (s *Service) descriptorForRow(row sqlite.MessageAttachment) (Descriptor, error) {
+	ref, err := blobRefForAttachment(row)
+	if err != nil {
+		return Descriptor{}, err
+	}
+	reader, err := s.blobs.Open(ref)
+	if err != nil {
+		return Descriptor{}, fmt.Errorf("describe media: open blob: %w", err)
+	}
+	sniff, readErr := io.ReadAll(io.LimitReader(reader, 512))
+	closeErr := reader.Close()
+	if readErr != nil {
+		return Descriptor{}, fmt.Errorf("describe media: sniff blob: %w", readErr)
+	}
+	if closeErr != nil {
+		return Descriptor{}, fmt.Errorf("describe media: close blob: %w", closeErr)
+	}
+
+	resolvedMIME := normalizeMIME(firstNonEmpty(row.MIME, ref.MIME, "application/octet-stream"))
+	if resolvedMIME == "" {
+		resolvedMIME = "application/octet-stream"
+	}
+	disposition := ServingDisposition(resolvedMIME, sniff)
+	if disposition == DispositionForcedDownload {
+		resolvedMIME = "application/octet-stream"
+	}
+	return Descriptor{
+		Ref:         ref,
+		MIME:        resolvedMIME,
+		Filename:    sanitizeMediaFilename(row.Filename),
+		Size:        ref.Size,
+		Disposition: disposition,
+	}, nil
+}
+
+func (s *Service) recordFailure(
+	ctx context.Context,
+	row sqlite.MessageAttachment,
+	failure error,
+) error {
+	mutationCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failureRecordTimeout)
+	defer cancel()
+	if err := s.attachments.MarkFailed(
+		mutationCtx,
+		row.MessageID,
+		row.Ordinal,
+		failure.Error(),
+	); err != nil {
+		return errors.Join(failure, fmt.Errorf("record media download failure: %w", err))
+	}
+	return failure
+}
+
+func blobRefForAttachment(row sqlite.MessageAttachment) (blob.BlobRef, error) {
+	if row.State != "downloaded" || row.BlobHash == nil {
+		return blob.BlobRef{}, fmt.Errorf("describe media: attachment is not downloaded")
+	}
+	var size int64
+	if row.SizeBytes != nil {
+		size = *row.SizeBytes
+	}
+	return blob.BlobRef{Hash: *row.BlobHash, Size: size, MIME: row.MIME}, nil
+}
+
+func classifyTransportError(err error) error {
+	failure, ok := asOpError(err)
+	if ok && failure.Class == bridge.FailureUnsupported {
+		return errors.Join(ErrUnsupported, err)
+	}
+	// The service returns all other adapter errors intact. Their OpError class
+	// tells callers whether the result is terminal (unsupported, unpaired, or
+	// expired credentials) or transient without inventing a durable failed state.
+	return err
+}
+
+func asOpError(err error) (bridge.OpError, bool) {
+	var pointer *bridge.OpError
+	if errors.As(err, &pointer) && pointer != nil {
+		return *pointer, true
+	}
+	var value bridge.OpError
+	if errors.As(err, &value) {
+		return value, true
+	}
+	return bridge.OpError{}, false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/media/service_test.go
+++ b/internal/media/service_test.go
@@ -1,0 +1,886 @@
+package media
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+var mediaTestTime = time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
+
+func TestResolveDownloadsBlobFirstAndReturnsSafeDescriptor(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-happy", []sqlite.MessageAttachment{{
+		Ordinal:   0,
+		RemoteID:  "remote-media",
+		RemoteRef: []byte("opaque-ref"),
+		Filename:  "../../photo.png",
+		MIME:      "image/png",
+	}})
+	payload := append([]byte("\x89PNG\r\n\x1a\n"), bytes.Repeat([]byte{0x42}, 64)...)
+	downloader := &scriptedDownloader{steps: []downloadStep{byteStreamStep(payload, "image/png")}}
+	registry := availableDownloadRegistry(downloader)
+	service := newMediaTestService(t, env, registry)
+
+	descriptor, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "account-1",
+		MessageID: "message-happy",
+		Ordinal:   0,
+	})
+	if err != nil {
+		t.Fatalf("Resolve(): %v", err)
+	}
+	if descriptor.Ref.Hash == "" || descriptor.Ref.Size != int64(len(payload)) ||
+		descriptor.Ref.MIME != "image/png" || descriptor.Size != int64(len(payload)) ||
+		descriptor.MIME != "image/png" || descriptor.Filename != "photo.png" ||
+		descriptor.Disposition != DispositionInline {
+		t.Fatalf("Resolve() descriptor = %+v", descriptor)
+	}
+	requests := downloader.snapshotRequests()
+	if len(requests) != 1 || requests[0].accountID != "account-1" ||
+		requests[0].ref.RemoteID != "remote-media" ||
+		!bytes.Equal(requests[0].ref.Opaque, []byte("opaque-ref")) ||
+		requests[0].ref.Filename != "../../photo.png" || requests[0].ref.MIME != "image/png" {
+		t.Fatalf("DownloadMedia requests = %+v", requests)
+	}
+	row := getMediaAttachment(t, env, "message-happy", 0)
+	if row.State != "downloaded" || row.BlobHash == nil || *row.BlobHash != descriptor.Ref.Hash ||
+		row.SizeBytes == nil || *row.SizeBytes != int64(len(payload)) {
+		t.Fatalf("downloaded attachment = %+v", row)
+	}
+
+	reader, err := service.Open(descriptor.Ref)
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	opened, readErr := io.ReadAll(reader)
+	closeErr := reader.Close()
+	if readErr != nil || closeErr != nil || !bytes.Equal(opened, payload) {
+		t.Fatalf("Open() = %d bytes, read=%v close=%v", len(opened), readErr, closeErr)
+	}
+}
+
+func TestResolveUsesStreamMIMEPersistedByDownload(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-stream-mime", []sqlite.MessageAttachment{{
+		Ordinal: 0, RemoteID: "remote-stream-mime", Filename: "resolved.png",
+		MIME: "application/octet-stream",
+	}})
+	payload := append([]byte("\x89PNG\r\n\x1a\n"), bytes.Repeat([]byte{0x24}, 64)...)
+	downloader := &scriptedDownloader{steps: []downloadStep{
+		byteStreamStep(payload, " IMAGE/PNG ; charset=binary "),
+	}}
+	service := newMediaTestService(t, env, availableDownloadRegistry(downloader))
+
+	descriptor, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "account-1", MessageID: "message-stream-mime", Ordinal: 0,
+	})
+	if err != nil {
+		t.Fatalf("Resolve(): %v", err)
+	}
+	if descriptor.MIME != "image/png" || descriptor.Disposition != DispositionInline ||
+		descriptor.Ref.MIME != "IMAGE/PNG ; charset=binary" {
+		t.Fatalf("stream-resolved descriptor = %+v", descriptor)
+	}
+	row := getMediaAttachment(t, env, "message-stream-mime", 0)
+	if row.MIME != "IMAGE/PNG ; charset=binary" {
+		t.Fatalf("persisted stream MIME = %q", row.MIME)
+	}
+}
+
+func TestResolveSingleFlightFetchesAndPublishesOnce(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-single-flight", []sqlite.MessageAttachment{{
+		Ordinal:   0,
+		RemoteID:  "remote-single-flight",
+		RemoteRef: []byte("single-flight-ref"),
+		Filename:  "shared.bin",
+		MIME:      "application/octet-stream",
+	}})
+	payload := bytes.Repeat([]byte("single-flight"), 128)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	downloader := &scriptedDownloader{steps: []downloadStep{{
+		beforeReturn: func() {
+			close(entered)
+			<-release
+		},
+		stream: func() bridge.MediaStream {
+			return byteMediaStream(payload, "application/octet-stream")
+		},
+	}}}
+	service := newMediaTestService(t, env, availableDownloadRegistry(downloader))
+	command := DownloadCommand{AccountID: "account-1", MessageID: "message-single-flight", Ordinal: 0}
+
+	const callers = 8
+	start := make(chan struct{})
+	results := make(chan resolveResult, callers)
+	for range callers {
+		go func() {
+			<-start
+			descriptor, err := service.Resolve(context.Background(), command)
+			results <- resolveResult{descriptor: descriptor, err: err}
+		}()
+	}
+	close(start)
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("DownloadMedia was not entered")
+	}
+	// Give every released caller an opportunity to join the occupied slot before
+	// allowing its only scripted transport result to complete.
+	for range 100 {
+		runtime.Gosched()
+	}
+	close(release)
+
+	var first blob.BlobRef
+	for i := 0; i < callers; i++ {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("Resolve()[%d]: %v", i, result.err)
+		}
+		if i == 0 {
+			first = result.descriptor.Ref
+		} else if result.descriptor.Ref != first {
+			t.Fatalf("Resolve()[%d] ref = %+v, want %+v", i, result.descriptor.Ref, first)
+		}
+	}
+	if got := downloader.requestCount(); got != 1 {
+		t.Fatalf("DownloadMedia calls = %d, want 1", got)
+	}
+	if files := blobFiles(t, env.blobRoot); len(files) != 1 {
+		t.Fatalf("blob files = %v, want exactly one", files)
+	}
+}
+
+func TestResolveDeduplicatesIdenticalAttachmentBytes(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-dedup", []sqlite.MessageAttachment{
+		{Ordinal: 0, RemoteID: "remote-a", Filename: "a.bin", MIME: "application/octet-stream"},
+		{Ordinal: 1, RemoteID: "remote-b", Filename: "b.bin", MIME: "application/octet-stream"},
+	})
+	payload := bytes.Repeat([]byte("same bytes"), 64)
+	downloader := &scriptedDownloader{steps: []downloadStep{
+		byteStreamStep(payload, "application/octet-stream"),
+		byteStreamStep(payload, "application/octet-stream"),
+	}}
+	service := newMediaTestService(t, env, availableDownloadRegistry(downloader))
+
+	first, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "account-1", MessageID: "message-dedup", Ordinal: 0,
+	})
+	if err != nil {
+		t.Fatalf("Resolve(first): %v", err)
+	}
+	second, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "account-1", MessageID: "message-dedup", Ordinal: 1,
+	})
+	if err != nil {
+		t.Fatalf("Resolve(second): %v", err)
+	}
+	if first.Ref.Hash != second.Ref.Hash {
+		t.Fatalf("deduplicated hashes = %q, %q", first.Ref.Hash, second.Ref.Hash)
+	}
+	if got := downloader.requestCount(); got != 2 {
+		t.Fatalf("DownloadMedia calls = %d, want 2 for different attachments", got)
+	}
+	if files := blobFiles(t, env.blobRoot); len(files) != 1 {
+		t.Fatalf("deduplicated blob files = %v, want one", files)
+	}
+}
+
+func TestResolveTooLargeLeavesAttachmentPendingAndNoBlob(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-too-large", []sqlite.MessageAttachment{{
+		Ordinal: 0, RemoteID: "remote-large", Filename: "large.bin", MIME: "application/octet-stream",
+	}})
+	downloader := &scriptedDownloader{steps: []downloadStep{
+		byteStreamStep([]byte("12345"), "application/octet-stream"),
+	}}
+	service := newMediaTestService(t, env, availableDownloadRegistry(downloader))
+	service.maxBytes = 4
+
+	_, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "account-1", MessageID: "message-too-large", Ordinal: 0,
+	})
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("Resolve() error = %v, want ErrTooLarge", err)
+	}
+	assertPendingWithoutBlob(t, env, "message-too-large", 0)
+	if files := blobFiles(t, env.blobRoot); len(files) != 0 {
+		t.Fatalf("oversize download left blob files: %v", files)
+	}
+	if got := attachmentLastError(t, env.dbPath, "message-too-large", 0); !got.Valid {
+		t.Fatal("oversize download did not record last_error")
+	}
+}
+
+func TestResolvePartialStreamFailureLeavesAttachmentPendingAndNoBlob(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-partial", []sqlite.MessageAttachment{{
+		Ordinal: 0, RemoteID: "remote-partial", Filename: "partial.bin", MIME: "application/octet-stream",
+	}})
+	sourceErr := errors.New("source stream failed")
+	downloader := &scriptedDownloader{steps: []downloadStep{{stream: func() bridge.MediaStream {
+		return bridge.MediaStream{
+			ReadCloser: &partialErrorReadCloser{data: []byte("partial bytes"), err: sourceErr},
+			Size:       1024,
+			MIME:       "application/octet-stream",
+		}
+	}}}}
+	service := newMediaTestService(t, env, availableDownloadRegistry(downloader))
+
+	_, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "account-1", MessageID: "message-partial", Ordinal: 0,
+	})
+	if !errors.Is(err, sourceErr) {
+		t.Fatalf("Resolve() error = %v, want source error", err)
+	}
+	assertPendingWithoutBlob(t, env, "message-partial", 0)
+	if files := blobFiles(t, env.blobRoot); len(files) != 0 {
+		t.Fatalf("partial download left blob files: %v", files)
+	}
+	if got := attachmentLastError(t, env.dbPath, "message-partial", 0); !got.Valid ||
+		!strings.Contains(got.String, sourceErr.Error()) {
+		t.Fatalf("partial download last_error = %+v", got)
+	}
+}
+
+// A transport returning (MediaStream{}, nil) — nil error with a nil embedded
+// ReadCloser — must be a recorded transient failure, not a panic at
+// stream.Close/blob.Put (the MediaStream value wrapping a nil interface is
+// itself non-nil, so blob.Put's nil-reader guard cannot catch it).
+func TestResolveNilStreamWithoutErrorIsTransientNotPanic(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-nilstream", []sqlite.MessageAttachment{{
+		Ordinal: 0, RemoteID: "remote-nilstream", Filename: "x.bin", MIME: "application/octet-stream",
+	}})
+	downloader := &scriptedDownloader{steps: []downloadStep{{stream: func() bridge.MediaStream {
+		return bridge.MediaStream{}
+	}}}}
+	service := newMediaTestService(t, env, availableDownloadRegistry(downloader))
+
+	_, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "account-1", MessageID: "message-nilstream", Ordinal: 0,
+	})
+	if err == nil || !strings.Contains(err.Error(), "transport returned no stream") {
+		t.Fatalf("Resolve() error = %v, want transport-returned-no-stream failure", err)
+	}
+	assertPendingWithoutBlob(t, env, "message-nilstream", 0)
+	if got := attachmentLastError(t, env.dbPath, "message-nilstream", 0); !got.Valid ||
+		!strings.Contains(got.String, "transport returned no stream") {
+		t.Fatalf("nil-stream download last_error = %+v", got)
+	}
+}
+
+func TestResolveForcesSpoofedActiveContentToDownload(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-spoof", []sqlite.MessageAttachment{{
+		Ordinal: 0, RemoteID: "remote-spoof", Filename: "../unsafe.html", MIME: "image/png",
+	}})
+	downloader := &scriptedDownloader{steps: []downloadStep{
+		byteStreamStep([]byte("<html><script>alert(1)</script></html>"), ""),
+	}}
+	service := newMediaTestService(t, env, availableDownloadRegistry(downloader))
+
+	descriptor, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "account-1", MessageID: "message-spoof", Ordinal: 0,
+	})
+	if err != nil {
+		t.Fatalf("Resolve(): %v", err)
+	}
+	if descriptor.Disposition != DispositionForcedDownload ||
+		descriptor.MIME != "application/octet-stream" || descriptor.Filename != "unsafe.html" {
+		t.Fatalf("spoofed descriptor = %+v", descriptor)
+	}
+}
+
+func TestResolveCapabilityRouting(t *testing.T) {
+	tests := []struct {
+		name        string
+		configure   func(*fakeRegistry)
+		want        error
+		wantAcquire int
+	}{
+		{
+			name: "unsupported",
+			configure: func(registry *fakeRegistry) {
+				registry.capabilities = bridge.CapabilitySet{}
+			},
+			want: ErrUnsupported,
+		},
+		{
+			name: "declared but unwired",
+			configure: func(registry *fakeRegistry) {
+				registry.capabilities.MediaDownload = true
+				registry.acquireErr = bridge.ErrCapabilityUnavailable
+			},
+			want:        ErrUnavailable,
+			wantAcquire: 1,
+		},
+		{
+			name: "lease has nil downloader",
+			configure: func(registry *fakeRegistry) {
+				registry.capabilities.MediaDownload = true
+				registry.nilDownload = true
+			},
+			want:        ErrUnavailable,
+			wantAcquire: 1,
+		},
+		{
+			name: "account not registered",
+			configure: func(registry *fakeRegistry) {
+				registry.registered = false
+			},
+			want: ErrUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newMediaTestEnvironment(t)
+			seedMediaMessage(t, env, "message-routing", []sqlite.MessageAttachment{{
+				Ordinal: 0, RemoteID: "remote-routing", Filename: "routing.bin", MIME: "application/octet-stream",
+			}})
+			downloader := &scriptedDownloader{}
+			registry := &fakeRegistry{registered: true, downloader: downloader}
+			tt.configure(registry)
+			service := newMediaTestService(t, env, registry)
+
+			_, err := service.Resolve(context.Background(), DownloadCommand{
+				AccountID: "account-1", MessageID: "message-routing", Ordinal: 0,
+			})
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Resolve() error = %v, want %v", err, tt.want)
+			}
+			if got := registry.acquireCalls(); got != tt.wantAcquire {
+				t.Fatalf("Acquire calls = %d, want %d", got, tt.wantAcquire)
+			}
+			if got := downloader.requestCount(); got != 0 {
+				t.Fatalf("DownloadMedia calls = %d, want 0", got)
+			}
+			assertPendingWithoutBlob(t, env, "message-routing", 0)
+		})
+	}
+}
+
+func TestResolveTerminalTransportErrorRecordsFailure(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-terminal", []sqlite.MessageAttachment{{
+		Ordinal: 0, RemoteID: "remote-terminal", Filename: "terminal.bin", MIME: "application/octet-stream",
+	}})
+	terminal := bridge.OpError{
+		Class:     bridge.FailureUnpaired,
+		Operation: "download_media",
+		Cause:     errors.New("pairing was removed"),
+	}
+	downloader := &scriptedDownloader{steps: []downloadStep{{err: terminal}}}
+	service := newMediaTestService(t, env, availableDownloadRegistry(downloader))
+
+	_, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "account-1", MessageID: "message-terminal", Ordinal: 0,
+	})
+	var got bridge.OpError
+	if !errors.As(err, &got) || got.Class != bridge.FailureUnpaired {
+		t.Fatalf("Resolve() error = %v, want unpaired OpError", err)
+	}
+	assertPendingWithoutBlob(t, env, "message-terminal", 0)
+	lastError := attachmentLastError(t, env.dbPath, "message-terminal", 0)
+	if !lastError.Valid || !strings.Contains(lastError.String, terminal.Error()) {
+		t.Fatalf("terminal last_error = %+v", lastError)
+	}
+}
+
+func TestResolveTransientTransportErrorRetries(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-transient", []sqlite.MessageAttachment{{
+		Ordinal: 0, RemoteID: "remote-transient", Filename: "transient.txt", MIME: "text/plain",
+	}})
+	transient := bridge.OpError{
+		Class:     bridge.FailureTransient,
+		Operation: "download_media",
+		Cause:     errors.New("temporary transport failure"),
+	}
+	downloader := &scriptedDownloader{steps: []downloadStep{
+		{err: transient},
+		byteStreamStep([]byte("retry succeeded"), "text/plain"),
+	}}
+	service := newMediaTestService(t, env, availableDownloadRegistry(downloader))
+	command := DownloadCommand{AccountID: "account-1", MessageID: "message-transient", Ordinal: 0}
+
+	if _, err := service.Resolve(context.Background(), command); err == nil {
+		t.Fatal("Resolve(first) succeeded, want transient error")
+	}
+	assertPendingWithoutBlob(t, env, "message-transient", 0)
+	descriptor, err := service.Resolve(context.Background(), command)
+	if err != nil {
+		t.Fatalf("Resolve(retry): %v", err)
+	}
+	if descriptor.Ref.Hash == "" || downloader.requestCount() != 2 {
+		t.Fatalf("retry descriptor/calls = %+v / %d", descriptor, downloader.requestCount())
+	}
+	if got := attachmentLastError(t, env.dbPath, "message-transient", 0); got.Valid {
+		t.Fatalf("successful retry retained last_error = %q", got.String)
+	}
+}
+
+func TestResolveCanceledTransportStillRecordsFailure(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-canceled", []sqlite.MessageAttachment{{
+		Ordinal: 0, RemoteID: "remote-canceled", Filename: "canceled.bin", MIME: "application/octet-stream",
+	}})
+	ctx, cancel := context.WithCancel(context.Background())
+	transportErr := errors.New("transport canceled the operation")
+	downloader := &scriptedDownloader{steps: []downloadStep{{
+		beforeReturn: cancel,
+		err:          transportErr,
+	}}}
+	service := newMediaTestService(t, env, availableDownloadRegistry(downloader))
+
+	_, err := service.Resolve(ctx, DownloadCommand{
+		AccountID: "account-1", MessageID: "message-canceled", Ordinal: 0,
+	})
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("Resolve() error = %v, want transport error", err)
+	}
+	assertPendingWithoutBlob(t, env, "message-canceled", 0)
+	lastError := attachmentLastError(t, env.dbPath, "message-canceled", 0)
+	if !lastError.Valid || !strings.Contains(lastError.String, transportErr.Error()) {
+		t.Fatalf("canceled transport last_error = %+v", lastError)
+	}
+}
+
+func TestResolveAccountFenceDoesNotLeakOrFetch(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-fenced", []sqlite.MessageAttachment{{
+		Ordinal: 0, RemoteID: "remote-fenced", Filename: "fenced.bin", MIME: "application/octet-stream",
+	}})
+	downloader := &scriptedDownloader{steps: []downloadStep{
+		byteStreamStep([]byte("must not fetch"), "application/octet-stream"),
+	}}
+	registry := availableDownloadRegistry(downloader)
+	service := newMediaTestService(t, env, registry)
+
+	_, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "different-account", MessageID: "message-fenced", Ordinal: 0,
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Resolve() error = %v, want ErrNotFound", err)
+	}
+	if registry.acquireCalls() != 0 || downloader.requestCount() != 0 {
+		t.Fatalf("account fence transport calls = acquire %d, download %d",
+			registry.acquireCalls(), downloader.requestCount())
+	}
+}
+
+func TestResolveAlreadyDownloadedMakesNoTransportCall(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	seedMediaMessage(t, env, "message-cached", []sqlite.MessageAttachment{{
+		Ordinal: 0, RemoteID: "remote-cached", Filename: "cached.txt", MIME: "text/plain",
+	}})
+	payload := []byte("already cached")
+	ref, err := env.blobs.Put(context.Background(), bytes.NewReader(payload), "text/plain", int64(len(payload)))
+	if err != nil {
+		t.Fatalf("Put(): %v", err)
+	}
+	if err := env.attachments.MarkDownloaded(
+		context.Background(), "message-cached", 0, ref.Hash, ref.Size, ref.MIME,
+	); err != nil {
+		t.Fatalf("MarkDownloaded(): %v", err)
+	}
+	downloader := &scriptedDownloader{}
+	registry := availableDownloadRegistry(downloader)
+	service := newMediaTestService(t, env, registry)
+
+	descriptor, err := service.Resolve(context.Background(), DownloadCommand{
+		AccountID: "account-1", MessageID: "message-cached", Ordinal: 0,
+	})
+	if err != nil {
+		t.Fatalf("Resolve(): %v", err)
+	}
+	if descriptor.Ref.Hash != ref.Hash || descriptor.Ref.Size != ref.Size {
+		t.Fatalf("cached descriptor = %+v, want ref %+v", descriptor, ref)
+	}
+	if registry.acquireCalls() != 0 || downloader.requestCount() != 0 {
+		t.Fatalf("cached transport calls = acquire %d, download %d",
+			registry.acquireCalls(), downloader.requestCount())
+	}
+}
+
+func TestNewServiceRejectsMissingDependencies(t *testing.T) {
+	env := newMediaTestEnvironment(t)
+	registry := availableDownloadRegistry(&scriptedDownloader{})
+	tests := []struct {
+		name     string
+		store    *sqlite.Store
+		registry bridge.Registry
+		blobs    *blob.BlobStore
+		clock    Clock
+	}{
+		{name: "store", registry: registry, blobs: env.blobs, clock: env.clock},
+		{name: "registry", store: env.store, blobs: env.blobs, clock: env.clock},
+		{name: "blobs", store: env.store, registry: registry, clock: env.clock},
+		{name: "clock", store: env.store, registry: registry, blobs: env.blobs},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewService(tt.store, tt.registry, tt.blobs, tt.clock); err == nil {
+				t.Fatal("NewService() succeeded with missing dependency")
+			}
+		})
+	}
+}
+
+type mediaTestEnvironment struct {
+	store       *sqlite.Store
+	attachments *sqlite.MessageAttachmentRepository
+	blobs       *blob.BlobStore
+	clock       *mediaManualClock
+	dbPath      string
+	blobRoot    string
+}
+
+func newMediaTestEnvironment(t *testing.T) *mediaTestEnvironment {
+	t.Helper()
+	clock := &mediaManualClock{now: mediaTestTime}
+	dbPath := filepath.Join(t.TempDir(), "media.sqlite")
+	store, err := sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID: "account-1", BridgeKey: "test", DisplayName: "Test account",
+		Mode: sqlite.AccountModeLive, Enabled: true, ConfigJSON: `{}`,
+		CreatedAtMS: clock.Now().UnixMilli(), UpdatedAtMS: clock.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	if err := store.UpsertConversation(sqlite.Conversation{
+		ConversationID: "conversation-1", AccountID: "account-1",
+		RemoteConversationID: "remote-conversation", Kind: sqlite.ConversationKindDirect,
+		Title: "Test conversation", NotificationMode: sqlite.NotificationModeAll,
+		MetadataJSON: `{}`, CreatedAtMS: clock.Now().UnixMilli(), UpdatedAtMS: clock.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatalf("UpsertConversation(): %v", err)
+	}
+	attachments, err := sqlite.NewMessageAttachmentRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageAttachmentRepository(): %v", err)
+	}
+	blobRoot := filepath.Join(t.TempDir(), "blobs")
+	blobs, err := blob.New(blobRoot)
+	if err != nil {
+		t.Fatalf("blob.New(): %v", err)
+	}
+	return &mediaTestEnvironment{
+		store: store, attachments: attachments, blobs: blobs, clock: clock,
+		dbPath: dbPath, blobRoot: blobRoot,
+	}
+}
+
+func seedMediaMessage(
+	t *testing.T,
+	env *mediaTestEnvironment,
+	messageID string,
+	attachments []sqlite.MessageAttachment,
+) {
+	t.Helper()
+	repository, err := sqlite.NewMessageRepository(env.store, env.clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	inboxID := "inbox-" + messageID
+	if _, err := repository.AppendInbox(context.Background(), sqlite.InboxRecord{
+		InboxID: inboxID, AccountID: "account-1", Generation: 1,
+		DedupeKey: "dedupe-" + messageID, Codec: "test", CodecVersion: 1,
+		Payload: []byte("payload"),
+	}); err != nil {
+		t.Fatalf("AppendInbox(): %v", err)
+	}
+	for index := range attachments {
+		attachments[index].MessageID = messageID
+	}
+	if err := repository.ProjectMessage(context.Background(), sqlite.MessageProjection{
+		InboxID: inboxID,
+		Message: sqlite.Message{
+			MessageID: messageID, ConversationID: "conversation-1", AccountID: "account-1",
+			RemoteMessageID: "remote-" + messageID, Direction: sqlite.MessageDirectionIncoming,
+			Body: "media", State: sqlite.MessageStateActive, OccurredAtMS: env.clock.Now().UnixMilli(),
+		},
+		Attachments: attachments,
+	}); err != nil {
+		t.Fatalf("ProjectMessage(): %v", err)
+	}
+}
+
+func newMediaTestService(
+	t *testing.T,
+	env *mediaTestEnvironment,
+	registry bridge.Registry,
+) *Service {
+	t.Helper()
+	service, err := NewService(env.store, registry, env.blobs, env.clock)
+	if err != nil {
+		t.Fatalf("NewService(): %v", err)
+	}
+	return service
+}
+
+func getMediaAttachment(
+	t *testing.T,
+	env *mediaTestEnvironment,
+	messageID string,
+	ordinal int64,
+) sqlite.MessageAttachment {
+	t.Helper()
+	row, err := env.attachments.GetForDownload(context.Background(), messageID, ordinal)
+	if err != nil {
+		t.Fatalf("GetForDownload(): %v", err)
+	}
+	return row
+}
+
+func assertPendingWithoutBlob(
+	t *testing.T,
+	env *mediaTestEnvironment,
+	messageID string,
+	ordinal int64,
+) {
+	t.Helper()
+	row := getMediaAttachment(t, env, messageID, ordinal)
+	if row.State != "pending" || row.BlobHash != nil {
+		t.Fatalf("attachment after failed download = %+v, want pending without blob", row)
+	}
+}
+
+func attachmentLastError(t *testing.T, dbPath, messageID string, ordinal int64) sql.NullString {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open(): %v", err)
+	}
+	defer db.Close()
+	var lastError sql.NullString
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT last_error
+		FROM message_attachments
+		WHERE message_id = ? AND ordinal = ?
+	`, messageID, ordinal).Scan(&lastError); err != nil {
+		t.Fatalf("read last_error: %v", err)
+	}
+	return lastError
+}
+
+func blobFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	if err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkDir(blob root): %v", err)
+	}
+	return files
+}
+
+type resolveResult struct {
+	descriptor Descriptor
+	err        error
+}
+
+type mediaManualClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *mediaManualClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *mediaManualClock) NewTimer(delay time.Duration) messaging.Timer {
+	return mediaSystemTimer{Timer: time.NewTimer(delay)}
+}
+
+type mediaSystemTimer struct{ *time.Timer }
+
+func (t mediaSystemTimer) C() <-chan time.Time { return t.Timer.C }
+
+type fakeRegistry struct {
+	mu           sync.Mutex
+	registered   bool
+	capabilities bridge.CapabilitySet
+	downloader   bridge.MediaDownloader
+	acquireErr   error
+	nilDownload  bool
+	acquires     int
+}
+
+func availableDownloadRegistry(downloader bridge.MediaDownloader) *fakeRegistry {
+	return &fakeRegistry{
+		registered:   true,
+		capabilities: bridge.CapabilitySet{MediaDownload: true},
+		downloader:   downloader,
+	}
+}
+
+func (r *fakeRegistry) Snapshot(accountID string) (bridge.Snapshot, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if accountID != "account-1" || !r.registered {
+		return bridge.Snapshot{}, false
+	}
+	return bridge.Snapshot{AccountID: accountID, Platform: "test", Generation: 1}, true
+}
+
+func (r *fakeRegistry) Acquire(
+	ctx context.Context,
+	accountID string,
+	capability bridge.Capability,
+) (*bridge.DispatchLease, error) {
+	r.mu.Lock()
+	r.acquires++
+	err := r.acquireErr
+	downloader := r.downloader
+	nilDownload := r.nilDownload
+	r.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err != nil {
+		return nil, fmt.Errorf("acquire media download: %w", err)
+	}
+	if capability != bridge.CapabilityMediaDownload {
+		return nil, bridge.ErrCapabilityUnavailable
+	}
+	lease := &bridge.DispatchLease{
+		AccountID: accountID, Platform: "test", Generation: 1, Ctx: ctx,
+	}
+	if !nilDownload {
+		lease.Download = downloader
+	}
+	return lease, nil
+}
+
+func (r *fakeRegistry) Capabilities(accountID string) bridge.CapabilitySet {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if accountID != "account-1" {
+		return bridge.CapabilitySet{}
+	}
+	return r.capabilities
+}
+
+func (r *fakeRegistry) acquireCalls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.acquires
+}
+
+type downloadStep struct {
+	stream       func() bridge.MediaStream
+	err          error
+	beforeReturn func()
+}
+
+func byteStreamStep(data []byte, mime string) downloadStep {
+	content := append([]byte(nil), data...)
+	return downloadStep{stream: func() bridge.MediaStream {
+		return byteMediaStream(content, mime)
+	}}
+}
+
+func byteMediaStream(data []byte, mime string) bridge.MediaStream {
+	return bridge.MediaStream{
+		ReadCloser: io.NopCloser(bytes.NewReader(data)),
+		Size:       int64(len(data)),
+		MIME:       mime,
+	}
+}
+
+type downloadRequest struct {
+	accountID string
+	ref       bridge.MediaRef
+}
+
+type scriptedDownloader struct {
+	mu       sync.Mutex
+	steps    []downloadStep
+	requests []downloadRequest
+}
+
+func (d *scriptedDownloader) DownloadMedia(
+	_ context.Context,
+	accountID string,
+	ref bridge.MediaRef,
+) (bridge.MediaStream, error) {
+	d.mu.Lock()
+	ref.Opaque = append([]byte(nil), ref.Opaque...)
+	d.requests = append(d.requests, downloadRequest{accountID: accountID, ref: ref})
+	if len(d.steps) == 0 {
+		d.mu.Unlock()
+		return bridge.MediaStream{}, errors.New("unexpected DownloadMedia call")
+	}
+	step := d.steps[0]
+	d.steps = d.steps[1:]
+	d.mu.Unlock()
+	if step.beforeReturn != nil {
+		step.beforeReturn()
+	}
+	if step.err != nil {
+		return bridge.MediaStream{}, step.err
+	}
+	return step.stream(), nil
+}
+
+func (d *scriptedDownloader) requestCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.requests)
+}
+
+func (d *scriptedDownloader) snapshotRequests() []downloadRequest {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]downloadRequest(nil), d.requests...)
+}
+
+type partialErrorReadCloser struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *partialErrorReadCloser) Read(buffer []byte) (int, error) {
+	if !r.done {
+		r.done = true
+		return copy(buffer, r.data), nil
+	}
+	return 0, r.err
+}
+
+func (r *partialErrorReadCloser) Close() error { return nil }

--- a/internal/storage/sqlite/attachments.go
+++ b/internal/storage/sqlite/attachments.go
@@ -149,6 +149,8 @@ func (r *AttachmentRepository) ListUnreferencedBlobHashes(
 				SELECT blob_hash FROM attachments
 				UNION
 				SELECT blob_hash FROM outbox_attachments
+				UNION
+				SELECT blob_hash FROM message_attachments WHERE blob_hash IS NOT NULL
 			)
 			SELECT blob_hash
 			FROM referenced

--- a/internal/storage/sqlite/attachments_test.go
+++ b/internal/storage/sqlite/attachments_test.go
@@ -129,6 +129,56 @@ func TestAttachmentRepositoryTreatsQueuedOutboxBlobAsReferenced(t *testing.T) {
 	}
 }
 
+func TestAttachmentRepositoryTreatsDownloadedMessageBlobAsReferenced(t *testing.T) {
+	store, repository := openAttachmentTestRepository(t)
+	seedMessageAccount(t, store, "account-a", "test")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	seedOutboxTestMessage(t, store, "message-inbound-media", "account-a", "conversation-a")
+	messageAttachments, err := NewMessageAttachmentRepository(
+		store,
+		func() time.Time { return time.UnixMilli(attachmentTestTimeMS) },
+	)
+	if err != nil {
+		t.Fatalf("NewMessageAttachmentRepository(): %v", err)
+	}
+	tx, err := store.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin message attachment transaction: %v", err)
+	}
+	defer tx.Rollback()
+	for ordinal := range int64(2) {
+		if err := messageAttachments.RecordInboundAttachment(context.Background(), tx, MessageAttachment{
+			MessageID: "message-inbound-media",
+			Ordinal:   ordinal,
+			MIME:      "application/octet-stream",
+		}); err != nil {
+			t.Fatalf("RecordInboundAttachment(%d): %v", ordinal, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit message attachments: %v", err)
+	}
+
+	downloadedHash := strings.Repeat("6f", 32)
+	pendingCandidate := strings.Repeat("7a", 32)
+	orphanHash := strings.Repeat("8b", 32)
+	if err := messageAttachments.MarkDownloaded(
+		context.Background(), "message-inbound-media", 0, downloadedHash, 10, "image/png",
+	); err != nil {
+		t.Fatalf("MarkDownloaded(): %v", err)
+	}
+	got, err := repository.ListUnreferencedBlobHashes(
+		context.Background(),
+		[]string{downloadedHash, pendingCandidate, orphanHash},
+	)
+	if err != nil {
+		t.Fatalf("ListUnreferencedBlobHashes(): %v", err)
+	}
+	if want := []string{pendingCandidate, orphanHash}; !slices.Equal(got, want) {
+		t.Fatalf("ListUnreferencedBlobHashes() = %v, want %v", got, want)
+	}
+}
+
 func TestAttachmentRepositoryMissingRowPreservesSentinel(t *testing.T) {
 	_, repository := openAttachmentTestRepository(t)
 
@@ -272,8 +322,8 @@ func openAttachmentTestRepository(t *testing.T) (*Store, *AttachmentRepository) 
 		}
 	})
 
-	if len(embeddedMigrations) != 7 {
-		t.Fatalf("embedded migrations = %d, want 7", len(embeddedMigrations))
+	if len(embeddedMigrations) != 8 {
+		t.Fatalf("embedded migrations = %d, want 8", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 3)

--- a/internal/storage/sqlite/identity_graph_test.go
+++ b/internal/storage/sqlite/identity_graph_test.go
@@ -162,8 +162,8 @@ func openIdentityGraphTestStore(t *testing.T) *Store {
 		}
 	})
 
-	if len(embeddedMigrations) != 7 {
-		t.Fatalf("embedded migrations = %d, want 7", len(embeddedMigrations))
+	if len(embeddedMigrations) != 8 {
+		t.Fatalf("embedded migrations = %d, want 8", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 2)

--- a/internal/storage/sqlite/message_attachments.go
+++ b/internal/storage/sqlite/message_attachments.go
@@ -1,0 +1,260 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MessageAttachment is one inbound attachment associated with a normalized
+// message. AccountID is populated only by GetForDownload's messages join.
+type MessageAttachment struct {
+	MessageID string
+	RemoteID  string
+	Ordinal   int64
+	RemoteRef []byte
+	Filename  string
+	MIME      string
+	SizeBytes *int64
+	State     string
+	BlobHash  *string
+	AccountID string
+}
+
+// MessageAttachmentRepository owns inbound attachment lifecycle state.
+type MessageAttachmentRepository struct {
+	store *Store
+	now   func() time.Time
+}
+
+// NewMessageAttachmentRepository creates an inbound attachment repository.
+func NewMessageAttachmentRepository(
+	store *Store,
+	now func() time.Time,
+) (*MessageAttachmentRepository, error) {
+	if store == nil || store.db == nil {
+		return nil, fmt.Errorf("create message attachment repository: store is nil")
+	}
+	if now == nil {
+		return nil, fmt.Errorf("create message attachment repository: now function is nil")
+	}
+	return &MessageAttachmentRepository{store: store, now: now}, nil
+}
+
+// RecordInboundAttachment inserts or refreshes one pending attachment inside
+// the caller's projection transaction. A downloaded row is never modified.
+func (r *MessageAttachmentRepository) RecordInboundAttachment(
+	ctx context.Context,
+	tx *sql.Tx,
+	attachment MessageAttachment,
+) error {
+	if tx == nil {
+		return fmt.Errorf("record inbound attachment: transaction is nil")
+	}
+	if strings.TrimSpace(attachment.MessageID) == "" {
+		return fmt.Errorf("record inbound attachment: message ID is empty")
+	}
+	if attachment.Ordinal < 0 {
+		return fmt.Errorf("record inbound attachment: ordinal is negative")
+	}
+	if attachment.SizeBytes != nil && *attachment.SizeBytes < 0 {
+		return fmt.Errorf("record inbound attachment: size is negative")
+	}
+	if attachment.RemoteRef == nil {
+		attachment.RemoteRef = []byte{}
+	}
+	if strings.TrimSpace(attachment.MIME) == "" {
+		attachment.MIME = "application/octet-stream"
+	}
+	nowMS, err := r.nowMS("record inbound attachment")
+	if err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO message_attachments (
+			message_id,
+			ordinal,
+			remote_id,
+			remote_ref,
+			filename,
+			mime,
+			size_bytes,
+			state,
+			blob_hash,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', NULL, ?, ?)
+		ON CONFLICT(message_id, ordinal) DO UPDATE SET
+			remote_id = excluded.remote_id,
+			remote_ref = excluded.remote_ref,
+			filename = excluded.filename,
+			mime = excluded.mime,
+			size_bytes = excluded.size_bytes,
+			updated_at_ms = excluded.updated_at_ms
+		WHERE message_attachments.blob_hash IS NULL
+	`,
+		attachment.MessageID,
+		attachment.Ordinal,
+		attachment.RemoteID,
+		attachment.RemoteRef,
+		attachment.Filename,
+		attachment.MIME,
+		attachment.SizeBytes,
+		nowMS,
+		nowMS,
+	); err != nil {
+		return fmt.Errorf(
+			"record inbound attachment for message %q ordinal %d: %w",
+			attachment.MessageID,
+			attachment.Ordinal,
+			err,
+		)
+	}
+	return nil
+}
+
+// GetForDownload returns an attachment joined to its owning account. A missing
+// row wraps database/sql.ErrNoRows.
+func (r *MessageAttachmentRepository) GetForDownload(
+	ctx context.Context,
+	messageID string,
+	ordinal int64,
+) (MessageAttachment, error) {
+	var (
+		attachment MessageAttachment
+		size       sql.NullInt64
+		hash       sql.NullString
+	)
+	err := r.store.db.QueryRowContext(ctx, `
+		SELECT
+			ma.message_id,
+			ma.ordinal,
+			ma.remote_id,
+			ma.remote_ref,
+			ma.filename,
+			ma.mime,
+			ma.size_bytes,
+			ma.state,
+			ma.blob_hash,
+			m.account_id
+		FROM message_attachments AS ma
+		JOIN messages AS m ON m.message_id = ma.message_id
+		WHERE ma.message_id = ? AND ma.ordinal = ?
+	`, messageID, ordinal).Scan(
+		&attachment.MessageID,
+		&attachment.Ordinal,
+		&attachment.RemoteID,
+		&attachment.RemoteRef,
+		&attachment.Filename,
+		&attachment.MIME,
+		&size,
+		&attachment.State,
+		&hash,
+		&attachment.AccountID,
+	)
+	if err != nil {
+		return MessageAttachment{}, fmt.Errorf(
+			"get message attachment %q ordinal %d for download: %w",
+			messageID,
+			ordinal,
+			err,
+		)
+	}
+	if size.Valid {
+		attachment.SizeBytes = &size.Int64
+	}
+	if hash.Valid {
+		attachment.BlobHash = &hash.String
+	}
+	return attachment, nil
+}
+
+// MarkDownloaded atomically publishes a blob reference on a still-pending
+// attachment. A missing or already-downloaded row is an idempotent no-op.
+func (r *MessageAttachmentRepository) MarkDownloaded(
+	ctx context.Context,
+	messageID string,
+	ordinal int64,
+	blobHash string,
+	size int64,
+	mime string,
+) error {
+	if err := validateBlobHash(blobHash); err != nil {
+		return fmt.Errorf("mark message attachment downloaded: %w", err)
+	}
+	if size < 0 {
+		return fmt.Errorf("mark message attachment downloaded: size is negative")
+	}
+	if strings.TrimSpace(mime) == "" {
+		return fmt.Errorf("mark message attachment downloaded: MIME type is empty")
+	}
+	nowMS, err := r.nowMS("mark message attachment downloaded")
+	if err != nil {
+		return err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE message_attachments
+		SET state = 'downloaded',
+		    blob_hash = ?,
+		    size_bytes = ?,
+		    mime = ?,
+		    last_error = NULL,
+		    updated_at_ms = ?
+		WHERE message_id = ? AND ordinal = ? AND state = 'pending'
+	`, blobHash, size, mime, nowMS, messageID, ordinal)
+	if err != nil {
+		return fmt.Errorf(
+			"mark message attachment %q ordinal %d downloaded: %w",
+			messageID,
+			ordinal,
+			err,
+		)
+	}
+	if _, err := result.RowsAffected(); err != nil {
+		return fmt.Errorf(
+			"mark message attachment %q ordinal %d downloaded: read rows affected: %w",
+			messageID,
+			ordinal,
+			err,
+		)
+	}
+	return nil
+}
+
+// MarkFailed records diagnostic text while leaving the attachment pending and
+// retryable. A missing or downloaded row is a no-op.
+func (r *MessageAttachmentRepository) MarkFailed(
+	ctx context.Context,
+	messageID string,
+	ordinal int64,
+	errText string,
+) error {
+	nowMS, err := r.nowMS("mark message attachment failed")
+	if err != nil {
+		return err
+	}
+	if _, err := r.store.db.ExecContext(ctx, `
+		UPDATE message_attachments
+		SET last_error = ?, updated_at_ms = ?
+		WHERE message_id = ? AND ordinal = ? AND state = 'pending'
+	`, errText, nowMS, messageID, ordinal); err != nil {
+		return fmt.Errorf(
+			"mark message attachment %q ordinal %d failed: %w",
+			messageID,
+			ordinal,
+			err,
+		)
+	}
+	return nil
+}
+
+func (r *MessageAttachmentRepository) nowMS(operation string) (int64, error) {
+	nowMS := r.now().UnixMilli()
+	if nowMS <= 0 {
+		return 0, fmt.Errorf("%s: current Unix time is not positive", operation)
+	}
+	return nowMS, nil
+}

--- a/internal/storage/sqlite/message_attachments_test.go
+++ b/internal/storage/sqlite/message_attachments_test.go
@@ -1,0 +1,354 @@
+package sqlite
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+const messageAttachmentTestTimeMS int64 = 1_950_000_000_000
+
+func TestMessageAttachmentsMigrationAppliesToBlankAndExistingV7AndReopens(t *testing.T) {
+	t.Run("blank", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "store.sqlite3")
+		first, err := Open(path)
+		if err != nil {
+			t.Fatalf("first Open(): %v", err)
+		}
+		assertMessageAttachmentsMigration(t, first)
+		firstLedger := readLedgerRows(t, first.db)
+		if err := first.Close(); err != nil {
+			t.Fatalf("first Close(): %v", err)
+		}
+
+		second, err := Open(path)
+		if err != nil {
+			t.Fatalf("second Open(): %v", err)
+		}
+		t.Cleanup(func() {
+			if err := second.Close(); err != nil {
+				t.Errorf("second Close(): %v", err)
+			}
+		})
+		assertMessageAttachmentsMigration(t, second)
+		if secondLedger := readLedgerRows(t, second.db); !slices.Equal(secondLedger, firstLedger) {
+			t.Fatalf("migration ledger changed on reopen:\nfirst:  %+v\nsecond: %+v", firstLedger, secondLedger)
+		}
+	})
+
+	t.Run("existing v7", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "store.sqlite3")
+		db, err := sql.Open("sqlite", storeDSN(path))
+		if err != nil {
+			t.Fatalf("sql.Open(): %v", err)
+		}
+		if err := db.Ping(); err != nil {
+			_ = db.Close()
+			t.Fatalf("Ping(): %v", err)
+		}
+		if err := enableWAL(context.Background(), db); err != nil {
+			_ = db.Close()
+			t.Fatalf("enableWAL(): %v", err)
+		}
+		if err := verifyConnectionPragmas(context.Background(), db); err != nil {
+			_ = db.Close()
+			t.Fatalf("verifyConnectionPragmas(): %v", err)
+		}
+		if err := runMigrations(context.Background(), db, embeddedMigrations[:7]); err != nil {
+			_ = db.Close()
+			t.Fatalf("runMigrations(v7): %v", err)
+		}
+		before := readLedgerRows(t, db)
+		if len(before) != 7 {
+			_ = db.Close()
+			t.Fatalf("v7 ledger rows = %d, want 7", len(before))
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close v7 database: %v", err)
+		}
+
+		store, err := Open(path)
+		if err != nil {
+			t.Fatalf("Open(v7): %v", err)
+		}
+		t.Cleanup(func() {
+			if err := store.Close(); err != nil {
+				t.Errorf("Close(): %v", err)
+			}
+		})
+		after := readLedgerRows(t, store.db)
+		if len(after) != 8 {
+			t.Fatalf("migrated ledger rows = %d, want 8", len(after))
+		}
+		if !slices.Equal(after[:7], before) {
+			t.Fatalf("migrations 0001-0007 changed:\nbefore: %+v\nafter:  %+v", before, after[:7])
+		}
+		assertMessageAttachmentsMigration(t, store)
+	})
+}
+
+func TestMessageAttachmentsTableEnforcesStateAndHashChecks(t *testing.T) {
+	store, _ := openMessageAttachmentTestRepository(t, func() time.Time {
+		return time.UnixMilli(messageAttachmentTestTimeMS)
+	})
+	seedMessageAttachmentParent(t, store, "message-checks")
+	validHash := strings.Repeat("ab", 32)
+
+	tests := []struct {
+		name     string
+		ordinal  int64
+		state    string
+		blobHash any
+	}{
+		{name: "downloaded without hash", ordinal: 0, state: "downloaded", blobHash: nil},
+		{name: "pending with hash", ordinal: 1, state: "pending", blobHash: validHash},
+		{name: "bad hex", ordinal: 2, state: "downloaded", blobHash: strings.Repeat("xz", 32)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expectExecError(t, store.db, test.name, `
+				INSERT INTO message_attachments (
+					message_id, ordinal, state, blob_hash, created_at_ms, updated_at_ms
+				) VALUES (?, ?, ?, ?, ?, ?)
+			`,
+				"message-checks",
+				test.ordinal,
+				test.state,
+				test.blobHash,
+				messageAttachmentTestTimeMS,
+				messageAttachmentTestTimeMS,
+			)
+		})
+	}
+	assertRowCount(t, store.db, "message_attachments", 0)
+}
+
+func TestMessageAttachmentRepositoryRecordsReadsAndMarksFailure(t *testing.T) {
+	clock := newMessageTestClock(messageAttachmentTestTimeMS)
+	store, repository := openMessageAttachmentTestRepository(t, clock.Now)
+	seedMessageAttachmentParent(t, store, "message-round-trip")
+	size := int64(17)
+	ignoredHash := strings.Repeat("ab", 32)
+	want := MessageAttachment{
+		MessageID: "message-round-trip",
+		Ordinal:   2,
+		RemoteID:  "remote-attachment",
+		RemoteRef: []byte("opaque transport reference"),
+		Filename:  "photo.png",
+		MIME:      "image/png",
+		SizeBytes: &size,
+		State:     "downloaded",
+		BlobHash:  &ignoredHash,
+	}
+	recordMessageAttachment(t, store, repository, want)
+
+	got, err := repository.GetForDownload(context.Background(), want.MessageID, want.Ordinal)
+	if err != nil {
+		t.Fatalf("GetForDownload(): %v", err)
+	}
+	if got.MessageID != want.MessageID || got.Ordinal != want.Ordinal || got.RemoteID != want.RemoteID ||
+		!bytes.Equal(got.RemoteRef, want.RemoteRef) || got.Filename != want.Filename || got.MIME != want.MIME ||
+		got.SizeBytes == nil || *got.SizeBytes != size || got.State != "pending" || got.BlobHash != nil ||
+		got.AccountID != "account-a" {
+		t.Fatalf("GetForDownload() = %+v, want pending account-scoped row", got)
+	}
+
+	clock.Set(messageAttachmentTestTimeMS + 100)
+	if err := repository.MarkFailed(context.Background(), want.MessageID, want.Ordinal, "temporary transport failure"); err != nil {
+		t.Fatalf("MarkFailed(): %v", err)
+	}
+	var (
+		state       string
+		lastError   sql.NullString
+		updatedAtMS int64
+	)
+	if err := store.db.QueryRow(`
+		SELECT state, last_error, updated_at_ms
+		FROM message_attachments
+		WHERE message_id = ? AND ordinal = ?
+	`, want.MessageID, want.Ordinal).Scan(&state, &lastError, &updatedAtMS); err != nil {
+		t.Fatalf("read failed attachment: %v", err)
+	}
+	if state != "pending" || !lastError.Valid || lastError.String != "temporary transport failure" ||
+		updatedAtMS != messageAttachmentTestTimeMS+100 {
+		t.Fatalf("failed attachment = state %q error %+v updated %d", state, lastError, updatedAtMS)
+	}
+
+	if _, err := repository.GetForDownload(context.Background(), "missing", 0); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetForDownload(missing) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestMessageAttachmentRepositoryMarkDownloadedIsIdempotent(t *testing.T) {
+	clock := newMessageTestClock(messageAttachmentTestTimeMS)
+	store, repository := openMessageAttachmentTestRepository(t, clock.Now)
+	seedMessageAttachmentParent(t, store, "message-download")
+	recordMessageAttachment(t, store, repository, MessageAttachment{
+		MessageID: "message-download",
+		Ordinal:   0,
+		MIME:      "application/octet-stream",
+	})
+
+	firstHash := strings.Repeat("1a", 32)
+	clock.Set(messageAttachmentTestTimeMS + 100)
+	if err := repository.MarkDownloaded(
+		context.Background(), "message-download", 0, firstHash, 42, "image/png",
+	); err != nil {
+		t.Fatalf("MarkDownloaded(first): %v", err)
+	}
+	secondHash := strings.Repeat("2b", 32)
+	clock.Set(messageAttachmentTestTimeMS + 200)
+	if err := repository.MarkDownloaded(
+		context.Background(), "message-download", 0, secondHash, 99, "text/plain",
+	); err != nil {
+		t.Fatalf("MarkDownloaded(second): %v", err)
+	}
+
+	got, err := repository.GetForDownload(context.Background(), "message-download", 0)
+	if err != nil {
+		t.Fatalf("GetForDownload(): %v", err)
+	}
+	if got.State != "downloaded" || got.BlobHash == nil || *got.BlobHash != firstHash ||
+		got.SizeBytes == nil || *got.SizeBytes != 42 || got.MIME != "image/png" {
+		t.Fatalf("downloaded attachment = %+v, want first update preserved", got)
+	}
+	var updatedAtMS int64
+	if err := store.db.QueryRow(`
+		SELECT updated_at_ms FROM message_attachments WHERE message_id = ? AND ordinal = ?
+	`, "message-download", 0).Scan(&updatedAtMS); err != nil {
+		t.Fatalf("read downloaded timestamp: %v", err)
+	}
+	if updatedAtMS != messageAttachmentTestTimeMS+100 {
+		t.Fatalf("updated_at_ms = %d, want first update %d", updatedAtMS, messageAttachmentTestTimeMS+100)
+	}
+	if err := repository.MarkDownloaded(
+		context.Background(), "message-download", 0, strings.Repeat("AB", 32), 1, "image/png",
+	); err == nil {
+		t.Fatal("MarkDownloaded(invalid hash) succeeded")
+	}
+}
+
+func TestMessageAttachmentRowsCascadeWithMessageDeletion(t *testing.T) {
+	store, repository := openMessageAttachmentTestRepository(t, func() time.Time {
+		return time.UnixMilli(messageAttachmentTestTimeMS)
+	})
+	seedMessageAttachmentParent(t, store, "message-cascade")
+	recordMessageAttachment(t, store, repository, MessageAttachment{
+		MessageID: "message-cascade",
+		Ordinal:   0,
+		MIME:      "image/png",
+	})
+	if _, err := store.db.Exec(`DELETE FROM messages WHERE message_id = ?`, "message-cascade"); err != nil {
+		t.Fatalf("delete parent message: %v", err)
+	}
+	assertRowCount(t, store.db, "message_attachments", 0)
+}
+
+func assertMessageAttachmentsMigration(t *testing.T, store *Store) {
+	t.Helper()
+	if len(embeddedMigrations) != 8 {
+		t.Fatalf("embedded migrations = %d, want 8", len(embeddedMigrations))
+	}
+	assertPragmaInt(t, store.db, "user_version", 8)
+	ledger := readLedgerRow(t, store.db, 8)
+	if ledger.name != "message_attachments" {
+		t.Fatalf("migration 0008 name = %q, want message_attachments", ledger.name)
+	}
+	if ledger.checksum != embeddedMigrations[7].checksumSHA256 {
+		t.Fatalf(
+			"migration 0008 checksum = %q, want %q",
+			ledger.checksum,
+			embeddedMigrations[7].checksumSHA256,
+		)
+	}
+	var strict int
+	if err := store.db.QueryRow(`
+		SELECT strict
+		FROM pragma_table_list
+		WHERE schema = 'main' AND name = 'message_attachments'
+	`).Scan(&strict); err != nil {
+		t.Fatalf("read message_attachments STRICT flag: %v", err)
+	}
+	if strict != 1 {
+		t.Fatalf("message_attachments strict = %d, want 1", strict)
+	}
+	var indexExists bool
+	if err := store.db.QueryRow(`
+		SELECT EXISTS (
+			SELECT 1 FROM sqlite_schema
+			WHERE type = 'index' AND name = 'message_attachments_blob_hash_idx'
+		)
+	`).Scan(&indexExists); err != nil {
+		t.Fatalf("inspect message_attachments blob index: %v", err)
+	}
+	if !indexExists {
+		t.Fatal("message_attachments_blob_hash_idx is missing")
+	}
+}
+
+func openMessageAttachmentTestRepository(
+	t *testing.T,
+	now func() time.Time,
+) (*Store, *MessageAttachmentRepository) {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+	repository, err := NewMessageAttachmentRepository(store, now)
+	if err != nil {
+		t.Fatalf("NewMessageAttachmentRepository(): %v", err)
+	}
+	return store, repository
+}
+
+func seedMessageAttachmentParent(t *testing.T, store *Store, messageID string) {
+	t.Helper()
+	seedMessageAccount(t, store, "account-a", "test")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	mustExec(t, store.db, `
+		INSERT INTO messages (
+			message_id, conversation_id, account_id, remote_message_id,
+			sender_identity_id, direction, body, reply_to_remote_id, state,
+			occurred_at_ms, created_at_ms, updated_at_ms
+		) VALUES (?, 'conversation-a', 'account-a', ?, NULL, 'incoming', '', NULL,
+		          'active', ?, ?, ?)
+	`,
+		messageID,
+		"remote-"+messageID,
+		messageAttachmentTestTimeMS-1_000,
+		messageAttachmentTestTimeMS,
+		messageAttachmentTestTimeMS,
+	)
+}
+
+func recordMessageAttachment(
+	t *testing.T,
+	store *Store,
+	repository *MessageAttachmentRepository,
+	attachment MessageAttachment,
+) {
+	t.Helper()
+	tx, err := store.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin attachment transaction: %v", err)
+	}
+	defer tx.Rollback()
+	if err := repository.RecordInboundAttachment(context.Background(), tx, attachment); err != nil {
+		t.Fatalf("RecordInboundAttachment(): %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit attachment transaction: %v", err)
+	}
+}

--- a/internal/storage/sqlite/messages.go
+++ b/internal/storage/sqlite/messages.go
@@ -60,8 +60,9 @@ type Message struct {
 // MessageProjection couples a normalized message to the durable inbox frame
 // from which it was decoded.
 type MessageProjection struct {
-	InboxID string
-	Message Message
+	InboxID     string
+	Message     Message
+	Attachments []MessageAttachment
 }
 
 // MessageRepository owns durable inbox ingestion and normalized projection.
@@ -289,6 +290,42 @@ func (r *MessageRepository) ProjectMessage(
 	}
 	if err := r.upsertMessage(ctx, tx, message, nowMS); err != nil {
 		return err
+	}
+	attachmentMessageID := message.MessageID
+	if len(projection.Attachments) > 0 {
+		// upsertMessage preserves the first local message_id on a natural-key
+		// conflict. Resolve that effective parent inside this transaction so a
+		// duplicate inbound frame cannot point attachments at a discarded ID.
+		if err := tx.QueryRowContext(ctx, `
+			SELECT message_id
+			FROM messages
+			WHERE account_id = ?
+			  AND conversation_id = ?
+			  AND remote_message_id = ?
+		`, message.AccountID, message.ConversationID, message.RemoteMessageID).Scan(
+			&attachmentMessageID,
+		); err != nil {
+			return fmt.Errorf(
+				"project message %q: resolve attachment parent: %w",
+				message.MessageID,
+				err,
+			)
+		}
+	}
+	attachmentRepository := &MessageAttachmentRepository{store: r.store, now: r.now}
+	for _, attachment := range projection.Attachments {
+		// Normalized bridge attachments do not carry a local message ID. Bind
+		// every row to the parent selected by this projection rather than
+		// trusting caller-supplied attachment ownership.
+		attachment.MessageID = attachmentMessageID
+		if err := attachmentRepository.RecordInboundAttachment(ctx, tx, attachment); err != nil {
+			return fmt.Errorf(
+				"project message %q: record attachment ordinal %d: %w",
+				message.MessageID,
+				attachment.Ordinal,
+				err,
+			)
+		}
 	}
 
 	result, err := tx.ExecContext(ctx, `

--- a/internal/storage/sqlite/messages_test.go
+++ b/internal/storage/sqlite/messages_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -418,6 +419,196 @@ func TestProjectMessageRollsBackMessageWhenInboxMarkFails(t *testing.T) {
 	assertInboxUnprocessed(t, store, inbox.InboxID)
 }
 
+func TestProjectMessagePersistsAttachmentsInProjectionTransaction(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageProjectionGraph(t, store)
+	inbox := messageTestInbox("inbox-attachment", "account-a", "event-attachment", []byte("frame"))
+	if _, err := repository.AppendInbox(context.Background(), inbox); err != nil {
+		t.Fatalf("AppendInbox(): %v", err)
+	}
+	message := messageTestMessage(
+		"message-attachment", "conversation-a", "account-a", "remote-attachment", pointer("identity-a"),
+	)
+	size := int64(321)
+	attachment := MessageAttachment{
+		MessageID: message.MessageID,
+		Ordinal:   0,
+		RemoteID:  "remote-media-1",
+		RemoteRef: []byte("opaque-ref"),
+		Filename:  "photo.png",
+		MIME:      "image/png",
+		SizeBytes: &size,
+	}
+	if err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID:     inbox.InboxID,
+		Message:     message,
+		Attachments: []MessageAttachment{attachment},
+	}); err != nil {
+		t.Fatalf("ProjectMessage(): %v", err)
+	}
+
+	attachmentRepository, err := NewMessageAttachmentRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageAttachmentRepository(): %v", err)
+	}
+	got, err := attachmentRepository.GetForDownload(context.Background(), message.MessageID, 0)
+	if err != nil {
+		t.Fatalf("GetForDownload(): %v", err)
+	}
+	if got.AccountID != "account-a" || got.State != "pending" || got.BlobHash != nil ||
+		got.RemoteID != attachment.RemoteID || !bytes.Equal(got.RemoteRef, attachment.RemoteRef) ||
+		got.Filename != attachment.Filename || got.MIME != attachment.MIME ||
+		got.SizeBytes == nil || *got.SizeBytes != size {
+		t.Fatalf("projected attachment = %+v, want %+v", got, attachment)
+	}
+	assertInboxProcessedAt(t, store, inbox.InboxID, messageTestTimeMS)
+}
+
+func TestProjectMessageRollsBackWhenAttachmentInsertFails(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageProjectionGraph(t, store)
+	inbox := messageTestInbox("inbox-attachment-rollback", "account-a", "event-attachment-rollback", []byte("frame"))
+	if _, err := repository.AppendInbox(context.Background(), inbox); err != nil {
+		t.Fatalf("AppendInbox(): %v", err)
+	}
+	mustExec(t, store.db, `
+		CREATE TRIGGER fail_message_attachment_insert
+		BEFORE INSERT ON message_attachments
+		BEGIN
+			SELECT RAISE(ABORT, 'injected message attachment failure');
+		END
+	`)
+	message := messageTestMessage(
+		"message-attachment-rollback", "conversation-a", "account-a", "remote-attachment-rollback", pointer("identity-a"),
+	)
+	err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: inbox.InboxID,
+		Message: message,
+		Attachments: []MessageAttachment{{
+			MessageID: message.MessageID,
+			Ordinal:   0,
+			MIME:      "image/png",
+		}},
+	})
+	if err == nil {
+		t.Fatal("ProjectMessage() succeeded, want injected attachment failure")
+	}
+	assertRowCount(t, store.db, "messages", 0)
+	assertRowCount(t, store.db, "message_attachments", 0)
+	assertInboxUnprocessed(t, store, inbox.InboxID)
+}
+
+func TestProjectMessageAttachmentReplayPreservesDownloadedBlob(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageProjectionGraph(t, store)
+	message := messageTestMessage(
+		"message-attachment-replay", "conversation-a", "account-a", "remote-attachment-replay", pointer("identity-a"),
+	)
+
+	firstInbox := messageTestInbox("inbox-attachment-first", "account-a", "event-attachment-first", []byte("first"))
+	if _, err := repository.AppendInbox(context.Background(), firstInbox); err != nil {
+		t.Fatalf("AppendInbox(first): %v", err)
+	}
+	firstSize := int64(10)
+	first := MessageAttachment{
+		MessageID: message.MessageID,
+		Ordinal:   0,
+		RemoteID:  "remote-first",
+		RemoteRef: []byte("ref-first"),
+		Filename:  "first.png",
+		MIME:      "image/png",
+		SizeBytes: &firstSize,
+	}
+	firstProjection := MessageProjection{InboxID: firstInbox.InboxID, Message: message, Attachments: []MessageAttachment{first}}
+	if err := repository.ProjectMessage(context.Background(), firstProjection); err != nil {
+		t.Fatalf("ProjectMessage(first): %v", err)
+	}
+
+	clock.Set(messageTestTimeMS + 100)
+	secondInbox := messageTestInbox("inbox-attachment-second", "account-a", "event-attachment-second", []byte("second"))
+	if _, err := repository.AppendInbox(context.Background(), secondInbox); err != nil {
+		t.Fatalf("AppendInbox(second): %v", err)
+	}
+	secondSize := int64(20)
+	second := MessageAttachment{
+		MessageID: message.MessageID,
+		Ordinal:   0,
+		RemoteID:  "remote-second",
+		RemoteRef: []byte("ref-second"),
+		Filename:  "second.jpg",
+		MIME:      "image/jpeg",
+		SizeBytes: &secondSize,
+	}
+	duplicateMessage := message
+	duplicateMessage.MessageID = "message-attachment-replay-discarded"
+	if err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: secondInbox.InboxID, Message: duplicateMessage, Attachments: []MessageAttachment{second},
+	}); err != nil {
+		t.Fatalf("ProjectMessage(pending replay): %v", err)
+	}
+	attachmentRepository, err := NewMessageAttachmentRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageAttachmentRepository(): %v", err)
+	}
+	pending, err := attachmentRepository.GetForDownload(context.Background(), message.MessageID, 0)
+	if err != nil {
+		t.Fatalf("GetForDownload(pending replay): %v", err)
+	}
+	if pending.RemoteID != second.RemoteID || !bytes.Equal(pending.RemoteRef, second.RemoteRef) ||
+		pending.Filename != second.Filename || pending.MIME != second.MIME ||
+		pending.SizeBytes == nil || *pending.SizeBytes != secondSize {
+		t.Fatalf("pending replay attachment = %+v, want refreshed metadata %+v", pending, second)
+	}
+
+	blobHash := strings.Repeat("3c", 32)
+	clock.Set(messageTestTimeMS + 200)
+	if err := attachmentRepository.MarkDownloaded(
+		context.Background(), message.MessageID, 0, blobHash, 30, "image/webp",
+	); err != nil {
+		t.Fatalf("MarkDownloaded(): %v", err)
+	}
+
+	clock.Set(messageTestTimeMS + 300)
+	thirdInbox := messageTestInbox("inbox-attachment-third", "account-a", "event-attachment-third", []byte("third"))
+	if _, err := repository.AppendInbox(context.Background(), thirdInbox); err != nil {
+		t.Fatalf("AppendInbox(third): %v", err)
+	}
+	thirdSize := int64(40)
+	third := MessageAttachment{
+		MessageID: message.MessageID,
+		Ordinal:   0,
+		RemoteID:  "remote-third",
+		RemoteRef: []byte("ref-third"),
+		Filename:  "third.txt",
+		MIME:      "text/plain",
+		SizeBytes: &thirdSize,
+	}
+	thirdProjection := MessageProjection{InboxID: thirdInbox.InboxID, Message: message, Attachments: []MessageAttachment{third}}
+	if err := repository.ProjectMessage(context.Background(), thirdProjection); err != nil {
+		t.Fatalf("ProjectMessage(downloaded replay): %v", err)
+	}
+	clock.Set(messageTestTimeMS + 400)
+	if err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: thirdInbox.InboxID, Message: message, Attachments: []MessageAttachment{first},
+	}); err != nil {
+		t.Fatalf("ProjectMessage(processed replay): %v", err)
+	}
+
+	downloaded, err := attachmentRepository.GetForDownload(context.Background(), message.MessageID, 0)
+	if err != nil {
+		t.Fatalf("GetForDownload(downloaded replay): %v", err)
+	}
+	if downloaded.State != "downloaded" || downloaded.BlobHash == nil || *downloaded.BlobHash != blobHash ||
+		downloaded.RemoteID != second.RemoteID || !bytes.Equal(downloaded.RemoteRef, second.RemoteRef) ||
+		downloaded.Filename != second.Filename || downloaded.MIME != "image/webp" ||
+		downloaded.SizeBytes == nil || *downloaded.SizeBytes != 30 {
+		t.Fatalf("downloaded replay attachment = %+v, want downloaded row preserved", downloaded)
+	}
+}
+
 func TestProjectMessageMapsSQLiteOwnershipFailures(t *testing.T) {
 	store, repository := openMessageTestRepository(
 		t,
@@ -542,8 +733,8 @@ func TestMessagesInboxMigrationIsChecksummedAndStrict(t *testing.T) {
 		t,
 		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
 	)
-	if len(embeddedMigrations) != 7 {
-		t.Fatalf("embedded migrations = %d, want 7", len(embeddedMigrations))
+	if len(embeddedMigrations) != 8 {
+		t.Fatalf("embedded migrations = %d, want 8", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 4)

--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -57,6 +57,9 @@ var migration0006SQL string
 //go:embed migrations/0007_reactions_read.sql
 var migration0007SQL string
 
+//go:embed migrations/0008_message_attachments.sql
+var migration0008SQL string
+
 var embeddedMigrations = []migration{
 	newMigration(1, "storage_shell", migration0001SQL, newStorageShellArguments),
 	newMigration(2, "identity_graph", migration0002SQL, nil),
@@ -65,6 +68,7 @@ var embeddedMigrations = []migration{
 	newMigration(5, "outbox", migration0005SQL, nil),
 	newMigration(6, "outbox_attachments", migration0006SQL, nil),
 	newMigration(7, "reactions_read", migration0007SQL, nil),
+	newMigration(8, "message_attachments", migration0008SQL, nil),
 }
 
 func newMigration(

--- a/internal/storage/sqlite/migrations/0008_message_attachments.sql
+++ b/internal/storage/sqlite/migrations/0008_message_attachments.sql
@@ -1,0 +1,37 @@
+-- Inbound attachment lifecycle. One row per attachment carried by an inbound
+-- message projection. blob_hash is NULL until the media download service
+-- materializes bytes into the private BlobStore; blob existence is
+-- filesystem-owned, so (like outbox_attachments, 0006) there is no SQL FK for it.
+CREATE TABLE message_attachments (
+    message_id     TEXT NOT NULL,
+    ordinal        INTEGER NOT NULL CHECK (ordinal >= 0),
+    remote_id      TEXT NOT NULL DEFAULT '',
+    remote_ref     BLOB NOT NULL DEFAULT x'',        -- bridge.Attachment.RemoteRef (opaque)
+    filename       TEXT NOT NULL DEFAULT '',
+    mime           TEXT NOT NULL DEFAULT 'application/octet-stream'
+                   CHECK (trim(mime) <> ''),
+    size_bytes     INTEGER CHECK (size_bytes IS NULL OR size_bytes >= 0),
+    state          TEXT NOT NULL DEFAULT 'pending'
+                   CHECK (state IN ('pending', 'downloaded')),
+    blob_hash      TEXT CHECK (
+        blob_hash IS NULL OR (
+            length(blob_hash) = 64
+            AND blob_hash = lower(blob_hash)
+            AND blob_hash NOT GLOB '*[^0-9a-f]*'
+        )
+    ),
+    last_error     TEXT,
+    created_at_ms  INTEGER NOT NULL CHECK (created_at_ms > 0),
+    updated_at_ms  INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    PRIMARY KEY (message_id, ordinal),
+    FOREIGN KEY (message_id) REFERENCES messages(message_id) ON DELETE CASCADE,
+    CHECK (
+        (state = 'pending'    AND blob_hash IS NULL)
+        OR (state = 'downloaded' AND blob_hash IS NOT NULL)
+    )
+) STRICT;
+
+-- Partial index feeds the GC union (only downloaded rows pin a blob).
+CREATE INDEX message_attachments_blob_hash_idx
+    ON message_attachments(blob_hash)
+    WHERE blob_hash IS NOT NULL;

--- a/internal/storage/sqlite/outbox_test.go
+++ b/internal/storage/sqlite/outbox_test.go
@@ -1360,10 +1360,10 @@ func TestOutboxMigrationIsChecksummedAndStrict(t *testing.T) {
 	store, _ := openOutboxTestRepository(t, func() time.Time {
 		return time.UnixMilli(outboxTestTimeMS)
 	})
-	if len(embeddedMigrations) != 7 {
-		t.Fatalf("embedded migrations = %d, want 7", len(embeddedMigrations))
+	if len(embeddedMigrations) != 8 {
+		t.Fatalf("embedded migrations = %d, want 8", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 7)
+	assertPragmaInt(t, store.db, "user_version", 8)
 	ledger := readLedgerRow(t, store.db, 5)
 	if ledger.name != "outbox" {
 		t.Fatalf("migration 0005 name = %q, want outbox", ledger.name)
@@ -1439,8 +1439,8 @@ func TestOutboxAttachmentsMigrationAppliesToBlankAndExistingV5Database(t *testin
 			}
 		})
 		after := readLedgerRows(t, store.db)
-		if len(after) != 7 {
-			t.Fatalf("migrated ledger rows = %d, want 7", len(after))
+		if len(after) != 8 {
+			t.Fatalf("migrated ledger rows = %d, want 8", len(after))
 		}
 		if !slices.Equal(after[:5], before) {
 			t.Fatalf("migrations 0001-0005 changed:\nbefore: %+v\nafter:  %+v", before, after[:5])
@@ -1451,7 +1451,7 @@ func TestOutboxAttachmentsMigrationAppliesToBlankAndExistingV5Database(t *testin
 
 func assertOutboxAttachmentsMigration(t *testing.T, store *Store) {
 	t.Helper()
-	assertPragmaInt(t, store.db, "user_version", 7)
+	assertPragmaInt(t, store.db, "user_version", 8)
 	ledger := readLedgerRow(t, store.db, 6)
 	if ledger.name != "outbox_attachments" {
 		t.Fatalf("migration 0006 name = %q, want outbox_attachments", ledger.name)
@@ -1506,7 +1506,7 @@ func TestReactionsReadMigrationAppliesToBlankAndReopens(t *testing.T) {
 
 func assertReactionsReadMigration(t *testing.T, store *Store) {
 	t.Helper()
-	assertPragmaInt(t, store.db, "user_version", 7)
+	assertPragmaInt(t, store.db, "user_version", 8)
 	ledger := readLedgerRow(t, store.db, 7)
 	if ledger.name != "reactions_read" {
 		t.Fatalf("migration 0007 name = %q, want reactions_read", ledger.name)

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -79,6 +79,7 @@ func TestOpenInitializesBlankDatabase(t *testing.T) {
 		"devices",
 		"identities",
 		"inbox",
+		"message_attachments",
 		"messages",
 		"outbox",
 		"outbox_attachments",


### PR DESCRIPTION
## Rebuild Wave 2 / M4a — app-owned media download service

Inbound media gets a durable download lifecycle and a platform-blind, **ref-based** download service. Storage + service + policy only — the adapter `MediaDownloader` shims are M4b/T5, and the v2 pipeline has no production callers, so **no live path changes**.

### What it does
- **Migration 0008** — `message_attachments`: one row per inbound attachment, `pending → downloaded` with a two-way `state ⇔ blob_hash` CHECK; opaque transport ref; CASCADE on message delete. The projection persists attachment rows **in the same tx** as the message, and replays can never clobber a downloaded `blob_hash` (guarded upsert).
- **`internal/media.Service`** — `Resolve(account, message, ordinal) → Descriptor` carrying a blob ref, **never a filesystem path**; account-fenced (wrong account reads as not-found, no existence leak); **single-flight** (concurrent requests share one transport fetch); **blob-first** write-back (a crash leaves only an unreferenced, collectable orphan); oversize terminal at the blob cap; partial streams transient with no referenced blob.
- **Forced-download policy** — the F5 serving rules (passive-inline allowlist + active-content sniff veto) ported verbatim into `media.ServingDisposition`: the single choke point both HTTP and MCP will consume at Wave-3 wiring, so active/unknown media (SVG/HTML/XML/spoofed PNG-that-sniffs-HTML) always serves as an inert attachment. This is what makes the plan's two exit criteria ("HTTP/MCP cannot access arbitrary paths"; "active/unknown media is forced to download") structurally unbypassable once wired.
- **GC contract** — `ListUnreferencedBlobHashes` now unions `message_attachments`, so a future sweeper can never delete downloaded inbound media.

### Verification
- Full `go test -race ./...` green — 24 packages (media additionally `-shuffle=on -count=10`).
- Adversarial review verdict **mergeable, no fixes**: migration applied to real scratch DBs (blank 0001→0008 **and** a populated-v7 upgrade); the GC union run on a three-table scratch DB; the policy port diffed byte-for-byte against the web F5 functions; the capability three-way (incl. unregistered-account vs undeclared-capability) traced against the real registry.
- The reviewer's one forward-looking hardening — a nil-stream-with-nil-error transport return would have panicked at `stream.Close` — is folded in and regression-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
