### PR TITLE
Add echo reconciliation, the remote-id repoint, and store_failed repair (rebuild Wave 2 / M5a-1)

### DIFF
--- a/internal/messaging/dispatch.go
+++ b/internal/messaging/dispatch.go
@@ -31,6 +31,9 @@ func (s *MessageService) Run(ctx context.Context) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		if _, err := s.reconcileStoreFailedDue(ctx, s.batchLimit); err != nil {
+			return fmt.Errorf("run message service: reconcile store-failed deliveries: %w", err)
+		}
 		if _, err := s.DispatchDue(ctx, s.batchLimit); err != nil {
 			return fmt.Errorf("run message service: %w", err)
 		}

--- a/internal/messaging/dispatch_reconcile_test.go
+++ b/internal/messaging/dispatch_reconcile_test.go
@@ -1,0 +1,714 @@
+package messaging
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func TestObserveTransportEchoConfirmsUncertainAndRepointsMessage(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{result: bridge.SendResult{}}}}
+	registry := newScriptedRegistry("reconcile-uncertain", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-reconcile-uncertain"),
+		Body:          "accept the later echo",
+	})
+	item := mustOutboxItem(t, service, submission.OutboxID)
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+	if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxUncertain {
+		t.Fatalf("delivery before echo = %+v, want uncertain", got)
+	}
+	if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != item.TransportRequestID {
+		t.Fatalf("message remote ID before echo = %q, want placeholder %q", got, item.TransportRequestID)
+	}
+
+	const realID = "remote-reconciled"
+	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+		AccountID:          item.AccountID,
+		TransportRequestID: item.TransportRequestID,
+		RemoteMessageID:    realID,
+	}); err != nil {
+		t.Fatalf("ObserveTransportEcho(): %v", err)
+	}
+	if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxConfirmed || got.RemoteMessageID != realID {
+		t.Fatalf("delivery after echo = %+v, want confirmed at %q", got, realID)
+	}
+	message := mustReconcileMessage(t, service, submission.LocalMessageID)
+	if message.MessageID != submission.LocalMessageID || message.RemoteMessageID != realID {
+		t.Fatalf("repointed message = %+v, want stable local ID and remote ID %q", message, realID)
+	}
+}
+
+func TestObserveTransportEchoCollisionKeepsOptimisticFKAnchor(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{result: bridge.SendResult{}}}}
+	registry := newScriptedRegistry("reconcile-collision", sender)
+	registry.setReactionSender(&scriptedReactionSender{})
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-reconcile-collision"),
+		Body:          "keep this optimistic row",
+	})
+	item := mustOutboxItem(t, service, submission.OutboxID)
+
+	const (
+		echoMessageID = "echo-projected-duplicate"
+		realID        = "remote-collision"
+	)
+	projectReconcileEchoMessage(t, store, clock, echoMessageID, realID)
+	dependent := mustSendReaction(t, service, SendReactionCommand{
+		CommonCommand: CommonCommand{
+			AccountID:      item.AccountID,
+			ConversationID: item.ConversationID,
+			IdempotencyKey: "key-reconcile-dependent-on-m",
+			NotBefore:      clock.Now().Add(time.Hour),
+		},
+		TargetMessageID: submission.LocalMessageID,
+		Emoji:           "👍",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+	if got := mustDelivery(t, service, submission.OutboxID).State; got != OutboxUncertain {
+		t.Fatalf("delivery before echo = %q, want uncertain", got)
+	}
+	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+		AccountID:          item.AccountID,
+		TransportRequestID: item.TransportRequestID,
+		RemoteMessageID:    realID,
+	}); err != nil {
+		t.Fatalf("ObserveTransportEcho(): %v", err)
+	}
+
+	message := mustReconcileMessage(t, service, submission.LocalMessageID)
+	if message.MessageID != submission.LocalMessageID || message.RemoteMessageID != realID {
+		t.Fatalf("collision survivor = %+v, want optimistic message %q at %q", message, submission.LocalMessageID, realID)
+	}
+	if _, err := service.messages.GetMessage(context.Background(), echoMessageID); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("GetMessage(echo duplicate) error = %v, want ErrNotFound", err)
+	}
+	reaction, err := service.outbox.GetOutboxReaction(context.Background(), dependent.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxReaction(dependent): %v", err)
+	}
+	if reaction.TargetMessageID != submission.LocalMessageID {
+		t.Fatalf("dependent reaction target = %q, want surviving message %q", reaction.TargetMessageID, submission.LocalMessageID)
+	}
+}
+
+func TestObserveTransportEchoEnrichesPlaceholderConfirmation(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{}
+	registry := newScriptedRegistry("reconcile-enrich", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-reconcile-enrich"),
+		Body:          "confirm provisionally",
+	})
+	item := mustOutboxItem(t, service, submission.OutboxID)
+	setReconcileTextSteps(sender, sendStep{result: bridge.SendResult{RemoteMessageID: item.TransportRequestID}})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+	if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxConfirmed || got.RemoteMessageID != item.TransportRequestID {
+		t.Fatalf("provisional delivery = %+v, want confirmed at placeholder", got)
+	}
+	if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != item.TransportRequestID {
+		t.Fatalf("message remote ID before enrichment = %q, want %q", got, item.TransportRequestID)
+	}
+
+	const permanentID = "remote-permanent"
+	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+		AccountID:          item.AccountID,
+		TransportRequestID: item.TransportRequestID,
+		RemoteMessageID:    permanentID,
+	}); err != nil {
+		t.Fatalf("ObserveTransportEcho(): %v", err)
+	}
+	if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxConfirmed || got.RemoteMessageID != permanentID {
+		t.Fatalf("enriched delivery = %+v, want confirmed at %q", got, permanentID)
+	}
+	if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != permanentID {
+		t.Fatalf("enriched message remote ID = %q, want %q", got, permanentID)
+	}
+}
+
+func TestObserveTransportEchoNoOpsNeverCreateOrCorrupt(t *testing.T) {
+	t.Run("duplicate foreign and orphan", func(t *testing.T) {
+		clock := newManualClock(messagingTestTime)
+		store := openMessagingTestStore(t, clock.Now())
+		sender := &scriptedTextSender{}
+		registry := newScriptedRegistry("reconcile-noop", sender)
+		registry.setAvailable(true)
+		service := newMessagingTestService(t, store, registry, clock)
+		submission := mustSendText(t, service, SendTextCommand{
+			CommonCommand: testCommonCommand("key-reconcile-noop"),
+			Body:          "already authoritative",
+		})
+		item := mustOutboxItem(t, service, submission.OutboxID)
+		const authoritativeID = "remote-authoritative"
+		setReconcileTextSteps(sender, sendStep{result: bridge.SendResult{RemoteMessageID: authoritativeID}})
+		if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+			t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+		}
+
+		for _, echo := range []TransportEcho{
+			{AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: authoritativeID},
+			{AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: "remote-foreign"},
+			{AccountID: item.AccountID, TransportRequestID: "missing-request", RemoteMessageID: "remote-orphan"},
+		} {
+			if err := service.ObserveTransportEcho(context.Background(), echo); err != nil {
+				t.Fatalf("ObserveTransportEcho(%+v): %v", echo, err)
+			}
+		}
+		if _, err := service.outbox.FindByTransportRequestID(context.Background(), item.AccountID, "missing-request"); !errors.Is(err, sqlite.ErrNotFound) {
+			t.Fatalf("FindByTransportRequestID(orphan) error = %v, want ErrNotFound", err)
+		}
+		if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxConfirmed || got.RemoteMessageID != authoritativeID {
+			t.Fatalf("delivery after no-op echoes = %+v, want original confirmation", got)
+		}
+		if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != authoritativeID {
+			t.Fatalf("message remote ID after foreign echo = %q, want %q", got, authoritativeID)
+		}
+	})
+
+	t.Run("rejected stays rejected", func(t *testing.T) {
+		clock := newManualClock(messagingTestTime)
+		store := openMessagingTestStore(t, clock.Now())
+		sender := &scriptedTextSender{steps: []sendStep{{err: bridge.OpError{
+			Class:     bridge.FailureUnsupported,
+			Operation: "send_text",
+			Dispatch:  bridge.DispatchNotCalled,
+			Cause:     errors.New("terminal rejection"),
+		}}}}
+		registry := newScriptedRegistry("reconcile-rejected", sender)
+		registry.setAvailable(true)
+		service := newMessagingTestService(t, store, registry, clock)
+		submission := mustSendText(t, service, SendTextCommand{
+			CommonCommand: testCommonCommand("key-reconcile-rejected"),
+			Body:          "terminal",
+		})
+		item := mustOutboxItem(t, service, submission.OutboxID)
+		if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+			t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+		}
+		if got := mustDelivery(t, service, submission.OutboxID).State; got != OutboxRejected {
+			t.Fatalf("delivery before echo = %q, want rejected", got)
+		}
+		if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+			AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: "remote-rejected",
+		}); err != nil {
+			t.Fatalf("ObserveTransportEcho(rejected): %v", err)
+		}
+		if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxRejected || got.RemoteMessageID != "" {
+			t.Fatalf("rejected delivery after echo = %+v", got)
+		}
+		if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != item.TransportRequestID {
+			t.Fatalf("rejected message remote ID = %q, want placeholder %q", got, item.TransportRequestID)
+		}
+	})
+
+	t.Run("canceled stays canceled", func(t *testing.T) {
+		clock := newManualClock(messagingTestTime)
+		store := openMessagingTestStore(t, clock.Now())
+		registry := newScriptedRegistry("reconcile-canceled", &scriptedTextSender{})
+		service := newMessagingTestService(t, store, registry, clock)
+		command := SendTextCommand{
+			CommonCommand: testCommonCommand("key-reconcile-canceled"),
+			Body:          "cancel first",
+		}
+		command.NotBefore = clock.Now().Add(time.Hour)
+		submission := mustSendText(t, service, command)
+		item := mustOutboxItem(t, service, submission.OutboxID)
+		if _, err := service.Cancel(context.Background(), submission.OutboxID); err != nil {
+			t.Fatalf("Cancel(): %v", err)
+		}
+		if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+			AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: "remote-canceled",
+		}); err != nil {
+			t.Fatalf("ObserveTransportEcho(canceled): %v", err)
+		}
+		if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxCanceled || got.RemoteMessageID != "" {
+			t.Fatalf("canceled delivery after echo = %+v", got)
+		}
+		if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != item.TransportRequestID {
+			t.Fatalf("canceled message remote ID = %q, want placeholder %q", got, item.TransportRequestID)
+		}
+	})
+}
+
+func TestObserveTransportEchoDuringDispatchingDefersToLeaseOwner(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	const realID = "remote-lease-result"
+	sender := &scriptedTextSender{steps: []sendStep{{result: bridge.SendResult{RemoteMessageID: realID}}}}
+	registry := newScriptedRegistry("reconcile-dispatching", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-reconcile-dispatching"),
+		Body:          "lease owner wins",
+	})
+	item := mustOutboxItem(t, service, submission.OutboxID)
+
+	var (
+		echoErr       error
+		during        Delivery
+		duringErr     error
+		duringMessage sqlite.Message
+		messageErr    error
+	)
+	sender.onSend = func() {
+		echoErr = service.ObserveTransportEcho(context.Background(), TransportEcho{
+			AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: realID,
+		})
+		during, duringErr = service.Get(context.Background(), submission.OutboxID)
+		duringMessage, messageErr = service.messages.GetMessage(context.Background(), submission.LocalMessageID)
+	}
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+	if echoErr != nil || duringErr != nil || messageErr != nil {
+		t.Fatalf("during-send echo/get errors = %v / %v / %v", echoErr, duringErr, messageErr)
+	}
+	if during.State != OutboxDispatching || during.RemoteMessageID != "" {
+		t.Fatalf("delivery during transport call = %+v, want unchanged dispatching", during)
+	}
+	if duringMessage.RemoteMessageID != item.TransportRequestID {
+		t.Fatalf("message during transport call = %q, want placeholder %q", duringMessage.RemoteMessageID, item.TransportRequestID)
+	}
+	if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxConfirmed || got.RemoteMessageID != realID {
+		t.Fatalf("delivery after lease confirmation = %+v, want confirmed at %q", got, realID)
+	}
+	if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != realID {
+		t.Fatalf("message after lease confirmation = %q, want %q", got, realID)
+	}
+	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+		AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: realID,
+	}); err != nil {
+		t.Fatalf("ObserveTransportEcho(replay): %v", err)
+	}
+	if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxConfirmed || got.RemoteMessageID != realID {
+		t.Fatalf("delivery after echo replay = %+v", got)
+	}
+}
+
+func TestStoreFailedRepointRepair(t *testing.T) {
+	t.Run("explicit repair", func(t *testing.T) {
+		clock := newManualClock(messagingTestTime)
+		fixture := newStoreFailedRepointFixture(t, clock)
+		fixture.removeBlocker(t)
+
+		delivery, err := fixture.service.RepairStoreFailed(context.Background(), fixture.submission.OutboxID)
+		if err != nil {
+			t.Fatalf("RepairStoreFailed(): %v", err)
+		}
+		fixture.assertRepaired(t, delivery)
+
+		// The public repair API is state-guarded. A second call is idempotent in
+		// effect: it reports ErrInvalidState and leaves the confirmed row intact.
+		if _, err := fixture.service.RepairStoreFailed(context.Background(), fixture.submission.OutboxID); !errors.Is(err, ErrInvalidState) {
+			t.Fatalf("RepairStoreFailed(second) error = %v, want ErrInvalidState", err)
+		}
+		fixture.assertRepaired(t, mustDelivery(t, fixture.service, fixture.submission.OutboxID))
+	})
+
+	t.Run("Run tolerates blocked row then sweeps it", func(t *testing.T) {
+		clock := newNotifyingReconcileClock(messagingTestTime)
+		fixture := newStoreFailedRepointFixture(t, clock)
+		fixture.service.pollDelay = time.Hour
+		drainReconcileWake(fixture.service)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- fixture.service.Run(ctx) }()
+		defer func() {
+			cancel()
+			select {
+			case err := <-done:
+				if !errors.Is(err, context.Canceled) {
+					t.Errorf("Run() error = %v, want context.Canceled", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Error("Run() did not stop after cancellation")
+			}
+		}()
+
+		select {
+		case <-clock.timerCreated:
+			// Reaching the poll timer proves the first, still-blocked repair
+			// attempt was contained instead of terminating Run.
+		case err := <-done:
+			t.Fatalf("Run() returned on unrepairable row: %v", err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("Run() did not finish its first bounded repair pass")
+		}
+		if got := mustDelivery(t, fixture.service, fixture.submission.OutboxID).State; got != OutboxStoreFailed {
+			t.Fatalf("blocked sweep state = %q, want store_failed", got)
+		}
+
+		fixture.removeBlocker(t)
+		fixture.service.signalWake()
+		select {
+		case <-clock.timerCreated:
+			// A new timer is created only after the woken loop has run its
+			// bounded repair and dispatch passes.
+		case err := <-done:
+			t.Fatalf("Run() returned during repair sweep: %v", err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("Run() did not finish its unblocked repair pass")
+		}
+		fixture.assertRepaired(t, mustDelivery(t, fixture.service, fixture.submission.OutboxID))
+	})
+}
+
+// An idempotent SendText replay must keep working AFTER the repoint — the
+// exact case the idempotency key exists for: delivery succeeds, the API
+// response is lost, the client retries the same key. Pre-fix, pair validation
+// still demanded remote_message_id == transport_request_id, which stops
+// holding once a Signal-style Confirm (real id differs from the request id)
+// repoints the message, so the retry spuriously failed instead of returning
+// the original Submission.
+func TestSendTextReplayAfterConfirmRepointReturnsOriginalSubmission(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{}
+	registry := newScriptedRegistry("replay-after-repoint", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	command := SendTextCommand{
+		CommonCommand: testCommonCommand("key-replay-after-repoint"),
+		Body:          "deliver then replay",
+	}
+	submission := mustSendText(t, service, command)
+	item := mustOutboxItem(t, service, submission.OutboxID)
+
+	// Signal-style: the transport's real id differs from the request id, so
+	// Confirm repoints the optimistic message at confirm time.
+	const realID = "remote-signal-timestamp"
+	setReconcileTextSteps(sender, sendStep{result: bridge.SendResult{RemoteMessageID: realID}})
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+	if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != realID {
+		t.Fatalf("message remote ID after confirm = %q, want repointed %q", got, realID)
+	}
+
+	replay := mustSendText(t, service, command)
+	if replay.OutboxID != submission.OutboxID || replay.LocalMessageID != submission.LocalMessageID {
+		t.Fatalf("replay = %+v, want original submission %+v", replay, submission)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("transport sends after replay = %d, want exactly 1", got)
+	}
+	if got := mustDelivery(t, service, submission.OutboxID); got.State != OutboxConfirmed ||
+		got.RemoteMessageID != realID {
+		t.Fatalf("delivery after replay = %+v, want confirmed at %q", got, realID)
+	}
+	if item.TransportRequestID == realID {
+		t.Fatal("test fixture degenerate: real id must differ from the request id")
+	}
+}
+
+// The Google-style variant: Confirm records the placeholder, the later echo
+// repoints to the permanent id — and an idempotent replay after the echo must
+// still return the original Submission.
+func TestSendTextReplayAfterEchoRepointReturnsOriginalSubmission(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{}
+	registry := newScriptedRegistry("replay-after-echo", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	command := SendTextCommand{
+		CommonCommand: testCommonCommand("key-replay-after-echo"),
+		Body:          "confirm provisionally then echo then replay",
+	}
+	submission := mustSendText(t, service, command)
+	item := mustOutboxItem(t, service, submission.OutboxID)
+	setReconcileTextSteps(sender, sendStep{result: bridge.SendResult{RemoteMessageID: item.TransportRequestID}})
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+
+	const permanentID = "remote-permanent-echo"
+	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+		AccountID:          item.AccountID,
+		TransportRequestID: item.TransportRequestID,
+		RemoteMessageID:    permanentID,
+	}); err != nil {
+		t.Fatalf("ObserveTransportEcho(): %v", err)
+	}
+	if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != permanentID {
+		t.Fatalf("message remote ID after echo = %q, want %q", got, permanentID)
+	}
+
+	replay := mustSendText(t, service, command)
+	if replay.OutboxID != submission.OutboxID || replay.LocalMessageID != submission.LocalMessageID {
+		t.Fatalf("replay = %+v, want original submission %+v", replay, submission)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("transport sends after replay = %d, want exactly 1", got)
+	}
+}
+
+func TestUncertainCannotReenterDispatchWhenArtificiallyArmed(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store, raw := openReconcileTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{result: bridge.SendResult{}}}}
+	registry := newScriptedRegistry("reconcile-unleaseable", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-reconcile-unleaseable"),
+		Body:          "never send twice",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(first) = %d, %v; want 1, nil", processed, err)
+	}
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	if row.State != sqlite.OutboxUncertain || row.NextAttemptAtMS != nil {
+		t.Fatalf("uncertain row = %+v, want no next attempt", row)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("send count before artificial arm = %d, want 1", got)
+	}
+
+	dueAt := clock.Now().Add(time.Minute)
+	mustReconcileExecOne(t, raw, `
+		UPDATE outbox
+		SET next_attempt_at_ms = ?
+		WHERE outbox_id = ? AND state = 'uncertain'
+	`, dueAt.UnixMilli(), submission.OutboxID)
+	clock.Advance(2 * time.Minute)
+	if processed, err := service.DispatchDue(context.Background(), 8); err != nil || processed != 0 {
+		t.Fatalf("DispatchDue(artificially armed uncertain) = %d, %v; want 0, nil", processed, err)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("send count after artificial arm = %d, want exactly 1", got)
+	}
+	if got := mustDelivery(t, service, submission.OutboxID).State; got != OutboxUncertain {
+		t.Fatalf("state after artificial arm = %q, want uncertain", got)
+	}
+}
+
+type storeFailedRepointFixture struct {
+	service            *MessageService
+	raw                *sql.DB
+	submission         Submission
+	transportRequestID string
+	realID             string
+	echoMessageID      string
+	blockerOutboxID    string
+}
+
+func newStoreFailedRepointFixture(t *testing.T, clock Clock) storeFailedRepointFixture {
+	t.Helper()
+	store, raw := openReconcileTestStore(t, clock.Now())
+	const realID = "remote-store-failed"
+	sender := &scriptedTextSender{steps: []sendStep{{result: bridge.SendResult{RemoteMessageID: realID}}}}
+	registry := newScriptedRegistry("reconcile-store-failed", sender)
+	registry.setReactionSender(&scriptedReactionSender{})
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-reconcile-store-failed"),
+		Body:          "remote accepted this",
+	})
+	item := mustOutboxItem(t, service, submission.OutboxID)
+	const echoMessageID = "echo-store-failed-collision"
+	projectReconcileEchoMessage(t, store, clock, echoMessageID, realID)
+	blocker := mustSendReaction(t, service, SendReactionCommand{
+		CommonCommand: CommonCommand{
+			AccountID:      item.AccountID,
+			ConversationID: item.ConversationID,
+			IdempotencyKey: "key-reconcile-store-failed-blocker",
+			NotBefore:      clock.Now().Add(time.Hour),
+		},
+		TargetMessageID: echoMessageID,
+		Emoji:           "🔒",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(store failure) = %d, %v; want 1, nil", processed, err)
+	}
+	delivery := mustDelivery(t, service, submission.OutboxID)
+	if delivery.State != OutboxStoreFailed || delivery.RemoteMessageID != realID {
+		t.Fatalf("delivery after failed repoint = %+v, want store_failed at %q", delivery, realID)
+	}
+	if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != item.TransportRequestID {
+		t.Fatalf("optimistic message after rolled-back Confirm = %q, want %q", got, item.TransportRequestID)
+	}
+	if got := mustReconcileMessage(t, service, echoMessageID).RemoteMessageID; got != realID {
+		t.Fatalf("colliding echo after rolled-back Confirm = %q, want %q", got, realID)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("send count after store failure = %d, want 1", got)
+	}
+
+	return storeFailedRepointFixture{
+		service:            service,
+		raw:                raw,
+		submission:         submission,
+		transportRequestID: item.TransportRequestID,
+		realID:             realID,
+		echoMessageID:      echoMessageID,
+		blockerOutboxID:    blocker.OutboxID,
+	}
+}
+
+func (f storeFailedRepointFixture) removeBlocker(t *testing.T) {
+	t.Helper()
+	mustReconcileExecOne(t, f.raw, `DELETE FROM outbox WHERE outbox_id = ?`, f.blockerOutboxID)
+	if _, err := f.service.outbox.GetOutboxReaction(context.Background(), f.blockerOutboxID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetOutboxReaction(removed blocker) error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func (f storeFailedRepointFixture) assertRepaired(t *testing.T, delivery Delivery) {
+	t.Helper()
+	if delivery.State != OutboxConfirmed || delivery.RemoteMessageID != f.realID {
+		t.Fatalf("repaired delivery = %+v, want confirmed at %q", delivery, f.realID)
+	}
+	message := mustReconcileMessage(t, f.service, f.submission.LocalMessageID)
+	if message.MessageID != f.submission.LocalMessageID || message.RemoteMessageID != f.realID {
+		t.Fatalf("repaired optimistic message = %+v", message)
+	}
+	if _, err := f.service.messages.GetMessage(context.Background(), f.echoMessageID); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("GetMessage(repaired echo duplicate) error = %v, want ErrNotFound", err)
+	}
+}
+
+func openReconcileTestStore(t *testing.T, now time.Time) (*sqlite.Store, *sql.DB) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "message.sqlite")
+	store, err := sqlite.Open(path)
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	query := make(url.Values)
+	query.Add("_pragma", "busy_timeout(5000)")
+	query.Add("_pragma", "foreign_keys(ON)")
+	raw, err := sql.Open("sqlite", (&url.URL{
+		Scheme:   "file",
+		Path:     filepath.ToSlash(path),
+		RawQuery: query.Encode(),
+	}).String())
+	if err != nil {
+		_ = store.Close()
+		t.Fatalf("sql.Open(raw test database): %v", err)
+	}
+	raw.SetMaxOpenConns(1)
+	raw.SetMaxIdleConns(1)
+	if err := raw.PingContext(context.Background()); err != nil {
+		_ = raw.Close()
+		_ = store.Close()
+		t.Fatalf("ping raw test database: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = raw.Close()
+		_ = store.Close()
+	})
+	seedMessagingStore(t, store, now)
+	return store, raw
+}
+
+func projectReconcileEchoMessage(
+	t *testing.T,
+	store *sqlite.Store,
+	clock Clock,
+	messageID, remoteID string,
+) {
+	t.Helper()
+	seedMessagingMessage(t, store, clock, sqlite.Message{
+		MessageID:       messageID,
+		ConversationID:  "conversation-1",
+		AccountID:       "account-1",
+		RemoteMessageID: remoteID,
+		Direction:       sqlite.MessageDirectionOutgoing,
+		Body:            "projected own-message echo",
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    clock.Now().UnixMilli(),
+	})
+}
+
+func mustReconcileMessage(t *testing.T, service *MessageService, messageID string) sqlite.Message {
+	t.Helper()
+	message, err := service.messages.GetMessage(context.Background(), messageID)
+	if err != nil {
+		t.Fatalf("GetMessage(%q): %v", messageID, err)
+	}
+	return message
+}
+
+func mustReconcileExecOne(t *testing.T, db *sql.DB, statement string, args ...any) {
+	t.Helper()
+	result, err := db.ExecContext(context.Background(), statement, args...)
+	if err != nil {
+		t.Fatalf("test database mutation: %v", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		t.Fatalf("test database mutation RowsAffected(): %v", err)
+	}
+	if affected != 1 {
+		t.Fatalf("test database mutation affected %d rows, want 1", affected)
+	}
+}
+
+func setReconcileTextSteps(sender *scriptedTextSender, steps ...sendStep) {
+	sender.mu.Lock()
+	sender.steps = append([]sendStep(nil), steps...)
+	sender.mu.Unlock()
+}
+
+type notifyingReconcileClock struct {
+	*manualClock
+	timerCreated chan struct{}
+}
+
+func newNotifyingReconcileClock(now time.Time) *notifyingReconcileClock {
+	return &notifyingReconcileClock{
+		manualClock:  newManualClock(now),
+		timerCreated: make(chan struct{}, 4),
+	}
+}
+
+func (c *notifyingReconcileClock) NewTimer(delay time.Duration) Timer {
+	select {
+	case c.timerCreated <- struct{}{}:
+	default:
+	}
+	return c.manualClock.NewTimer(delay)
+}
+
+func drainReconcileWake(service *MessageService) {
+	for {
+		select {
+		case <-service.wake:
+		default:
+			return
+		}
+	}
+}

--- a/internal/messaging/service.go
+++ b/internal/messaging/service.go
@@ -633,9 +633,130 @@ func (s *MessageService) SendAgain(
 	return Submission{}, fmt.Errorf("send again: %w", ErrNotImplemented)
 }
 
-// ObserveTransportEcho is reserved for the M5 reconciliation path.
-func (s *MessageService) ObserveTransportEcho(context.Context, TransportEcho) error {
-	return fmt.Errorf("observe transport echo: %w", ErrNotImplemented)
+// ObserveTransportEcho correlates an accepted transport result to an existing
+// durable intent. Missing and inapplicable echoes are successful no-ops.
+// ObserveTransportEcho reconciles on the caller's context deliberately (no
+// detached mutation context): echoes are at-least-once and reconciliation is
+// idempotent, so a canceled write is simply replayed by the next delivery —
+// unlike dispatch finalization, where losing the write loses real state.
+func (s *MessageService) ObserveTransportEcho(ctx context.Context, echo TransportEcho) error {
+	if ctx == nil {
+		return fmt.Errorf("observe transport echo: context is nil")
+	}
+	checks := []struct {
+		name  string
+		value string
+	}{
+		{name: "account ID", value: echo.AccountID},
+		{name: "transport request ID", value: echo.TransportRequestID},
+		{name: "remote message ID", value: echo.RemoteMessageID},
+	}
+	for _, check := range checks {
+		if strings.TrimSpace(check.value) == "" {
+			return fmt.Errorf("%w: %s is empty", ErrInvalidCommand, check.name)
+		}
+	}
+
+	outcome, err := s.outbox.ReconcileConfirm(ctx, sqlite.ReconcileRequest{
+		AccountID:          echo.AccountID,
+		TransportRequestID: echo.TransportRequestID,
+		ResultRemoteID:     echo.RemoteMessageID,
+	})
+	if err != nil {
+		return fmt.Errorf("observe transport echo: %w", err)
+	}
+	switch outcome {
+	case sqlite.ReconcileOutcomeNotFound, sqlite.ReconcileOutcomeNoop:
+		return nil
+	case sqlite.ReconcileOutcomeReconciled, sqlite.ReconcileOutcomeEnriched:
+		s.signalChange()
+		return nil
+	default:
+		return fmt.Errorf("observe transport echo: unexpected reconcile outcome %q", outcome)
+	}
+}
+
+// RepairStoreFailed re-drives local confirmation for a result the transport
+// already accepted. It never sends the intent again.
+func (s *MessageService) RepairStoreFailed(
+	ctx context.Context,
+	outboxID string,
+) (Delivery, error) {
+	if ctx == nil {
+		return Delivery{}, fmt.Errorf("repair store-failed delivery: context is nil")
+	}
+	if strings.TrimSpace(outboxID) == "" {
+		return Delivery{}, fmt.Errorf("repair store-failed delivery: outbox ID is empty")
+	}
+	item, err := s.outbox.FindByID(ctx, outboxID)
+	if err != nil {
+		return Delivery{}, fmt.Errorf("repair store-failed delivery: %w", err)
+	}
+	current := deliveryFromItem(item)
+	if item.State != sqlite.OutboxStoreFailed {
+		return current, fmt.Errorf(
+			"%w: cannot repair outbox item %q from %q",
+			ErrInvalidState,
+			outboxID,
+			item.State,
+		)
+	}
+	if item.ResultRemoteID == nil || strings.TrimSpace(*item.ResultRemoteID) == "" {
+		return current, fmt.Errorf(
+			"repair store-failed delivery %q: persisted remote result ID is missing",
+			outboxID,
+		)
+	}
+
+	if _, err := s.outbox.ReconcileConfirm(ctx, sqlite.ReconcileRequest{
+		AccountID:          item.AccountID,
+		TransportRequestID: item.TransportRequestID,
+		ResultRemoteID:     *item.ResultRemoteID,
+	}); err != nil {
+		return current, fmt.Errorf("repair store-failed delivery %q: %w", outboxID, err)
+	}
+	s.signalChange()
+	return s.Get(ctx, outboxID)
+}
+
+func (s *MessageService) reconcileStoreFailedDue(ctx context.Context, limit int) (int, error) {
+	if ctx == nil {
+		return 0, fmt.Errorf("reconcile store-failed deliveries: context is nil")
+	}
+	if limit <= 0 {
+		return 0, fmt.Errorf("reconcile store-failed deliveries: limit must be positive")
+	}
+	items, err := s.outbox.FindStoreFailedDue(ctx, limit)
+	if err != nil {
+		return 0, fmt.Errorf("find store-failed deliveries: %w", err)
+	}
+
+	reconciled := 0
+	for _, item := range items {
+		if err := ctx.Err(); err != nil {
+			return reconciled, err
+		}
+		if item.ResultRemoteID == nil || strings.TrimSpace(*item.ResultRemoteID) == "" {
+			continue
+		}
+		outcome, err := s.outbox.ReconcileConfirm(ctx, sqlite.ReconcileRequest{
+			AccountID:          item.AccountID,
+			TransportRequestID: item.TransportRequestID,
+			ResultRemoteID:     *item.ResultRemoteID,
+		})
+		if err != nil {
+			// A row that still cannot be repaired remains store_failed for a
+			// later bounded pass or explicit repair.
+			continue
+		}
+		if outcome == sqlite.ReconcileOutcomeReconciled || outcome == sqlite.ReconcileOutcomeEnriched {
+			reconciled++
+		}
+	}
+	if reconciled > 0 {
+		s.signalChange()
+	}
+	return reconciled, nil
 }
 
 func (s *MessageService) newSubmissionIDs() (string, string, string, error) {

--- a/internal/messaging/service_test.go
+++ b/internal/messaging/service_test.go
@@ -1147,8 +1147,8 @@ func TestCancelAndDeferredAPIs(t *testing.T) {
 	if _, err := service.SendAgain(context.Background(), submission.OutboxID, "new-key"); !errors.Is(err, ErrNotImplemented) {
 		t.Fatalf("SendAgain() error = %v, want ErrNotImplemented", err)
 	}
-	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{}); !errors.Is(err, ErrNotImplemented) {
-		t.Fatalf("ObserveTransportEcho() error = %v, want ErrNotImplemented", err)
+	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{}); !errors.Is(err, ErrInvalidCommand) {
+		t.Fatalf("ObserveTransportEcho() error = %v, want ErrInvalidCommand", err)
 	}
 }
 

--- a/internal/storage/sqlite/outbox.go
+++ b/internal/storage/sqlite/outbox.go
@@ -159,6 +159,27 @@ type Confirmation struct {
 	TransportResultID string
 }
 
+// ReconcileRequest identifies one accepted transport request and its
+// authoritative remote result without requiring an active dispatch lease.
+type ReconcileRequest struct {
+	AccountID          string
+	TransportRequestID string
+	ResultRemoteID     string
+}
+
+// ReconcileOutcome describes whether a transport result changed durable
+// state. A missing correlation row and an inapplicable result are distinct so
+// callers can observe the storage decision without treating either as an
+// error.
+type ReconcileOutcome string
+
+const (
+	ReconcileOutcomeReconciled ReconcileOutcome = "reconciled"
+	ReconcileOutcomeEnriched   ReconcileOutcome = "enriched"
+	ReconcileOutcomeNoop       ReconcileOutcome = "noop"
+	ReconcileOutcomeNotFound   ReconcileOutcome = "notfound"
+)
+
 // RecoveredLeases reports how expired dispatch leases were classified.
 type RecoveredLeases struct {
 	NotDispatched int
@@ -850,7 +871,7 @@ func validateExistingOutgoingPair(
 		message.ConversationID != item.ConversationID ||
 		message.Direction != MessageDirectionOutgoing ||
 		message.State != MessageStateActive ||
-		message.RemoteMessageID != item.TransportRequestID {
+		!isRequestBoundOrConfirmedRemoteID(message.RemoteMessageID, item) {
 		return fmt.Errorf(
 			"enqueue outgoing message for existing outbox item %q: %w: message %q is not its active request-bound outgoing pair",
 			item.OutboxID,
@@ -861,9 +882,22 @@ func validateExistingOutgoingPair(
 	return nil
 }
 
-// LeaseDue atomically claims due queued, retryable, and explicitly eligible
-// uncertain rows. Uncertain rows produced by recovery have no next-attempt time
-// and therefore are never auto-leased.
+// isRequestBoundOrConfirmedRemoteID accepts the message's remote id in both of
+// its legitimate lifetimes: the placeholder transport_request_id it is born
+// with, and the confirmed result id the reconcile repoint moves it to. Without
+// the second arm, an idempotent replay AFTER delivery (the exact case the
+// idempotency key exists for -- a lost API response, client retries the same
+// key) would spuriously fail pair validation on any platform whose real remote
+// id differs from the request id (Signal at Confirm time, Google at echo time).
+func isRequestBoundOrConfirmedRemoteID(remoteMessageID string, item OutboxItem) bool {
+	if remoteMessageID == item.TransportRequestID {
+		return true
+	}
+	return item.ResultRemoteID != nil && remoteMessageID == *item.ResultRemoteID
+}
+
+// LeaseDue atomically claims due queued and retryable rows. An uncertain row is
+// structurally ineligible regardless of its next-attempt value.
 func (r *OutboxRepository) LeaseDue(
 	ctx context.Context,
 	req LeaseRequest,
@@ -896,10 +930,7 @@ func (r *OutboxRepository) LeaseDue(
 		SELECT outbox_id
 		FROM outbox
 		WHERE scheduled_for_ms <= ?
-		  AND (
-			state IN ('queued', 'not_dispatched')
-			OR (state = 'uncertain' AND next_attempt_at_ms IS NOT NULL)
-		  )
+		  AND state IN ('queued', 'not_dispatched')
 		  AND (next_attempt_at_ms IS NULL OR next_attempt_at_ms <= ?)
 		  AND (lease_expires_at_ms IS NULL OR lease_expires_at_ms <= ?)
 		ORDER BY COALESCE(next_attempt_at_ms, scheduled_for_ms), created_at_ms, outbox_id
@@ -937,10 +968,7 @@ func (r *OutboxRepository) LeaseDue(
 				updated_at_ms = ?
 			WHERE outbox_id = ?
 			  AND scheduled_for_ms <= ?
-			  AND (
-				state IN ('queued', 'not_dispatched')
-				OR (state = 'uncertain' AND next_attempt_at_ms IS NOT NULL)
-			  )
+			  AND state IN ('queued', 'not_dispatched')
 			  AND (next_attempt_at_ms IS NULL OR next_attempt_at_ms <= ?)
 			  AND (lease_expires_at_ms IS NULL OR lease_expires_at_ms <= ?)
 		`, req.Owner, token, expiresAtMS, nowMS, id, nowMS, nowMS, nowMS)
@@ -1311,8 +1339,290 @@ func (r *OutboxRepository) Confirm(
 	if err := r.requireLeaseMutationWithQueryer(ctx, tx, "confirm", confirmation.OutboxID, result); err != nil {
 		return err
 	}
+
+	var (
+		accountID          string
+		conversationID     string
+		localMessageID     sql.NullString
+		transportRequestID string
+	)
+	if err := tx.QueryRowContext(ctx, `
+		SELECT account_id, conversation_id, local_message_id, transport_request_id
+		FROM outbox
+		WHERE outbox_id = ?
+	`, confirmation.OutboxID).Scan(
+		&accountID,
+		&conversationID,
+		&localMessageID,
+		&transportRequestID,
+	); err != nil {
+		return fmt.Errorf(
+			"confirm outbox item %q: read local message identity: %w",
+			confirmation.OutboxID,
+			err,
+		)
+	}
+	if localMessageID.Valid {
+		if err := r.repointLocalMessage(
+			ctx,
+			tx,
+			accountID,
+			conversationID,
+			localMessageID.String,
+			transportRequestID,
+			resultRemoteID,
+		); err != nil {
+			return fmt.Errorf("confirm outbox item %q: %w", confirmation.OutboxID, err)
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("confirm outbox item %q: commit: %w", confirmation.OutboxID, err)
+	}
+	return nil
+}
+
+// ReconcileConfirm applies an accepted transport result without requiring a
+// dispatch lease. The account-scoped transport request ID is the sole
+// correlation key.
+func (r *OutboxRepository) ReconcileConfirm(
+	ctx context.Context,
+	req ReconcileRequest,
+) (ReconcileOutcome, error) {
+	checks := []struct {
+		name  string
+		value string
+	}{
+		{name: "account ID", value: req.AccountID},
+		{name: "transport request ID", value: req.TransportRequestID},
+		{name: "remote result ID", value: req.ResultRemoteID},
+	}
+	for _, check := range checks {
+		if strings.TrimSpace(check.value) == "" {
+			return "", fmt.Errorf("reconcile transport result: %s is empty", check.name)
+		}
+	}
+
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("reconcile transport result: begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	var (
+		outboxID                string
+		conversationID          string
+		state                   OutboxState
+		localMessageID          sql.NullString
+		persistedResultRemoteID sql.NullString
+		localRemoteMessageID    sql.NullString
+	)
+	err = tx.QueryRowContext(ctx, `
+		SELECT
+			o.outbox_id,
+			o.conversation_id,
+			o.state,
+			o.local_message_id,
+			o.result_remote_id,
+			m.remote_message_id
+		FROM outbox AS o
+		LEFT JOIN messages AS m ON m.message_id = o.local_message_id
+		WHERE o.account_id = ? AND o.transport_request_id = ?
+	`, req.AccountID, req.TransportRequestID).Scan(
+		&outboxID,
+		&conversationID,
+		&state,
+		&localMessageID,
+		&persistedResultRemoteID,
+		&localRemoteMessageID,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ReconcileOutcomeNotFound, nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("reconcile transport result: read correlated outbox item: %w", err)
+	}
+
+	switch state {
+	case OutboxUncertain, OutboxStoreFailed:
+		nowMS, err := r.nowMS("reconcile transport result")
+		if err != nil {
+			return "", err
+		}
+		result, err := tx.ExecContext(ctx, `
+			UPDATE outbox
+			SET state = 'confirmed',
+				result_remote_id = ?,
+				error_class = NULL,
+				error_code = NULL,
+				error_detail = NULL,
+				next_attempt_at_ms = NULL,
+				updated_at_ms = ?
+			WHERE outbox_id = ?
+			  AND state IN ('uncertain', 'store_failed')
+		`, req.ResultRemoteID, nowMS, outboxID)
+		if err != nil {
+			return "", fmt.Errorf("reconcile outbox item %q: confirm: %w", outboxID, err)
+		}
+		if err := requireSingleReconcileMutation(result, outboxID); err != nil {
+			return "", err
+		}
+		if localMessageID.Valid &&
+			localRemoteMessageID.Valid &&
+			localRemoteMessageID.String == req.TransportRequestID &&
+			req.ResultRemoteID != req.TransportRequestID {
+			if err := r.repointLocalMessage(
+				ctx,
+				tx,
+				req.AccountID,
+				conversationID,
+				localMessageID.String,
+				req.TransportRequestID,
+				req.ResultRemoteID,
+			); err != nil {
+				return "", fmt.Errorf("reconcile outbox item %q: %w", outboxID, err)
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return "", fmt.Errorf("reconcile outbox item %q: commit: %w", outboxID, err)
+		}
+		return ReconcileOutcomeReconciled, nil
+
+	case OutboxConfirmed:
+		if persistedResultRemoteID.Valid && persistedResultRemoteID.String == req.ResultRemoteID {
+			return ReconcileOutcomeNoop, nil
+		}
+		if !localMessageID.Valid ||
+			!localRemoteMessageID.Valid ||
+			localRemoteMessageID.String != req.TransportRequestID ||
+			req.ResultRemoteID == req.TransportRequestID {
+			return ReconcileOutcomeNoop, nil
+		}
+
+		nowMS, err := r.nowMS("reconcile transport result")
+		if err != nil {
+			return "", err
+		}
+		result, err := tx.ExecContext(ctx, `
+			UPDATE outbox
+			SET result_remote_id = ?,
+				error_class = NULL,
+				error_code = NULL,
+				error_detail = NULL,
+				updated_at_ms = ?
+			WHERE outbox_id = ?
+			  AND state = 'confirmed'
+			  AND result_remote_id = transport_request_id
+		`, req.ResultRemoteID, nowMS, outboxID)
+		if err != nil {
+			return "", fmt.Errorf("reconcile outbox item %q: enrich: %w", outboxID, err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return "", fmt.Errorf(
+				"reconcile outbox item %q: read enrich rows affected: %w",
+				outboxID,
+				err,
+			)
+		}
+		if affected == 0 {
+			return ReconcileOutcomeNoop, nil
+		}
+		if affected != 1 {
+			return "", fmt.Errorf(
+				"reconcile outbox item %q: enrich affected %d rows, want 1",
+				outboxID,
+				affected,
+			)
+		}
+		if err := r.repointLocalMessage(
+			ctx,
+			tx,
+			req.AccountID,
+			conversationID,
+			localMessageID.String,
+			req.TransportRequestID,
+			req.ResultRemoteID,
+		); err != nil {
+			return "", fmt.Errorf("reconcile outbox item %q: %w", outboxID, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return "", fmt.Errorf("reconcile outbox item %q: commit enrichment: %w", outboxID, err)
+		}
+		return ReconcileOutcomeEnriched, nil
+
+	default:
+		return ReconcileOutcomeNoop, nil
+	}
+}
+
+func requireSingleReconcileMutation(result sql.Result, outboxID string) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf(
+			"reconcile outbox item %q: read confirm rows affected: %w",
+			outboxID,
+			err,
+		)
+	}
+	if affected != 1 {
+		return fmt.Errorf(
+			"reconcile outbox item %q: confirm affected %d rows, want 1",
+			outboxID,
+			affected,
+		)
+	}
+	return nil
+}
+
+func (r *OutboxRepository) repointLocalMessage(
+	ctx context.Context,
+	tx *sql.Tx,
+	accountID, conversationID, localMessageID, transportRequestID, realID string,
+) error {
+	if realID == transportRequestID {
+		return nil
+	}
+	nowMS, err := r.nowMS("repoint local message")
+	if err != nil {
+		return err
+	}
+
+	var collisionMessageID string
+	err = tx.QueryRowContext(ctx, `
+		SELECT message_id
+		FROM messages
+		WHERE account_id = ?
+		  AND conversation_id = ?
+		  AND remote_message_id = ?
+	`, accountID, conversationID, realID).Scan(&collisionMessageID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("repoint local message %q: read remote-ID collision: %w", localMessageID, err)
+	}
+	if err == nil && collisionMessageID != localMessageID {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM messages
+			WHERE message_id = ?
+		`, collisionMessageID); err != nil {
+			return fmt.Errorf(
+				"repoint local message %q: delete echo duplicate %q: %w",
+				localMessageID,
+				collisionMessageID,
+				mapConstraintError(err),
+			)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE messages
+		SET remote_message_id = ?,
+			updated_at_ms = ?
+		WHERE message_id = ?
+	`, realID, nowMS, localMessageID); err != nil {
+		return fmt.Errorf(
+			"repoint local message %q: update remote ID: %w",
+			localMessageID,
+			mapConstraintError(err),
+		)
 	}
 	return nil
 }
@@ -1441,6 +1751,32 @@ func (r *OutboxRepository) FindByID(
 		return OutboxItem{}, fmt.Errorf("find outbox item %q: %w", outboxID, err)
 	}
 	return item, nil
+}
+
+// FindStoreFailedDue returns a deterministic bounded batch of accepted
+// results whose local confirmation still needs repair.
+func (r *OutboxRepository) FindStoreFailedDue(
+	ctx context.Context,
+	limit int,
+) ([]OutboxItem, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("find store-failed outbox items: limit must be positive")
+	}
+	rows, err := r.store.db.QueryContext(ctx, `
+		SELECT `+outboxColumns+`
+		FROM outbox
+		WHERE state = 'store_failed'
+		ORDER BY updated_at_ms, outbox_id
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("find store-failed outbox items: query: %w", err)
+	}
+	items, err := collectRows(rows, scanOutboxItem)
+	if err != nil {
+		return nil, fmt.Errorf("find store-failed outbox items: scan: %w", err)
+	}
+	return items, nil
 }
 
 // FindByTransportRequestID returns the account-scoped row carrying the stable

--- a/internal/storage/sqlite/outbox_test.go
+++ b/internal/storage/sqlite/outbox_test.go
@@ -841,6 +841,526 @@ func TestOutboxConfirmWithoutResultRequiresCalledActiveLease(t *testing.T) {
 	}
 }
 
+func TestOutboxReconcileConfirmMergesCollisionAndPreservesLocalAnchor(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	ctx := context.Background()
+
+	item := outboxTestItem("reconcile-collision")
+	mustEnqueueOutgoingOutbox(t, repository, item, "optimistic body")
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	token := mustLeaseToken(t, lease)
+	if err := repository.MarkTransportCalled(ctx, Attempt{
+		OutboxID: item.OutboxID, LeaseToken: token,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(): %v", err)
+	}
+	if err := repository.MarkUncertain(
+		ctx,
+		item.OutboxID,
+		token,
+		"timeout",
+		"deadline",
+		"outcome unknown",
+	); err != nil {
+		t.Fatalf("MarkUncertain(): %v", err)
+	}
+
+	const echoMessageID = "message-echo-duplicate"
+	seedOutboxTestMessage(t, store, echoMessageID, item.AccountID, item.ConversationID)
+	realID := "remote-" + echoMessageID
+
+	dependent := outboxTestReactionItem("reconcile-local-anchor")
+	if _, disposition, err := repository.EnqueueReaction(ctx, dependent, OutboxReaction{
+		TargetMessageID: item.LocalMessageID,
+		Emoji:           "thumbs-up",
+		Action:          "add",
+	}); err != nil {
+		t.Fatalf("EnqueueReaction(dependent): %v", err)
+	} else if disposition != EnqueueInserted {
+		t.Fatalf("EnqueueReaction(dependent) disposition = %q, want %q", disposition, EnqueueInserted)
+	}
+
+	clock.Set(outboxTestTimeMS + 1_000)
+	outcome, err := repository.ReconcileConfirm(ctx, ReconcileRequest{
+		AccountID:          item.AccountID,
+		TransportRequestID: item.TransportRequestID,
+		ResultRemoteID:     realID,
+	})
+	if err != nil {
+		t.Fatalf("ReconcileConfirm(): %v", err)
+	}
+	if outcome != ReconcileOutcome("reconciled") {
+		t.Fatalf("ReconcileConfirm() outcome = %q, want reconciled", outcome)
+	}
+
+	reconciled, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(reconciled): %v", err)
+	}
+	if reconciled.State != OutboxConfirmed || reconciled.ResultRemoteID == nil ||
+		*reconciled.ResultRemoteID != realID || reconciled.ErrorClass != nil ||
+		reconciled.ErrorCode != nil || reconciled.ErrorDetail != nil {
+		t.Fatalf("reconciled row = %+v", reconciled)
+	}
+
+	messages, err := NewMessageRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	survivor, err := messages.GetMessage(ctx, item.LocalMessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(local survivor): %v", err)
+	}
+	if survivor.RemoteMessageID != realID {
+		t.Fatalf("local survivor remote ID = %q, want %q", survivor.RemoteMessageID, realID)
+	}
+	if _, err := messages.GetMessage(ctx, echoMessageID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetMessage(echo duplicate) error = %v, want ErrNotFound", err)
+	}
+	carrier, err := repository.GetOutboxReaction(ctx, dependent.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxReaction(dependent): %v", err)
+	}
+	if carrier.TargetMessageID != item.LocalMessageID {
+		t.Fatalf("dependent target = %q, want local survivor %q", carrier.TargetMessageID, item.LocalMessageID)
+	}
+	var survivorID string
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT message_id
+		FROM messages
+		WHERE account_id = ? AND conversation_id = ? AND remote_message_id = ?
+	`, item.AccountID, item.ConversationID, realID).Scan(&survivorID); err != nil {
+		t.Fatalf("read survivor by remote ID: %v", err)
+	}
+	if survivorID != item.LocalMessageID {
+		t.Fatalf("remote-ID survivor = %q, want %q", survivorID, item.LocalMessageID)
+	}
+
+	duplicate, err := repository.ReconcileConfirm(ctx, ReconcileRequest{
+		AccountID:          item.AccountID,
+		TransportRequestID: item.TransportRequestID,
+		ResultRemoteID:     realID,
+	})
+	if err != nil {
+		t.Fatalf("ReconcileConfirm(duplicate): %v", err)
+	}
+	if duplicate != ReconcileOutcome("noop") {
+		t.Fatalf("ReconcileConfirm(duplicate) outcome = %q, want noop", duplicate)
+	}
+	foreign, err := repository.ReconcileConfirm(ctx, ReconcileRequest{
+		AccountID:          item.AccountID,
+		TransportRequestID: item.TransportRequestID,
+		ResultRemoteID:     "remote-foreign",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileConfirm(foreign): %v", err)
+	}
+	if foreign != ReconcileOutcome("noop") {
+		t.Fatalf("ReconcileConfirm(foreign) outcome = %q, want noop", foreign)
+	}
+	unchanged, err := messages.GetMessage(ctx, item.LocalMessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(after foreign echo): %v", err)
+	}
+	if unchanged.RemoteMessageID != realID {
+		t.Fatalf("message remote ID after foreign echo = %q, want %q", unchanged.RemoteMessageID, realID)
+	}
+}
+
+func TestOutboxReconcileConfirmEnrichesPlaceholderAndLeavesDispatchOwnerInCharge(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	ctx := context.Background()
+
+	provisional := outboxTestItem("reconcile-enrich")
+	mustEnqueueOutgoingOutbox(t, repository, provisional, "provisional body")
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	token := mustLeaseToken(t, lease)
+	if err := repository.MarkTransportCalled(ctx, Attempt{
+		OutboxID: provisional.OutboxID, LeaseToken: token,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(provisional): %v", err)
+	}
+	if err := repository.Confirm(ctx, Confirmation{
+		OutboxID:       provisional.OutboxID,
+		LeaseToken:     token,
+		ResultRemoteID: provisional.TransportRequestID,
+	}); err != nil {
+		t.Fatalf("Confirm(provisional): %v", err)
+	}
+
+	const permanentID = "remote-permanent"
+	outcome, err := repository.ReconcileConfirm(ctx, ReconcileRequest{
+		AccountID:          provisional.AccountID,
+		TransportRequestID: provisional.TransportRequestID,
+		ResultRemoteID:     permanentID,
+	})
+	if err != nil {
+		t.Fatalf("ReconcileConfirm(enrich): %v", err)
+	}
+	if outcome != ReconcileOutcome("enriched") {
+		t.Fatalf("ReconcileConfirm(enrich) outcome = %q, want enriched", outcome)
+	}
+	confirmed, err := repository.FindByID(ctx, provisional.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(enriched): %v", err)
+	}
+	if confirmed.State != OutboxConfirmed || confirmed.ResultRemoteID == nil ||
+		*confirmed.ResultRemoteID != permanentID {
+		t.Fatalf("enriched row = %+v", confirmed)
+	}
+	messages, err := NewMessageRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	enrichedMessage, err := messages.GetMessage(ctx, provisional.LocalMessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(enriched): %v", err)
+	}
+	if enrichedMessage.RemoteMessageID != permanentID {
+		t.Fatalf("enriched message remote ID = %q, want %q", enrichedMessage.RemoteMessageID, permanentID)
+	}
+
+	racing := outboxTestItem("reconcile-dispatching")
+	mustEnqueueOutgoingOutbox(t, repository, racing, "racing body")
+	lease = mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "lease-owner", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	token = mustLeaseToken(t, lease)
+	if err := repository.MarkTransportCalled(ctx, Attempt{
+		OutboxID: racing.OutboxID, LeaseToken: token,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(racing): %v", err)
+	}
+	racedOutcome, err := repository.ReconcileConfirm(ctx, ReconcileRequest{
+		AccountID:          racing.AccountID,
+		TransportRequestID: racing.TransportRequestID,
+		ResultRemoteID:     "remote-racing",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileConfirm(dispatching): %v", err)
+	}
+	if racedOutcome != ReconcileOutcome("noop") {
+		t.Fatalf("ReconcileConfirm(dispatching) outcome = %q, want noop", racedOutcome)
+	}
+	stillDispatching, err := repository.FindByID(ctx, racing.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(dispatching): %v", err)
+	}
+	if stillDispatching.State != OutboxDispatching || stillDispatching.LeaseToken == nil ||
+		*stillDispatching.LeaseToken != token {
+		t.Fatalf("dispatching row changed during echo = %+v", stillDispatching)
+	}
+	if err := repository.Confirm(ctx, Confirmation{
+		OutboxID: racing.OutboxID, LeaseToken: token, ResultRemoteID: "remote-racing",
+	}); err != nil {
+		t.Fatalf("Confirm(lease owner): %v", err)
+	}
+	replayed, err := repository.ReconcileConfirm(ctx, ReconcileRequest{
+		AccountID:          racing.AccountID,
+		TransportRequestID: racing.TransportRequestID,
+		ResultRemoteID:     "remote-racing",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileConfirm(after lease confirm): %v", err)
+	}
+	if replayed != ReconcileOutcome("noop") {
+		t.Fatalf("ReconcileConfirm(after lease confirm) outcome = %q, want noop", replayed)
+	}
+
+	missing, err := repository.ReconcileConfirm(ctx, ReconcileRequest{
+		AccountID:          provisional.AccountID,
+		TransportRequestID: "request-missing",
+		ResultRemoteID:     "remote-missing",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileConfirm(missing): %v", err)
+	}
+	if missing != ReconcileOutcome("notfound") {
+		t.Fatalf("ReconcileConfirm(missing) outcome = %q, want notfound", missing)
+	}
+}
+
+func TestOutboxReconcileConfirmRepairsStoreFailedAndNoopsTerminalStates(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	ctx := context.Background()
+
+	failed := outboxTestItem("reconcile-store-failed")
+	mustEnqueueOutgoingOutbox(t, repository, failed, "store-failed body")
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	token := mustLeaseToken(t, lease)
+	if err := repository.MarkTransportCalled(ctx, Attempt{
+		OutboxID: failed.OutboxID, LeaseToken: token,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(store failed): %v", err)
+	}
+	const resultID = "remote-store-failed"
+	if err := repository.MarkStoreFailed(ctx, failed.OutboxID, token, resultID, "local write failed"); err != nil {
+		t.Fatalf("MarkStoreFailed(): %v", err)
+	}
+	outcome, err := repository.ReconcileConfirm(ctx, ReconcileRequest{
+		AccountID:          failed.AccountID,
+		TransportRequestID: failed.TransportRequestID,
+		ResultRemoteID:     resultID,
+	})
+	if err != nil {
+		t.Fatalf("ReconcileConfirm(store failed): %v", err)
+	}
+	if outcome != ReconcileOutcome("reconciled") {
+		t.Fatalf("ReconcileConfirm(store failed) outcome = %q, want reconciled", outcome)
+	}
+	repaired, err := repository.FindByID(ctx, failed.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(repaired): %v", err)
+	}
+	if repaired.State != OutboxConfirmed || repaired.ResultRemoteID == nil ||
+		*repaired.ResultRemoteID != resultID || repaired.ErrorClass != nil ||
+		repaired.ErrorCode != nil || repaired.ErrorDetail != nil {
+		t.Fatalf("repaired row = %+v", repaired)
+	}
+	messages, err := NewMessageRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	repairedMessage, err := messages.GetMessage(ctx, failed.LocalMessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(repaired): %v", err)
+	}
+	if repairedMessage.RemoteMessageID != resultID {
+		t.Fatalf("repaired message remote ID = %q, want %q", repairedMessage.RemoteMessageID, resultID)
+	}
+
+	terminalCases := []struct {
+		name       string
+		transition func(OutboxItem) error
+		wantState  OutboxState
+	}{
+		{
+			name: "queued",
+			transition: func(OutboxItem) error {
+				return nil
+			},
+			wantState: OutboxQueued,
+		},
+		{
+			name: "canceled",
+			transition: func(item OutboxItem) error {
+				return repository.Cancel(ctx, item.OutboxID)
+			},
+			wantState: OutboxCanceled,
+		},
+	}
+	for _, test := range terminalCases {
+		t.Run(test.name, func(t *testing.T) {
+			item := outboxTestItem("reconcile-noop-" + test.name)
+			mustEnqueueOutgoingOutbox(t, repository, item, test.name+" body")
+			current, err := repository.FindByID(ctx, item.OutboxID)
+			if err != nil {
+				t.Fatalf("FindByID(before transition): %v", err)
+			}
+			if err := test.transition(current); err != nil {
+				t.Fatalf("transition: %v", err)
+			}
+			got, err := repository.ReconcileConfirm(ctx, ReconcileRequest{
+				AccountID:          item.AccountID,
+				TransportRequestID: item.TransportRequestID,
+				ResultRemoteID:     "remote-anomalous-" + test.name,
+			})
+			if err != nil {
+				t.Fatalf("ReconcileConfirm(): %v", err)
+			}
+			if got != ReconcileOutcome("noop") {
+				t.Fatalf("ReconcileConfirm() outcome = %q, want noop", got)
+			}
+			unchanged, err := repository.FindByID(ctx, item.OutboxID)
+			if err != nil {
+				t.Fatalf("FindByID(after echo): %v", err)
+			}
+			if unchanged.State != test.wantState {
+				t.Fatalf("state after echo = %q, want %q", unchanged.State, test.wantState)
+			}
+			message, err := messages.GetMessage(ctx, item.LocalMessageID)
+			if err != nil {
+				t.Fatalf("GetMessage(after echo): %v", err)
+			}
+			if message.RemoteMessageID != item.TransportRequestID {
+				t.Fatalf("message remote ID after echo = %q, want %q", message.RemoteMessageID, item.TransportRequestID)
+			}
+		})
+	}
+}
+
+func TestOutboxFindStoreFailedDueIsBoundedOrderedAndStateFiltered(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+
+	items := []NewOutboxItem{
+		outboxTestItem("store-a"),
+		outboxTestItem("store-b"),
+		outboxTestItem("store-c"),
+	}
+	for _, item := range items {
+		mustEnqueueOutbox(t, repository, item)
+	}
+	leases, err := repository.LeaseDue(ctx, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: len(items),
+	})
+	if err != nil {
+		t.Fatalf("LeaseDue(store failed candidates): %v", err)
+	}
+	if len(leases) != len(items) {
+		t.Fatalf("LeaseDue(store failed candidates) = %d leases, want %d", len(leases), len(items))
+	}
+	leasesByID := make(map[string]OutboxItem, len(leases))
+	for _, lease := range leases {
+		leasesByID[lease.OutboxID] = lease.OutboxItem
+		if err := repository.MarkTransportCalled(ctx, Attempt{
+			OutboxID: lease.OutboxID, LeaseToken: mustLeaseToken(t, lease.OutboxItem),
+		}); err != nil {
+			t.Fatalf("MarkTransportCalled(%q): %v", lease.OutboxID, err)
+		}
+	}
+
+	clock.Set(outboxTestTimeMS + 100)
+	for _, id := range []string{"outbox-store-c", "outbox-store-a"} {
+		lease := leasesByID[id]
+		if err := repository.MarkStoreFailed(
+			ctx,
+			id,
+			mustLeaseToken(t, lease),
+			"remote-"+id,
+			"store failed",
+		); err != nil {
+			t.Fatalf("MarkStoreFailed(%q): %v", id, err)
+		}
+	}
+	clock.Set(outboxTestTimeMS + 200)
+	lease := leasesByID["outbox-store-b"]
+	if err := repository.MarkStoreFailed(
+		ctx,
+		lease.OutboxID,
+		mustLeaseToken(t, lease),
+		"remote-"+lease.OutboxID,
+		"store failed",
+	); err != nil {
+		t.Fatalf("MarkStoreFailed(%q): %v", lease.OutboxID, err)
+	}
+
+	confirmedInput := outboxTestItem("store-filter-confirmed")
+	mustEnqueueOutbox(t, repository, confirmedInput)
+	confirmedLease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	confirmedToken := mustLeaseToken(t, confirmedLease)
+	if err := repository.MarkTransportCalled(ctx, Attempt{
+		OutboxID: confirmedInput.OutboxID, LeaseToken: confirmedToken,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(confirmed filter): %v", err)
+	}
+	if err := repository.Confirm(ctx, Confirmation{
+		OutboxID:       confirmedInput.OutboxID,
+		LeaseToken:     confirmedToken,
+		ResultRemoteID: confirmedInput.TransportRequestID,
+	}); err != nil {
+		t.Fatalf("Confirm(filter): %v", err)
+	}
+	mustEnqueueOutbox(t, repository, outboxTestItem("store-filter-queued"))
+
+	bounded, err := repository.FindStoreFailedDue(ctx, 2)
+	if err != nil {
+		t.Fatalf("FindStoreFailedDue(2): %v", err)
+	}
+	wantBounded := []string{"outbox-store-a", "outbox-store-c"}
+	if got := outboxIDs(bounded); !slices.Equal(got, wantBounded) {
+		t.Fatalf("FindStoreFailedDue(2) IDs = %v, want %v", got, wantBounded)
+	}
+
+	all, err := repository.FindStoreFailedDue(ctx, 10)
+	if err != nil {
+		t.Fatalf("FindStoreFailedDue(10): %v", err)
+	}
+	wantAll := []string{"outbox-store-a", "outbox-store-c", "outbox-store-b"}
+	if got := outboxIDs(all); !slices.Equal(got, wantAll) {
+		t.Fatalf("FindStoreFailedDue(10) IDs = %v, want %v", got, wantAll)
+	}
+	for _, item := range all {
+		if item.State != OutboxStoreFailed {
+			t.Fatalf("FindStoreFailedDue() returned state %q for %q", item.State, item.OutboxID)
+		}
+	}
+	if _, err := repository.FindStoreFailedDue(ctx, 0); err == nil {
+		t.Fatal("FindStoreFailedDue(0) succeeded")
+	}
+}
+
+func TestOutboxLeaseDueNeverClaimsArtificiallyArmedUncertainRow(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	item := mustEnqueueOutbox(t, repository, outboxTestItem("armed-uncertain"))
+	lease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker", Now: clock.Now(), Duration: time.Minute, Limit: 1,
+	})
+	token := mustLeaseToken(t, lease)
+	if err := repository.MarkTransportCalled(ctx, Attempt{
+		OutboxID: item.OutboxID, LeaseToken: token,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(): %v", err)
+	}
+	if err := repository.MarkUncertain(ctx, item.OutboxID, token, "timeout", "deadline", "unknown"); err != nil {
+		t.Fatalf("MarkUncertain(): %v", err)
+	}
+
+	artificialNextAttemptMS := clock.Now().Add(time.Second).UnixMilli()
+	if _, err := store.db.ExecContext(ctx, `
+		UPDATE outbox
+		SET next_attempt_at_ms = ?
+		WHERE outbox_id = ? AND state = 'uncertain'
+	`, artificialNextAttemptMS, item.OutboxID); err != nil {
+		t.Fatalf("artificially arm uncertain row: %v", err)
+	}
+	armed, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(armed uncertain): %v", err)
+	}
+	if armed.State != OutboxUncertain || armed.NextAttemptAtMS == nil ||
+		*armed.NextAttemptAtMS != artificialNextAttemptMS {
+		t.Fatalf("artificially armed row = %+v", armed)
+	}
+
+	leases, err := repository.LeaseDue(ctx, LeaseRequest{
+		Owner: "worker-later", Now: clock.Now().Add(time.Hour), Duration: time.Minute, Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("LeaseDue(artificially armed uncertain): %v", err)
+	}
+	if len(leases) != 0 {
+		t.Fatalf("LeaseDue(artificially armed uncertain) = %+v, want none", leases)
+	}
+	unchanged, err := repository.FindByID(ctx, item.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(after LeaseDue): %v", err)
+	}
+	if unchanged.State != OutboxUncertain {
+		t.Fatalf("state after LeaseDue = %q, want %q", unchanged.State, OutboxUncertain)
+	}
+}
+
 func TestOutboxLeaseDueRespectsScheduleRetryAndLiveLease(t *testing.T) {
 	clock := newOutboxTestClock(outboxTestTimeMS)
 	_, repository := openOutboxTestRepository(t, clock.Now)
@@ -1714,6 +2234,40 @@ func mustEnqueueOutbox(
 		t.Fatalf("Enqueue(%q) disposition = %q, want %q", item.OutboxID, disposition, EnqueueInserted)
 	}
 	return row
+}
+
+func mustEnqueueOutgoingOutbox(
+	t *testing.T,
+	repository *OutboxRepository,
+	item NewOutboxItem,
+	body string,
+) OutboxItem {
+	t.Helper()
+	row, disposition, err := repository.EnqueueOutgoingMessage(
+		context.Background(),
+		item,
+		outboxTestOutgoingMessage(item, body),
+	)
+	if err != nil {
+		t.Fatalf("EnqueueOutgoingMessage(%q): %v", item.OutboxID, err)
+	}
+	if disposition != EnqueueInserted {
+		t.Fatalf(
+			"EnqueueOutgoingMessage(%q) disposition = %q, want %q",
+			item.OutboxID,
+			disposition,
+			EnqueueInserted,
+		)
+	}
+	return row
+}
+
+func outboxIDs(items []OutboxItem) []string {
+	ids := make([]string, len(items))
+	for index, item := range items {
+		ids[index] = item.OutboxID
+	}
+	return ids
 }
 
 func mustLeaseOne(


### PR DESCRIPTION
## Rebuild Wave 2 / M5a-1 — echo reconciliation, the remote-id repoint, and store_failed repair

The reconciliation engine — the heart of the milestone this rebuild exists for. The legacy Retry re-sent ambiguous messages; the durable outbox made `uncertain` absorbing; **M5a-1 adds the safe ways out of uncertain.** Hermetic (fake transports; echoes injected in tests); the v2 pipeline still has no production callers. SendAgain + the 0009 link column follow as M5a-2.

### What it does
- **`ReconcileConfirm`** — a lease-free primitive keyed on `(account, transport_request_id)` that moves `uncertain`/`store_failed` rows to `confirmed` when a matching transport echo or persisted result proves delivery. Idempotent under at-least-once echo redelivery; no-op on `dispatching` rows (the lease owner wins); never creates or corrupts on a miss.
- **The repoint** — confirming now atomically moves the optimistic message's `remote_message_id` from the request placeholder to the real remote id, in the same transaction. Collision merge: an echo-projected duplicate row is deleted **first** and the local optimistic message always survives (it's the FK anchor for reactions, read cursors, and attachments).
- **`store_failed` repair** — `RepairStoreFailed` re-drives the persisted result through the same primitive, and `Run` performs a bounded self-heal sweep each tick: a delivered message can never stay stuck locally.
- **LeaseDue hardening** — the dormant `uncertain` branch is removed from the leasing SQL, making *"uncertain cannot re-enter dispatch"* a structural property of the query. A discriminating test artificially arms an uncertain row and proves it still can't be leased (verified failing on pre-change code).

### The review catch
The adversarial review found (and proved with a before/after repro) that the repoint broke **idempotent SendText replay after delivery** — retrying a delivered send with the same idempotency key (the exact case the key exists for: lost API response) would spuriously fail pair validation on Signal/Google. Fixed: pair validation accepts the placeholder **or** the confirmed result id; two discriminating regression tests pin it (verified failing pre-fix, passing post-fix).

### Verification
- Full `go test -race ./...` green — 24 packages (plus `-shuffle=on` in review).
- Review exercised the collision merge on a **real scratch DB** (FK-dependent survival with seeded reactions + read cursors; RESTRICT rollback with no partial merge) and verified the `ReconcileConfirm` decision table against the spec row by row.
- `_txlock=immediate` makes every reconcile transaction write-serialized from the start — no TOCTOU against a concurrent dispatch Confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
