### PR TITLE
Add text-send adapter shims for Google, WhatsApp, and Signal (rebuild T1-T3)

### DIFF
--- a/internal/bridgeadapters/google/send.go
+++ b/internal/bridgeadapters/google/send.go
@@ -15,6 +15,15 @@ import (
 	"github.com/maxghenis/openmessage/internal/client"
 )
 
+type textSendClient interface {
+	GetConversation(conversationID string) (*gmproto.Conversation, error)
+	SendMessage(payload *gmproto.SendMessageRequest) (*gmproto.SendMessageResponse, error)
+}
+
+var textSendClientFor = func(cli *client.Client) textSendClient {
+	return cli.GM
+}
+
 type mediaSendClient interface {
 	UploadMedia(data []byte, filename, mime string) (*gmproto.MediaContent, error)
 	GetConversation(conversationID string) (*gmproto.Conversation, error)
@@ -23,6 +32,101 @@ type mediaSendClient interface {
 
 var mediaSendClientFor = func(cli *client.Client) mediaSendClient {
 	return cli.GM
+}
+
+// SendText adapts the durable text outbox request to the connected libgm
+// client retained by the lifecycle-owned App generation.
+func (a *Adapter) SendText(
+	ctx context.Context,
+	req bridge.TextRequest,
+) (bridge.SendResult, error) {
+	if a == nil || a.host == nil || !a.host.Connected.Load() {
+		return bridge.SendResult{}, notConnectedTextError()
+	}
+	cli := a.host.GetClient()
+	if cli == nil || cli.GM == nil {
+		return bridge.SendResult{}, notConnectedTextError()
+	}
+	transport := textSendClientFor(cli)
+	if transport == nil {
+		return bridge.SendResult{}, notConnectedTextError()
+	}
+	if ctx == nil {
+		return bridge.SendResult{}, preDispatchTextError(
+			"google_text_context_invalid",
+			errors.New("Google text send context is nil"),
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.SendResult{}, preDispatchTextError("google_text_context_done", err)
+	}
+
+	conversation, err := transport.GetConversation(req.Conversation.RemoteID)
+	if err != nil {
+		failure := a.classifyTextTransportError(
+			fmt.Errorf("get Google conversation: %w", err),
+			"google_conversation_get_failed",
+			bridge.DispatchNotCalled,
+		)
+		return bridge.SendResult{}, failure
+	}
+	if conversation == nil {
+		failure := a.classifyTextTransportError(
+			errors.New("get Google conversation: transport returned no conversation"),
+			"google_conversation_get_failed",
+			bridge.DispatchNotCalled,
+		)
+		return bridge.SendResult{}, failure
+	}
+	participantID, sim := app.ExtractSIMAndParticipant(conversation)
+	replyToID := ""
+	if req.ReplyTo != nil {
+		replyToID = req.ReplyTo.RemoteID
+	}
+	payload := app.BuildSendPayloadWithTmpID(
+		req.Conversation.RemoteID,
+		req.Body,
+		replyToID,
+		participantID,
+		sim,
+		req.RequestID,
+	)
+	response, err := transport.SendMessage(payload)
+	if err != nil {
+		failure := a.classifyTextTransportError(
+			fmt.Errorf("send Google text: %w", err),
+			"google_text_send_failed",
+			"",
+		)
+		return bridge.SendResult{}, failure
+	}
+	if response == nil {
+		failure := a.classifyTextTransportError(
+			errors.New("send Google text: transport returned no response"),
+			"google_text_send_failed",
+			"",
+		)
+		return bridge.SendResult{}, failure
+	}
+	if response.GetStatus() != gmproto.SendMessageResponse_SUCCESS {
+		// A rejected status proves the connection is healthy enough to respond;
+		// this must not touch the receive lifecycle.
+		return bridge.SendResult{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "send_text",
+			Fingerprint: "google_text_send_rejected",
+			Dispatch:    bridge.DispatchNotCalled,
+			Cause: fmt.Errorf(
+				"Google text send returned %s",
+				response.GetStatus().String(),
+			),
+		}
+	}
+
+	return bridge.SendResult{
+		RemoteMessageID: payload.GetTmpID(),
+		EchoExpected:    true,
+	}, nil
 }
 
 // SendMedia adapts the durable media outbox request to the connected libgm
@@ -207,6 +311,37 @@ func (a *Adapter) SendMedia(
 	}, nil
 }
 
+func notConnectedTextError() bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "send_text",
+		Fingerprint: "google_not_connected",
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       errors.New("Google Messages is not connected"),
+	}
+}
+
+func preDispatchTextError(fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "send_text",
+		Fingerprint: fingerprint,
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       cause,
+	}
+}
+
+func (a *Adapter) classifyTextTransportError(
+	err error,
+	fingerprint string,
+	dispatch bridge.DispatchCertainty,
+) bridge.OpError {
+	failure := a.classifyTransportError(err, "send_text", fingerprint)
+	failure.Dispatch = dispatch
+	a.reportIfAuthIndicting(failure)
+	return failure
+}
+
 func notConnectedMediaError() bridge.OpError {
 	return bridge.OpError{
 		Class:       bridge.FailureTransient,
@@ -254,4 +389,5 @@ func (a *Adapter) reportIfAuthIndicting(failure bridge.OpError) {
 	}
 }
 
+var _ bridge.TextSender = (*Adapter)(nil)
 var _ bridge.MediaSender = (*Adapter)(nil)

--- a/internal/bridgeadapters/google/send_test.go
+++ b/internal/bridgeadapters/google/send_test.go
@@ -15,6 +15,352 @@ import (
 	"github.com/maxghenis/openmessage/internal/client"
 )
 
+func TestSendTextNotConnectedIsClassifiedPreCall(t *testing.T) {
+	host := newTestApp(t)
+	a := New("google-primary", host, func() bool { return true })
+	a.newClient = func() (*client.Client, transportClient, error) {
+		t.Fatal("SendText must not construct a Google transport")
+		return nil, nil, nil
+	}
+
+	result, err := a.SendText(context.Background(), bridge.TextRequest{
+		AccountID: "google-primary",
+		Conversation: bridge.ConversationRef{
+			RemoteID: "conversation-id",
+		},
+		Body:      "hello",
+		RequestID: "request-id",
+	})
+	if result != (bridge.SendResult{}) {
+		t.Fatalf("result = %+v, want zero value", result)
+	}
+	failure := requireTextOpError(t, err)
+	if failure.Class != bridge.FailureTransient ||
+		failure.Dispatch != bridge.DispatchNotCalled ||
+		failure.Operation != "send_text" ||
+		failure.Fingerprint != "google_not_connected" {
+		t.Fatalf("failure = %+v, want transient pre-call google_not_connected", failure)
+	}
+}
+
+func TestSendTextContextGuardsAreClassifiedPreCall(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		fingerprint string
+	}{
+		{
+			name:        "nil",
+			ctx:         nil,
+			fingerprint: "google_text_context_invalid",
+		},
+		{
+			name: "done",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			fingerprint: "google_text_context_done",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeTextSendClient{}
+			a := newTextSendTestAdapter(t, fake)
+
+			_, err := a.SendText(test.ctx, bridge.TextRequest{})
+			failure := requireTextOpError(t, err)
+			if failure.Class != bridge.FailureTransient ||
+				failure.Dispatch != bridge.DispatchNotCalled ||
+				failure.Operation != "send_text" ||
+				failure.Fingerprint != test.fingerprint {
+				t.Fatalf("failure = %+v, want transient pre-call %s", failure, test.fingerprint)
+			}
+			if fake.conversationCalls != 0 || fake.sendCalls != 0 {
+				t.Fatalf("transport calls = (conversation %d, send %d), want (0, 0)",
+					fake.conversationCalls, fake.sendCalls)
+			}
+		})
+	}
+}
+
+func TestSendTextSuccessUsesStablePayloadAndMapsResult(t *testing.T) {
+	sim := &gmproto.SIMPayload{Two: 7, SIMNumber: 2}
+	conversation := &gmproto.Conversation{
+		ConversationID: "remote-conversation",
+		Participants: []*gmproto.Participant{{
+			ID:         &gmproto.SmallInfo{Number: "+15551234567"},
+			IsMe:       true,
+			SimPayload: sim,
+		}},
+	}
+	fake := &fakeTextSendClient{
+		conversationResult: conversation,
+		sendResult: &gmproto.SendMessageResponse{
+			Status: gmproto.SendMessageResponse_SUCCESS,
+		},
+	}
+	a := newTextSendTestAdapter(t, fake)
+
+	result, err := a.SendText(context.Background(), bridge.TextRequest{
+		AccountID: "google-primary",
+		Conversation: bridge.ConversationRef{
+			RemoteID: "remote-conversation",
+		},
+		Body:      "hello from the durable outbox",
+		ReplyTo:   &bridge.MessageRef{RemoteID: "reply-id"},
+		RequestID: "transport-request-id",
+	})
+	if err != nil {
+		t.Fatalf("SendText() error = %v", err)
+	}
+	if result.RemoteMessageID != "transport-request-id" || !result.EchoExpected || !result.AcceptedAt.IsZero() {
+		t.Fatalf("result = %+v, want stable TmpID, echo expected, and zero AcceptedAt", result)
+	}
+	if fake.conversationID != "remote-conversation" || fake.conversationCalls != 1 {
+		t.Fatalf("GetConversation = (%q, %d calls), want (remote-conversation, 1 call)",
+			fake.conversationID, fake.conversationCalls)
+	}
+	if fake.sendCalls != 1 || fake.sent == nil {
+		t.Fatalf("SendMessage = (%d calls, payload %p), want one non-nil payload", fake.sendCalls, fake.sent)
+	}
+	payload := fake.sent
+	if payload.GetTmpID() != "transport-request-id" ||
+		payload.GetMessagePayload().GetTmpID() != "transport-request-id" ||
+		payload.GetMessagePayload().GetTmpID2() != "transport-request-id" {
+		t.Fatalf("payload TmpIDs = (%q, %q, %q), want transport-request-id in all positions",
+			payload.GetTmpID(), payload.GetMessagePayload().GetTmpID(), payload.GetMessagePayload().GetTmpID2())
+	}
+	if payload.GetConversationID() != "remote-conversation" ||
+		payload.GetMessagePayload().GetConversationID() != "remote-conversation" {
+		t.Fatalf("payload conversation IDs = (%q, %q), want remote-conversation",
+			payload.GetConversationID(), payload.GetMessagePayload().GetConversationID())
+	}
+	if payload.GetMessagePayload().GetParticipantID() != "+15551234567" || payload.GetSIMPayload() != sim {
+		t.Fatalf("payload routing = participant %q SIM %p, want +15551234567 and %p",
+			payload.GetMessagePayload().GetParticipantID(), payload.GetSIMPayload(), sim)
+	}
+	infos := payload.GetMessagePayload().GetMessageInfo()
+	if len(infos) != 1 || infos[0].GetMessageContent().GetContent() != "hello from the durable outbox" {
+		t.Fatalf("payload MessageInfo = %+v, want request body", infos)
+	}
+	if payload.GetReply().GetMessageID() != "reply-id" {
+		t.Fatalf("payload reply ID = %q, want reply-id", payload.GetReply().GetMessageID())
+	}
+}
+
+func TestSendTextConversationFailuresAreClassifiedNotCalled(t *testing.T) {
+	tests := []struct {
+		name        string
+		fake        *fakeTextSendClient
+		wantClass   bridge.FailureClass
+		fingerprint string
+	}{
+		{
+			name: "transport error",
+			fake: &fakeTextSendClient{
+				conversationErr: errors.New("conversation unavailable"),
+			},
+			wantClass:   bridge.FailureTransient,
+			fingerprint: "google_conversation_get_failed",
+		},
+		{
+			name:        "nil conversation",
+			fake:        &fakeTextSendClient{},
+			wantClass:   bridge.FailureTransient,
+			fingerprint: "google_conversation_get_failed",
+		},
+		{
+			name: "auth expiry",
+			fake: &fakeTextSendClient{
+				conversationErr: errors.New("HTTP 401: invalid authentication credentials"),
+			},
+			wantClass:   bridge.FailureCredentialsExpired,
+			fingerprint: "google_auth_expired",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := newTextSendTestAdapter(t, test.fake)
+			_, err := a.SendText(context.Background(), bridge.TextRequest{
+				Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+				Body:         "hello",
+				RequestID:    "request-id",
+			})
+			failure := requireTextOpError(t, err)
+			if failure.Class != test.wantClass || failure.Dispatch != bridge.DispatchNotCalled ||
+				failure.Operation != "send_text" || failure.Fingerprint != test.fingerprint {
+				t.Fatalf("failure = %+v, want class %q pre-call %s", failure, test.wantClass, test.fingerprint)
+			}
+			if test.fake.sendCalls != 0 {
+				t.Fatalf("SendMessage calls = %d, want 0", test.fake.sendCalls)
+			}
+		})
+	}
+}
+
+func TestSendTextSendFailuresAreClassifiedUncertain(t *testing.T) {
+	tests := []struct {
+		name string
+		fake *fakeTextSendClient
+	}{
+		{
+			name: "transport error",
+			fake: &fakeTextSendClient{
+				conversationResult: &gmproto.Conversation{},
+				sendErr:            errors.New("transport timeout"),
+			},
+		},
+		{
+			name: "nil response",
+			fake: &fakeTextSendClient{
+				conversationResult: &gmproto.Conversation{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := newTextSendTestAdapter(t, test.fake)
+			_, err := a.SendText(context.Background(), bridge.TextRequest{
+				Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+				Body:         "hello",
+				RequestID:    "request-id",
+			})
+			failure := requireTextOpError(t, err)
+			if failure.Class != bridge.FailureTransient || failure.Dispatch != "" ||
+				failure.Operation != "send_text" || failure.Fingerprint != "google_text_send_failed" {
+				t.Fatalf("failure = %+v, want ambiguous transient google_text_send_failed", failure)
+			}
+			if test.fake.sendCalls != 1 {
+				t.Fatalf("SendMessage calls = %d, want 1", test.fake.sendCalls)
+			}
+		})
+	}
+}
+
+func TestSendTextTransientAndRejectedFailuresDoNotRetireGeneration(t *testing.T) {
+	tests := []struct {
+		name        string
+		fake        *fakeTextSendClient
+		dispatch    bridge.DispatchCertainty
+		fingerprint string
+	}{
+		{
+			name: "ambiguous transport error",
+			fake: &fakeTextSendClient{
+				conversationResult: &gmproto.Conversation{},
+				sendErr:            errors.New("transport timeout"),
+			},
+			dispatch:    "",
+			fingerprint: "google_text_send_failed",
+		},
+		{
+			name: "nil response",
+			fake: &fakeTextSendClient{
+				conversationResult: &gmproto.Conversation{},
+			},
+			dispatch:    "",
+			fingerprint: "google_text_send_failed",
+		},
+		{
+			name: "rejected status",
+			fake: &fakeTextSendClient{
+				conversationResult: &gmproto.Conversation{},
+				sendResult: &gmproto.SendMessageResponse{
+					Status: gmproto.SendMessageResponse_UNKNOWN,
+				},
+			},
+			dispatch:    bridge.DispatchNotCalled,
+			fingerprint: "google_text_send_rejected",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			host := newTestApp(t)
+			transport := &fakeTransport{}
+			a := newTestAdapter(t, host, transport)
+			run, err := a.Start(context.Background(), bridge.StartRequest{
+				AccountID:  "google-primary",
+				Generation: 1,
+			}, nil)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			transport.emit(&gmproto.Conversation{ConversationID: "ready"})
+			<-run.Ready()
+
+			installTextSendClient(t, host.GetClient(), test.fake)
+			_, err = a.SendText(context.Background(), bridge.TextRequest{
+				Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+				Body:         "hello",
+				RequestID:    "request-id",
+			})
+			failure := requireTextOpError(t, err)
+			if failure.Class != bridge.FailureTransient || failure.Dispatch != test.dispatch ||
+				failure.Operation != "send_text" || failure.Fingerprint != test.fingerprint {
+				t.Fatalf("failure = %+v, want transient %q dispatch %q", failure, test.fingerprint, test.dispatch)
+			}
+			if !host.Connected.Load() {
+				t.Fatal("text send failure marked the connected receive generation lost")
+			}
+			select {
+			case terminal := <-run.Done():
+				t.Fatalf("text send failure retired the receive generation with %v", terminal)
+			default:
+			}
+			if host.GoogleStatus().NeedsRepair {
+				t.Fatal("text send failure parked the Google lifecycle")
+			}
+		})
+	}
+}
+
+func TestSendTextAuthExpiryStillReportsToLifecycle(t *testing.T) {
+	host := newTestApp(t)
+	transport := &fakeTransport{}
+	a := newTestAdapter(t, host, transport)
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	transport.emit(&gmproto.Conversation{ConversationID: "ready"})
+	<-run.Ready()
+
+	fake := &fakeTextSendClient{
+		conversationResult: &gmproto.Conversation{},
+		sendErr:            errors.New("google returned http 401 for send"),
+	}
+	installTextSendClient(t, host.GetClient(), fake)
+
+	_, err = a.SendText(context.Background(), bridge.TextRequest{
+		Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+		Body:         "hello",
+		RequestID:    "request-id",
+	})
+	failure := requireTextOpError(t, err)
+	if failure.Fingerprint != "google_auth_expired" {
+		t.Fatalf("failure = %+v, want google_auth_expired classification", failure)
+	}
+	select {
+	case terminal := <-run.Done():
+		terminalFailure, ok := asOpError(terminal)
+		if !ok || (terminalFailure.Class != bridge.FailureCredentialsExpired &&
+			terminalFailure.Class != bridge.FailureUpgradeRequired) {
+			t.Fatalf("terminal = %v, want credentials_expired/upgrade_required", terminal)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("auth-expired text send failure did not reach the lifecycle owner")
+	}
+}
+
 func TestSendMediaNotConnectedIsClassifiedPreCall(t *testing.T) {
 	host := newTestApp(t)
 	a := New("google-primary", host, func() bool { return true })
@@ -510,6 +856,65 @@ func TestSendMediaCaptionFailureRemainsAmbiguousAfterMediaSuccess(t *testing.T) 
 			}
 		})
 	}
