### PR TITLE
Add pending-intent list queries and a sleep-until-due dispatch wake (rebuild Wave 2 / M6)

### DIFF
--- a/internal/messaging/dispatch.go
+++ b/internal/messaging/dispatch.go
@@ -38,7 +38,7 @@ func (s *MessageService) Run(ctx context.Context) error {
 			return fmt.Errorf("run message service: %w", err)
 		}
 
-		timer := s.clock.NewTimer(s.pollDelay)
+		timer := s.clock.NewTimer(s.nextPollDelay(ctx))
 		select {
 		case <-ctx.Done():
 			timer.Stop()

--- a/internal/messaging/service.go
+++ b/internal/messaging/service.go
@@ -28,9 +28,36 @@ const (
 	defaultFinalizeTime = 5 * time.Second
 	defaultRetryDelay   = 5 * time.Second
 	defaultPollDelay    = time.Second
+	defaultMaxPollDelay = 30 * time.Second
 	defaultBatchLimit   = 32
+	maxListPending      = 500
+	summaryMaxRunes     = 120
 	workerOwner         = "message-service"
 )
+
+// ListPendingQuery selects pending, cancelable deliveries in due order.
+type ListPendingQuery struct {
+	AccountID      string
+	ConversationID string
+	Limit          int
+}
+
+// PendingDelivery is the application-facing preview of one queued or
+// not-dispatched durable intent.
+type PendingDelivery struct {
+	OutboxID       string
+	AccountID      string
+	ConversationID string
+	Kind           sqlite.OutboxKind
+	State          OutboxState
+	ScheduledFor   time.Time
+	NextAttemptAt  time.Time
+	AttemptCount   int64
+	CreatedAt      time.Time
+	Summary        string
+	ErrorClass     string
+	ErrorCode      string
+}
 
 // MessageService owns message intent submission and durable dispatch. Concrete
 // platform selection remains behind bridge.Registry.
@@ -46,6 +73,7 @@ type MessageService struct {
 	leaseTime     time.Duration
 	retryDelay    time.Duration
 	pollDelay     time.Duration
+	maxPollDelay  time.Duration
 	maxMediaBytes int64
 	batchLimit    int
 
@@ -95,6 +123,7 @@ func NewMessageService(
 		leaseTime:     defaultLeaseTime,
 		retryDelay:    defaultRetryDelay,
 		pollDelay:     defaultPollDelay,
+		maxPollDelay:  defaultMaxPollDelay,
 		maxMediaBytes: DefaultMaxMediaBytes,
 		batchLimit:    defaultBatchLimit,
 		wake:          make(chan struct{}, 1),
@@ -544,6 +573,93 @@ func (s *MessageService) Get(ctx context.Context, outboxID string) (Delivery, er
 		return Delivery{}, fmt.Errorf("get delivery: %w", err)
 	}
 	return deliveryFromItem(item), nil
+}
+
+// ListPending returns queued and not-dispatched deliveries in storage due
+// order. The result is exactly the set that remains safe to cancel.
+func (s *MessageService) ListPending(
+	ctx context.Context,
+	q ListPendingQuery,
+) ([]PendingDelivery, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("list pending deliveries: context is nil")
+	}
+	if q.Limit <= 0 {
+		return nil, fmt.Errorf("list pending deliveries: limit must be positive")
+	}
+	if q.Limit > maxListPending {
+		q.Limit = maxListPending
+	}
+	rows, err := s.outbox.ListPending(ctx, sqlite.ListPendingParams{
+		AccountID:      q.AccountID,
+		ConversationID: q.ConversationID,
+		Limit:          q.Limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list pending deliveries: %w", err)
+	}
+
+	deliveries := make([]PendingDelivery, 0, len(rows))
+	for _, row := range rows {
+		delivery := PendingDelivery{
+			OutboxID:       row.OutboxID,
+			AccountID:      row.AccountID,
+			ConversationID: row.ConversationID,
+			Kind:           row.Kind,
+			State:          row.State,
+			ScheduledFor:   time.UnixMilli(row.ScheduledForMS),
+			AttemptCount:   row.AttemptCount,
+			CreatedAt:      time.UnixMilli(row.CreatedAtMS),
+			Summary:        pendingSummary(row),
+			ErrorClass:     stringValue(row.ErrorClass),
+			ErrorCode:      stringValue(row.ErrorCode),
+		}
+		if row.NextAttemptAtMS != nil {
+			delivery.NextAttemptAt = time.UnixMilli(*row.NextAttemptAtMS)
+		}
+		deliveries = append(deliveries, delivery)
+	}
+	return deliveries, nil
+}
+
+func pendingSummary(row sqlite.PendingRow) string {
+	var summary string
+	switch row.Kind {
+	case sqlite.OutboxKindText:
+		summary = stringValue(row.Body)
+	case sqlite.OutboxKindMedia:
+		summary = stringValue(row.MediaFile)
+		if summary == "" {
+			summary = "media"
+		}
+		if caption := stringValue(row.Body); caption != "" {
+			summary += ": " + caption
+		}
+	case sqlite.OutboxKindReaction:
+		summary = stringValue(row.Emoji)
+	case sqlite.OutboxKindRead:
+		return ""
+	}
+	runes := []rune(summary)
+	if len(runes) > summaryMaxRunes {
+		return string(runes[:summaryMaxRunes])
+	}
+	return summary
+}
+
+func (s *MessageService) nextPollDelay(ctx context.Context) time.Duration {
+	earliest, ok, err := s.outbox.EarliestDue(ctx)
+	if err != nil || !ok {
+		return s.maxPollDelay
+	}
+	delay := earliest.Sub(s.clock.Now())
+	if delay < s.pollDelay {
+		return s.pollDelay
+	}
+	if delay > s.maxPollDelay {
+		return s.maxPollDelay
+	}
+	return delay
 }
 
 // Wait blocks until the intent reaches a user-actionable or terminal state.

--- a/internal/messaging/service_test.go
+++ b/internal/messaging/service_test.go
@@ -20,6 +20,61 @@ import (
 
 var messagingTestTime = time.Date(2026, time.July, 12, 12, 0, 0, 0, time.UTC)
 
+func TestNextPollDelayClampsToDueWindow(t *testing.T) {
+	tests := []struct {
+		name            string
+		enqueue         bool
+		notBeforeOffset time.Duration
+		want            time.Duration
+	}{
+		{name: "far future", enqueue: true, notBeforeOffset: 6 * time.Hour, want: defaultMaxPollDelay},
+		{name: "near future", enqueue: true, notBeforeOffset: 2 * time.Second, want: 2 * time.Second},
+		{name: "overdue", enqueue: true, notBeforeOffset: -time.Second, want: defaultPollDelay},
+		{name: "empty", want: defaultMaxPollDelay},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := newManualClock(messagingTestTime)
+			store := openMessagingTestStore(t, clock.Now())
+			service := newMessagingTestService(
+				t,
+				store,
+				newScriptedRegistry("poll-delay", &scriptedTextSender{}),
+				clock,
+			)
+			if test.enqueue {
+				command := SendTextCommand{
+					CommonCommand: testCommonCommand("key-poll-delay"),
+					Body:          "wake at the right time",
+				}
+				command.NotBefore = clock.Now().Add(test.notBeforeOffset)
+				mustSendText(t, service, command)
+			}
+
+			if got := service.nextPollDelay(context.Background()); got != test.want {
+				t.Fatalf("nextPollDelay() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNextPollDelayUsesCeilingOnReadError(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	service := newMessagingTestService(
+		t,
+		store,
+		newScriptedRegistry("poll-read-error", &scriptedTextSender{}),
+		clock,
+	)
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+	if got := service.nextPollDelay(context.Background()); got != defaultMaxPollDelay {
+		t.Fatalf("nextPollDelay(read error) = %v, want %v", got, defaultMaxPollDelay)
+	}
+}
+
 func TestUnavailableTextReturnsToQueuedWithoutAttempt(t *testing.T) {
 	for _, platform := range []bridge.Platform{"scripted-alpha", "future-platform"} {
 		t.Run(string(platform), func(t *testing.T) {
@@ -57,6 +112,47 @@ func TestUnavailableTextReturnsToQueuedWithoutAttempt(t *testing.T) {
 				t.Fatalf("available delivery = %+v, want confirmed", got)
 			}
 		})
+	}
+}
+
+func TestOfflineConsumesZeroAttemptsAcrossCycles(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-after-offline-cycles"},
+	}}}
+	registry := newScriptedRegistry("offline-cycles", sender)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-offline-cycles"),
+		Body:          "wait without spending attempts",
+	})
+
+	for cycle := 1; cycle <= 5; cycle++ {
+		processed, err := service.DispatchDue(context.Background(), 8)
+		if err != nil || processed != 1 {
+			t.Fatalf("DispatchDue(offline cycle %d) = %d, %v; want 1, nil", cycle, processed, err)
+		}
+		row := mustOutboxItem(t, service, submission.OutboxID)
+		if row.State != sqlite.OutboxQueued || row.AttemptCount != 0 || row.NextAttemptAtMS != nil {
+			t.Fatalf("offline row after cycle %d = %+v, want queued/attempt=0/no next-attempt", cycle, row)
+		}
+		if got := sender.requestCount(); got != 0 {
+			t.Fatalf("offline send count after cycle %d = %d, want 0", cycle, got)
+		}
+		clock.Advance(time.Minute)
+	}
+
+	registry.setAvailable(true)
+	if processed, err := service.DispatchDue(context.Background(), 8); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(available) = %d, %v; want 1, nil", processed, err)
+	}
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	if row.State != sqlite.OutboxConfirmed || row.AttemptCount != 1 {
+		t.Fatalf("available row = %+v, want confirmed with one attempt", row)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("available send count = %d, want 1", got)
 	}
 }
 
