### PR TITLE
Add explicit SendAgain with a durable predecessor link (rebuild Wave 2 / M5a-2)

### DIFF
--- a/internal/messaging/send_again_test.go
+++ b/internal/messaging/send_again_test.go
@@ -1,0 +1,530 @@
+package messaging
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func TestSendAgainTextReconstructsAllowedStatesFromDurableMessage(t *testing.T) {
+	for _, state := range []OutboxState{OutboxUncertain, OutboxRejected} {
+		state := state
+		t.Run(string(state), func(t *testing.T) {
+			clock := newManualClock(messagingTestTime)
+			store := openMessagingTestStore(t, clock.Now())
+			const replyRemoteID = "remote-send-again-reply"
+			const replyMessageID = "message-send-again-reply"
+			seedMessagingMessage(t, store, clock, sqlite.Message{
+				MessageID:       replyMessageID,
+				ConversationID:  "conversation-1",
+				AccountID:       "account-1",
+				RemoteMessageID: replyRemoteID,
+				Direction:       sqlite.MessageDirectionIncoming,
+				Body:            "reply target",
+				State:           sqlite.MessageStateActive,
+				OccurredAtMS:    clock.Now().UnixMilli(),
+			})
+
+			sender := &scriptedTextSender{steps: []sendStep{sendAgainStepForState(state)}}
+			registry := newScriptedRegistry("send-again-text", sender)
+			registry.setAvailable(true)
+			service := newMessagingTestService(t, store, registry, clock)
+			original := mustSendText(t, service, SendTextCommand{
+				CommonCommand:    testCommonCommand("key-send-again-text-" + string(state)),
+				Body:             "durably reconstructed text",
+				ReplyToMessageID: replyMessageID,
+			})
+			if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+				t.Fatalf("DispatchDue(%s) = %d, %v; want 1, nil", state, processed, err)
+			}
+			before := mustOutboxItem(t, service, original.OutboxID)
+			if before.State != state {
+				t.Fatalf("original state = %q, want %q", before.State, state)
+			}
+			clock.Advance(time.Second)
+
+			changed := service.changeChannel()
+			drainSendAgainWake(service)
+			resent, err := service.SendAgain(
+				context.Background(),
+				original.OutboxID,
+				"key-send-again-text-new-"+string(state),
+			)
+			if err != nil {
+				t.Fatalf("SendAgain(%s): %v", state, err)
+			}
+			if resent.State != OutboxQueued || resent.OutboxID == original.OutboxID ||
+				resent.LocalMessageID == original.LocalMessageID || resent.LocalMessageID == "" {
+				t.Fatalf("resent submission = %+v, original = %+v", resent, original)
+			}
+			select {
+			case <-changed:
+			default:
+				t.Fatal("SendAgain(inserted) did not signal a delivery change")
+			}
+			select {
+			case <-service.wake:
+			default:
+				t.Fatal("SendAgain(inserted) did not wake the dispatcher")
+			}
+
+			after := mustOutboxItem(t, service, original.OutboxID)
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("SendAgain mutated old row:\n before=%+v\n  after=%+v", before, after)
+			}
+			resentItem := mustOutboxItem(t, service, resent.OutboxID)
+			if resentItem.State != sqlite.OutboxQueued || resentItem.SendAgainOfOutboxID == nil ||
+				*resentItem.SendAgainOfOutboxID != original.OutboxID ||
+				resentItem.TransportRequestID == before.TransportRequestID {
+				t.Fatalf("resent outbox row = %+v", resentItem)
+			}
+			resentMessage, err := service.messages.GetMessage(context.Background(), resent.LocalMessageID)
+			if err != nil {
+				t.Fatalf("GetMessage(resent): %v", err)
+			}
+			if resentMessage.Body != "durably reconstructed text" ||
+				resentMessage.ReplyToRemoteID == nil || *resentMessage.ReplyToRemoteID != replyRemoteID ||
+				resentMessage.RemoteMessageID != resentItem.TransportRequestID {
+				t.Fatalf("resent message = %+v", resentMessage)
+			}
+		})
+	}
+}
+
+func TestSendAgainMediaReusesDurableAttachmentWithoutBlobStore(t *testing.T) {
+	for _, state := range []OutboxState{OutboxUncertain, OutboxRejected} {
+		state := state
+		t.Run(string(state), func(t *testing.T) {
+			clock := newManualClock(messagingTestTime)
+			store := openMessagingTestStore(t, clock.Now())
+			replyMessageID := "message-send-again-media-reply-" + string(state)
+			replyRemoteID := "remote-send-again-media-reply-" + string(state)
+			seedMessagingMessage(t, store, clock, sqlite.Message{
+				MessageID:       replyMessageID,
+				ConversationID:  "conversation-1",
+				AccountID:       "account-1",
+				RemoteMessageID: replyRemoteID,
+				Direction:       sqlite.MessageDirectionIncoming,
+				Body:            "media reply target",
+				State:           sqlite.MessageStateActive,
+				OccurredAtMS:    clock.Now().UnixMilli(),
+			})
+			blobs, blobRoot := newMessagingTestBlobStore(t)
+			sender := &scriptedMediaSender{steps: []sendStep{sendAgainStepForState(state)}}
+			registry := newScriptedRegistry("send-again-media", nil)
+			registry.setMediaSender(sender)
+			registry.setAvailable(true)
+			service := newMessagingTestServiceWithBlobs(t, store, registry, blobs, clock)
+			content := []byte("send-again must reuse this content-addressed blob")
+			original := mustSendMedia(t, service, SendMediaCommand{
+				CommonCommand:    testCommonCommand("key-send-again-media-" + string(state)),
+				Content:          bytes.NewReader(content),
+				Filename:         "preserved.bin",
+				MIME:             "application/x-send-again",
+				Caption:          "durably reconstructed caption",
+				ReplyToMessageID: replyMessageID,
+			})
+			if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+				t.Fatalf("DispatchDue(%s) = %d, %v; want 1, nil", state, processed, err)
+			}
+			before := mustOutboxItem(t, service, original.OutboxID)
+			beforeAttachment, err := service.outbox.GetOutboxAttachment(context.Background(), original.OutboxID)
+			if err != nil {
+				t.Fatalf("GetOutboxAttachment(original): %v", err)
+			}
+			beforeFiles := messagingBlobFiles(t, blobRoot)
+			if len(beforeFiles) != 1 {
+				t.Fatalf("blob files before SendAgain = %v, want one", beforeFiles)
+			}
+			clock.Advance(time.Second)
+
+			// A nil blob store makes any Put, Open, or existence pre-check fail. The
+			// durable attachment carrier is sufficient for SendAgain.
+			service.blobs = nil
+			resent, err := service.SendAgain(
+				context.Background(),
+				original.OutboxID,
+				"key-send-again-media-new-"+string(state),
+			)
+			if err != nil {
+				t.Fatalf("SendAgain(%s): %v", state, err)
+			}
+			if resent.State != OutboxQueued || resent.OutboxID == original.OutboxID ||
+				resent.LocalMessageID == original.LocalMessageID || resent.LocalMessageID == "" {
+				t.Fatalf("resent submission = %+v, original = %+v", resent, original)
+			}
+			if after := mustOutboxItem(t, service, original.OutboxID); !reflect.DeepEqual(after, before) {
+				t.Fatalf("SendAgain mutated old media row:\n before=%+v\n  after=%+v", before, after)
+			}
+			resentItem := mustOutboxItem(t, service, resent.OutboxID)
+			if resentItem.SendAgainOfOutboxID == nil || *resentItem.SendAgainOfOutboxID != original.OutboxID ||
+				resentItem.TransportRequestID == before.TransportRequestID {
+				t.Fatalf("resent media outbox row = %+v", resentItem)
+			}
+			resentAttachment, err := service.outbox.GetOutboxAttachment(context.Background(), resent.OutboxID)
+			if err != nil {
+				t.Fatalf("GetOutboxAttachment(resent): %v", err)
+			}
+			if resentAttachment.BlobHash != beforeAttachment.BlobHash ||
+				resentAttachment.SizeBytes != beforeAttachment.SizeBytes ||
+				resentAttachment.MIME != beforeAttachment.MIME ||
+				resentAttachment.Filename != beforeAttachment.Filename {
+				t.Fatalf("resent attachment = %+v, want metadata from %+v", resentAttachment, beforeAttachment)
+			}
+			if afterFiles := messagingBlobFiles(t, blobRoot); !reflect.DeepEqual(afterFiles, beforeFiles) {
+				t.Fatalf("blob files after SendAgain = %v, want unchanged %v", afterFiles, beforeFiles)
+			}
+			resentMessage, err := service.messages.GetMessage(context.Background(), resent.LocalMessageID)
+			if err != nil {
+				t.Fatalf("GetMessage(resent media): %v", err)
+			}
+			if resentMessage.Body != "durably reconstructed caption" ||
+				resentMessage.ReplyToRemoteID == nil || *resentMessage.ReplyToRemoteID != replyRemoteID ||
+				resentMessage.RemoteMessageID != resentItem.TransportRequestID {
+				t.Fatalf("resent media message = %+v", resentMessage)
+			}
+		})
+	}
+}
+
+func TestSendAgainIdempotencyUsesNewKeyAndLinksEachDeliberateIntent(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{result: bridge.SendResult{}}}}
+	registry := newScriptedRegistry("send-again-idempotency", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	original := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-send-again-original"),
+		Body:          "repeat only when explicitly requested",
+	})
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+
+	first, err := service.SendAgain(context.Background(), original.OutboxID, "key-send-again-first")
+	if err != nil {
+		t.Fatalf("SendAgain(first): %v", err)
+	}
+	replay, err := service.SendAgain(context.Background(), original.OutboxID, "key-send-again-first")
+	if err != nil {
+		t.Fatalf("SendAgain(replay): %v", err)
+	}
+	if replay != first {
+		t.Fatalf("same-key replay = %+v, want %+v", replay, first)
+	}
+	second, err := service.SendAgain(context.Background(), original.OutboxID, "key-send-again-second")
+	if err != nil {
+		t.Fatalf("SendAgain(second key): %v", err)
+	}
+	if second.OutboxID == first.OutboxID || second.LocalMessageID == first.LocalMessageID {
+		t.Fatalf("different keys returned same identity: first=%+v second=%+v", first, second)
+	}
+	for _, submission := range []Submission{first, second} {
+		item := mustOutboxItem(t, service, submission.OutboxID)
+		if item.SendAgainOfOutboxID == nil || *item.SendAgainOfOutboxID != original.OutboxID {
+			t.Fatalf("linked row = %+v, want predecessor %q", item, original.OutboxID)
+		}
+	}
+	if got := mustOutboxItem(t, service, original.OutboxID).State; got != sqlite.OutboxUncertain {
+		t.Fatalf("original state = %q, want uncertain", got)
+	}
+}
+
+// The SendAgain link is part of an intent's identity: reusing one idempotency
+// key against two different predecessors whose payloads hash identically must
+// conflict loudly, never silently return the first successor.
+func TestSendAgainSameKeyAcrossDifferentPredecessorsConflicts(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{
+		{result: bridge.SendResult{}},
+		{result: bridge.SendResult{}},
+	}}
+	registry := newScriptedRegistry("send-again-cross-predecessor", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+
+	const identicalBody = "identical payload either way"
+	first := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-cross-predecessor-one"),
+		Body:          identicalBody,
+	})
+	second := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-cross-predecessor-two"),
+		Body:          identicalBody,
+	})
+	if processed, err := service.DispatchDue(context.Background(), 2); err != nil || processed != 2 {
+		t.Fatalf("DispatchDue() = %d, %v; want 2, nil", processed, err)
+	}
+
+	const sharedKey = "key-cross-predecessor-resend"
+	if _, err := service.SendAgain(context.Background(), first.OutboxID, sharedKey); err != nil {
+		t.Fatalf("SendAgain(first predecessor): %v", err)
+	}
+	if _, err := service.SendAgain(context.Background(), second.OutboxID, sharedKey); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("SendAgain(second predecessor, shared key) error = %v, want ErrIdempotencyConflict", err)
+	}
+}
+
+// A soft-deleted predecessor message must not be resent verbatim (mirrors
+// SendReaction's deleted-target refusal).
+func TestSendAgainRejectsDeletedPredecessorMessage(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store, raw := openReconcileTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{result: bridge.SendResult{}}}}
+	registry := newScriptedRegistry("send-again-deleted-predecessor", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	original := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-send-again-deleted"),
+		Body:          "soon to be deleted",
+	})
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+	mustReconcileExecOne(t, raw, `
+		UPDATE messages SET state = 'deleted' WHERE message_id = ?
+	`, original.LocalMessageID)
+
+	if _, err := service.SendAgain(context.Background(), original.OutboxID, "key-send-again-deleted-resend"); !errors.Is(err, ErrInvalidCommand) {
+		t.Fatalf("SendAgain(deleted predecessor) error = %v, want ErrInvalidCommand", err)
+	}
+}
+
+func TestSendAgainRejectsInvalidNewIdempotencyKeys(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{result: bridge.SendResult{}}}}
+	registry := newScriptedRegistry("send-again-key-guard", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	const originalKey = "key-send-again-key-guard"
+	original := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand(originalKey),
+		Body:          "guard the new key",
+	})
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+
+	for _, newKey := range []string{"", "   ", originalKey} {
+		if _, err := service.SendAgain(context.Background(), original.OutboxID, newKey); !errors.Is(err, ErrInvalidCommand) {
+			t.Errorf("SendAgain(new key %q) error = %v, want ErrInvalidCommand", newKey, err)
+		}
+	}
+}
+
+func TestSendAgainStrictStateGuard(t *testing.T) {
+	states := []OutboxState{
+		OutboxConfirmed,
+		OutboxQueued,
+		OutboxDispatching,
+		OutboxNotDispatched,
+		OutboxCanceled,
+		OutboxStoreFailed,
+	}
+	for _, state := range states {
+		state := state
+		t.Run(string(state), func(t *testing.T) {
+			service, submission := sendAgainTextFixtureInState(t, state)
+			if _, err := service.SendAgain(
+				context.Background(),
+				submission.OutboxID,
+				"key-send-again-invalid-state-"+string(state),
+			); !errors.Is(err, ErrInvalidState) {
+				t.Fatalf("SendAgain(%s) error = %v, want ErrInvalidState", state, err)
+			}
+		})
+	}
+}
+
+func TestSendAgainStrictKindGuard(t *testing.T) {
+	t.Run("reaction uncertain", func(t *testing.T) {
+		clock := newManualClock(messagingTestTime)
+		store := openMessagingTestStore(t, clock.Now())
+		target := seedSendAgainTarget(t, store, clock, "reaction")
+		sender := &scriptedReactionSender{steps: []sendStep{{err: sendAgainUncertainError("reaction")}}}
+		registry := newScriptedRegistry("send-again-reaction", nil)
+		registry.setReactionSender(sender)
+		registry.setAvailable(true)
+		service := newMessagingTestService(t, store, registry, clock)
+		submission := mustSendReaction(t, service, SendReactionCommand{
+			CommonCommand:   testCommonCommand("key-send-again-reaction"),
+			TargetMessageID: target,
+			Emoji:           "👍",
+		})
+		if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+			t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+		}
+		if got := mustOutboxItem(t, service, submission.OutboxID).State; got != sqlite.OutboxUncertain {
+			t.Fatalf("reaction state = %q, want uncertain", got)
+		}
+		if _, err := service.SendAgain(context.Background(), submission.OutboxID, "new-reaction-key"); !errors.Is(err, ErrInvalidState) {
+			t.Fatalf("SendAgain(reaction) error = %v, want ErrInvalidState", err)
+		}
+	})
+
+	t.Run("read rejected", func(t *testing.T) {
+		clock := newManualClock(messagingTestTime)
+		store := openMessagingTestStore(t, clock.Now())
+		target := seedSendAgainTarget(t, store, clock, "read")
+		seedMessagingDevice(t, store, "send-again-device", "account-1", clock.Now())
+		sender := &scriptedReadReceiptSender{steps: []readReceiptStep{{err: sendAgainRejectedError("read")}}}
+		registry := newScriptedRegistry("send-again-read", nil)
+		registry.setReadReceiptSender(sender)
+		registry.setAvailable(true)
+		service := newMessagingTestService(t, store, registry, clock)
+		submission := mustMarkRead(t, service, MarkReadCommand{
+			CommonCommand:     testCommonCommand("key-send-again-read"),
+			DeviceID:          "send-again-device",
+			LastReadMessageID: target,
+		})
+		if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+			t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+		}
+		if got := mustOutboxItem(t, service, submission.OutboxID).State; got != sqlite.OutboxRejected {
+			t.Fatalf("read state = %q, want rejected", got)
+		}
+		if _, err := service.SendAgain(context.Background(), submission.OutboxID, "new-read-key"); !errors.Is(err, ErrInvalidState) {
+			t.Fatalf("SendAgain(read) error = %v, want ErrInvalidState", err)
+		}
+	})
+}
+
+func sendAgainStepForState(state OutboxState) sendStep {
+	if state == OutboxRejected {
+		return sendStep{err: sendAgainRejectedError("message")}
+	}
+	return sendStep{result: bridge.SendResult{}}
+}
+
+func sendAgainRejectedError(operation string) error {
+	return bridge.OpError{
+		Class:     bridge.FailureUnsupported,
+		Operation: operation,
+		Dispatch:  bridge.DispatchNotCalled,
+		Cause:     errors.New("terminal send-again fixture failure"),
+	}
+}
+
+func sendAgainUncertainError(operation string) error {
+	return bridge.OpError{
+		Class:     bridge.FailureTransient,
+		Operation: operation,
+		Dispatch:  bridge.DispatchUncertain,
+		Cause:     context.DeadlineExceeded,
+	}
+}
+
+func sendAgainTextFixtureInState(t *testing.T, state OutboxState) (*MessageService, Submission) {
+	t.Helper()
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	var step sendStep
+	switch state {
+	case OutboxConfirmed:
+		step.result = bridge.SendResult{RemoteMessageID: "remote-send-again-confirmed"}
+	case OutboxNotDispatched:
+		step.err = bridge.OpError{
+			Class:     bridge.FailureTransient,
+			Operation: "send_text",
+			Dispatch:  bridge.DispatchNotCalled,
+			Cause:     errors.New("safe pre-call failure"),
+		}
+	}
+	sender := &scriptedTextSender{steps: []sendStep{step}}
+	registry := newScriptedRegistry("send-again-state-guard", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	command := SendTextCommand{
+		CommonCommand: testCommonCommand("key-send-again-state-" + string(state)),
+		Body:          "state guard",
+	}
+	if state == OutboxQueued || state == OutboxCanceled {
+		command.NotBefore = clock.Now().Add(time.Hour)
+	}
+	submission := mustSendText(t, service, command)
+
+	switch state {
+	case OutboxQueued:
+	case OutboxCanceled:
+		if _, err := service.Cancel(context.Background(), submission.OutboxID); err != nil {
+			t.Fatalf("Cancel(): %v", err)
+		}
+	case OutboxDispatching:
+		leases, err := service.outbox.LeaseDue(context.Background(), sqlite.LeaseRequest{
+			Owner:    "send-again-test",
+			Now:      clock.Now(),
+			Duration: time.Minute,
+			Limit:    1,
+		})
+		if err != nil || len(leases) != 1 {
+			t.Fatalf("LeaseDue() = %+v, %v; want one lease", leases, err)
+		}
+	case OutboxStoreFailed:
+		leases, err := service.outbox.LeaseDue(context.Background(), sqlite.LeaseRequest{
+			Owner:    "send-again-test",
+			Now:      clock.Now(),
+			Duration: time.Minute,
+			Limit:    1,
+		})
+		if err != nil || len(leases) != 1 || leases[0].LeaseToken == nil {
+			t.Fatalf("LeaseDue() = %+v, %v; want one tokened lease", leases, err)
+		}
+		lease := leases[0]
+		if err := service.outbox.MarkTransportCalled(context.Background(), sqlite.Attempt{
+			OutboxID:     submission.OutboxID,
+			LeaseToken:   *lease.LeaseToken,
+			AttemptToken: "send-again-store-failed-attempt",
+			StartedAt:    clock.Now(),
+		}); err != nil {
+			t.Fatalf("MarkTransportCalled(): %v", err)
+		}
+		if err := service.outbox.MarkStoreFailed(
+			context.Background(),
+			submission.OutboxID,
+			*lease.LeaseToken,
+			"remote-send-again-store-failed",
+			"local projection failed",
+		); err != nil {
+			t.Fatalf("MarkStoreFailed(): %v", err)
+		}
+	default:
+		if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+			t.Fatalf("DispatchDue(%s) = %d, %v; want 1, nil", state, processed, err)
+		}
+	}
+	if got := mustOutboxItem(t, service, submission.OutboxID).State; got != state {
+		t.Fatalf("fixture state = %q, want %q", got, state)
+	}
+	return service, submission
+}
+
+func seedSendAgainTarget(t *testing.T, store *sqlite.Store, clock Clock, suffix string) string {
+	t.Helper()
+	messageID := "message-send-again-target-" + suffix
+	return seedMessagingMessage(t, store, clock, sqlite.Message{
+		MessageID:       messageID,
+		ConversationID:  "conversation-1",
+		AccountID:       "account-1",
+		RemoteMessageID: "remote-send-again-target-" + suffix,
+		Direction:       sqlite.MessageDirectionIncoming,
+		Body:            "send-again target",
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    clock.Now().UnixMilli(),
+	})
+}
+
+func drainSendAgainWake(service *MessageService) {
+	select {
+	case <-service.wake:
+	default:
+	}
+}