+}
+
+func newTextSendTestAdapter(t *testing.T, fake *fakeTextSendClient) *Adapter {
+	t.Helper()
+	host := newTestApp(t)
+	legacy := newLegacyClient(t)
+	generation := host.BeginGoogleGeneration(legacy)
+	t.Cleanup(generation.Release)
+	host.Connected.Store(true)
+	installTextSendClient(t, legacy, fake)
+	return New("google-primary", host, func() bool { return true })
+}
+
+func installTextSendClient(t *testing.T, want *client.Client, fake textSendClient) {
+	t.Helper()
+	previous := textSendClientFor
+	textSendClientFor = func(got *client.Client) textSendClient {
+		if got != want {
+			t.Fatalf("text client source = %p, want App.GetClient() %p", got, want)
+		}
+		return fake
+	}
+	t.Cleanup(func() { textSendClientFor = previous })
+}
+
+func requireTextOpError(t *testing.T, err error) bridge.OpError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("SendText() error = nil, want classified failure")
+	}
+	failure, ok := asOpError(err)
+	if !ok {
+		t.Fatalf("SendText() error = %T %v, want bridge.OpError", err, err)
+	}
+	return failure
+}
+
+type fakeTextSendClient struct {
+	conversationResult *gmproto.Conversation
+	conversationErr    error
+	sendResult         *gmproto.SendMessageResponse
+	sendErr            error
+
+	conversationCalls int
+	conversationID    string
+	sendCalls         int
+	sent              *gmproto.SendMessageRequest
+}
+
+func (f *fakeTextSendClient) GetConversation(conversationID string) (*gmproto.Conversation, error) {
+	f.conversationCalls++
+	f.conversationID = conversationID
+	return f.conversationResult, f.conversationErr
+}
+
+func (f *fakeTextSendClient) SendMessage(payload *gmproto.SendMessageRequest) (*gmproto.SendMessageResponse, error) {
+	f.sendCalls++
+	f.sent = payload
+	return f.sendResult, f.sendErr
 }
 
 func newMediaSendTestAdapter(t *testing.T, fake *fakeMediaSendClient) *Adapter {

--- a/internal/bridgeadapters/signal/signal.go
+++ b/internal/bridgeadapters/signal/signal.go
@@ -19,6 +19,7 @@ import (
 
 type poller interface {
 	StartPoller(context.Context) (signallive.PollerRun, error)
+	SendTextRequest(string, string, string) (int64, error)
 	SendMediaRequest(string, io.Reader, int64, string, string, string, string) (int64, error)
 	Status() signallive.StatusSnapshot
 	ApplyPollerFailure(signallive.PollerExit)
@@ -59,6 +60,69 @@ func (a *Adapter) DeclaredCapabilities() bridge.CapabilitySet {
 	}
 }
 
+// SendText adapts a durable text request to signal-cli's structured send path.
+// Signal's canonical identity is the returned timestamp; RequestID remains
+// local-dedupe metadata, so an uncertain retry can duplicate until M5
+// reconciliation makes that retry safe.
+func (a *Adapter) SendText(
+	ctx context.Context,
+	req bridge.TextRequest,
+) (bridge.SendResult, error) {
+	if ctx == nil {
+		return bridge.SendResult{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "send_text",
+			Fingerprint: "signal_send_text_context_missing",
+			Dispatch:    bridge.DispatchNotCalled,
+			Cause:       errors.New("Signal text send context is nil"),
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.SendResult{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "send_text",
+			Fingerprint: "signal_send_text_context_done",
+			Dispatch:    bridge.DispatchNotCalled,
+			Cause:       err,
+		}
+	}
+	if a == nil || a.poller == nil {
+		return bridge.SendResult{}, signalNotConnectedError("send_text")
+	}
+	status := a.poller.Status()
+	if !status.Connected || strings.TrimSpace(status.Account) == "" {
+		return bridge.SendResult{}, signalNotConnectedError("send_text")
+	}
+
+	replyToID := ""
+	if req.ReplyTo != nil {
+		replyToID = req.ReplyTo.RemoteID
+	}
+	timestampMS, err := a.poller.SendTextRequest(
+		req.Conversation.RemoteID,
+		req.Body,
+		replyToID,
+	)
+	if err != nil {
+		a.ReportError(err)
+		failure := bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "send_text",
+			Fingerprint: "signal_send_text_failed",
+			Cause:       err,
+		}
+		if !signallive.IsCommandError(err) || signallive.IsSendNotDispatchedError(err) {
+			failure.Dispatch = bridge.DispatchNotCalled
+		}
+		return bridge.SendResult{}, failure
+	}
+
+	return bridge.SendResult{
+		RemoteMessageID: strconv.FormatInt(timestampMS, 10),
+		EchoExpected:    false,
+	}, nil
+}
+
 func (a *Adapter) SendMedia(
 	ctx context.Context,
 	req bridge.MediaRequest,
@@ -82,11 +146,11 @@ func (a *Adapter) SendMedia(
 		}
 	}
 	if a == nil || a.poller == nil {
-		return bridge.SendResult{}, signalNotConnectedError()
+		return bridge.SendResult{}, signalNotConnectedError("send_media")
 	}
 	status := a.poller.Status()
 	if !status.Connected || strings.TrimSpace(status.Account) == "" {
-		return bridge.SendResult{}, signalNotConnectedError()
+		return bridge.SendResult{}, signalNotConnectedError("send_media")
 	}
 
 	replyToID := ""
@@ -122,10 +186,10 @@ func (a *Adapter) SendMedia(
 	}, nil
 }
 
-func signalNotConnectedError() bridge.OpError {
+func signalNotConnectedError(operation string) bridge.OpError {
 	return bridge.OpError{
 		Class:       bridge.FailureTransient,
-		Operation:   "send_media",
+		Operation:   operation,
 		Fingerprint: "signal_not_connected",
 		Dispatch:    bridge.DispatchNotCalled,
 		Cause:       errors.New("Signal is not connected"),
@@ -562,6 +626,7 @@ func (r *run) recordActivity(activity signallive.PollerActivity) {
 var (
 	_ bridge.Adapter            = (*Adapter)(nil)
 	_ bridge.CapabilityDeclarer = (*Adapter)(nil)
+	_ bridge.TextSender         = (*Adapter)(nil)
 	_ bridge.MediaSender        = (*Adapter)(nil)
 	_ bridge.Run                = (*run)(nil)
 )

--- a/internal/bridgeadapters/signal/signal_test.go
+++ b/internal/bridgeadapters/signal/signal_test.go
@@ -20,6 +20,283 @@ const signalAdapterTestTimeout = 2 * time.Second
 
 var signalAdapterTestEpoch = time.Date(2026, time.July, 13, 12, 0, 0, 0, time.UTC)
 
+func TestAdapterImplementsTextSender(t *testing.T) {
+	var _ bridge.TextSender = (*Adapter)(nil)
+}
+
+func TestSendTextRequiresReadyRetainedBridge(t *testing.T) {
+	tests := []struct {
+		name   string
+		poller poller
+	}{
+		{name: "nil retained bridge"},
+		{name: "not connected", poller: newFakePoller()},
+		{
+			name: "connected without account",
+			poller: &fakePoller{
+				started: make(chan *fakePollerRun, 1),
+				status:  signallive.StatusSnapshot{Connected: true},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := &Adapter{accountID: "signal-primary", poller: tc.poller}
+			result, err := adapter.SendText(context.Background(), bridge.TextRequest{
+				AccountID:    "signal-primary",
+				Conversation: bridge.ConversationRef{RemoteID: "signal:+15551234567"},
+				Body:         "hello",
+			})
+			if result != (bridge.SendResult{}) {
+				t.Fatalf("SendText() result = %+v, want zero", result)
+			}
+			var operationError bridge.OpError
+			if !errors.As(err, &operationError) {
+				t.Fatalf("SendText() error = %v (%T), want bridge.OpError", err, err)
+			}
+			if operationError.Class != bridge.FailureTransient ||
+				operationError.Dispatch != bridge.DispatchNotCalled ||
+				operationError.Operation != "send_text" ||
+				operationError.Fingerprint != "signal_not_connected" {
+				t.Fatalf("SendText() OpError = %+v, want classified not-connected pre-call failure", operationError)
+			}
+			if fake, ok := tc.poller.(*fakePoller); ok && fake.textCallCount() != 0 {
+				t.Fatalf("SendTextRequest calls = %d, want 0 while not ready", fake.textCallCount())
+			}
+		})
+	}
+}
+
+func TestSendTextRejectsInvalidContextBeforeTransport(t *testing.T) {
+	tests := []struct {
+		name            string
+		context         func() context.Context
+		wantFingerprint string
+	}{
+		{
+			name:            "nil context",
+			context:         func() context.Context { return nil },
+			wantFingerprint: "signal_send_text_context_missing",
+		},
+		{
+			name: "done context",
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantFingerprint: "signal_send_text_context_done",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := newFakePoller()
+			poller.status = signallive.StatusSnapshot{Connected: true, Account: "+15551230000"}
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+			_, err := adapter.SendText(tc.context(), bridge.TextRequest{Body: "hello"})
+			var operationError bridge.OpError
+			if !errors.As(err, &operationError) ||
+				operationError.Class != bridge.FailureTransient ||
+				operationError.Dispatch != bridge.DispatchNotCalled ||
+				operationError.Operation != "send_text" ||
+				operationError.Fingerprint != tc.wantFingerprint {
+				t.Fatalf("SendText() error = %v, want pre-call context failure %q", err, tc.wantFingerprint)
+			}
+			if got := poller.textCallCount(); got != 0 {
+				t.Fatalf("SendTextRequest calls = %d, want 0 after context failure", got)
+			}
+		})
+	}
+}
+
+func TestSendTextMapsRetainedTimestampAndRequest(t *testing.T) {
+	poller := newFakePoller()
+	poller.status = signallive.StatusSnapshot{
+		Connected: true,
+		Paired:    true,
+		Account:   "+15551230000",
+	}
+	poller.textTimestamp = 1700000000123
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+	result, err := adapter.SendText(context.Background(), bridge.TextRequest{
+		AccountID:    "signal-primary",
+		Conversation: bridge.ConversationRef{RemoteID: "signal:+15551234567"},
+		Body:         "hello from durable Signal",
+		ReplyTo:      &bridge.MessageRef{RemoteID: "signal:1700000000000"},
+		RequestID:    "local-dedupe-only",
+	})
+	if err != nil {
+		t.Fatalf("SendText() error = %v", err)
+	}
+	if result.RemoteMessageID != strconv.FormatInt(poller.textTimestamp, 10) ||
+		result.EchoExpected || !result.AcceptedAt.IsZero() {
+		t.Fatalf("SendText() result = %+v, want canonical timestamp ID without echo", result)
+	}
+	request := poller.lastTextRequest()
+	if request.conversationID != "signal:+15551234567" ||
+		request.body != "hello from durable Signal" ||
+		request.replyToID != "signal:1700000000000" {
+		t.Fatalf("retained SendTextRequest = %+v, want mapped TextRequest", request)
+	}
+}
+
+func TestSendTextClassifiesPreCallAndCommandFailures(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantDispatch bridge.DispatchCertainty
+	}{
+		{
+			name:         "local validation",
+			err:          errors.New("Signal message body is required"),
+			wantDispatch: bridge.DispatchNotCalled,
+		},
+		{
+			name: "signal-cli command",
+			err:  signallive.NewCommandError("send Signal message: recipient is not registered"),
+		},
+		{
+			name: "structured all-recipient failure",
+			err: &fakeSignalSendNotDispatchedError{err: signallive.NewCommandError(
+				"send Signal message: every recipient failed",
+			)},
+			wantDispatch: bridge.DispatchNotCalled,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := newFakePoller()
+			poller.status = signallive.StatusSnapshot{
+				Connected: true,
+				Paired:    true,
+				Account:   "+15551230000",
+			}
+			poller.textErr = tc.err
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+			_, err := adapter.SendText(context.Background(), bridge.TextRequest{
+				AccountID:    "signal-primary",
+				Conversation: bridge.ConversationRef{RemoteID: "signal:+15551234567"},
+				Body:         "hello",
+			})
+			var operationError bridge.OpError
+			if !errors.As(err, &operationError) {
+				t.Fatalf("SendText() error = %v (%T), want bridge.OpError", err, err)
+			}
+			if operationError.Class != bridge.FailureTransient ||
+				operationError.Dispatch != tc.wantDispatch ||
+				operationError.Operation != "send_text" ||
+				operationError.Fingerprint != "signal_send_text_failed" ||
+				!errors.Is(operationError.Cause, tc.err) {
+				t.Fatalf("SendText() OpError = %+v, want transient classified failure with dispatch %q", operationError, tc.wantDispatch)
+			}
+			if got := poller.appliedCount(); got != 0 {
+				t.Fatalf("recipient/local send failure applied %d lifecycle transitions, want 0", got)
+			}
+		})
+	}
+}
+
+// A text send can fail on a recipient, an identity change, or the network;
+// none indict the local account or widen ReportError's C6 matcher.
+func TestSendTextDoesNotWidenGuardedLifecycleReporting(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "unregistered recipient",
+			err:  signallive.NewCommandError("send Signal message: user +15551234567 is not registered"),
+		},
+		{
+			name: "untrusted identity",
+			err:  signallive.NewCommandError("send Signal message: Untrusted identity key for +15551234567"),
+		},
+		{
+			name: "network blip",
+			err:  signallive.NewCommandError("send Signal message: Connection reset by peer"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := newFakePoller()
+			poller.status = signallive.StatusSnapshot{
+				Connected: true,
+				Paired:    true,
+				Account:   "+15551230000",
+			}
+			poller.textErr = tc.err
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+			run, err := adapter.Start(context.Background(), bridge.StartRequest{
+				AccountID:  "signal-primary",
+				Generation: 1,
+			}, nil)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			receiveValue(t, poller.started, "retained poller start")
+			t.Cleanup(func() { stopAdapterRun(t, run) })
+
+			if _, err := adapter.SendText(context.Background(), bridge.TextRequest{
+				Conversation: bridge.ConversationRef{RemoteID: "signal:+15551234567"},
+				Body:         "hello",
+			}); err == nil {
+				t.Fatal("SendText() error = nil, want scripted command failure")
+			}
+			current := adapter.currentRun()
+			if current == nil || !current.admitCallback() {
+				t.Fatal("non-account text failure closed callback admission on the receive generation")
+			}
+			current.callbacks.Done()
+			select {
+			case terminal := <-run.Done():
+				t.Fatalf("non-account text failure terminated receive generation: %v", terminal)
+			default:
+			}
+			if got := poller.appliedCount(); got != 0 {
+				t.Fatalf("non-account text failure applied %d lifecycle transitions, want 0", got)
+			}
+		})
+	}
+}
+
+func TestSendTextRoutesLocalAccountFailureThroughGuardedLifecycleReporting(t *testing.T) {
+	poller := newFakePoller()
+	poller.status = signallive.StatusSnapshot{
+		Connected: true,
+		Paired:    true,
+		Account:   "+15551230000",
+	}
+	poller.textErr = signallive.NewCommandError("send Signal message: authorization failed")
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	run, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "signal-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	receiveValue(t, poller.started, "retained poller start")
+
+	if _, err := adapter.SendText(context.Background(), bridge.TextRequest{
+		Conversation: bridge.ConversationRef{RemoteID: "signal:+15551234567"},
+		Body:         "hello",
+	}); err == nil {
+		t.Fatal("SendText() error = nil, want local-account command failure")
+	}
+	terminal := receiveValue(t, run.Done(), "guarded text-send terminal")
+	assertOpError(t, terminal, bridge.FailureTransient, "signal_send_account_check")
+	if got := poller.appliedCount(); got != 1 {
+		t.Fatalf("local-account text failure status projections = %d, want one transient projection", got)
+	}
+}
+
 func TestSendMediaRequiresReadyRetainedBridge(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -716,9 +993,18 @@ type fakePoller struct {
 	applied        []signallive.PollerExit
 	fingerprint    string
 	status         signallive.StatusSnapshot
+	textCalls      []fakeTextRequest
+	textTimestamp  int64
+	textErr        error
 	mediaCalls     []fakeMediaRequest
 	mediaTimestamp int64
 	mediaErr       error
+}
+
+type fakeTextRequest struct {
+	conversationID string
+	body           string
+	replyToID      string
 }
 
 type fakeMediaRequest struct {
@@ -781,6 +1067,33 @@ func (p *fakePoller) Status() signallive.StatusSnapshot {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.status
+}
+
+func (p *fakePoller) SendTextRequest(conversationID, body, replyToID string) (int64, error) {
+	p.mu.Lock()
+	p.textCalls = append(p.textCalls, fakeTextRequest{
+		conversationID: conversationID,
+		body:           body,
+		replyToID:      replyToID,
+	})
+	timestamp, err := p.textTimestamp, p.textErr
+	p.mu.Unlock()
+	return timestamp, err
+}
+
+func (p *fakePoller) textCallCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.textCalls)
+}
+
+func (p *fakePoller) lastTextRequest() fakeTextRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.textCalls) == 0 {
+		return fakeTextRequest{}
+	}
+	return p.textCalls[len(p.textCalls)-1]
 }
 
 func (p *fakePoller) SendMediaRequest(

--- a/internal/bridgeadapters/whatsapp/send_test.go
+++ b/internal/bridgeadapters/whatsapp/send_test.go
@@ -18,6 +18,241 @@ func TestAdapterImplementsMediaSender(t *testing.T) {
 	var _ bridge.MediaSender = (*Adapter)(nil)
 }
 
+func TestAdapterImplementsTextSender(t *testing.T) {
+	var _ bridge.TextSender = (*Adapter)(nil)
+}
+
+func TestSendTextRequiresReadyTransportWithoutLifecycleAction(t *testing.T) {
+	var connectCalls, sendCalls int
+	a := &Adapter{
+		accountID: "whatsapp-primary",
+		connect: func(context.Context) error {
+			connectCalls++
+			return nil
+		},
+		mediaReady: func() bool { return false },
+		sendTextRequest: func(string, string, string, string) (string, time.Time, error) {
+			sendCalls++
+			return "", time.Time{}, nil
+		},
+	}
+
+	result, err := a.SendText(context.Background(), bridge.TextRequest{})
+	if result != (bridge.SendResult{}) {
+		t.Fatalf("SendText() result = %+v, want zero result", result)
+	}
+	failure, ok := asOpError(err)
+	if !ok {
+		t.Fatalf("SendText() error = %T %v, want bridge.OpError", err, err)
+	}
+	if failure.Class != bridge.FailureTransient ||
+		failure.Dispatch != bridge.DispatchNotCalled ||
+		failure.Operation != "send_text" ||
+		failure.Fingerprint != "whatsapp_not_connected" ||
+		!errors.Is(failure.Cause, whatsmeow.ErrNotConnected) {
+		t.Fatalf("SendText() failure = %+v, want classified not-connected pre-call failure", failure)
+	}
+	if connectCalls != 0 {
+		t.Fatalf("connect calls = %d, want zero", connectCalls)
+	}
+	if sendCalls != 0 {
+		t.Fatalf("transport send calls = %d, want zero", sendCalls)
+	}
+}
+
+func TestSendTextContextGuardsRunBeforeTransport(t *testing.T) {
+	tests := []struct {
+		name            string
+		ctx             context.Context
+		wantFingerprint string
+		wantCause       error
+	}{
+		{
+			name:            "nil context",
+			ctx:             nil,
+			wantFingerprint: "whatsapp_text_context_missing",
+		},
+		{
+			name:            "done context",
+			ctx:             canceledTextSendContext(),
+			wantFingerprint: "whatsapp_text_context_done",
+			wantCause:       context.Canceled,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var sendCalls int
+			a := &Adapter{
+				mediaReady: func() bool { return true },
+				sendTextRequest: func(string, string, string, string) (string, time.Time, error) {
+					sendCalls++
+					return "unexpected", time.Time{}, nil
+				},
+			}
+
+			_, err := a.SendText(test.ctx, bridge.TextRequest{})
+			failure, ok := asOpError(err)
+			if !ok || failure.Class != bridge.FailureTransient ||
+				failure.Dispatch != bridge.DispatchNotCalled ||
+				failure.Operation != "send_text" ||
+				failure.Fingerprint != test.wantFingerprint {
+				t.Fatalf("SendText() error = %v, want context pre-call failure %q", err, test.wantFingerprint)
+			}
+			if test.wantCause != nil && !errors.Is(failure.Cause, test.wantCause) {
+				t.Fatalf("SendText() cause = %v, want %v", failure.Cause, test.wantCause)
+			}
+			if sendCalls != 0 {
+				t.Fatalf("transport send calls = %d, want zero", sendCalls)
+			}
+		})
+	}
+}
+
+func canceledTextSendContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+func TestSendTextSuccessMapping(t *testing.T) {
+	acceptedAt := time.Date(2026, time.July, 13, 15, 4, 5, 0, time.UTC)
+	var gotConversationID, gotBody, gotReplyToID, gotRequestID string
+	a := &Adapter{
+		accountID:  "whatsapp-primary",
+		mediaReady: func() bool { return true },
+		sendTextRequest: func(conversationID, body, replyToID, requestID string) (string, time.Time, error) {
+			gotConversationID = conversationID
+			gotBody = body
+			gotReplyToID = replyToID
+			gotRequestID = requestID
+			return "derived-whatsapp-message-id", acceptedAt, nil
+		},
+	}
+
+	result, err := a.SendText(context.Background(), bridge.TextRequest{
+		AccountID: "whatsapp-primary",
+		Conversation: bridge.ConversationRef{
+			RemoteID: "whatsapp:15551234567@s.whatsapp.net",
+		},
+		Body:      "hello from v2",
+		ReplyTo:   &bridge.MessageRef{RemoteID: "whatsapp:reply-123"},
+		RequestID: "outbox-request-123",
+	})
+	if err != nil {
+		t.Fatalf("SendText() error = %v", err)
+	}
+	if result != (bridge.SendResult{
+		RemoteMessageID: "derived-whatsapp-message-id",
+		AcceptedAt:      acceptedAt,
+		EchoExpected:    false,
+	}) {
+		t.Fatalf("SendText() result = %+v, want derived remote ID and transport timestamp", result)
+	}
+	if gotConversationID != "whatsapp:15551234567@s.whatsapp.net" ||
+		gotBody != "hello from v2" ||
+		gotReplyToID != "whatsapp:reply-123" ||
+		gotRequestID != "outbox-request-123" {
+		t.Fatalf("SendTextRequest args = conversation=%q body=%q reply=%q request=%q",
+			gotConversationID, gotBody, gotReplyToID, gotRequestID)
+	}
+}
+
+func TestSendTextTransportErrorClassification(t *testing.T) {
+	tests := []struct {
+		name            string
+		err             error
+		wantDispatch    bridge.DispatchCertainty
+		wantFingerprint string
+	}{
+		{
+			name:            "connection disappeared before transport call",
+			err:             fmt.Errorf("%w: %w", whatsapplive.ErrSendNotDispatched, whatsmeow.ErrNotConnected),
+			wantDispatch:    bridge.DispatchNotCalled,
+			wantFingerprint: "whatsapp_not_connected",
+		},
+		{
+			name:            "validation failed before dispatch",
+			err:             fmt.Errorf("%w: invalid WhatsApp conversation", whatsapplive.ErrSendNotDispatched),
+			wantDispatch:    bridge.DispatchNotCalled,
+			wantFingerprint: "whatsapp_send_text_failed",
+		},
+		{
+			name:            "send returned not connected is uncertain",
+			err:             fmt.Errorf("send WhatsApp message: %w", whatsmeow.ErrNotConnected),
+			wantDispatch:    "",
+			wantFingerprint: "whatsapp_send_text_failed",
+		},
+		{
+			name:            "ambiguous send error is uncertain",
+			err:             errors.New("websocket closed while awaiting response"),
+			wantDispatch:    "",
+			wantFingerprint: "whatsapp_send_text_failed",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := &Adapter{
+				mediaReady: func() bool { return true },
+				sendTextRequest: func(string, string, string, string) (string, time.Time, error) {
+					return "", time.Time{}, test.err
+				},
+			}
+
+			_, err := a.SendText(context.Background(), bridge.TextRequest{})
+			failure, ok := asOpError(err)
+			if !ok || failure.Class != bridge.FailureTransient ||
+				failure.Dispatch != test.wantDispatch ||
+				failure.Operation != "send_text" ||
+				failure.Fingerprint != test.wantFingerprint ||
+				!errors.Is(failure.Cause, test.err) {
+				t.Fatalf("SendText() error = %v, want dispatch=%q fingerprint=%q",
+					err, test.wantDispatch, test.wantFingerprint)
+			}
+		})
+	}
+}
+
+// The adapter shim must never forward a text-send failure into the lifecycle.
+// Reconnect-worthy transport errors are already reported from the retained
+// core through its guarded reportConnectionError -> OnConnectionError chain.
+func TestSendTextFailureDoesNotRetireReceiveGeneration(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{"ambiguous send failure", errors.New("ambiguous send failure")},
+		{"not connected", fmt.Errorf("send WhatsApp message: %w", whatsmeow.ErrNotConnected)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ready := make(chan struct{})
+			close(ready)
+			r := &run{
+				ready:     ready,
+				finish:    make(chan error, 1),
+				admitting: true,
+			}
+			a := &Adapter{
+				current:    r,
+				mediaReady: func() bool { return true },
+				sendTextRequest: func(string, string, string, string) (string, time.Time, error) {
+					return "", time.Time{}, test.err
+				},
+			}
+
+			_, err := a.SendText(context.Background(), bridge.TextRequest{})
+			returnedFailure, ok := asOpError(err)
+			if !ok || !errors.Is(returnedFailure.Cause, test.err) {
+				t.Fatalf("SendText() error = %v, want classified transport failure", err)
+			}
+			select {
+			case reported := <-r.finish:
+				t.Fatalf("SendText() retired the receive generation with %v", reported)
+			default:
+			}
+		})
+	}
+}
+
 func TestSendMediaRequiresReadyTransportWithoutLifecycleAction(t *testing.T) {
 	var connectCalls, sendCalls int
 	a := &Adapter{
@@ -184,7 +419,7 @@ func TestSendMediaTransportErrorClassification(t *testing.T) {
 	}{
 		{
 			name:            "connection disappeared before transport call",
-			err:             fmt.Errorf("%w: %w", whatsapplive.ErrMediaNotDispatched, whatsmeow.ErrNotConnected),
+			err:             fmt.Errorf("%w: %w", whatsapplive.ErrSendNotDispatched, whatsmeow.ErrNotConnected),
 			wantClass:       bridge.FailureTransient,
 			wantDispatch:    bridge.DispatchNotCalled,
 			wantFingerprint: "whatsapp_not_connected",
@@ -198,7 +433,7 @@ func TestSendMediaTransportErrorClassification(t *testing.T) {
 		},
 		{
 			name:            "upload failed before dispatch",
-			err:             fmt.Errorf("%w: upload WhatsApp media: storage unavailable", whatsapplive.ErrMediaNotDispatched),
+			err:             fmt.Errorf("%w: upload WhatsApp media: storage unavailable", whatsapplive.ErrSendNotDispatched),
 			wantClass:       bridge.FailureTransient,
 			wantDispatch:    bridge.DispatchNotCalled,
 			wantFingerprint: "whatsapp_send_media_failed",

--- a/internal/bridgeadapters/whatsapp/whatsapp.go
+++ b/internal/bridgeadapters/whatsapp/whatsapp.go
@@ -36,7 +36,8 @@ type Adapter struct {
 	pairPhone        func(context.Context, string) (string, error)
 	unpair           func() error
 	now              func() time.Time
-	mediaReady       func() bool
+	mediaReady       func() bool // Shared connection gate; it does no media-specific work.
+	sendTextRequest  func(string, string, string, string) (string, time.Time, error)
 	sendMediaRequest func(string, []byte, string, string, string, string, string) (string, time.Time, error)
 
 	mu       sync.Mutex
@@ -63,6 +64,7 @@ func New(accountID string, host *whatsapplive.Bridge) *Adapter {
 		a.pairPhone = host.PairPhoneContext
 		a.unpair = host.Unpair
 		a.mediaReady = func() bool { return host.Status().Connected }
+		a.sendTextRequest = host.SendTextRequest
 		a.sendMediaRequest = host.SendMediaRequest
 		host.ObserveLifecycle(a.handleLifecycleEvent)
 	}
@@ -85,6 +87,68 @@ func (a *Adapter) DeclaredCapabilities() bridge.CapabilitySet {
 		MediaDownload:     true,
 	}
 }
+
+// SendText bridges the v2 request contract to the already-owned whatsmeow
+// transport. Readiness is checked without constructing or connecting a client.
+func (a *Adapter) SendText(ctx context.Context, req bridge.TextRequest) (bridge.SendResult, error) {
+	if a == nil || a.mediaReady == nil || !a.mediaReady() || a.sendTextRequest == nil {
+		return bridge.SendResult{}, whatsappTextPreCallFailure(
+			"whatsapp_not_connected",
+			whatsmeow.ErrNotConnected,
+		)
+	}
+	if ctx == nil {
+		return bridge.SendResult{}, whatsappTextPreCallFailure(
+			"whatsapp_text_context_missing",
+			errors.New("WhatsApp text send context is nil"),
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.SendResult{}, whatsappTextPreCallFailure("whatsapp_text_context_done", err)
+	}
+
+	replyToID := ""
+	if req.ReplyTo != nil {
+		replyToID = req.ReplyTo.RemoteID
+	}
+	remoteID, acceptedAt, err := a.sendTextRequest(
+		req.Conversation.RemoteID,
+		req.Body,
+		replyToID,
+		req.RequestID,
+	)
+	if err != nil {
+		// Deliberately no adapter-level lifecycle report: the retained transport
+		// core owns reconnect reporting through its guarded reportConnectionError
+		// -> OnConnectionError chain.
+		failure := a.classifyError(err, "send_text", "whatsapp_send_text_failed")
+		if errors.Is(err, whatsapplive.ErrSendNotDispatched) {
+			failure.Dispatch = bridge.DispatchNotCalled
+			if errors.Is(err, whatsmeow.ErrNotConnected) {
+				failure.Fingerprint = "whatsapp_not_connected"
+			}
+		}
+		return bridge.SendResult{}, failure
+	}
+
+	return bridge.SendResult{
+		RemoteMessageID: remoteID,
+		AcceptedAt:      acceptedAt,
+		EchoExpected:    false,
+	}, nil
+}
+
+func whatsappTextPreCallFailure(fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "send_text",
+		Fingerprint: fingerprint,
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       cause,
+	}
+}
+
+var _ bridge.TextSender = (*Adapter)(nil)
 
 // SendMedia bridges the v2 request contract to the already-owned whatsmeow
 // transport. Readiness is checked without constructing or connecting a client.
@@ -154,7 +218,7 @@ func (a *Adapter) SendMedia(ctx context.Context, req bridge.MediaRequest) (bridg
 		// through its internal reportConnectionError -> OnConnectionError chain,
 		// which carries the legacy ShouldReconnect guard.
 		failure := a.classifyError(err, "send_media", "whatsapp_send_media_failed")
-		if errors.Is(err, whatsapplive.ErrMediaNotDispatched) {
+		if errors.Is(err, whatsapplive.ErrSendNotDispatched) {
 			failure.Dispatch = bridge.DispatchNotCalled
 			if errors.Is(err, whatsmeow.ErrNotConnected) {
 				failure.Fingerprint = "whatsapp_not_connected"

--- a/internal/signallive/client.go
+++ b/internal/signallive/client.go
@@ -929,6 +929,71 @@ func (b *Bridge) SendText(conversationID, body, replyToID string) (*db.Message, 
 	return msg, nil
 }
 
+// SendTextRequest sends one text message through signal-cli's structured JSON
+// path and returns Signal's canonical outgoing identity. Signal uses the send
+// timestamp as its message ID; the durable request ID remains local dedupe
+// metadata until reconciliation can make uncertain retries safe.
+func (b *Bridge) SendTextRequest(conversationID, body, replyToID string) (timestampMS int64, err error) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return 0, errors.New("signal message body is required")
+	}
+
+	account, err := b.usableAccount()
+	if err != nil {
+		return 0, err
+	}
+	target, isGroup, err := parseConversationTarget(conversationID)
+	if err != nil {
+		return 0, err
+	}
+
+	args := []string{"--output=json", "-a", account, "send", "-m", body}
+	quoteArgs, err := b.signalQuoteArgs(replyToID, account)
+	if err != nil {
+		return 0, err
+	}
+	args = append(args, quoteArgs...)
+	if isGroup {
+		args = append(args, "--group-id", target)
+	} else {
+		args = append(args, target)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
+	defer cancel()
+	b.commandMu.Lock()
+	output, commandErr := runSignalCLI(ctx, b.configDir, args...)
+	b.commandMu.Unlock()
+	timestampMS, resultErr := parseSignalSendResult(output)
+	if commandErr != nil {
+		timedOut := errors.Is(commandErr, context.Canceled) ||
+			errors.Is(commandErr, context.DeadlineExceeded) ||
+			ctx.Err() != nil
+		if !timedOut && signalSendAllRecipientsFailed(resultErr) {
+			return 0, commandNotDispatchedError(
+				"send Signal message",
+				errors.Join(commandErr, resultErr),
+				output,
+			)
+		}
+		return 0, commandError("send Signal message", commandErr, output)
+	}
+	if resultErr != nil {
+		if signalSendAllRecipientsFailed(resultErr) {
+			return 0, commandNotDispatchedError("send Signal message", resultErr, output)
+		}
+		var partial *signalSendRecipientResultsError
+		if !errors.As(resultErr, &partial) || timestampMS <= 0 {
+			return 0, commandError("parse Signal text send result", resultErr, output)
+		}
+		// Mixed per-recipient results with >=1 SUCCESS: signal-cli exits 0
+		// because the message went out. Per-recipient delivery gaps are M5
+		// reconciliation's job.
+	}
+	return timestampMS, nil
+}
+
 func (b *Bridge) SendMedia(conversationID string, data []byte, filename, mime, caption, replyToID string) (*db.Message, error) {
 	if len(data) == 0 {
 		return nil, errors.New("signal attachment is required")
@@ -1059,12 +1124,12 @@ func (b *Bridge) sendMediaRequest(
 	b.commandMu.Lock()
 	output, commandErr := runSignalCLI(ctx, b.configDir, args...)
 	b.commandMu.Unlock()
-	timestampMS, resultErr := parseSignalMediaSendResult(output)
+	timestampMS, resultErr := parseSignalSendResult(output)
 	if commandErr != nil {
 		timedOut := errors.Is(commandErr, context.Canceled) ||
 			errors.Is(commandErr, context.DeadlineExceeded) ||
 			ctx.Err() != nil
-		if !timedOut && signalMediaAllRecipientsFailed(resultErr) {
+		if !timedOut && signalSendAllRecipientsFailed(resultErr) {
 			return result, commandNotDispatchedError(
 				"send Signal media",
 				errors.Join(commandErr, resultErr),
@@ -1074,10 +1139,10 @@ func (b *Bridge) sendMediaRequest(
 		return result, commandError("send Signal media", commandErr, output)
 	}
 	if resultErr != nil {
-		if signalMediaAllRecipientsFailed(resultErr) {
+		if signalSendAllRecipientsFailed(resultErr) {
 			return result, commandNotDispatchedError("send Signal media", resultErr, output)
 		}
-		var partial *signalMediaRecipientResultsError
+		var partial *signalSendRecipientResultsError
 		if !errors.As(resultErr, &partial) || timestampMS <= 0 {
 			return result, commandError("parse Signal media send result", resultErr, output)
 		}
@@ -1095,7 +1160,7 @@ func (b *Bridge) sendMediaRequest(
 	return result, nil
 }
 
-type signalMediaSendResult struct {
+type signalSendResult struct {
 	Timestamp int64 `json:"timestamp"`
 	Results   []struct {
 		RecipientAddress json.RawMessage `json:"recipientAddress"`
@@ -1103,7 +1168,7 @@ type signalMediaSendResult struct {
 	} `json:"results"`
 }
 
-// parseSignalMediaSendResult decodes signal-cli's --output=json send result
+// parseSignalSendResult decodes signal-cli's --output=json send result
 // from CombinedOutput. The buffer can carry stderr noise (signal-cli WARN
 // lines, JVM notes) around the JSON object on a fully successful send, so a
 // whole-buffer decode falls back to a per-line scan for the object carrying a
@@ -1111,8 +1176,8 @@ type signalMediaSendResult struct {
 // On mixed per-recipient results the timestamp is returned ALONGSIDE the
 // recipient-results error so callers can honor signal-cli's own exit-0
 // semantics (>=1 success means the message went out).
-func parseSignalMediaSendResult(output []byte) (int64, error) {
-	result, decodeErr := decodeSignalMediaSendJSON(output)
+func parseSignalSendResult(output []byte) (int64, error) {
+	result, decodeErr := decodeSignalSendJSON(output)
 	if decodeErr != nil {
 		return 0, decodeErr
 	}
@@ -1145,7 +1210,7 @@ func parseSignalMediaSendResult(output []byte) (int64, error) {
 		}
 	}
 	if len(failures) > 0 {
-		return result.Timestamp, &signalMediaRecipientResultsError{
+		return result.Timestamp, &signalSendRecipientResultsError{
 			failures:            failures,
 			allRecipientsFailed: successCount == 0,
 		}
@@ -1153,8 +1218,8 @@ func parseSignalMediaSendResult(output []byte) (int64, error) {
 	return result.Timestamp, nil
 }
 
-func decodeSignalMediaSendJSON(output []byte) (signalMediaSendResult, error) {
-	var result signalMediaSendResult
+func decodeSignalSendJSON(output []byte) (signalSendResult, error) {
+	var result signalSendResult
 	wholeErr := json.Unmarshal(output, &result)
 	if wholeErr == nil {
 		return result, nil
@@ -1164,7 +1229,7 @@ func decodeSignalMediaSendJSON(output []byte) (signalMediaSendResult, error) {
 		if !strings.HasPrefix(line, "{") {
 			continue
 		}
-		var candidate signalMediaSendResult
+		var candidate signalSendResult
 		if err := json.Unmarshal([]byte(line), &candidate); err != nil {
 			continue
 		}
@@ -1175,17 +1240,17 @@ func decodeSignalMediaSendJSON(output []byte) (signalMediaSendResult, error) {
 	return result, fmt.Errorf("decode Signal media send JSON: %w", wholeErr)
 }
 
-type signalMediaRecipientResultsError struct {
+type signalSendRecipientResultsError struct {
 	failures            []string
 	allRecipientsFailed bool
 }
 
-func (e *signalMediaRecipientResultsError) Error() string {
+func (e *signalSendRecipientResultsError) Error() string {
 	return "Signal media send failed for " + strings.Join(e.failures, ", ")
 }
 
-func signalMediaAllRecipientsFailed(err error) bool {
-	var resultErr *signalMediaRecipientResultsError
+func signalSendAllRecipientsFailed(err error) bool {
+	var resultErr *signalSendRecipientResultsError
 	return errors.As(err, &resultErr) && resultErr.allRecipientsFailed
 }
 

--- a/internal/signallive/client_test.go
+++ b/internal/signallive/client_test.go
@@ -50,6 +50,7 @@ func TestParseSignalAccountsAcceptsJSONPhoneNumbers(t *testing.T) {
 }
 
 func TestBridgeSendTextRunsSignalCLI(t *testing.T) {
+	t.Setenv("OPENMESSAGES_MY_NAME", "")
 	bridge := &Bridge{
 		account:   "+15551230000",
 		connected: true,
@@ -77,29 +78,252 @@ func TestBridgeSendTextRunsSignalCLI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SendText(): %v", err)
 	}
-	if got := strings.Join(captured[1:], " "); !strings.Contains(got, "-a +15551230000 send -m hello from signal +15551234567") {
-		t.Fatalf("unexpected signal-cli args: %q", got)
+	wantArgs := []string{
+		"-a", "+15551230000",
+		"send",
+		"-m", "hello from signal",
+		"+15551234567",
 	}
-	if msg.ConversationID != "signal:+15551234567" {
-		t.Fatalf("conversation id = %q", msg.ConversationID)
+	if !slices.Equal(captured[1:], wantArgs) {
+		t.Fatalf("legacy signal-cli args = %q, want %q", captured[1:], wantArgs)
 	}
-	if msg.Status != "sent" || !msg.IsFromMe {
-		t.Fatalf("unexpected outgoing message %+v", msg)
-	}
-	if msg.ReplyToID != "signal:quoted" {
-		t.Fatalf("reply_to_id = %q", msg.ReplyToID)
-	}
-	if msg.SourceID != strings.TrimPrefix(msg.MessageID, "signal:") {
-		t.Fatalf("source_id = %q, want trimmed message id", msg.SourceID)
+	if msg.MessageID != "signal:local:ff9f0accc4bd325d662c082170f55eea5c1f550d" ||
+		msg.SourceID != "local:ff9f0accc4bd325d662c082170f55eea5c1f550d" ||
+		msg.ConversationID != "signal:+15551234567" ||
+		msg.SenderName != "Me" ||
+		msg.SenderNumber != "+15551230000" ||
+		msg.Body != "hello from signal" ||
+		msg.TimestampMS != 1700000000123 ||
+		msg.Status != "sent" ||
+		!msg.IsFromMe ||
+		msg.ReplyToID != "signal:quoted" ||
+		msg.SourcePlatform != "signal" {
+		t.Fatalf("legacy SendText() message = %+v, want fabricated local identity and unchanged db.Message form", msg)
 	}
 }
 
-func TestParseSignalMediaSendResultFixtures(t *testing.T) {
+func TestBridgeSendTextRequestRunsJSONSendAndReturnsSignalTimestamp(t *testing.T) {
+	success, err := os.ReadFile(filepath.Join("testdata", "send-media-success.json"))
+	if err != nil {
+		t.Fatalf("read success fixture: %v", err)
+	}
+	tests := []struct {
+		name           string
+		conversationID string
+		wantTargetArgs []string
+	}{
+		{
+			name:           "recipient",
+			conversationID: "signal:+15551234567",
+			wantTargetArgs: []string{"+15551234567"},
+		},
+		{
+			name:           "group",
+			conversationID: "signal-group:test-group",
+			wantTargetArgs: []string{"--group-id", "test-group"},
+		},
+	}
+
+	originalRun := runSignalCLI
+	defer func() { runSignalCLI = originalRun }()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bridge := &Bridge{
+				account:   "+15551230000",
+				connected: true,
+				configDir: t.TempDir(),
+				logger:    zerolog.Nop(),
+			}
+			var captured []string
+			runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+				captured = append([]string{}, args...)
+				return success, nil
+			}
+
+			timestamp, err := bridge.SendTextRequest(tc.conversationID, "  hello from durable Signal  ", "")
+			if err != nil {
+				t.Fatalf("SendTextRequest(): %v", err)
+			}
+			if timestamp != 1700000000123 {
+				t.Fatalf("SendTextRequest() timestamp = %d, want 1700000000123", timestamp)
+			}
+			wantArgs := []string{
+				"--output=json",
+				"-a", "+15551230000",
+				"send",
+				"-m", "hello from durable Signal",
+			}
+			wantArgs = append(wantArgs, tc.wantTargetArgs...)
+			if !slices.Equal(captured, wantArgs) {
+				t.Fatalf("signal-cli args = %q, want %q", captured, wantArgs)
+			}
+		})
+	}
+}
+
+func TestBridgeSendTextRequestIncludesSignalQuoteArguments(t *testing.T) {
+	dataDir := t.TempDir()
+	store, err := db.New(filepath.Join(dataDir, "messages.db"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	const conversationID = "signal:+15551234567"
+	if err := store.UpsertMessage(&db.Message{
+		MessageID:      "signal:reply-1",
+		ConversationID: conversationID,
+		SenderName:     "Taylor",
+		SenderNumber:   "+15551234567",
+		Body:           "quoted body",
+		TimestampMS:    1700000000123,
+		SourcePlatform: "signal",
+	}); err != nil {
+		t.Fatalf("seed reply target: %v", err)
+	}
+	success, err := os.ReadFile(filepath.Join("testdata", "send-media-success.json"))
+	if err != nil {
+		t.Fatalf("read success fixture: %v", err)
+	}
+	bridge := &Bridge{
+		account:   "+15551230000",
+		connected: true,
+		configDir: t.TempDir(),
+		store:     store,
+		logger:    zerolog.Nop(),
+	}
+
+	originalRun := runSignalCLI
+	defer func() { runSignalCLI = originalRun }()
+	var captured []string
+	runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		captured = append([]string{}, args...)
+		return success, nil
+	}
+
+	if _, err := bridge.SendTextRequest(conversationID, "replying", "signal:reply-1"); err != nil {
+		t.Fatalf("SendTextRequest(): %v", err)
+	}
+	wantArgs := []string{
+		"--output=json",
+		"-a", "+15551230000",
+		"send",
+		"-m", "replying",
+		"--quote-timestamp", "1700000000123",
+		"--quote-author", "+15551234567",
+		"--quote-message", "quoted body",
+		"+15551234567",
+	}
+	if !slices.Equal(captured, wantArgs) {
+		t.Fatalf("signal-cli args = %q, want %q", captured, wantArgs)
+	}
+}
+
+func TestBridgeSendTextRequestClassifiesStructuredAndOpaqueFailures(t *testing.T) {
+	allFailed, err := os.ReadFile(filepath.Join("testdata", "send-media-all-recipients-failed.json"))
+	if err != nil {
+		t.Fatalf("read all-failed fixture: %v", err)
+	}
+	malformed, err := os.ReadFile(filepath.Join("testdata", "send-media-unparseable.txt"))
+	if err != nil {
+		t.Fatalf("read malformed fixture: %v", err)
+	}
+	tests := []struct {
+		name              string
+		output            []byte
+		commandErr        error
+		wantNotDispatched bool
+		wantDiagnostics   []string
+	}{
+		{
+			name:              "all recipients failed with nonzero exit",
+			output:            allFailed,
+			commandErr:        errors.New("exit status 1"),
+			wantNotDispatched: true,
+			wantDiagnostics:   []string{"exit status 1", "UNREGISTERED_FAILURE"},
+		},
+		{
+			name:            "malformed successful output",
+			output:          malformed,
+			wantDiagnostics: []string{"decode Signal media send JSON"},
+		},
+		{
+			name:            "opaque nonzero exit",
+			output:          []byte("signal-cli transport failed"),
+			commandErr:      errors.New("exit status 2"),
+			wantDiagnostics: []string{"exit status 2", "signal-cli transport failed"},
+		},
+		{
+			name:            "timeout despite all-failed output",
+			output:          allFailed,
+			commandErr:      context.DeadlineExceeded,
+			wantDiagnostics: []string{"context deadline exceeded", "UNREGISTERED_FAILURE"},
+		},
+	}
+
+	originalRun := runSignalCLI
+	defer func() { runSignalCLI = originalRun }()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bridge := &Bridge{
+				account:   "+15551230000",
+				connected: true,
+				configDir: t.TempDir(),
+				logger:    zerolog.Nop(),
+			}
+			runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+				return tc.output, tc.commandErr
+			}
+
+			_, err := bridge.SendTextRequest("signal:+15551234567", "hello", "")
+			if err == nil || !IsCommandError(err) {
+				t.Fatalf("SendTextRequest() error = %v (%T), want CommandError", err, err)
+			}
+			if got := IsSendNotDispatchedError(err); got != tc.wantNotDispatched {
+				t.Fatalf("IsSendNotDispatchedError() = %v, want %v for %v", got, tc.wantNotDispatched, err)
+			}
+			for _, diagnostic := range tc.wantDiagnostics {
+				if !strings.Contains(err.Error(), diagnostic) {
+					t.Fatalf("SendTextRequest() error = %q, want diagnostic %q", err, diagnostic)
+				}
+			}
+		})
+	}
+}
+
+func TestBridgeSendTextRequestSucceedsOnMixedRecipientResults(t *testing.T) {
+	mixed, err := os.ReadFile(filepath.Join("testdata", "send-media-mixed-results.json"))
+	if err != nil {
+		t.Fatalf("read mixed-results fixture: %v", err)
+	}
+	bridge := &Bridge{
+		account:   "+15551230000",
+		connected: true,
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+
+	originalRun := runSignalCLI
+	defer func() { runSignalCLI = originalRun }()
+	runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		return mixed, nil
+	}
+
+	timestamp, err := bridge.SendTextRequest("signal-group:test-group", "hello group", "")
+	if err != nil {
+		t.Fatalf("SendTextRequest() on mixed results = %v, want success", err)
+	}
+	if timestamp != 1700000000678 {
+		t.Fatalf("SendTextRequest() timestamp = %d, want 1700000000678", timestamp)
+	}
+}
+
+func TestParseSignalSendResultPreservesMediaFixtures(t *testing.T) {
 	tests := []struct {
 		name          string
 		fixture       string
 		want          int64
-		wantErrText   string
+		wantErr       string
 		wantAllFailed bool
 	}{
 		{
@@ -111,24 +335,24 @@ func TestParseSignalMediaSendResultFixtures(t *testing.T) {
 			name:          "all recipients failed",
 			fixture:       "send-media-all-recipients-failed.json",
 			want:          1700000000456,
-			wantErrText:   "UNREGISTERED_FAILURE",
+			wantErr:       "Signal media send failed for recipient 0: UNREGISTERED_FAILURE, recipient 1: NETWORK_FAILURE",
 			wantAllFailed: true,
 		},
 		{
 			name:          "all recipients failed with invalid pre-key",
 			fixture:       "send-media-invalid-pre-key.json",
 			want:          1700000000555,
-			wantErrText:   "INVALID_PRE_KEY_FAILURE",
+			wantErr:       "Signal media send failed for recipient 0: INVALID_PRE_KEY_FAILURE",
 			wantAllFailed: true,
 		},
 		{
 			// Mixed results return the timestamp ALONGSIDE the recipient error so
 			// callers can honor signal-cli's exit-0 semantics (>=1 success means
 			// the message went out).
-			name:        "mixed success and failure",
-			fixture:     "send-media-mixed-results.json",
-			want:        1700000000678,
-			wantErrText: "UNREGISTERED_FAILURE",
+			name:    "mixed success and failure",
+			fixture: "send-media-mixed-results.json",
+			want:    1700000000678,
+			wantErr: "Signal media send failed for recipient 1: UNREGISTERED_FAILURE",
 		},
 		{
 			// signal-cli WARN/JVM stderr noise rides CombinedOutput around the JSON
@@ -139,24 +363,24 @@ func TestParseSignalMediaSendResultFixtures(t *testing.T) {
 			want:    1700000000123,
 		},
 		{
-			name:        "zero timestamp",
-			fixture:     "send-media-zero-timestamp.json",
-			wantErrText: "timestamp",
+			name:    "zero timestamp",
+			fixture: "send-media-zero-timestamp.json",
+			wantErr: "Signal media send result has no valid timestamp",
 		},
 		{
-			name:        "missing timestamp",
-			fixture:     "send-media-missing-timestamp.json",
-			wantErrText: "timestamp",
+			name:    "missing timestamp",
+			fixture: "send-media-missing-timestamp.json",
+			wantErr: "Signal media send result has no valid timestamp",
 		},
 		{
-			name:        "empty recipient results",
-			fixture:     "send-media-empty-results.json",
-			wantErrText: "recipient",
+			name:    "empty recipient results",
+			fixture: "send-media-empty-results.json",
+			wantErr: "Signal media send result has no recipient results",
 		},
 		{
-			name:        "unparseable output",
-			fixture:     "send-media-unparseable.txt",
-			wantErrText: "JSON",
+			name:    "unparseable output",
+			fixture: "send-media-unparseable.txt",
+			wantErr: "decode Signal media send JSON: invalid character 's' looking for beginning of value",
 		},
 	}
 
@@ -166,24 +390,24 @@ func TestParseSignalMediaSendResultFixtures(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read fixture: %v", err)
 			}
-			got, err := parseSignalMediaSendResult(output)
-			if tc.wantErrText != "" {
-				if err == nil || !strings.Contains(err.Error(), tc.wantErrText) {
-					t.Fatalf("parseSignalMediaSendResult() error = %v, want containing %q", err, tc.wantErrText)
+			got, err := parseSignalSendResult(output)
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("parseSignalSendResult() error = %v, want %q", err, tc.wantErr)
 				}
-				if got := signalMediaAllRecipientsFailed(err); got != tc.wantAllFailed {
-					t.Fatalf("signalMediaAllRecipientsFailed() = %v, want %v for %v", got, tc.wantAllFailed, err)
+				if got := signalSendAllRecipientsFailed(err); got != tc.wantAllFailed {
+					t.Fatalf("signalSendAllRecipientsFailed() = %v, want %v for %v", got, tc.wantAllFailed, err)
 				}
 				if got != tc.want {
-					t.Fatalf("parseSignalMediaSendResult() timestamp = %d, want %d alongside error", got, tc.want)
+					t.Fatalf("parseSignalSendResult() timestamp = %d, want %d alongside error", got, tc.want)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("parseSignalMediaSendResult() error = %v", err)
+				t.Fatalf("parseSignalSendResult() error = %v", err)
 			}
 			if got != tc.want {
-				t.Fatalf("parseSignalMediaSendResult() = %d, want %d", got, tc.want)
+				t.Fatalf("parseSignalSendResult() = %d, want %d", got, tc.want)
 			}
 		})
 	}

--- a/internal/whatsapplive/client.go
+++ b/internal/whatsapplive/client.go
@@ -47,10 +47,15 @@ var ErrProfilePhotoNotFound = errors.New("whatsapp profile photo not found")
 
 var ErrTemporaryBanActive = errors.New("whatsapp temporary ban is still active")
 
-// ErrMediaNotDispatched marks failures that happened before whatsmeow's send
+// ErrSendNotDispatched marks failures that happened before whatsmeow's send
 // call. Callers may safely retry those failures without treating the attempt as
 // an ambiguous dispatch.
-var ErrMediaNotDispatched = errors.New("whatsapp media was not dispatched")
+var ErrSendNotDispatched = errors.New("whatsapp send was not dispatched")
+
+// ErrMediaNotDispatched is a forward-compat alias for the pre-rename exported
+// symbol; no in-tree caller remains, but removing an exported marker would be
+// a gratuitous API break.
+var ErrMediaNotDispatched = ErrSendNotDispatched
 
 const whatsappRuntimeStateSchema = `
 CREATE TABLE IF NOT EXISTS openmessage_whatsapp_runtime_state (
@@ -1146,66 +1151,110 @@ func (b *Bridge) Close() error {
 	return errors.Join(errs...)
 }
 
+type sendTextResult struct {
+	remoteID  string
+	timestamp time.Time
+	client    *whatsmeow.Client
+	body      string
+	replyToID string
+}
+
+// SendTextRequest sends text with a stable caller-owned request ID and returns
+// the transport identity used by the v2 dispatch path.
+func (b *Bridge) SendTextRequest(conversationID, body, replyToID, requestID string) (remoteID string, ts time.Time, err error) {
+	result, err := b.sendTextRequest(
+		conversationID,
+		body,
+		replyToID,
+		deriveWebMessageID(requestID),
+		true,
+	)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return result.remoteID, result.timestamp, nil
+}
+
 func (b *Bridge) SendText(conversationID, body, replyToID string) (*db.Message, error) {
-	body = strings.TrimSpace(body)
-	if conversationID == "" || body == "" {
-		return nil, errors.New("conversation_id and body are required")
-	}
-
-	chatJID, err := parseConversationJID(conversationID)
+	// An empty ID preserves the legacy GenerateMessageID call at the pre-send
+	// boundary. The v2 request path supplies its stable derived ID instead.
+	result, err := b.sendTextRequest(conversationID, body, replyToID, "", false)
 	if err != nil {
 		return nil, err
-	}
-
-	cli, err := b.ensureSendClient()
-	if err != nil {
-		return nil, err
-	}
-
-	reqID := cli.GenerateMessageID()
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
-	defer cancel()
-
-	resp, err := sendTextMessage(cli, ctx, chatJID, outgoingTextMessage(body, replyToID), whatsmeow.SendRequestExtra{
-		ID: reqID,
-	})
-	if err != nil {
-		b.reportConnectionError(err)
-		return nil, fmt.Errorf("send WhatsApp message: %w", err)
-	}
-
-	now := time.Now().UnixMilli()
-	if !resp.Timestamp.IsZero() {
-		now = resp.Timestamp.UnixMilli()
-	}
-	messageID := string(resp.ID)
-	if messageID == "" {
-		messageID = string(reqID)
 	}
 
 	senderName := "Me"
 	senderNumber := ""
-	if cli.Store != nil {
-		if push := strings.TrimSpace(cli.Store.PushName); push != "" {
+	if result.client.Store != nil {
+		if push := strings.TrimSpace(result.client.Store.PushName); push != "" {
 			senderName = push
 		}
-		if cli.Store.ID != nil {
-			senderNumber = jidToPhone(*cli.Store.ID)
+		if result.client.Store.ID != nil {
+			senderNumber = jidToPhone(*result.client.Store.ID)
 		}
 	}
 
 	return &db.Message{
-		MessageID:      "whatsapp:" + messageID,
+		MessageID:      "whatsapp:" + result.remoteID,
 		ConversationID: conversationID,
 		SenderName:     senderName,
 		SenderNumber:   senderNumber,
-		Body:           body,
-		TimestampMS:    now,
+		Body:           result.body,
+		TimestampMS:    result.timestamp.UnixMilli(),
 		Status:         "sent",
 		IsFromMe:       true,
-		ReplyToID:      normalizeReplyToID(replyToID),
+		ReplyToID:      result.replyToID,
 		SourcePlatform: "whatsapp",
-		SourceID:       messageID,
+		SourceID:       result.remoteID,
+	}, nil
+}
+
+func (b *Bridge) sendTextRequest(conversationID, body, replyToID string, requestID watypes.MessageID, markPreDispatch bool) (sendTextResult, error) {
+	body = strings.TrimSpace(body)
+	if conversationID == "" || body == "" {
+		return sendTextResult{}, markSendNotDispatched(errors.New("conversation_id and body are required"), markPreDispatch)
+	}
+	replyToID = normalizeReplyToID(replyToID)
+
+	chatJID, err := parseConversationJID(conversationID)
+	if err != nil {
+		return sendTextResult{}, markSendNotDispatched(err, markPreDispatch)
+	}
+
+	cli, err := b.ensureSendClient()
+	if err != nil {
+		return sendTextResult{}, markSendNotDispatched(err, markPreDispatch)
+	}
+
+	if requestID == "" {
+		requestID = cli.GenerateMessageID()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	resp, err := sendTextMessage(cli, ctx, chatJID, outgoingTextMessage(body, replyToID), whatsmeow.SendRequestExtra{
+		ID: requestID,
+	})
+	if err != nil {
+		b.reportConnectionError(err)
+		return sendTextResult{}, fmt.Errorf("send WhatsApp message: %w", err)
+	}
+
+	acceptedAt := time.Now()
+	if !resp.Timestamp.IsZero() {
+		acceptedAt = resp.Timestamp
+	}
+	messageID := string(resp.ID)
+	if messageID == "" {
+		messageID = string(requestID)
+	}
+
+	return sendTextResult{
+		remoteID:  messageID,
+		timestamp: acceptedAt,
+		client:    cli,
+		body:      body,
+		replyToID: replyToID,
 	}, nil
 }
 
@@ -1228,7 +1277,7 @@ func (b *Bridge) SendMediaRequest(conversationID string, data []byte, filename, 
 		mime,
 		caption,
 		replyToID,
-		deriveMediaRequestID(requestID),
+		deriveWebMessageID(requestID),
 		true,
 	)
 	if err != nil {
@@ -1276,22 +1325,22 @@ func (b *Bridge) SendMedia(conversationID string, data []byte, filename, mime, c
 
 func (b *Bridge) sendMediaRequest(conversationID string, data []byte, filename, mime, caption, replyToID string, requestID watypes.MessageID, markPreDispatch bool) (sendMediaResult, error) {
 	if conversationID == "" || len(data) == 0 {
-		return sendMediaResult{}, markMediaNotDispatched(errors.New("conversation_id and file are required"), markPreDispatch)
+		return sendMediaResult{}, markSendNotDispatched(errors.New("conversation_id and file are required"), markPreDispatch)
 	}
 	caption = strings.TrimSpace(caption)
 	replyToID = normalizeReplyToID(replyToID)
 	chatJID, err := parseConversationJID(conversationID)
 	if err != nil {
-		return sendMediaResult{}, markMediaNotDispatched(err, markPreDispatch)
+		return sendMediaResult{}, markSendNotDispatched(err, markPreDispatch)
 	}
 	mediaType, err := mediaTypeForMIME(mime)
 	if err != nil {
-		return sendMediaResult{}, markMediaNotDispatched(err, markPreDispatch)
+		return sendMediaResult{}, markSendNotDispatched(err, markPreDispatch)
 	}
 
 	cli, err := b.ensureSendClient()
 	if err != nil {
-		return sendMediaResult{}, markMediaNotDispatched(err, markPreDispatch)
+		return sendMediaResult{}, markSendNotDispatched(err, markPreDispatch)
 	}
 
 	uploadCtx, cancelUpload := context.WithTimeout(context.Background(), 90*time.Second)
@@ -1300,7 +1349,7 @@ func (b *Bridge) sendMediaRequest(conversationID string, data []byte, filename, 
 	upload, err := uploadMedia(cli, uploadCtx, data, mediaType)
 	if err != nil {
 		b.reportConnectionError(err)
-		return sendMediaResult{}, markMediaNotDispatched(fmt.Errorf("upload WhatsApp media: %w", err), markPreDispatch)
+		return sendMediaResult{}, markSendNotDispatched(fmt.Errorf("upload WhatsApp media: %w", err), markPreDispatch)
 	}
 	if requestID == "" {
 		requestID = cli.GenerateMessageID()
@@ -1335,28 +1384,28 @@ func (b *Bridge) sendMediaRequest(conversationID string, data []byte, filename, 
 	}, nil
 }
 
-func deriveMediaRequestID(requestID string) watypes.MessageID {
+func deriveWebMessageID(requestID string) watypes.MessageID {
 	digest := sha256.Sum256([]byte(requestID))
 	return whatsmeow.WebMessageIDPrefix + strings.ToUpper(hex.EncodeToString(digest[:9]))
 }
 
-type mediaNotDispatchedError struct {
+type sendNotDispatchedError struct {
 	cause error
 }
 
-func markMediaNotDispatched(err error, mark bool) error {
-	if !mark || err == nil || errors.Is(err, ErrMediaNotDispatched) {
+func markSendNotDispatched(err error, mark bool) error {
+	if !mark || err == nil || errors.Is(err, ErrSendNotDispatched) {
 		return err
 	}
-	return mediaNotDispatchedError{cause: err}
+	return sendNotDispatchedError{cause: err}
 }
 
-func (e mediaNotDispatchedError) Error() string { return e.cause.Error() }
+func (e sendNotDispatchedError) Error() string { return e.cause.Error() }
 
-func (e mediaNotDispatchedError) Unwrap() error { return e.cause }
+func (e sendNotDispatchedError) Unwrap() error { return e.cause }
 
-func (e mediaNotDispatchedError) Is(target error) bool {
-	return target == ErrMediaNotDispatched
+func (e sendNotDispatchedError) Is(target error) bool {
+	return target == ErrSendNotDispatched
 }
 
 func (b *Bridge) SendReaction(conversationID, targetMessageID, emoji, action string) error {

--- a/internal/whatsapplive/m2b_characterization_test.go
+++ b/internal/whatsapplive/m2b_characterization_test.go
@@ -166,7 +166,7 @@ func TestLegacySendMediaUploadErrorContractIsPreserved(t *testing.T) {
 	if err.Error() != "upload WhatsApp media: legacy upload failure" {
 		t.Fatalf("SendMedia() error text = %q, want unchanged legacy text", err.Error())
 	}
-	if errors.Is(err, ErrMediaNotDispatched) {
+	if errors.Is(err, ErrSendNotDispatched) {
 		t.Fatalf("legacy SendMedia() error gained the v2-only marker: %v", err)
 	}
 }

--- a/internal/whatsapplive/send_media_request_test.go
+++ b/internal/whatsapplive/send_media_request_test.go
@@ -15,20 +15,31 @@ import (
 	watypes "go.mau.fi/whatsmeow/types"
 )
 
-func TestDeriveMediaRequestID(t *testing.T) {
+func TestDeriveWebMessageIDPreservesMediaDerivationBytes(t *testing.T) {
 	const requestID = "outbox-request-123"
 	const want = "3EB05F7E578787F3196B49"
 
-	if got := deriveMediaRequestID(requestID); got != want {
-		t.Fatalf("deriveMediaRequestID(%q) = %q, want %q", requestID, got, want)
+	if got := deriveWebMessageID(requestID); !bytes.Equal([]byte(got), []byte(want)) {
+		t.Fatalf("deriveWebMessageID(%q) bytes = %x, want pre-rename bytes %x", requestID, []byte(got), []byte(want))
 	}
-	if got := deriveMediaRequestID(requestID); got != want {
-		t.Fatalf("second deriveMediaRequestID(%q) = %q, want deterministic %q", requestID, got, want)
+	if got := deriveWebMessageID(requestID); got != want {
+		t.Fatalf("second deriveWebMessageID(%q) = %q, want deterministic %q", requestID, got, want)
 	}
-	if got := deriveMediaRequestID(requestID + "-different"); got == want {
+	if got := deriveWebMessageID(requestID + "-different"); got == want {
 		t.Fatalf("different request ID derived %q, want a distinct transport ID", got)
 	}
 	assertWhatsAppWebMessageID(t, want)
+}
+
+func TestErrMediaNotDispatchedAliasesErrSendNotDispatched(t *testing.T) {
+	if ErrMediaNotDispatched != ErrSendNotDispatched {
+		t.Fatal("ErrMediaNotDispatched must preserve identity with ErrSendNotDispatched")
+	}
+	want := errors.New("pre-send failure")
+	err := markSendNotDispatched(want, true)
+	if !errors.Is(err, ErrSendNotDispatched) || !errors.Is(err, ErrMediaNotDispatched) || !errors.Is(err, want) {
+		t.Fatalf("marked error = %v, want send marker, media compatibility alias, and cause", err)
+	}
 }
 
 func TestSendMediaRequestUsesDerivedIDAndReturnsTransportResult(t *testing.T) {
@@ -175,7 +186,7 @@ func TestSendMediaRequestMarksOnlyPreDispatchFailures(t *testing.T) {
 			"",
 			"request-1",
 		)
-		if !errors.Is(err, want) || !errors.Is(err, ErrMediaNotDispatched) {
+		if !errors.Is(err, want) || !errors.Is(err, ErrSendNotDispatched) {
 			t.Fatalf("SendMediaRequest() error = %v, want upload cause and not-dispatched marker", err)
 		}
 		if err.Error() != "upload WhatsApp media: upload unavailable" {
@@ -214,7 +225,7 @@ func TestSendMediaRequestMarksOnlyPreDispatchFailures(t *testing.T) {
 		if !errors.Is(err, want) {
 			t.Fatalf("SendMediaRequest() error = %v, want send cause", err)
 		}
-		if errors.Is(err, ErrMediaNotDispatched) {
+		if errors.Is(err, ErrSendNotDispatched) {
 			t.Fatalf("SendMediaRequest() error = %v, ambiguous send must not claim no dispatch", err)
 		}
 		if err.Error() != "send WhatsApp media: send acknowledgement lost" {

--- a/internal/whatsapplive/send_text_request_test.go
+++ b/internal/whatsapplive/send_text_request_test.go
@@ -1,0 +1,224 @@
+package whatsapplive
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+	watypes "go.mau.fi/whatsmeow/types"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+func TestSendTextRequestUsesDerivedIDAndReturnsTransportResult(t *testing.T) {
+	bridge := connectedMediaTestBridge()
+
+	originalSend := sendTextMessage
+	originalIsConnected := clientIsConnected
+	defer func() {
+		sendTextMessage = originalSend
+		clientIsConnected = originalIsConnected
+	}()
+	clientIsConnected = func(*whatsmeow.Client) bool { return true }
+
+	wantTimestamp := time.UnixMilli(1700000000456)
+	var gotTo watypes.JID
+	var gotMessage *waE2E.Message
+	var gotRequestID string
+	sendTextMessage = func(_ *whatsmeow.Client, _ context.Context, to watypes.JID, message *waE2E.Message, extra ...whatsmeow.SendRequestExtra) (whatsmeow.SendResponse, error) {
+		gotTo = to
+		gotMessage = message
+		if len(extra) != 1 {
+			t.Fatalf("SendMessage extras = %d, want exactly one", len(extra))
+		}
+		gotRequestID = string(extra[0].ID)
+		return whatsmeow.SendResponse{
+			ID:        watypes.MessageID("server-remote-id"),
+			Timestamp: wantTimestamp,
+		}, nil
+	}
+
+	remoteID, acceptedAt, err := bridge.SendTextRequest(
+		"whatsapp:15551234567@s.whatsapp.net",
+		"  hello from v2  ",
+		"whatsapp:reply-123",
+		"outbox-request-123",
+	)
+	if err != nil {
+		t.Fatalf("SendTextRequest() error = %v", err)
+	}
+	if remoteID != "server-remote-id" {
+		t.Fatalf("remote ID = %q, want raw server ID", remoteID)
+	}
+	if !acceptedAt.Equal(wantTimestamp) {
+		t.Fatalf("accepted at = %s, want %s", acceptedAt, wantTimestamp)
+	}
+	if gotRequestID != "3EB05F7E578787F3196B49" {
+		t.Fatalf("transport request ID = %q, want derived web message ID", gotRequestID)
+	}
+	if gotTo.String() != "15551234567@s.whatsapp.net" {
+		t.Fatalf("recipient = %q, want target JID", gotTo.String())
+	}
+	if gotMessage.GetExtendedTextMessage().GetText() != "hello from v2" {
+		t.Fatalf("sent text = %q, want trimmed body", gotMessage.GetExtendedTextMessage().GetText())
+	}
+	if gotMessage.GetExtendedTextMessage().GetContextInfo().GetStanzaID() != "reply-123" {
+		t.Fatalf("reply stanza = %q, want reply-123", gotMessage.GetExtendedTextMessage().GetContextInfo().GetStanzaID())
+	}
+}
+
+func TestSendTextRequestFallsBackToDerivedIDWhenResponseOmitsID(t *testing.T) {
+	bridge := connectedMediaTestBridge()
+
+	originalSend := sendTextMessage
+	originalIsConnected := clientIsConnected
+	defer func() {
+		sendTextMessage = originalSend
+		clientIsConnected = originalIsConnected
+	}()
+	clientIsConnected = func(*whatsmeow.Client) bool { return true }
+	sendTextMessage = func(*whatsmeow.Client, context.Context, watypes.JID, *waE2E.Message, ...whatsmeow.SendRequestExtra) (whatsmeow.SendResponse, error) {
+		return whatsmeow.SendResponse{Timestamp: time.UnixMilli(1700000000456)}, nil
+	}
+
+	remoteID, _, err := bridge.SendTextRequest(
+		"whatsapp:15551234567@s.whatsapp.net",
+		"hello",
+		"",
+		"outbox-request-123",
+	)
+	if err != nil {
+		t.Fatalf("SendTextRequest() error = %v", err)
+	}
+	if remoteID != "3EB05F7E578787F3196B49" {
+		t.Fatalf("remote ID = %q, want derived request ID fallback", remoteID)
+	}
+}
+
+func TestSendTextRequestMarksOnlyPreDispatchFailures(t *testing.T) {
+	t.Run("invalid conversation", func(t *testing.T) {
+		bridge := connectedMediaTestBridge()
+
+		_, _, err := bridge.SendTextRequest("invalid", "hello", "", "request-1")
+		if err == nil || !errors.Is(err, ErrSendNotDispatched) {
+			t.Fatalf("SendTextRequest() error = %v, want not-dispatched marker", err)
+		}
+		if err.Error() != "invalid WhatsApp conversation id: invalid" {
+			t.Fatalf("error text = %q, want legacy-compatible parse error", err.Error())
+		}
+	})
+
+	t.Run("send failure", func(t *testing.T) {
+		bridge := connectedMediaTestBridge()
+		originalSend := sendTextMessage
+		originalIsConnected := clientIsConnected
+		defer func() {
+			sendTextMessage = originalSend
+			clientIsConnected = originalIsConnected
+		}()
+		clientIsConnected = func(*whatsmeow.Client) bool { return true }
+		want := errors.New("send acknowledgement lost")
+		sendTextMessage = func(*whatsmeow.Client, context.Context, watypes.JID, *waE2E.Message, ...whatsmeow.SendRequestExtra) (whatsmeow.SendResponse, error) {
+			return whatsmeow.SendResponse{}, want
+		}
+
+		_, _, err := bridge.SendTextRequest(
+			"whatsapp:15551234567@s.whatsapp.net",
+			"hello",
+			"",
+			"request-1",
+		)
+		if !errors.Is(err, want) {
+			t.Fatalf("SendTextRequest() error = %v, want send cause", err)
+		}
+		if errors.Is(err, ErrSendNotDispatched) {
+			t.Fatalf("SendTextRequest() error = %v, ambiguous send must not claim no dispatch", err)
+		}
+		if err.Error() != "send WhatsApp message: send acknowledgement lost" {
+			t.Fatalf("error text = %q, want legacy-compatible send error", err.Error())
+		}
+	})
+
+	t.Run("transport disconnected before send", func(t *testing.T) {
+		bridge := &Bridge{}
+
+		_, _, err := bridge.SendTextRequest(
+			"whatsapp:15551234567@s.whatsapp.net",
+			"hello",
+			"",
+			"request-1",
+		)
+		if !errors.Is(err, whatsmeow.ErrNotConnected) || !errors.Is(err, ErrSendNotDispatched) {
+			t.Fatalf("SendTextRequest() error = %v, want not-connected cause and not-dispatched marker", err)
+		}
+	})
+}
+
+func TestLegacySendTextContractIsPreserved(t *testing.T) {
+	bridge := connectedMediaTestBridge()
+
+	originalSend := sendTextMessage
+	originalIsConnected := clientIsConnected
+	defer func() {
+		sendTextMessage = originalSend
+		clientIsConnected = originalIsConnected
+	}()
+	clientIsConnected = func(*whatsmeow.Client) bool { return true }
+
+	var generatedID string
+	sendTextMessage = func(_ *whatsmeow.Client, _ context.Context, _ watypes.JID, message *waE2E.Message, extra ...whatsmeow.SendRequestExtra) (whatsmeow.SendResponse, error) {
+		if len(extra) != 1 {
+			t.Fatalf("SendMessage extras = %d, want exactly one", len(extra))
+		}
+		generatedID = string(extra[0].ID)
+		if generatedID == "" {
+			t.Fatal("legacy SendText passed an empty generated message ID")
+		}
+		if generatedID == string(deriveWebMessageID("")) {
+			t.Fatal("legacy SendText derived the empty request ID instead of calling GenerateMessageID")
+		}
+		if message.GetExtendedTextMessage().GetText() != "legacy text" {
+			t.Fatalf("sent text = %q, want trimmed legacy text", message.GetExtendedTextMessage().GetText())
+		}
+		return whatsmeow.SendResponse{Timestamp: time.UnixMilli(1700000000123)}, nil
+	}
+
+	message, err := bridge.SendText(
+		"whatsapp:15551234567@s.whatsapp.net",
+		"  legacy text  ",
+		"whatsapp:reply-123",
+	)
+	if err != nil {
+		t.Fatalf("SendText() error = %v", err)
+	}
+	wantMessage := &db.Message{
+		MessageID:      "whatsapp:" + generatedID,
+		ConversationID: "whatsapp:15551234567@s.whatsapp.net",
+		SenderName:     "OpenMessage",
+		SenderNumber:   "+15551230000",
+		Body:           "legacy text",
+		TimestampMS:    1700000000123,
+		Status:         "sent",
+		IsFromMe:       true,
+		ReplyToID:      "whatsapp:reply-123",
+		SourcePlatform: "whatsapp",
+		SourceID:       generatedID,
+	}
+	if !reflect.DeepEqual(message, wantMessage) {
+		t.Fatalf("legacy SendText message =\n%#v\nwant unchanged value =\n%#v", message, wantMessage)
+	}
+}
+
+func TestLegacySendTextPreDispatchErrorContractIsPreserved(t *testing.T) {
+	_, err := (&Bridge{}).SendText("invalid", "hello", "")
+	if err == nil || err.Error() != "invalid WhatsApp conversation id: invalid" {
+		t.Fatalf("SendText() error = %v, want unchanged parse error", err)
+	}
+	if errors.Is(err, ErrSendNotDispatched) {
+		t.Fatalf("legacy SendText() error gained the v2-only marker: %v", err)
+	}
+}


### PR DESCRIPTION
## Rebuild T1–T3 — text-send adapter shims (Google, WhatsApp, Signal)

The v2 dispatch pipeline can now send text through all three retained live transports: each lifecycle adapter implements `bridge.TextSender`, flipping the capability from declared to wired. **Still no production wiring** — nothing changes live behavior on merge.

### Per platform
- **Google** — additive shim over the retained `BuildSendPayloadWithTmpID` + `SendMessage` path with a stable caller-owned TmpID; `SendResult{RemoteMessageID: TmpID, EchoExpected: true}` (the Wave-4 echo upgrades provisional→permanent via M5 reconciliation). Only auth-indicting failures reach the lifecycle; a rejected status proves the connection healthy and touches nothing.
- **WhatsApp** — `whatsapplive.SendTextRequest` refactors the legacy send core to accept a caller-supplied request id (derived stable web id) and return the transport result; legacy `SendText` delegates with the empty id, keeping its `GenerateMessageID` boundary byte-identical (full-DeepEqual characterization). Send failures never touch the adapter lifecycle; the transport core's guarded `reportConnectionError` chain stays the sole reconnect route, at the same boundary as before.
- **Signal** — `signallive.SendTextRequest` sends with `--output=json` and returns signal-cli's real timestamp as the remote id, sharing the media path's noise-tolerant parse (generalized by **pure rename**, bodies byte-identical, media fixtures unchanged) including mixed-results exit-0 semantics. Legacy `SendText` is zero-diff. The send-scoped account matcher is not widened.
- **Shared** — `deriveMediaRequestID → deriveWebMessageID` (output byte-identity characterized) and `ErrMediaNotDispatched → ErrSendNotDispatched` (exported alias retained).

### Verification
- Adversarial review verdict **mergeable, zero blocking defects**: legacy paths range-diffed against pre-change main (WhatsApp: one idempotent hoist; Signal: zero diff); **D1/D2 lifecycle isolation tested in both directions on all three platforms** (transient failures leave the receive generation running; auth-indicting ones still route to repair); result contracts verified field-by-field against the M5 reconciliation expectations; readiness guards proven passive (transport never constructed on the not-connected paths).
- Full `go test -race ./...` green — 24 packages, shuffled in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