@@ -155,6 +251,147 @@ func TestRetryableNotDispatchedReusesTransportRequestID(t *testing.T) {
 			if len(requests) != 2 || requests[0].RequestID == "" ||
 				requests[0].RequestID != requests[1].RequestID {
 				t.Fatalf("request IDs = %+v, want same stable ID", requests)
+			}
+		})
+	}
+}
+
+func TestListPendingSurfacesNotDispatchedErrorState(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{
+		err: bridge.OpError{
+			Class:     bridge.FailureTransient,
+			Operation: "prepare_pending",
+			Dispatch:  bridge.DispatchNotCalled,
+			Cause:     errors.New("failed before remote dispatch"),
+		},
+	}}}
+	registry := newScriptedRegistry("pending-error", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-list-pending-error"),
+		Body:          "retry this message later",
+	})
+
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+	pending, err := service.ListPending(context.Background(), ListPendingQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListPending(): %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("ListPending() returned %d rows, want 1: %+v", len(pending), pending)
+	}
+	got := pending[0]
+	if got.OutboxID != submission.OutboxID ||
+		got.AccountID != "account-1" ||
+		got.ConversationID != "conversation-1" ||
+		got.Kind != sqlite.OutboxKindText ||
+		got.State != OutboxNotDispatched ||
+		!got.ScheduledFor.Equal(clock.Now()) ||
+		!got.NextAttemptAt.Equal(clock.Now().Add(defaultRetryDelay)) ||
+		got.AttemptCount != 1 ||
+		!got.CreatedAt.Equal(clock.Now()) ||
+		got.Summary != "retry this message later" ||
+		got.ErrorClass != string(bridge.FailureTransient) ||
+		got.ErrorCode != "prepare_pending" {
+		t.Fatalf("ListPending() row = %+v, want populated not_dispatched error surface", got)
+	}
+}
+
+func TestListPendingValidatesQuery(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	service := newMessagingTestService(
+		t,
+		store,
+		newScriptedRegistry("list-validation", &scriptedTextSender{}),
+		clock,
+	)
+	if _, err := service.ListPending(nil, ListPendingQuery{Limit: 1}); err == nil {
+		t.Fatal("ListPending(nil context) succeeded, want error")
+	}
+	if _, err := service.ListPending(context.Background(), ListPendingQuery{}); err == nil {
+		t.Fatal("ListPending(zero limit) succeeded, want error")
+	}
+	if got, err := service.ListPending(
+		context.Background(),
+		ListPendingQuery{Limit: maxListPending + 1},
+	); err != nil || len(got) != 0 {
+		t.Fatalf("ListPending(clamped empty query) = %+v, %v; want empty, nil", got, err)
+	}
+}
+
+func TestPendingSummaryKindsAndRuneSafeTruncation(t *testing.T) {
+	stringPointer := func(value string) *string { return &value }
+	tests := []struct {
+		name string
+		row  sqlite.PendingRow
+		want string
+	}{
+		{
+			name: "text",
+			row: sqlite.PendingRow{
+				OutboxItem: sqlite.OutboxItem{Kind: sqlite.OutboxKindText},
+				Body:       stringPointer("message preview"),
+			},
+			want: "message preview",
+		},
+		{
+			name: "media filename and caption",
+			row: sqlite.PendingRow{
+				OutboxItem: sqlite.OutboxItem{Kind: sqlite.OutboxKindMedia},
+				Body:       stringPointer("caption preview"),
+				MediaFile:  stringPointer("photo.jpg"),
+			},
+			want: "photo.jpg: caption preview",
+		},
+		{
+			name: "media fallback",
+			row: sqlite.PendingRow{
+				OutboxItem: sqlite.OutboxItem{Kind: sqlite.OutboxKindMedia},
+			},
+			want: "media",
+		},
+		{
+			name: "media fallback and caption",
+			row: sqlite.PendingRow{
+				OutboxItem: sqlite.OutboxItem{Kind: sqlite.OutboxKindMedia},
+				Body:       stringPointer("caption preview"),
+			},
+			want: "media: caption preview",
+		},
+		{
+			name: "reaction",
+			row: sqlite.PendingRow{
+				OutboxItem: sqlite.OutboxItem{Kind: sqlite.OutboxKindReaction},
+				Emoji:      stringPointer("👍"),
+			},
+			want: "👍",
+		},
+		{
+			name: "read",
+			row: sqlite.PendingRow{
+				OutboxItem: sqlite.OutboxItem{Kind: sqlite.OutboxKindRead},
+			},
+			want: "",
+		},
+		{
+			name: "rune safe truncation",
+			row: sqlite.PendingRow{
+				OutboxItem: sqlite.OutboxItem{Kind: sqlite.OutboxKindText},
+				Body:       stringPointer(strings.Repeat("世", summaryMaxRunes+1)),
+			},
+			want: strings.Repeat("世", summaryMaxRunes),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := pendingSummary(test.row); got != test.want {
+				t.Fatalf("pendingSummary() = %q, want %q", got, test.want)
 			}
 		})
 	}