--- a/internal/messaging/service.go
+++ b/internal/messaging/service.go
@@ -623,14 +623,143 @@ func (s *MessageService) RetryNotDispatched(
 	return s.Get(ctx, outboxID)
 }
 
-// SendAgain is reserved for M5, where the new intent can be durably linked to
-// the ambiguous or rejected prior intent.
+// SendAgain creates a new text or media intent from the durable payload of an
+// uncertain or rejected predecessor. The predecessor remains unchanged. A late
+// echo may confirm the predecessor between the state read and the enqueue;
+// that is the same accepted outcome as the echo arriving a moment after the
+// resend (both delivered) — the user explicitly chose to resend a
+// maybe-delivered message, and the two intents stay distinct rows.
 func (s *MessageService) SendAgain(
-	context.Context,
-	string,
-	string,
+	ctx context.Context,
+	outboxID string,
+	newIdempotencyKey string,
 ) (Submission, error) {
-	return Submission{}, fmt.Errorf("send again: %w", ErrNotImplemented)
+	if ctx == nil {
+		return Submission{}, fmt.Errorf("send again: context is nil")
+	}
+	item, err := s.outbox.FindByID(ctx, outboxID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("send again: read prior outbox item: %w", err)
+	}
+	if item.State != sqlite.OutboxUncertain && item.State != sqlite.OutboxRejected {
+		return Submission{}, fmt.Errorf(
+			"%w: cannot send again outbox item %q from %q",
+			ErrInvalidState,
+			outboxID,
+			item.State,
+		)
+	}
+	if item.Kind != sqlite.OutboxKindText && item.Kind != sqlite.OutboxKindMedia {
+		return Submission{}, fmt.Errorf(
+			"%w: cannot send again outbox item %q of kind %q",
+			ErrInvalidState,
+			outboxID,
+			item.Kind,
+		)
+	}
+	if strings.TrimSpace(newIdempotencyKey) == "" {
+		return Submission{}, fmt.Errorf("%w: new idempotency key is empty", ErrInvalidCommand)
+	}
+	if newIdempotencyKey == item.IdempotencyKey {
+		return Submission{}, fmt.Errorf(
+			"%w: new idempotency key must differ from the prior key",
+			ErrInvalidCommand,
+		)
+	}
+	if item.LocalMessageID == nil || strings.TrimSpace(*item.LocalMessageID) == "" {
+		return Submission{}, fmt.Errorf(
+			"send again: prior outbox item %q has no local message",
+			outboxID,
+		)
+	}
+	message, err := s.messages.GetMessage(ctx, *item.LocalMessageID)
+	if err != nil {
+		return Submission{}, fmt.Errorf("send again: read prior local message: %w", err)
+	}
+	if message.State == sqlite.MessageStateDeleted {
+		return Submission{}, fmt.Errorf(
+			"%w: prior message %q is deleted",
+			ErrInvalidCommand,
+			message.MessageID,
+		)
+	}
+
+	newOutboxID, newLocalMessageID, newRequestID, err := s.newSubmissionIDs()
+	if err != nil {
+		return Submission{}, err
+	}
+	now := s.clock.Now()
+	newItem := sqlite.NewOutboxItem{
+		OutboxID:            newOutboxID,
+		AccountID:           item.AccountID,
+		ConversationID:      item.ConversationID,
+		Kind:                item.Kind,
+		IdempotencyKey:      newIdempotencyKey,
+		LocalMessageID:      newLocalMessageID,
+		TransportRequestID:  newRequestID,
+		ScheduledFor:        now,
+		SendAgainOfOutboxID: item.OutboxID,
+	}
+	newMessage := sqlite.Message{
+		MessageID:       newLocalMessageID,
+		ConversationID:  item.ConversationID,
+		AccountID:       item.AccountID,
+		RemoteMessageID: newRequestID,
+		Direction:       sqlite.MessageDirectionOutgoing,
+		Body:            message.Body,
+		ReplyToRemoteID: message.ReplyToRemoteID,
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    now.UnixMilli(),
+	}
+	replyToRemoteID := stringValue(message.ReplyToRemoteID)
+
+	var resent sqlite.OutboxItem
+	var disposition sqlite.EnqueueDisposition
+	switch item.Kind {
+	case sqlite.OutboxKindText:
+		newItem.Operation = textOperation
+		newItem.PayloadHash, err = textPayloadHash(message.Body, replyToRemoteID)
+		if err != nil {
+			return Submission{}, fmt.Errorf("send again: hash text payload: %w", err)
+		}
+		resent, disposition, err = s.outbox.EnqueueOutgoingMessage(ctx, newItem, newMessage)
+	case sqlite.OutboxKindMedia:
+		attachment, attachmentErr := s.outbox.GetOutboxAttachment(ctx, item.OutboxID)
+		if attachmentErr != nil {
+			return Submission{}, fmt.Errorf("send again: read prior media attachment: %w", attachmentErr)
+		}
+		newItem.Operation = mediaOperation
+		newItem.PayloadHash, err = mediaPayloadHash(
+			attachment.BlobHash,
+			attachment.SizeBytes,
+			attachment.MIME,
+			attachment.Filename,
+			message.Body,
+			replyToRemoteID,
+		)
+		if err != nil {
+			return Submission{}, fmt.Errorf("send again: hash media payload: %w", err)
+		}
+		resent, disposition, err = s.outbox.EnqueueOutgoingMediaMessage(
+			ctx,
+			newItem,
+			newMessage,
+			sqlite.OutboxAttachment{
+				BlobHash:  attachment.BlobHash,
+				SizeBytes: attachment.SizeBytes,
+				MIME:      attachment.MIME,
+				Filename:  attachment.Filename,
+			},
+		)
+	}
+	if err != nil {
+		return Submission{}, fmt.Errorf("send again: enqueue reconstructed intent: %w", err)
+	}
+	if disposition == sqlite.EnqueueInserted {
+		s.signalChange()
+		s.signalWake()
+	}
+	return submissionFromItem(resent), nil
 }
 
 // ObserveTransportEcho correlates an accepted transport result to an existing