@@ -331,6 +568,55 @@ func TestNewServiceOverSameStoreDispatchesQueuedText(t *testing.T) {
 	requests := sender.snapshotRequests()
 	if len(requests) != 1 || requests[0].Body != "survive service restart" {
 		t.Fatalf("request after restart = %+v", requests)
+	}
+}
+
+func TestNewServiceOverSameStoreRecoversFarFutureText(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	first := newMessagingTestService(
+		t,
+		store,
+		newScriptedRegistry("future-before-restart", &scriptedTextSender{}),
+		clock,
+	)
+	command := SendTextCommand{
+		CommonCommand: testCommonCommand("key-future-restart"),
+		Body:          "survive until the future",
+	}
+	command.NotBefore = clock.Now().Add(6 * time.Hour)
+	submission := mustSendText(t, first, command)
+
+	sender := &scriptedTextSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-future-restart"},
+	}}}
+	available := newScriptedRegistry("future-after-restart", sender)
+	available.setAvailable(true)
+	restarted := newMessagingTestService(t, store, available, clock)
+
+	before := mustOutboxItem(t, restarted, submission.OutboxID)
+	if before.State != sqlite.OutboxQueued ||
+		before.ScheduledForMS != command.NotBefore.UnixMilli() ||
+		before.AttemptCount != 0 {
+		t.Fatalf("future row after restart = %+v, want queued with preserved schedule and zero attempts", before)
+	}
+	if processed, err := restarted.DispatchDue(context.Background(), 4); err != nil || processed != 0 {
+		t.Fatalf("DispatchDue(before due) = %d, %v; want 0, nil", processed, err)
+	}
+	if got := sender.requestCount(); got != 0 {
+		t.Fatalf("send count before due = %d, want 0", got)
+	}
+
+	clock.Advance(6*time.Hour + time.Millisecond)
+	if processed, err := restarted.DispatchDue(context.Background(), 4); err != nil || processed != 1 {
+		t.Fatalf("DispatchDue(after due) = %d, %v; want 1, nil", processed, err)
+	}
+	after := mustOutboxItem(t, restarted, submission.OutboxID)
+	if after.State != sqlite.OutboxConfirmed || after.AttemptCount != 1 {
+		t.Fatalf("future row after dispatch = %+v, want confirmed with one attempt", after)
+	}
+	if got := sender.requestCount(); got != 1 {
+		t.Fatalf("send count after due = %d, want 1", got)
 	}
 }
 
@@ -1149,6 +1435,109 @@ func TestCancelAndDeferredAPIs(t *testing.T) {
 	}
 	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{}); !errors.Is(err, ErrInvalidCommand) {
 		t.Fatalf("ObserveTransportEcho() error = %v, want ErrInvalidCommand", err)
+	}
+}
+
+func TestCancelFarFutureRowPreventsDispatchAfterDue(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-canceled-future"},
+	}}}
+	registry := newScriptedRegistry("cancel-future", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	command := SendTextCommand{
+		CommonCommand: testCommonCommand("key-cancel-future"),
+		Body:          "cancel before the future",
+	}
+	command.NotBefore = clock.Now().Add(6 * time.Hour)
+	submission := mustSendText(t, service, command)
+	if row := mustOutboxItem(t, service, submission.OutboxID); row.State != sqlite.OutboxQueued {
+		t.Fatalf("future row before cancel = %+v, want queued", row)
+	}
+
+	canceled, err := service.Cancel(context.Background(), submission.OutboxID)
+	if err != nil || canceled.State != OutboxCanceled {
+		t.Fatalf("Cancel(future) = %+v, %v; want canceled, nil", canceled, err)
+	}
+	clock.Advance(6*time.Hour + time.Millisecond)
+	if processed, err := service.DispatchDue(context.Background(), 1); err != nil || processed != 0 {
+		t.Fatalf("DispatchDue(canceled after due) = %d, %v; want 0, nil", processed, err)
+	}
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	if row.State != sqlite.OutboxCanceled || row.AttemptCount != 0 {
+		t.Fatalf("canceled row after due = %+v, want canceled with zero attempts", row)
+	}
+	if got := sender.requestCount(); got != 0 {
+		t.Fatalf("canceled send count = %d, want 0", got)
+	}
+}
+
+func TestCancelRaceWithDispatchSettlesExactlyOnce(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	sender := &scriptedTextSender{steps: []sendStep{{
+		result: bridge.SendResult{RemoteMessageID: "remote-cancel-race"},
+	}}}
+	registry := newScriptedRegistry("cancel-race", sender)
+	registry.setAvailable(true)
+	service := newMessagingTestService(t, store, registry, clock)
+	submission := mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("key-cancel-race"),
+		Body:          "cancel or dispatch once",
+	})
+
+	start := make(chan struct{})
+	var wait sync.WaitGroup
+	var canceled Delivery
+	var cancelErr error
+	var processed int
+	var dispatchErr error
+	wait.Add(2)
+	go func() {
+		defer wait.Done()
+		<-start
+		canceled, cancelErr = service.Cancel(context.Background(), submission.OutboxID)
+	}()
+	go func() {
+		defer wait.Done()
+		<-start
+		processed, dispatchErr = service.DispatchDue(context.Background(), 1)
+	}()
+	close(start)
+	wait.Wait()
+
+	if dispatchErr != nil {
+		t.Fatalf("DispatchDue(racing cancel) error = %v", dispatchErr)
+	}
+	row := mustOutboxItem(t, service, submission.OutboxID)
+	switch row.State {
+	case sqlite.OutboxCanceled:
+		if cancelErr != nil || canceled.State != OutboxCanceled || processed != 0 ||
+			row.AttemptCount != 0 || sender.requestCount() != 0 {
+			t.Fatalf(
+				"cancel-won outcome = delivery %+v, cancel err %v, processed %d, row %+v, sends %d",
+				canceled,
+				cancelErr,
+				processed,
+				row,
+				sender.requestCount(),
+			)
+		}
+	case sqlite.OutboxConfirmed:
+		if !errors.Is(cancelErr, ErrInvalidState) || processed != 1 ||
+			row.AttemptCount != 1 || sender.requestCount() != 1 {
+			t.Fatalf(
+				"dispatch-won outcome = cancel err %v, processed %d, row %+v, sends %d",
+				cancelErr,
+				processed,
+				row,
+				sender.requestCount(),
+			)
+		}
+	default:
+		t.Fatalf("racing cancel left outbox row in %q: %+v", row.State, row)
 	}
 }
 