--- a/internal/messaging/service_test.go
+++ b/internal/messaging/service_test.go
@@ -1144,8 +1144,8 @@ func TestCancelAndDeferredAPIs(t *testing.T) {
 	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 0 {
 		t.Fatalf("DispatchDue(canceled) = %d, %v", processed, err)
 	}
-	if _, err := service.SendAgain(context.Background(), submission.OutboxID, "new-key"); !errors.Is(err, ErrNotImplemented) {
-		t.Fatalf("SendAgain() error = %v, want ErrNotImplemented", err)
+	if _, err := service.SendAgain(context.Background(), submission.OutboxID, "new-key"); !errors.Is(err, ErrInvalidState) {
+		t.Fatalf("SendAgain(canceled) error = %v, want ErrInvalidState", err)
 	}
 	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{}); !errors.Is(err, ErrInvalidCommand) {
 		t.Fatalf("ObserveTransportEcho() error = %v, want ErrInvalidCommand", err)

--- a/internal/storage/sqlite/attachments_test.go
+++ b/internal/storage/sqlite/attachments_test.go
@@ -322,8 +322,8 @@ func openAttachmentTestRepository(t *testing.T) (*Store, *AttachmentRepository) 
 		}
 	})
 
-	if len(embeddedMigrations) != 8 {
-		t.Fatalf("embedded migrations = %d, want 8", len(embeddedMigrations))
+	if len(embeddedMigrations) != 9 {
+		t.Fatalf("embedded migrations = %d, want 9", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 3)

--- a/internal/storage/sqlite/identity_graph_test.go
+++ b/internal/storage/sqlite/identity_graph_test.go
@@ -162,8 +162,8 @@ func openIdentityGraphTestStore(t *testing.T) *Store {
 		}
 	})
 