--- a/internal/storage/sqlite/outbox.go
+++ b/internal/storage/sqlite/outbox.go
@@ -94,6 +94,24 @@ type OutboxItem struct {
 	UpdatedAtMS         int64
 }
 
+// ListPendingParams scopes a deterministic pending-outbox read. Empty account
+// and conversation IDs leave their respective dimensions unfiltered.
+type ListPendingParams struct {
+	AccountID      string
+	ConversationID string
+	Limit          int
+}
+
+// PendingRow embeds the durable outbox row and carries nullable sources used
+// by the messaging layer to build kind-specific summaries.
+type PendingRow struct {
+	OutboxItem
+	Body      *string
+	MediaFile *string
+	MediaMIME *string
+	Emoji     *string
+}
+
 // OutboxAttachment is the persisted blob metadata for one media outbox intent.
 // M2 stores exactly one attachment at ordinal zero. Enqueue stamps OutboxID,
 // Ordinal, and CreatedAtMS; GetOutboxAttachment populates every field.
@@ -903,6 +921,69 @@ func isRequestBoundOrConfirmedRemoteID(remoteMessageID string, item OutboxItem) 
 		return true
 	}
 	return item.ResultRemoteID != nil && remoteMessageID == *item.ResultRemoteID
+}
+
+// EarliestDue returns the wall-clock time at which the earliest queued or
+// not-dispatched row becomes leaseable, or ok=false when none exist.
+func (r *OutboxRepository) EarliestDue(ctx context.Context) (time.Time, bool, error) {
+	var earliestMS sql.NullInt64
+	if err := r.store.db.QueryRowContext(ctx, `
+		SELECT MIN(COALESCE(next_attempt_at_ms, scheduled_for_ms))
+		FROM outbox
+		WHERE state IN ('queued','not_dispatched')
+	`).Scan(&earliestMS); err != nil {
+		return time.Time{}, false, fmt.Errorf("find earliest due outbox item: %w", err)
+	}
+	if !earliestMS.Valid {
+		return time.Time{}, false, nil
+	}
+	return time.UnixMilli(earliestMS.Int64), true, nil
+}
+
+// ListPending returns exactly the cancelable outbox set, ordered by the same
+// due key used by LeaseDue and enriched with nullable per-kind summary data.
+func (r *OutboxRepository) ListPending(
+	ctx context.Context,
+	p ListPendingParams,
+) ([]PendingRow, error) {
+	if p.Limit <= 0 {
+		return nil, fmt.Errorf("list pending outbox items: limit must be positive")
+	}
+
+	query := `
+		SELECT ` + prefixedOutboxColumns("o") + `,
+			m.body,
+			oa.filename,
+			oa.mime,
+			orx.emoji
+		FROM outbox o
+		LEFT JOIN messages m ON m.message_id = o.local_message_id
+		LEFT JOIN outbox_attachments oa ON oa.outbox_id = o.outbox_id AND oa.ordinal = 0
+		LEFT JOIN outbox_reactions orx ON orx.outbox_id = o.outbox_id
+		WHERE o.state IN ('queued','not_dispatched')`
+	args := make([]any, 0, 3)
+	if p.AccountID != "" {
+		query += ` AND o.account_id = ?`
+		args = append(args, p.AccountID)
+	}
+	if p.ConversationID != "" {
+		query += ` AND o.conversation_id = ?`
+		args = append(args, p.ConversationID)
+	}
+	query += `
+		ORDER BY COALESCE(o.next_attempt_at_ms, o.scheduled_for_ms), o.created_at_ms, o.outbox_id
+		LIMIT ?`
+	args = append(args, p.Limit)
+
+	rows, err := r.store.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list pending outbox items: query: %w", err)
+	}
+	items, err := collectRows(rows, scanPendingRow)
+	if err != nil {
+		return nil, fmt.Errorf("list pending outbox items: scan: %w", err)
+	}
+	return items, nil
 }
 
 // LeaseDue atomically claims due queued and retryable rows. An uncertain row is
@@ -1838,6 +1919,46 @@ const outboxColumns = `
 	next_attempt_at_ms,
 	created_at_ms,
 	updated_at_ms`
+
+func prefixedOutboxColumns(alias string) string {
+	columns := strings.TrimSpace(outboxColumns)
+	return alias + "." + strings.ReplaceAll(columns, "\n\t", "\n\t"+alias+".")
+}
+
+func scanPendingRow(row rowScanner) (PendingRow, error) {
+	var pending PendingRow
+	err := row.Scan(
+		&pending.OutboxID,
+		&pending.AccountID,
+		&pending.ConversationID,
+		&pending.Kind,
+		&pending.IdempotencyKey,
+		&pending.PayloadHash,
+		&pending.Operation,
+		&pending.State,
+		&pending.LocalMessageID,
+		&pending.TransportRequestID,
+		&pending.SendAgainOfOutboxID,
+		&pending.ResultRemoteID,
+		&pending.ErrorClass,
+		&pending.ErrorCode,
+		&pending.ErrorDetail,
+		&pending.AttemptCount,
+		&pending.LeaseOwner,
+		&pending.LeaseToken,
+		&pending.LeaseExpiresAtMS,
+		&pending.TransportCalledAtMS,
+		&pending.ScheduledForMS,
+		&pending.NextAttemptAtMS,
+		&pending.CreatedAtMS,
+		&pending.UpdatedAtMS,
+		&pending.Body,
+		&pending.MediaFile,
+		&pending.MediaMIME,
+		&pending.Emoji,
+	)
+	return pending, err
+}
 
 func scanOutboxItem(row rowScanner) (OutboxItem, error) {
 	var item OutboxItem

--- a/internal/storage/sqlite/outbox_test.go
+++ b/internal/storage/sqlite/outbox_test.go
@@ -1489,6 +1489,280 @@ func TestOutboxLeaseDueRespectsScheduleRetryAndLiveLease(t *testing.T) {
 	}
 }
 