-	if len(embeddedMigrations) != 8 {
-		t.Fatalf("embedded migrations = %d, want 8", len(embeddedMigrations))
+	if len(embeddedMigrations) != 9 {
+		t.Fatalf("embedded migrations = %d, want 9", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 2)

--- a/internal/storage/sqlite/message_attachments_test.go
+++ b/internal/storage/sqlite/message_attachments_test.go
@@ -83,8 +83,8 @@ func TestMessageAttachmentsMigrationAppliesToBlankAndExistingV7AndReopens(t *tes
 			}
 		})
 		after := readLedgerRows(t, store.db)
-		if len(after) != 8 {
-			t.Fatalf("migrated ledger rows = %d, want 8", len(after))
+		if len(after) != 9 {
+			t.Fatalf("migrated ledger rows = %d, want 9", len(after))
 		}
 		if !slices.Equal(after[:7], before) {
 			t.Fatalf("migrations 0001-0007 changed:\nbefore: %+v\nafter:  %+v", before, after[:7])
@@ -252,10 +252,10 @@ func TestMessageAttachmentRowsCascadeWithMessageDeletion(t *testing.T) {
 
 func assertMessageAttachmentsMigration(t *testing.T, store *Store) {
 	t.Helper()
-	if len(embeddedMigrations) != 8 {
-		t.Fatalf("embedded migrations = %d, want 8", len(embeddedMigrations))
+	if len(embeddedMigrations) != 9 {
+		t.Fatalf("embedded migrations = %d, want 9", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 8)
+	assertPragmaInt(t, store.db, "user_version", 9)
 	ledger := readLedgerRow(t, store.db, 8)
 	if ledger.name != "message_attachments" {
 		t.Fatalf("migration 0008 name = %q, want message_attachments", ledger.name)

--- a/internal/storage/sqlite/messages_test.go
+++ b/internal/storage/sqlite/messages_test.go
@@ -733,8 +733,8 @@ func TestMessagesInboxMigrationIsChecksummedAndStrict(t *testing.T) {
 		t,
 		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
 	)
-	if len(embeddedMigrations) != 8 {
-		t.Fatalf("embedded migrations = %d, want 8", len(embeddedMigrations))
+	if len(embeddedMigrations) != 9 {
+		t.Fatalf("embedded migrations = %d, want 9", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 4)

--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -60,6 +60,9 @@ var migration0007SQL string
 //go:embed migrations/0008_message_attachments.sql
 var migration0008SQL string
 
+//go:embed migrations/0009_outbox_send_again.sql
+var migration0009SQL string
+
 var embeddedMigrations = []migration{
 	newMigration(1, "storage_shell", migration0001SQL, newStorageShellArguments),
 	newMigration(2, "identity_graph", migration0002SQL, nil),
@@ -69,6 +72,7 @@ var embeddedMigrations = []migration{
 	newMigration(6, "outbox_attachments", migration0006SQL, nil),
 	newMigration(7, "reactions_read", migration0007SQL, nil),
 	newMigration(8, "message_attachments", migration0008SQL, nil),
+	newMigration(9, "outbox_send_again", migration0009SQL, nil),
 }
 
 func newMigration(

--- a/internal/storage/sqlite/migrations/0009_outbox_send_again.sql
+++ b/internal/storage/sqlite/migrations/0009_outbox_send_again.sql
@@ -1,0 +1,14 @@
+-- M5 SendAgain linkage: a new outbound intent created by "Send Again" records
+-- the ambiguous/rejected prior intent it supersedes. outbox_id is globally
+-- unique (PRIMARY KEY, 0005), so a single-column self reference suffices;
+-- account scoping is enforced in the service. Nullable, no default: SQLite
+-- forbids ADD COLUMN of a REFERENCES column with a non-NULL default under
+-- enforced foreign keys, and PRAGMA foreign_key_check (run post-migration)
+-- passes trivially because every existing row gets NULL.
+ALTER TABLE outbox
+    ADD COLUMN send_again_of_outbox_id TEXT
+    REFERENCES outbox(outbox_id) ON DELETE SET NULL;
+
+CREATE INDEX outbox_send_again_of_idx
+    ON outbox(send_again_of_outbox_id)
+    WHERE send_again_of_outbox_id IS NOT NULL;

--- a/internal/storage/sqlite/outbox.go
+++ b/internal/storage/sqlite/outbox.go
@@ -52,17 +52,18 @@ const (
 // NewOutboxItem contains the caller-owned identity and intent fields for a new
 // durable outbound operation. A zero ScheduledFor means immediately eligible.
 type NewOutboxItem struct {
-	OutboxID           string
-	AccountID          string
-	ConversationID     string
-	Kind               OutboxKind
-	IdempotencyKey     string
-	PayloadHash        string
-	Operation          string
-	LocalMessageID     string
-	TransportRequestID string
-	ScheduledFor       time.Time
-	ScheduledForMS     int64
+	OutboxID            string
+	AccountID           string
+	ConversationID      string
+	Kind                OutboxKind
+	IdempotencyKey      string
+	PayloadHash         string
+	Operation           string
+	LocalMessageID      string
+	TransportRequestID  string
+	SendAgainOfOutboxID string
+	ScheduledFor        time.Time
+	ScheduledForMS      int64
 }
 
 // OutboxItem mirrors one row in outbox. Nullable database fields are pointers.
@@ -77,6 +78,7 @@ type OutboxItem struct {
 	State               OutboxState
 	LocalMessageID      *string
 	TransportRequestID  string
+	SendAgainOfOutboxID *string
 	ResultRemoteID      *string
 	ErrorClass          *string
 	ErrorCode           *string
@@ -404,11 +406,12 @@ func (r *OutboxRepository) enqueue(
 			state,
 			local_message_id,
 			transport_request_id,
+			send_again_of_outbox_id,
 			attempt_count,
 			scheduled_for_ms,
 			created_at_ms,
 			updated_at_ms
-		) VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, 0, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, 0, ?, ?, ?)
 		ON CONFLICT(account_id, idempotency_key) DO NOTHING
 	`,
 		item.OutboxID,
@@ -420,6 +423,7 @@ func (r *OutboxRepository) enqueue(
 		item.Operation,
 		nullableOutboxText(item.LocalMessageID),
 		item.TransportRequestID,
+		nullableOutboxText(item.SendAgainOfOutboxID),
 		scheduledForMS,
 		nowMS,
 		nowMS,
@@ -452,9 +456,14 @@ func (r *OutboxRepository) enqueue(
 			FROM outbox
 			WHERE account_id = ? AND idempotency_key = ?
 		`, item.AccountID, item.IdempotencyKey))
+		// The SendAgain link is part of an intent's identity: reusing one
+		// idempotency key against two different predecessors (whose payloads may
+		// hash identically) must conflict loudly, not silently return the first
+		// successor.
 		if err == nil && (row.Operation != item.Operation ||
 			row.ConversationID != item.ConversationID ||
-			row.PayloadHash != item.PayloadHash) {
+			row.PayloadHash != item.PayloadHash ||
+			!sameSendAgainLink(row.SendAgainOfOutboxID, item.SendAgainOfOutboxID)) {
 			return OutboxItem{}, "", fmt.Errorf(
 				"enqueue outbox item %q for account %q and idempotency key %q: %w",
 				item.OutboxID,
@@ -1815,6 +1824,7 @@ const outboxColumns = `
 	state,
 	local_message_id,
 	transport_request_id,
+	send_again_of_outbox_id,
 	result_remote_id,
 	error_class,
 	error_code,
@@ -1842,6 +1852,7 @@ func scanOutboxItem(row rowScanner) (OutboxItem, error) {
 		&item.State,
 		&item.LocalMessageID,
 		&item.TransportRequestID,
+		&item.SendAgainOfOutboxID,
 		&item.ResultRemoteID,
 		&item.ErrorClass,
 		&item.ErrorCode,
@@ -1877,6 +1888,9 @@ func validateNewOutboxItem(item NewOutboxItem) error {
 			return fmt.Errorf("%s is empty", check.name)
 		}
 	}
+	if item.SendAgainOfOutboxID != "" && strings.TrimSpace(item.SendAgainOfOutboxID) == "" {
+		return fmt.Errorf("send again predecessor outbox ID is empty")
+	}
 	switch item.Kind {
 	case OutboxKindText, OutboxKindMedia, OutboxKindReaction, OutboxKindRead:
 	default:
@@ -1910,6 +1924,15 @@ func nullableOutboxText(value string) any {
 		return nil
 	}
 	return value
+}
+
+// sameSendAgainLink compares a stored nullable link against an incoming
+// command's link, where the empty string means "no link" (stored as NULL).
+func sameSendAgainLink(stored *string, incoming string) bool {
+	if stored == nil {
+		return incoming == ""
+	}
+	return *stored == incoming
 }
 
 func newOutboxLeaseToken() (string, error) {

--- a/internal/storage/sqlite/outbox_test.go
+++ b/internal/storage/sqlite/outbox_test.go
@@ -85,6 +85,66 @@ func TestOutboxEnqueueIdempotencyAndConflict(t *testing.T) {
 	}
 }
 
+func TestOutboxSendAgainLinkRoundTripsAndClearsWhenPredecessorDeleted(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+
+	predecessor := outboxTestItem("send-again-predecessor")
+	mustEnqueueOutbox(t, repository, predecessor)
+
+	successor := outboxTestItem("send-again-successor")
+	successor.SendAgainOfOutboxID = predecessor.OutboxID
+	inserted, disposition, err := repository.Enqueue(ctx, successor)
+	if err != nil {
+		t.Fatalf("Enqueue(successor): %v", err)
+	}
+	if disposition != EnqueueInserted {
+		t.Fatalf("Enqueue(successor) disposition = %q, want %q", disposition, EnqueueInserted)
+	}
+	assertOutboxText(
+		t,
+		"inserted send_again_of_outbox_id",
+		inserted.SendAgainOfOutboxID,
+		predecessor.OutboxID,
+	)
+
+	found, err := repository.FindByID(ctx, successor.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(successor): %v", err)
+	}
+	assertOutboxText(
+		t,
+		"scanned send_again_of_outbox_id",
+		found.SendAgainOfOutboxID,
+		predecessor.OutboxID,
+	)
+
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM outbox WHERE outbox_id = ?`, predecessor.OutboxID); err != nil {
+		t.Fatalf("delete predecessor: %v", err)
+	}
+	found, err = repository.FindByID(ctx, successor.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(successor after predecessor delete): %v", err)
+	}
+	if found.SendAgainOfOutboxID != nil {
+		t.Fatalf("send_again_of_outbox_id after predecessor delete = %v, want nil", found.SendAgainOfOutboxID)
+	}
+}
+
+func TestOutboxEnqueueRejectsBlankSendAgainLink(t *testing.T) {
+	_, repository := openOutboxTestRepository(t, func() time.Time {
+		return time.UnixMilli(outboxTestTimeMS)
+	})
+	item := outboxTestItem("blank-send-again-link")
+	item.SendAgainOfOutboxID = " \t "
+
+	if _, _, err := repository.Enqueue(context.Background(), item); err == nil ||
+		!strings.Contains(err.Error(), "send again predecessor outbox ID is empty") {
+		t.Fatalf("Enqueue(blank send-again link) error = %v", err)
+	}
+}
+
 func TestOutboxEnqueueOutgoingMessageIsAtomicAndDeduplicated(t *testing.T) {
 	clock := newOutboxTestClock(outboxTestTimeMS)
 	store, repository := openOutboxTestRepository(t, clock.Now)
@@ -1880,10 +1940,10 @@ func TestOutboxMigrationIsChecksummedAndStrict(t *testing.T) {
 	store, _ := openOutboxTestRepository(t, func() time.Time {
 		return time.UnixMilli(outboxTestTimeMS)
 	})
-	if len(embeddedMigrations) != 8 {
-		t.Fatalf("embedded migrations = %d, want 8", len(embeddedMigrations))
+	if len(embeddedMigrations) != 9 {
+		t.Fatalf("embedded migrations = %d, want 9", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 8)
+	assertPragmaInt(t, store.db, "user_version", 9)
 	ledger := readLedgerRow(t, store.db, 5)
 	if ledger.name != "outbox" {
 		t.Fatalf("migration 0005 name = %q, want outbox", ledger.name)
@@ -1901,6 +1961,169 @@ func TestOutboxMigrationIsChecksummedAndStrict(t *testing.T) {
 	}
 	if strict != 1 {
 		t.Fatalf("outbox strict = %d, want 1", strict)
+	}
+}
+
+func TestOutboxSendAgainMigrationAppliesToBlankAndExistingV8DatabaseWithRows(t *testing.T) {
+	t.Run("blank", func(t *testing.T) {
+		store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+		if err != nil {
+			t.Fatalf("Open(): %v", err)
+		}
+		t.Cleanup(func() {
+			if err := store.Close(); err != nil {
+				t.Errorf("Close(): %v", err)
+			}
+		})
+		assertOutboxSendAgainMigration(t, store)
+	})
+
+	t.Run("existing v8 with rows", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "store.sqlite3")
+		db, err := sql.Open("sqlite", storeDSN(path))
+		if err != nil {
+			t.Fatalf("sql.Open(): %v", err)
+		}
+		if err := db.Ping(); err != nil {
+			_ = db.Close()
+			t.Fatalf("Ping(): %v", err)
+		}
+		if err := enableWAL(context.Background(), db); err != nil {
+			_ = db.Close()
+			t.Fatalf("enableWAL(): %v", err)
+		}
+		if err := verifyConnectionPragmas(context.Background(), db); err != nil {
+			_ = db.Close()
+			t.Fatalf("verifyConnectionPragmas(): %v", err)
+		}
+		if err := runMigrations(context.Background(), db, embeddedMigrations[:8]); err != nil {
+			_ = db.Close()
+			t.Fatalf("runMigrations(v8): %v", err)
+		}
+		mustExec(t, db, `
+			INSERT INTO accounts (account_id, bridge_key, created_at_ms, updated_at_ms)
+			VALUES ('account-existing-v8', 'test', ?, ?)
+		`, outboxTestTimeMS, outboxTestTimeMS)
+		mustExec(t, db, `
+			INSERT INTO outbox (
+				outbox_id,
+				account_id,
+				conversation_id,
+				kind,
+				idempotency_key,
+				payload_hash,
+				operation,
+				state,
+				transport_request_id,
+				attempt_count,
+				scheduled_for_ms,
+				created_at_ms,
+				updated_at_ms
+			) VALUES (?, ?, ?, 'text', ?, ?, 'send_text', 'uncertain', ?, 1, ?, ?, ?)
+		`,
+			"outbox-existing-v8",
+			"account-existing-v8",
+			"conversation-existing-v8",
+			"idempotency-existing-v8",
+			"payload-existing-v8",
+			"request-existing-v8",
+			outboxTestTimeMS,
+			outboxTestTimeMS,
+			outboxTestTimeMS,
+		)
+		before := readLedgerRows(t, db)
+		if len(before) != 8 {
+			_ = db.Close()
+			t.Fatalf("v8 ledger rows = %d, want 8", len(before))
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close v8 database: %v", err)
+		}
+
+		store, err := Open(path)
+		if err != nil {
+			t.Fatalf("Open(v8): %v", err)
+		}
+		t.Cleanup(func() {
+			if err := store.Close(); err != nil {
+				t.Errorf("Close(): %v", err)
+			}
+		})
+		after := readLedgerRows(t, store.db)
+		if len(after) != 9 {
+			t.Fatalf("migrated ledger rows = %d, want 9", len(after))
+		}
+		if !slices.Equal(after[:8], before) {
+			t.Fatalf("migrations 0001-0008 changed:\nbefore: %+v\nafter:  %+v", before, after[:8])
+		}
+		assertOutboxSendAgainMigration(t, store)
+		var sendAgainOf sql.NullString
+		if err := store.db.QueryRow(`
+			SELECT send_again_of_outbox_id
+			FROM outbox
+			WHERE outbox_id = 'outbox-existing-v8'
+		`).Scan(&sendAgainOf); err != nil {
+			t.Fatalf("read existing v8 outbox row: %v", err)
+		}
+		if sendAgainOf.Valid {
+			t.Fatalf("existing v8 send_again_of_outbox_id = %q, want NULL", sendAgainOf.String)
+		}
+		var foreignKeyViolations int
+		if err := store.db.QueryRow(`SELECT count(*) FROM pragma_foreign_key_check`).Scan(&foreignKeyViolations); err != nil {
+			t.Fatalf("PRAGMA foreign_key_check: %v", err)
+		}
+		if foreignKeyViolations != 0 {
+			t.Fatalf("PRAGMA foreign_key_check returned %d violations, want 0", foreignKeyViolations)
+		}
+	})
+}
+
+func assertOutboxSendAgainMigration(t *testing.T, store *Store) {
+	t.Helper()
+	assertPragmaInt(t, store.db, "user_version", 9)
+	ledger := readLedgerRow(t, store.db, 9)
+	if ledger.name != "outbox_send_again" {
+		t.Fatalf("migration 0009 name = %q, want outbox_send_again", ledger.name)
+	}
+	if ledger.checksum != embeddedMigrations[8].checksumSHA256 {
+		t.Fatalf(
+			"migration 0009 checksum = %q, want %q",
+			ledger.checksum,
+			embeddedMigrations[8].checksumSHA256,
+		)
+	}
+
+	var columnType string
+	var notNull int
+	var defaultValue sql.NullString
+	var primaryKey int
+	if err := store.db.QueryRow(`
+		SELECT type, "notnull", dflt_value, pk
+		FROM pragma_table_info('outbox')
+		WHERE name = 'send_again_of_outbox_id'
+	`).Scan(&columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+		t.Fatalf("inspect send_again_of_outbox_id: %v", err)
+	}
+	if columnType != "TEXT" || notNull != 0 || defaultValue.Valid || primaryKey != 0 {
+		t.Fatalf(
+			"send_again_of_outbox_id schema = type %q, notnull %d, default %v, pk %d",
+			columnType,
+			notNull,
+			defaultValue,
+			primaryKey,
+		)
+	}
+
+	var partial int
+	if err := store.db.QueryRow(`
+		SELECT partial
+		FROM pragma_index_list('outbox')
+		WHERE name = 'outbox_send_again_of_idx'
+	`).Scan(&partial); err != nil {
+		t.Fatalf("inspect outbox_send_again_of_idx: %v", err)
+	}
+	if partial != 1 {
+		t.Fatalf("outbox_send_again_of_idx partial = %d, want 1", partial)
 	}
 }
 
@@ -1959,8 +2182,8 @@ func TestOutboxAttachmentsMigrationAppliesToBlankAndExistingV5Database(t *testin
 			}
 		})
 		after := readLedgerRows(t, store.db)
-		if len(after) != 8 {
-			t.Fatalf("migrated ledger rows = %d, want 8", len(after))
+		if len(after) != 9 {
+			t.Fatalf("migrated ledger rows = %d, want 9", len(after))
 		}
 		if !slices.Equal(after[:5], before) {
 			t.Fatalf("migrations 0001-0005 changed:\nbefore: %+v\nafter:  %+v", before, after[:5])
@@ -1971,7 +2194,7 @@ func TestOutboxAttachmentsMigrationAppliesToBlankAndExistingV5Database(t *testin
 
 func assertOutboxAttachmentsMigration(t *testing.T, store *Store) {
 	t.Helper()
-	assertPragmaInt(t, store.db, "user_version", 8)
+	assertPragmaInt(t, store.db, "user_version", 9)
 	ledger := readLedgerRow(t, store.db, 6)
 	if ledger.name != "outbox_attachments" {
 		t.Fatalf("migration 0006 name = %q, want outbox_attachments", ledger.name)
@@ -2026,7 +2249,7 @@ func TestReactionsReadMigrationAppliesToBlankAndReopens(t *testing.T) {
 
 func assertReactionsReadMigration(t *testing.T, store *Store) {
 	t.Helper()
-	assertPragmaInt(t, store.db, "user_version", 8)
+	assertPragmaInt(t, store.db, "user_version", 9)
 	ledger := readLedgerRow(t, store.db, 7)
 	if ledger.name != "reactions_read" {
 		t.Fatalf("migration 0007 name = %q, want reactions_read", ledger.name)


### PR DESCRIPTION
## Rebuild Wave 2 / M5a-2 — explicit SendAgain with a durable predecessor link

**Completes milestone M5 — the fix for the legacy broken Retry.** Retry silently re-sent ambiguous messages from an ephemeral browser queue; `SendAgain` is an explicit user action that creates a **new, durably-linked intent**, reconstructed from durable state — never a mutation of the old row, never an implicit resend.

### What it does
- **Migration 0009** — additive `outbox.send_again_of_outbox_id` self-link (`ON DELETE SET NULL`) + partial index. `0001–0008` untouched.
- **`SendAgain(outboxID, newIdempotencyKey)`** — allowed only from `uncertain`/`rejected` (the strict-guard house idiom; `store_failed` means *delivered*, so its path is `RepairStoreFailed`, never a resend); text/media kinds only; reconstructs body/reply from the old message row and media from the old attachment row (**same `blob_hash` — zero blob-store interaction**); fresh outbox/message/transport-request ids; the old row is never mutated.
- **Idempotency** — same-key double-SendAgain returns the same linked row. Review hardenings folded in: the link is part of intent identity (reusing one key across two different predecessors with identical payloads conflicts loudly), and a soft-deleted predecessor is refused.

### Verification
- Adversarial review verdict **mergeable, zero required fixes** — including two dynamic proofs: same-key replay after the successor's own delivery+repoint (works via the confirmed-remote-id arm), and a late echo for the predecessor after SendAgain (old row confirms + repoints; successor untouched; "both delivered" is the accepted outcome of explicitly resending a maybe-delivered message).
- Migration 0009 exercised on **real scratch DBs** (blank + populated-v8 upgrade + `ON DELETE SET NULL` proof, STRICT enforcement live on the ALTER-added column).
- Full `go test -race ./...` green — 24 packages, two shuffle seeds.

With this, **M5's exit criteria are fully met**: `uncertain` cannot re-enter dispatch (structural, M5a-1); a matching echo confirms (M5a-1); Send Again creates a linked new intent (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