+func TestOutboxEarliestDueReturnsMinimumLeaseOrderingKey(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	_, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	now := clock.Now()
+
+	earliest, ok, err := repository.EarliestDue(ctx)
+	if err != nil {
+		t.Fatalf("EarliestDue(empty): %v", err)
+	}
+	if ok || !earliest.IsZero() {
+		t.Fatalf("EarliestDue(empty) = (%v, %t), want (zero, false)", earliest, ok)
+	}
+
+	futureAt := now.Add(10 * time.Second)
+	future := outboxTestItem("earliest-future")
+	future.ScheduledFor = futureAt
+	mustEnqueueOutbox(t, repository, future)
+	earliest, ok, err = repository.EarliestDue(ctx)
+	if err != nil {
+		t.Fatalf("EarliestDue(only future): %v", err)
+	}
+	if !ok || !earliest.Equal(futureAt) {
+		t.Fatalf("EarliestDue(only future) = (%v, %t), want (%v, true)", earliest, ok, futureAt)
+	}
+
+	retry := outboxTestItem("earliest-retry")
+	mustEnqueueOutbox(t, repository, retry)
+	retryLease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker-retry", Now: now, Duration: time.Minute, Limit: 1,
+	})
+	retryAt := now.Add(5 * time.Second)
+	if err := repository.MarkNotDispatched(
+		ctx,
+		retry.OutboxID,
+		mustLeaseToken(t, retryLease),
+		"transient",
+		"offline",
+		"retry later",
+		retryAt,
+	); err != nil {
+		t.Fatalf("MarkNotDispatched(): %v", err)
+	}
+	earliest, ok, err = repository.EarliestDue(ctx)
+	if err != nil {
+		t.Fatalf("EarliestDue(retry and future): %v", err)
+	}
+	if !ok || !earliest.Equal(retryAt) {
+		t.Fatalf("EarliestDue(retry and future) = (%v, %t), want (%v, true)", earliest, ok, retryAt)
+	}
+
+	dueAt := now.Add(-time.Second)
+	due := outboxTestItem("earliest-due")
+	due.ScheduledFor = dueAt
+	mustEnqueueOutbox(t, repository, due)
+	earliest, ok, err = repository.EarliestDue(ctx)
+	if err != nil {
+		t.Fatalf("EarliestDue(due, retry, and future): %v", err)
+	}
+	if !ok || !earliest.Equal(dueAt) {
+		t.Fatalf("EarliestDue(due, retry, and future) = (%v, %t), want (%v, true)", earliest, ok, dueAt)
+	}
+}
+
+func TestOutboxListPendingReturnsCancelableRowsDueOrderedWithSummarySources(t *testing.T) {
+	clock := newOutboxTestClock(outboxTestTimeMS)
+	store, repository := openOutboxTestRepository(t, clock.Now)
+	ctx := context.Background()
+	now := clock.Now()
+
+	seedMessageIdentity(t, store, "identity-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	seedMessageConversation(t, store, "conversation-b", "account-a")
+	seedMessageAccount(t, store, "account-b", "test-b")
+	seedMessageConversation(t, store, "conversation-c", "account-b")
+	seedOutboxTestMessage(t, store, "target-reaction", "account-b", "conversation-c")
+	seedOutboxTestDevice(t, store, "device-a", "account-a")
+	seedOutboxTestMessage(t, store, "target-read", "account-a", "conversation-a")
+
+	confirmed := outboxTestItem("list-confirmed")
+	mustEnqueueOutbox(t, repository, confirmed)
+	confirmedLease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker-confirmed", Now: now, Duration: time.Minute, Limit: 1,
+	})
+	confirmedToken := mustLeaseToken(t, confirmedLease)
+	if err := repository.MarkTransportCalled(ctx, Attempt{
+		OutboxID: confirmed.OutboxID, LeaseToken: confirmedToken,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(confirmed): %v", err)
+	}
+	if err := repository.ConfirmWithoutResult(ctx, confirmed.OutboxID, confirmedToken); err != nil {
+		t.Fatalf("ConfirmWithoutResult(): %v", err)
+	}
+
+	canceled := outboxTestItem("list-canceled")
+	mustEnqueueOutbox(t, repository, canceled)
+	if err := repository.Cancel(ctx, canceled.OutboxID); err != nil {
+		t.Fatalf("Cancel(): %v", err)
+	}
+
+	reaction := outboxTestReactionItem("list-reaction")
+	reaction.AccountID = "account-b"
+	reaction.ConversationID = "conversation-c"
+	reaction.ScheduledFor = now.Add(-2 * time.Minute)
+	if _, disposition, err := repository.EnqueueReaction(ctx, reaction, OutboxReaction{
+		TargetMessageID: "target-reaction",
+		Emoji:           "👍",
+		Action:          "add",
+	}); err != nil {
+		t.Fatalf("EnqueueReaction(): %v", err)
+	} else if disposition != EnqueueInserted {
+		t.Fatalf("EnqueueReaction() disposition = %q, want %q", disposition, EnqueueInserted)
+	}
+	reactionLease := mustLeaseOne(t, repository, LeaseRequest{
+		Owner: "worker-reaction", Now: now, Duration: time.Minute, Limit: 1,
+	})
+	retryAt := now.Add(5 * time.Minute)
+	if err := repository.MarkNotDispatched(
+		ctx,
+		reaction.OutboxID,
+		mustLeaseToken(t, reactionLease),
+		"transient",
+		"offline",
+		"bridge unavailable",
+		retryAt,
+	); err != nil {
+		t.Fatalf("MarkNotDispatched(reaction): %v", err)
+	}
+
+	dueText := outboxTestItem("list-due-text")
+	dueText.ScheduledFor = now.Add(-time.Minute)
+	mustEnqueueOutgoingOutbox(t, repository, dueText, "due text body")
+
+	media := outboxTestMediaItem("list-media")
+	media.ConversationID = "conversation-b"
+	media.ScheduledFor = now.Add(10 * time.Minute)
+	attachment := outboxTestAttachment()
+	if _, disposition, err := repository.EnqueueOutgoingMediaMessage(
+		ctx,
+		media,
+		outboxTestOutgoingMessage(media, "media caption"),
+		attachment,
+	); err != nil {
+		t.Fatalf("EnqueueOutgoingMediaMessage(): %v", err)
+	} else if disposition != EnqueueInserted {
+		t.Fatalf("EnqueueOutgoingMediaMessage() disposition = %q, want %q", disposition, EnqueueInserted)
+	}
+
+	read := outboxTestReadItem("list-read")
+	read.ScheduledFor = now.Add(20 * time.Minute)
+	targetID := "target-read"
+	if _, disposition, err := repository.EnqueueReadReceipt(
+		ctx,
+		read,
+		OutboxReadReceipt{
+			DeviceID:          "device-a",
+			LastReadMessageID: targetID,
+			ReadAtMS:          now.Add(-time.Second).UnixMilli(),
+		},
+		ReadCursor{
+			AccountID:         "account-a",
+			DeviceID:          "device-a",
+			ConversationID:    "conversation-a",
+			LastReadMessageID: &targetID,
+			LastReadAtMS:      now.Add(-time.Second).UnixMilli(),
+			UpdatedAtMS:       now.UnixMilli(),
+		},
+	); err != nil {
+		t.Fatalf("EnqueueReadReceipt(): %v", err)
+	} else if disposition != EnqueueInserted {
+		t.Fatalf("EnqueueReadReceipt() disposition = %q, want %q", disposition, EnqueueInserted)
+	}
+
+	futureText := outboxTestItem("list-future-text")
+	futureText.ScheduledFor = now.Add(30 * time.Minute)
+	mustEnqueueOutgoingOutbox(t, repository, futureText, "future text body")
+
+	rows, err := repository.ListPending(ctx, ListPendingParams{Limit: 20})
+	if err != nil {
+		t.Fatalf("ListPending(): %v", err)
+	}
+	wantIDs := []string{
+		dueText.OutboxID,
+		reaction.OutboxID,
+		media.OutboxID,
+		read.OutboxID,
+		futureText.OutboxID,
+	}
+	gotIDs := make([]string, len(rows))
+	for i, row := range rows {
+		gotIDs[i] = row.OutboxID
+	}
+	if !slices.Equal(gotIDs, wantIDs) {
+		t.Fatalf("ListPending() IDs = %v, want %v", gotIDs, wantIDs)
+	}
+	for _, row := range rows {
+		if row.State != OutboxQueued && row.State != OutboxNotDispatched {
+			t.Fatalf("ListPending() returned non-cancelable row = %+v", row)
+		}
+		if row.ScheduledForMS <= 0 || row.CreatedAtMS != now.UnixMilli() {
+			t.Fatalf("ListPending() timing fields = %+v", row)
+		}
+	}
+
+	if rows[0].Body == nil || *rows[0].Body != "due text body" ||
+		rows[0].MediaFile != nil || rows[0].MediaMIME != nil || rows[0].Emoji != nil {
+		t.Fatalf("text summary sources = %+v", rows[0])
+	}
+	if rows[1].State != OutboxNotDispatched || rows[1].NextAttemptAtMS == nil ||
+		*rows[1].NextAttemptAtMS != retryAt.UnixMilli() || rows[1].AttemptCount != 0 ||
+		rows[1].ErrorClass == nil || *rows[1].ErrorClass != "transient" ||
+		rows[1].ErrorCode == nil || *rows[1].ErrorCode != "offline" ||
+		rows[1].Emoji == nil || *rows[1].Emoji != "👍" || rows[1].Body != nil {
+		t.Fatalf("not-dispatched reaction row = %+v", rows[1])
+	}
+	if rows[2].Body == nil || *rows[2].Body != "media caption" ||
+		rows[2].MediaFile == nil || *rows[2].MediaFile != attachment.Filename ||
+		rows[2].MediaMIME == nil || *rows[2].MediaMIME != attachment.MIME || rows[2].Emoji != nil {
+		t.Fatalf("media summary sources = %+v", rows[2])
+	}
+	if rows[3].Kind != OutboxKindRead || rows[3].Body != nil || rows[3].MediaFile != nil ||
+		rows[3].MediaMIME != nil || rows[3].Emoji != nil {
+		t.Fatalf("read summary sources = %+v", rows[3])
+	}
+	if rows[4].Body == nil || *rows[4].Body != "future text body" {
+		t.Fatalf("future text summary sources = %+v", rows[4])
+	}
+
+	accountRows, err := repository.ListPending(ctx, ListPendingParams{
+		AccountID: "account-a",
+		Limit:     2,
+	})
+	if err != nil {
+		t.Fatalf("ListPending(account, limit): %v", err)
+	}
+	if len(accountRows) != 2 {
+		t.Fatalf("ListPending(account, limit) returned %d rows, want 2: %+v", len(accountRows), accountRows)
+	}
+	if got := []string{accountRows[0].OutboxID, accountRows[1].OutboxID}; !slices.Equal(got, []string{dueText.OutboxID, media.OutboxID}) {
+		t.Fatalf("ListPending(account, limit) IDs = %v", got)
+	}
+
+	reactionRows, err := repository.ListPending(ctx, ListPendingParams{
+		ConversationID: "conversation-c",
+		Limit:          20,
+	})
+	if err != nil {
+		t.Fatalf("ListPending(conversation): %v", err)
+	}
+	if len(reactionRows) != 1 || reactionRows[0].OutboxID != reaction.OutboxID {
+		t.Fatalf("ListPending(conversation) = %+v, want only %q", reactionRows, reaction.OutboxID)
+	}
+
+	conversationRows, err := repository.ListPending(ctx, ListPendingParams{
+		AccountID:      "account-a",
+		ConversationID: "conversation-a",
+		Limit:          20,
+	})
+	if err != nil {
+		t.Fatalf("ListPending(account, conversation): %v", err)
+	}
+	conversationIDs := make([]string, len(conversationRows))
+	for i, row := range conversationRows {
+		conversationIDs[i] = row.OutboxID
+	}
+	if want := []string{dueText.OutboxID, read.OutboxID, futureText.OutboxID}; !slices.Equal(conversationIDs, want) {
+		t.Fatalf("ListPending(account, conversation) IDs = %v, want %v", conversationIDs, want)
+	}
+
+	if _, err := repository.ListPending(ctx, ListPendingParams{}); err == nil {
+		t.Fatal("ListPending(non-positive limit) succeeded")
+	}
+}
+
 func TestOutboxPreCallExpiredLeaseRetriesAndStaleTokenLoses(t *testing.T) {
 	clock := newOutboxTestClock(outboxTestTimeMS)
 	_, repository := openOutboxTestRepository(t, clock.Now)


### PR DESCRIPTION
## Rebuild Wave 2 / M6 — pending-intent list queries + sleep-until-due dispatch wake

**The final Wave-2 milestone.** The v2 outbox already subsumed the legacy scheduler's semantics (future `NotBefore` rows, due-gated leasing, offline-zero-attempts, restart recovery, cancelable future rows) — M6 adds the two missing pieces and pins the rest with exit-criteria tests.

### What it adds
- **`ListPending`** — the Wave-3 list primitive: exactly the cancelable set (`queued` + `not_dispatched`), ordered by the same key `LeaseDue` dispatches in, kind-appropriate summaries, account/conversation filters, clamped limit. Single query, PK-keyed LEFT JOINs.
- **Sleep-until-nearest-due wake** — `Run`'s fixed 1s timer becomes `min(nearest leaseable time, 30s ceiling)`, floored at the old poll delay. A +6h scheduled send wakes the loop ~720 times instead of ~21,600. The ceiling is the laptop-sleep safety net (post-suspend catch-up ≤30s) and preserves the `store_failed` self-heal cadence; a read error degrades to the ceiling, never kills the dispatcher.
- **Exit-criteria pins** — cancel-future (including the cancel/dispatch race, settled exactly-once by `_txlock=immediate`), restart + far-future recovery (exactly one send when due), offline-zero-attempts across cycles.

**The legacy scheduler stays live and untouched** — its retirement is the Wave-4 cutover (R9), after R2 migrates pending `scheduled_messages` rows.

### Verification
- Adversarial review verdict **mergeable, zero defects** — the `EarliestDue` ≡ `LeaseDue` key equivalence proven on a real-DDL scratch DB at every boundary (including `next_attempt` outranking `scheduled_for` on retrying rows); the schema CHECKs make the equivalence structural rather than conventional.
- Full `go test -race ./...` green — 24 packages, shuffled.

With this, **Wave 2 is complete**: the entire v2 service layer (text, media, reactions, read receipts, download, reconciliation, SendAgain, scheduling) is merged and hermetically verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
