### PR TITLE
Add reaction adapter shims for Google, WhatsApp, and Signal (rebuild T5a)

### DIFF
--- a/internal/bridgeadapters/google/send.go
+++ b/internal/bridgeadapters/google/send.go
@@ -24,6 +24,15 @@ var textSendClientFor = func(cli *client.Client) textSendClient {
 	return cli.GM
 }
 
+type reactionSendClient interface {
+	GetConversation(conversationID string) (*gmproto.Conversation, error)
+	SendReaction(payload *gmproto.SendReactionRequest) (*gmproto.SendReactionResponse, error)
+}
+
+var reactionSendClientFor = func(cli *client.Client) reactionSendClient {
+	return cli.GM
+}
+
 type mediaSendClient interface {
 	UploadMedia(data []byte, filename, mime string) (*gmproto.MediaContent, error)
 	GetConversation(conversationID string) (*gmproto.Conversation, error)
@@ -127,6 +136,88 @@ func (a *Adapter) SendText(
 		RemoteMessageID: payload.GetTmpID(),
 		EchoExpected:    true,
 	}, nil
+}
+
+// SendReaction adapts a durable reaction request to the connected libgm
+// client retained by the lifecycle-owned App generation.
+func (a *Adapter) SendReaction(
+	ctx context.Context,
+	req bridge.ReactionRequest,
+) (bridge.SendResult, error) {
+	if a == nil || a.host == nil || !a.host.Connected.Load() {
+		return bridge.SendResult{}, notConnectedReactionError()
+	}
+	cli := a.host.GetClient()
+	if cli == nil || cli.GM == nil {
+		return bridge.SendResult{}, notConnectedReactionError()
+	}
+	transport := reactionSendClientFor(cli)
+	if transport == nil {
+		return bridge.SendResult{}, notConnectedReactionError()
+	}
+	if ctx == nil {
+		return bridge.SendResult{}, preDispatchReactionError(
+			"google_reaction_context_invalid",
+			errors.New("Google reaction send context is nil"),
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.SendResult{}, preDispatchReactionError("google_reaction_context_done", err)
+	}
+
+	conversation, err := transport.GetConversation(req.Conversation.RemoteID)
+	if err != nil {
+		failure := a.classifyReactionTransportError(
+			fmt.Errorf("get Google conversation: %w", err),
+			"google_conversation_get_failed",
+			bridge.DispatchNotCalled,
+		)
+		return bridge.SendResult{}, failure
+	}
+	if conversation == nil {
+		failure := a.classifyReactionTransportError(
+			errors.New("get Google conversation: transport returned no conversation"),
+			"google_conversation_get_failed",
+			bridge.DispatchNotCalled,
+		)
+		return bridge.SendResult{}, failure
+	}
+	_, sim := app.ExtractSIMAndParticipant(conversation)
+	payload := app.BuildReactionPayload(
+		req.Target.RemoteID,
+		req.Emoji,
+		string(req.Action),
+		sim,
+	)
+	response, err := transport.SendReaction(payload)
+	if err != nil {
+		failure := a.classifyReactionTransportError(
+			fmt.Errorf("send Google reaction: %w", err),
+			"google_reaction_send_failed",
+			"",
+		)
+		return bridge.SendResult{}, failure
+	}
+	if !response.GetSuccess() {
+		// A rejected response proves the connection is healthy enough to
+		// respond; this must not touch the receive lifecycle. A nil response
+		// also has GetSuccess false and is equally safe to retry.
+		cause := errors.New("Google reaction send was rejected")
+		if response == nil {
+			cause = errors.New("send Google reaction: transport returned no response")
+		}
+		return bridge.SendResult{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "send_reaction",
+			Fingerprint: "google_reaction_rejected",
+			Dispatch:    bridge.DispatchNotCalled,
+			Cause:       cause,
+		}
+	}
+
+	// Reaction dispatch confirms an empty result via ConfirmWithoutResult;
+	// there is no reaction-message ID or echo-reconciliation consumer.
+	return bridge.SendResult{}, nil
 }
 
 // SendMedia adapts the durable media outbox request to the connected libgm
@@ -342,6 +433,37 @@ func (a *Adapter) classifyTextTransportError(
 	return failure
 }
 
+func notConnectedReactionError() bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "send_reaction",
+		Fingerprint: "google_not_connected",
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       errors.New("Google Messages is not connected"),
+	}
+}
+
+func preDispatchReactionError(fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "send_reaction",
+		Fingerprint: fingerprint,
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       cause,
+	}
+}
+
+func (a *Adapter) classifyReactionTransportError(
+	err error,
+	fingerprint string,
+	dispatch bridge.DispatchCertainty,
+) bridge.OpError {
+	failure := a.classifyTransportError(err, "send_reaction", fingerprint)
+	failure.Dispatch = dispatch
+	a.reportIfAuthIndicting(failure)
+	return failure
+}
+
 func notConnectedMediaError() bridge.OpError {
 	return bridge.OpError{
 		Class:       bridge.FailureTransient,
@@ -390,4 +512,5 @@ func (a *Adapter) reportIfAuthIndicting(failure bridge.OpError) {
 }
 
 var _ bridge.TextSender = (*Adapter)(nil)
+var _ bridge.ReactionSender = (*Adapter)(nil)
 var _ bridge.MediaSender = (*Adapter)(nil)

--- a/internal/bridgeadapters/google/send_test.go
+++ b/internal/bridgeadapters/google/send_test.go
@@ -361,6 +361,355 @@ func TestSendTextAuthExpiryStillReportsToLifecycle(t *testing.T) {
 	}
 }
 
+func TestSendReactionNotConnectedIsClassifiedPreCall(t *testing.T) {
+	host := newTestApp(t)
+	legacy := newLegacyClient(t)
+	generation := host.BeginGoogleGeneration(legacy)
+	t.Cleanup(generation.Release)
+	fake := &fakeReactionSendClient{}
+	installReactionSendClient(t, legacy, fake)
+	a := New("google-primary", host, func() bool { return true })
+	a.newClient = func() (*client.Client, transportClient, error) {
+		t.Fatal("SendReaction must not construct a Google transport")
+		return nil, nil, nil
+	}
+
+	result, err := a.SendReaction(context.Background(), bridge.ReactionRequest{
+		AccountID: "google-primary",
+		Conversation: bridge.ConversationRef{
+			RemoteID: "conversation-id",
+		},
+		Target: bridge.MessageRef{RemoteID: "target-id"},
+		Emoji:  "👍",
+		Action: bridge.ReactionAdd,
+	})
+	if result != (bridge.SendResult{}) {
+		t.Fatalf("result = %+v, want zero value", result)
+	}
+	failure := requireReactionOpError(t, err)
+	if failure.Class != bridge.FailureTransient ||
+		failure.Dispatch != bridge.DispatchNotCalled ||
+		failure.Operation != "send_reaction" ||
+		failure.Fingerprint != "google_not_connected" {
+		t.Fatalf("failure = %+v, want transient pre-call google_not_connected", failure)
+	}
+	if fake.conversationCalls != 0 || fake.sendCalls != 0 {
+		t.Fatalf("transport calls = (conversation %d, send %d), want (0, 0)",
+			fake.conversationCalls, fake.sendCalls)
+	}
+}
+
+func TestSendReactionContextGuardsAreClassifiedPreCall(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		fingerprint string
+	}{
+		{
+			name:        "nil",
+			ctx:         nil,
+			fingerprint: "google_reaction_context_invalid",
+		},
+		{
+			name: "done",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			fingerprint: "google_reaction_context_done",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeReactionSendClient{}
+			a := newReactionSendTestAdapter(t, fake)
+
+			_, err := a.SendReaction(test.ctx, bridge.ReactionRequest{})
+			failure := requireReactionOpError(t, err)
+			if failure.Class != bridge.FailureTransient ||
+				failure.Dispatch != bridge.DispatchNotCalled ||
+				failure.Operation != "send_reaction" ||
+				failure.Fingerprint != test.fingerprint {
+				t.Fatalf("failure = %+v, want transient pre-call %s", failure, test.fingerprint)
+			}
+			if fake.conversationCalls != 0 || fake.sendCalls != 0 {
+				t.Fatalf("transport calls = (conversation %d, send %d), want (0, 0)",
+					fake.conversationCalls, fake.sendCalls)
+			}
+		})
+	}
+}
+
+func TestSendReactionSuccessMapsNativeActionsAndReturnsEmptyResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		action     bridge.ReactionAction
+		wantAction gmproto.SendReactionRequest_Action
+	}{
+		{name: "add", action: bridge.ReactionAdd, wantAction: gmproto.SendReactionRequest_ADD},
+		{name: "remove", action: bridge.ReactionRemove, wantAction: gmproto.SendReactionRequest_REMOVE},
+		{name: "switch", action: bridge.ReactionSwitch, wantAction: gmproto.SendReactionRequest_SWITCH},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sim := &gmproto.SIMPayload{Two: 7, SIMNumber: 2}
+			fake := &fakeReactionSendClient{
+				conversationResult: &gmproto.Conversation{
+					ConversationID: "remote-conversation",
+					Participants: []*gmproto.Participant{{
+						ID:         &gmproto.SmallInfo{Number: "+15551234567"},
+						IsMe:       true,
+						SimPayload: sim,
+					}},
+				},
+				sendResult: &gmproto.SendReactionResponse{Success: true},
+			}
+			a := newReactionSendTestAdapter(t, fake)
+
+			result, err := a.SendReaction(context.Background(), bridge.ReactionRequest{
+				AccountID: "google-primary",
+				Conversation: bridge.ConversationRef{
+					RemoteID: "remote-conversation",
+				},
+				// Empty AuthorID is the cross-platform self-target representation.
+				// Google routes reactions by remote message ID and SIM, so it must
+				// neither reject nor invent an author identifier for this case.
+				Target: bridge.MessageRef{RemoteID: "target-message-id", AuthorID: ""},
+				Emoji:  "🫡",
+				Action: test.action,
+			})
+			if err != nil {
+				t.Fatalf("SendReaction() error = %v", err)
+			}
+			if result != (bridge.SendResult{}) {
+				t.Fatalf("result = %+v, want empty result for ConfirmWithoutResult", result)
+			}
+			if fake.conversationCalls != 1 || fake.conversationID != "remote-conversation" {
+				t.Fatalf("GetConversation = (%d calls, %q), want (1, remote-conversation)",
+					fake.conversationCalls, fake.conversationID)
+			}
+			if fake.sendCalls != 1 || fake.sent == nil {
+				t.Fatalf("SendReaction = (%d calls, payload %p), want one non-nil payload",
+					fake.sendCalls, fake.sent)
+			}
+			if fake.sent.GetMessageID() != "target-message-id" ||
+				fake.sent.GetReactionData().GetUnicode() != "🫡" ||
+				fake.sent.GetAction() != test.wantAction ||
+				fake.sent.GetSIMPayload() != sim {
+				t.Fatalf("payload = %+v, want target/emoji/action %s/original SIM", fake.sent, test.wantAction)
+			}
+		})
+	}
+}
+
+func TestSendReactionConversationFailuresAreClassifiedNotCalled(t *testing.T) {
+	tests := []struct {
+		name string
+		fake *fakeReactionSendClient
+	}{
+		{
+			name: "transport error",
+			fake: &fakeReactionSendClient{
+				conversationErr: errors.New("conversation unavailable"),
+			},
+		},
+		{
+			name: "nil conversation",
+			fake: &fakeReactionSendClient{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := newReactionSendTestAdapter(t, test.fake)
+			_, err := a.SendReaction(context.Background(), bridge.ReactionRequest{
+				Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+				Target:       bridge.MessageRef{RemoteID: "target-id"},
+				Emoji:        "👍",
+				Action:       bridge.ReactionAdd,
+			})
+			failure := requireReactionOpError(t, err)
+			if failure.Class != bridge.FailureTransient || failure.Dispatch != bridge.DispatchNotCalled ||
+				failure.Operation != "send_reaction" || failure.Fingerprint != "google_conversation_get_failed" {
+				t.Fatalf("failure = %+v, want transient pre-call google_conversation_get_failed", failure)
+			}
+			if test.fake.sendCalls != 0 {
+				t.Fatalf("SendReaction calls = %d, want 0", test.fake.sendCalls)
+			}
+		})
+	}
+}
+
+func TestSendReactionSendFailureIsClassifiedUncertain(t *testing.T) {
+	fake := &fakeReactionSendClient{
+		conversationResult: &gmproto.Conversation{},
+		sendErr:            errors.New("transport timeout"),
+	}
+	a := newReactionSendTestAdapter(t, fake)
+
+	_, err := a.SendReaction(context.Background(), bridge.ReactionRequest{
+		Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+		Target:       bridge.MessageRef{RemoteID: "target-id"},
+		Emoji:        "👍",
+		Action:       bridge.ReactionAdd,
+	})
+	failure := requireReactionOpError(t, err)
+	if failure.Class != bridge.FailureTransient || failure.Dispatch != "" ||
+		failure.Operation != "send_reaction" || failure.Fingerprint != "google_reaction_send_failed" {
+		t.Fatalf("failure = %+v, want ambiguous transient google_reaction_send_failed", failure)
+	}
+	if fake.sendCalls != 1 {
+		t.Fatalf("SendReaction calls = %d, want 1", fake.sendCalls)
+	}
+}
+
+func TestSendReactionRejectedIsClassifiedNotCalled(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *gmproto.SendReactionResponse
+	}{
+		{name: "success false", response: &gmproto.SendReactionResponse{}},
+		{name: "nil response", response: nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeReactionSendClient{
+				conversationResult: &gmproto.Conversation{},
+				sendResult:         test.response,
+			}
+			a := newReactionSendTestAdapter(t, fake)
+
+			_, err := a.SendReaction(context.Background(), bridge.ReactionRequest{
+				Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+				Target:       bridge.MessageRef{RemoteID: "target-id"},
+				Emoji:        "👍",
+				Action:       bridge.ReactionAdd,
+			})
+			failure := requireReactionOpError(t, err)
+			if failure.Class != bridge.FailureTransient || failure.Dispatch != bridge.DispatchNotCalled ||
+				failure.Operation != "send_reaction" || failure.Fingerprint != "google_reaction_rejected" {
+				t.Fatalf("failure = %+v, want transient pre-call google_reaction_rejected", failure)
+			}
+		})
+	}
+}
+
+func TestSendReactionTransientAndRejectedFailuresDoNotRetireGeneration(t *testing.T) {
+	tests := []struct {
+		name        string
+		fake        *fakeReactionSendClient
+		dispatch    bridge.DispatchCertainty
+		fingerprint string
+	}{
+		{
+			name: "ambiguous transport error",
+			fake: &fakeReactionSendClient{
+				conversationResult: &gmproto.Conversation{},
+				sendErr:            errors.New("transport timeout"),
+			},
+			dispatch:    "",
+			fingerprint: "google_reaction_send_failed",
+		},
+		{
+			name: "rejected response",
+			fake: &fakeReactionSendClient{
+				conversationResult: &gmproto.Conversation{},
+				sendResult:         &gmproto.SendReactionResponse{},
+			},
+			dispatch:    bridge.DispatchNotCalled,
+			fingerprint: "google_reaction_rejected",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			host := newTestApp(t)
+			transport := &fakeTransport{}
+			a := newTestAdapter(t, host, transport)
+			run, err := a.Start(context.Background(), bridge.StartRequest{
+				AccountID:  "google-primary",
+				Generation: 1,
+			}, nil)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			t.Cleanup(func() { stopRun(t, run) })
+			transport.emit(&gmproto.Conversation{ConversationID: "ready"})
+			<-run.Ready()
+
+			installReactionSendClient(t, host.GetClient(), test.fake)
+			_, err = a.SendReaction(context.Background(), bridge.ReactionRequest{
+				Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+				Target:       bridge.MessageRef{RemoteID: "target-id"},
+				Emoji:        "👍",
+				Action:       bridge.ReactionAdd,
+			})
+			failure := requireReactionOpError(t, err)
+			if failure.Class != bridge.FailureTransient || failure.Dispatch != test.dispatch ||
+				failure.Operation != "send_reaction" || failure.Fingerprint != test.fingerprint {
+				t.Fatalf("failure = %+v, want transient %q dispatch %q", failure, test.fingerprint, test.dispatch)
+			}
+			if !host.Connected.Load() {
+				t.Fatal("reaction failure marked the connected receive generation lost")
+			}
+			select {
+			case terminal := <-run.Done():
+				t.Fatalf("reaction failure retired the receive generation with %v", terminal)
+			default:
+			}
+			if host.GoogleStatus().NeedsRepair {
+				t.Fatal("reaction failure parked the Google lifecycle")
+			}
+		})
+	}
+}
+
+func TestSendReactionAuthExpiryStillReportsToLifecycle(t *testing.T) {
+	host := newTestApp(t)
+	transport := &fakeTransport{}
+	a := newTestAdapter(t, host, transport)
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	transport.emit(&gmproto.Conversation{ConversationID: "ready"})
+	<-run.Ready()
+
+	fake := &fakeReactionSendClient{
+		conversationResult: &gmproto.Conversation{},
+		sendErr:            errors.New("google returned http 401 for reaction send"),
+	}
+	installReactionSendClient(t, host.GetClient(), fake)
+
+	_, err = a.SendReaction(context.Background(), bridge.ReactionRequest{
+		Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+		Target:       bridge.MessageRef{RemoteID: "target-id"},
+		Emoji:        "👍",
+		Action:       bridge.ReactionAdd,
+	})
+	failure := requireReactionOpError(t, err)
+	if failure.Fingerprint != "google_auth_expired" || failure.Dispatch != "" {
+		t.Fatalf("failure = %+v, want ambiguous google_auth_expired classification", failure)
+	}
+	select {
+	case terminal := <-run.Done():
+		terminalFailure, ok := asOpError(terminal)
+		if !ok || (terminalFailure.Class != bridge.FailureCredentialsExpired &&
+			terminalFailure.Class != bridge.FailureUpgradeRequired) {
+			t.Fatalf("terminal = %v, want credentials_expired/upgrade_required", terminal)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("auth-expired reaction failure did not reach the lifecycle owner")
+	}
+}
+
 func TestSendMediaNotConnectedIsClassifiedPreCall(t *testing.T) {
 	host := newTestApp(t)
 	a := New("google-primary", host, func() bool { return true })
@@ -912,6 +1261,65 @@ func (f *fakeTextSendClient) GetConversation(conversationID string) (*gmproto.Co
 }
 
 func (f *fakeTextSendClient) SendMessage(payload *gmproto.SendMessageRequest) (*gmproto.SendMessageResponse, error) {
+	f.sendCalls++
+	f.sent = payload
+	return f.sendResult, f.sendErr
+}
+
+func newReactionSendTestAdapter(t *testing.T, fake *fakeReactionSendClient) *Adapter {
+	t.Helper()
+	host := newTestApp(t)
+	legacy := newLegacyClient(t)
+	generation := host.BeginGoogleGeneration(legacy)
+	t.Cleanup(generation.Release)
+	host.Connected.Store(true)
+	installReactionSendClient(t, legacy, fake)
+	return New("google-primary", host, func() bool { return true })
+}
+
+func installReactionSendClient(t *testing.T, want *client.Client, fake reactionSendClient) {
+	t.Helper()
+	previous := reactionSendClientFor
+	reactionSendClientFor = func(got *client.Client) reactionSendClient {
+		if got != want {
+			t.Fatalf("reaction client source = %p, want App.GetClient() %p", got, want)
+		}
+		return fake
+	}
+	t.Cleanup(func() { reactionSendClientFor = previous })
+}
+
+func requireReactionOpError(t *testing.T, err error) bridge.OpError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("SendReaction() error = nil, want classified failure")
+	}
+	failure, ok := asOpError(err)
+	if !ok {
+		t.Fatalf("SendReaction() error = %T %v, want bridge.OpError", err, err)
+	}
+	return failure
+}
+
+type fakeReactionSendClient struct {
+	conversationResult *gmproto.Conversation
+	conversationErr    error
+	sendResult         *gmproto.SendReactionResponse
+	sendErr            error
+
+	conversationCalls int
+	conversationID    string
+	sendCalls         int
+	sent              *gmproto.SendReactionRequest
+}
+
+func (f *fakeReactionSendClient) GetConversation(conversationID string) (*gmproto.Conversation, error) {
+	f.conversationCalls++
+	f.conversationID = conversationID
+	return f.conversationResult, f.conversationErr
+}
+
+func (f *fakeReactionSendClient) SendReaction(payload *gmproto.SendReactionRequest) (*gmproto.SendReactionResponse, error) {
 	f.sendCalls++
 	f.sent = payload
 	return f.sendResult, f.sendErr

--- a/internal/bridgeadapters/signal/signal.go
+++ b/internal/bridgeadapters/signal/signal.go
@@ -20,6 +20,7 @@ import (
 type poller interface {
 	StartPoller(context.Context) (signallive.PollerRun, error)
 	SendTextRequest(string, string, string) (int64, error)
+	SendReactionRequest(string, string, string, string, string) error
 	SendMediaRequest(string, io.Reader, int64, string, string, string, string) (int64, error)
 	Status() signallive.StatusSnapshot
 	ApplyPollerFailure(signallive.PollerExit)
@@ -121,6 +122,62 @@ func (a *Adapter) SendText(
 		RemoteMessageID: strconv.FormatInt(timestampMS, 10),
 		EchoExpected:    false,
 	}, nil
+}
+
+// SendReaction adapts a durable reaction request to Signal's store-free
+// signal-cli path. Reactions intentionally confirm without a remote result ID.
+func (a *Adapter) SendReaction(
+	ctx context.Context,
+	req bridge.ReactionRequest,
+) (bridge.SendResult, error) {
+	if ctx == nil {
+		return bridge.SendResult{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "send_reaction",
+			Fingerprint: "signal_send_reaction_context_missing",
+			Dispatch:    bridge.DispatchNotCalled,
+			Cause:       errors.New("Signal reaction send context is nil"),
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.SendResult{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "send_reaction",
+			Fingerprint: "signal_send_reaction_context_done",
+			Dispatch:    bridge.DispatchNotCalled,
+			Cause:       err,
+		}
+	}
+	if a == nil || a.poller == nil {
+		return bridge.SendResult{}, signalNotConnectedError("send_reaction")
+	}
+	status := a.poller.Status()
+	if !status.Connected || strings.TrimSpace(status.Account) == "" {
+		return bridge.SendResult{}, signalNotConnectedError("send_reaction")
+	}
+
+	err := a.poller.SendReactionRequest(
+		req.Conversation.RemoteID,
+		req.Target.RemoteID,
+		req.Target.AuthorID,
+		req.Emoji,
+		string(req.Action),
+	)
+	if err != nil {
+		a.ReportError(err)
+		failure := bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "send_reaction",
+			Fingerprint: "signal_reaction_failed",
+			Cause:       err,
+		}
+		if !signallive.IsCommandError(err) || signallive.IsSendNotDispatchedError(err) {
+			failure.Dispatch = bridge.DispatchNotCalled
+		}
+		return bridge.SendResult{}, failure
+	}
+
+	return bridge.SendResult{}, nil
 }
 
 func (a *Adapter) SendMedia(
@@ -627,6 +684,7 @@ var (
 	_ bridge.Adapter            = (*Adapter)(nil)
 	_ bridge.CapabilityDeclarer = (*Adapter)(nil)
 	_ bridge.TextSender         = (*Adapter)(nil)
+	_ bridge.ReactionSender     = (*Adapter)(nil)
 	_ bridge.MediaSender        = (*Adapter)(nil)
 	_ bridge.Run                = (*run)(nil)
 )

--- a/internal/bridgeadapters/signal/signal_test.go
+++ b/internal/bridgeadapters/signal/signal_test.go
@@ -24,6 +24,10 @@ func TestAdapterImplementsTextSender(t *testing.T) {
 	var _ bridge.TextSender = (*Adapter)(nil)
 }
 
+func TestAdapterImplementsReactionSender(t *testing.T) {
+	var _ bridge.ReactionSender = (*Adapter)(nil)
+}
+
 func TestSendTextRequiresReadyRetainedBridge(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -294,6 +298,281 @@ func TestSendTextRoutesLocalAccountFailureThroughGuardedLifecycleReporting(t *te
 	assertOpError(t, terminal, bridge.FailureTransient, "signal_send_account_check")
 	if got := poller.appliedCount(); got != 1 {
 		t.Fatalf("local-account text failure status projections = %d, want one transient projection", got)
+	}
+}
+
+func TestSendReactionRequiresReadyRetainedBridge(t *testing.T) {
+	tests := []struct {
+		name   string
+		poller poller
+	}{
+		{name: "nil retained bridge"},
+		{name: "not connected", poller: newFakePoller()},
+		{
+			name: "connected without account",
+			poller: &fakePoller{
+				started: make(chan *fakePollerRun, 1),
+				status:  signallive.StatusSnapshot{Connected: true},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := &Adapter{accountID: "signal-primary", poller: tc.poller}
+			result, err := adapter.SendReaction(context.Background(), bridge.ReactionRequest{
+				AccountID:    "signal-primary",
+				Conversation: bridge.ConversationRef{RemoteID: "signal:+15551234567"},
+				Target:       bridge.MessageRef{RemoteID: "1700000000123"},
+				Emoji:        "👍",
+				Action:       bridge.ReactionAdd,
+			})
+			if result != (bridge.SendResult{}) {
+				t.Fatalf("SendReaction() result = %+v, want zero", result)
+			}
+			var operationError bridge.OpError
+			if !errors.As(err, &operationError) {
+				t.Fatalf("SendReaction() error = %v (%T), want bridge.OpError", err, err)
+			}
+			if operationError.Class != bridge.FailureTransient ||
+				operationError.Dispatch != bridge.DispatchNotCalled ||
+				operationError.Operation != "send_reaction" ||
+				operationError.Fingerprint != "signal_not_connected" {
+				t.Fatalf("SendReaction() OpError = %+v, want classified not-connected pre-call failure", operationError)
+			}
+			if fake, ok := tc.poller.(*fakePoller); ok && fake.reactionCallCount() != 0 {
+				t.Fatalf("SendReactionRequest calls = %d, want 0 while not ready", fake.reactionCallCount())
+			}
+		})
+	}
+}
+
+func TestSendReactionRejectsInvalidContextBeforeTransport(t *testing.T) {
+	tests := []struct {
+		name            string
+		context         func() context.Context
+		wantFingerprint string
+	}{
+		{
+			name:            "nil context",
+			context:         func() context.Context { return nil },
+			wantFingerprint: "signal_send_reaction_context_missing",
+		},
+		{
+			name: "done context",
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantFingerprint: "signal_send_reaction_context_done",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := newFakePoller()
+			poller.status = signallive.StatusSnapshot{Connected: true, Account: "+15551230000"}
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+			_, err := adapter.SendReaction(tc.context(), bridge.ReactionRequest{})
+			var operationError bridge.OpError
+			if !errors.As(err, &operationError) ||
+				operationError.Class != bridge.FailureTransient ||
+				operationError.Dispatch != bridge.DispatchNotCalled ||
+				operationError.Operation != "send_reaction" ||
+				operationError.Fingerprint != tc.wantFingerprint {
+				t.Fatalf("SendReaction() error = %v, want pre-call context failure %q", err, tc.wantFingerprint)
+			}
+			if got := poller.reactionCallCount(); got != 0 {
+				t.Fatalf("SendReactionRequest calls = %d, want 0 after context failure", got)
+			}
+		})
+	}
+}
+
+func TestSendReactionMapsAllActionsAndReturnsEmptyResult(t *testing.T) {
+	for _, action := range []bridge.ReactionAction{
+		bridge.ReactionAdd,
+		bridge.ReactionRemove,
+		bridge.ReactionSwitch,
+	} {
+		t.Run(string(action), func(t *testing.T) {
+			poller := newFakePoller()
+			poller.status = signallive.StatusSnapshot{
+				Connected: true,
+				Paired:    true,
+				Account:   "+15551230000",
+			}
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+			result, err := adapter.SendReaction(context.Background(), bridge.ReactionRequest{
+				AccountID:    "signal-primary",
+				Conversation: bridge.ConversationRef{RemoteID: "signal-group:test-group"},
+				Target: bridge.MessageRef{
+					RemoteID: "1700000000123",
+					AuthorID: "+15551234567",
+				},
+				Emoji:     "👍",
+				Action:    action,
+				RequestID: "local-dedupe-only",
+			})
+			if err != nil {
+				t.Fatalf("SendReaction() error = %v", err)
+			}
+			if result != (bridge.SendResult{}) {
+				t.Fatalf("SendReaction() result = %+v, want empty ConfirmWithoutResult mapping", result)
+			}
+			request := poller.lastReactionRequest()
+			if request.conversationID != "signal-group:test-group" ||
+				request.targetRemoteID != "1700000000123" ||
+				request.targetAuthorID != "+15551234567" ||
+				request.emoji != "👍" ||
+				request.action != string(action) {
+				t.Fatalf("retained SendReactionRequest = %+v, want mapped ReactionRequest", request)
+			}
+		})
+	}
+}
+
+func TestSendReactionClassifiesPreCallAndCommandFailures(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantDispatch bridge.DispatchCertainty
+	}{
+		{
+			name:         "local validation",
+			err:          errors.New("signal target message is required"),
+			wantDispatch: bridge.DispatchNotCalled,
+		},
+		{
+			name: "signal-cli command",
+			err:  signallive.NewCommandError("send Signal reaction: transport failed"),
+		},
+		{
+			name: "proven not dispatched",
+			err: &fakeSignalSendNotDispatchedError{err: signallive.NewCommandError(
+				"send Signal reaction: not dispatched",
+			)},
+			wantDispatch: bridge.DispatchNotCalled,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := newFakePoller()
+			poller.status = signallive.StatusSnapshot{
+				Connected: true,
+				Paired:    true,
+				Account:   "+15551230000",
+			}
+			poller.reactionErr = tc.err
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+			_, err := adapter.SendReaction(context.Background(), bridge.ReactionRequest{})
+			var operationError bridge.OpError
+			if !errors.As(err, &operationError) {
+				t.Fatalf("SendReaction() error = %v (%T), want bridge.OpError", err, err)
+			}
+			if operationError.Class != bridge.FailureTransient ||
+				operationError.Dispatch != tc.wantDispatch ||
+				operationError.Operation != "send_reaction" ||
+				operationError.Fingerprint != "signal_reaction_failed" ||
+				!errors.Is(operationError.Cause, tc.err) {
+				t.Fatalf("SendReaction() OpError = %+v, want transient classified failure with dispatch %q", operationError, tc.wantDispatch)
+			}
+			if got := poller.appliedCount(); got != 0 {
+				t.Fatalf("recipient/local reaction failure applied %d lifecycle transitions, want 0", got)
+			}
+		})
+	}
+}
+
+func TestSendReactionDoesNotWidenGuardedLifecycleReporting(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "unregistered recipient",
+			err:  signallive.NewCommandError("send Signal reaction: user +15551234567 is not registered"),
+		},
+		{
+			name: "untrusted identity",
+			err:  signallive.NewCommandError("send Signal reaction: Untrusted identity key for +15551234567"),
+		},
+		{
+			name: "network blip",
+			err:  signallive.NewCommandError("send Signal reaction: Connection reset by peer"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := newFakePoller()
+			poller.status = signallive.StatusSnapshot{
+				Connected: true,
+				Paired:    true,
+				Account:   "+15551230000",
+			}
+			poller.reactionErr = tc.err
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+			run, err := adapter.Start(context.Background(), bridge.StartRequest{
+				AccountID:  "signal-primary",
+				Generation: 1,
+			}, nil)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			receiveValue(t, poller.started, "retained poller start")
+			t.Cleanup(func() { stopAdapterRun(t, run) })
+
+			if _, err := adapter.SendReaction(context.Background(), bridge.ReactionRequest{}); err == nil {
+				t.Fatal("SendReaction() error = nil, want scripted command failure")
+			}
+			current := adapter.currentRun()
+			if current == nil || !current.admitCallback() {
+				t.Fatal("non-account reaction failure closed callback admission on the receive generation")
+			}
+			current.callbacks.Done()
+			select {
+			case terminal := <-run.Done():
+				t.Fatalf("non-account reaction failure terminated receive generation: %v", terminal)
+			default:
+			}
+			if got := poller.appliedCount(); got != 0 {
+				t.Fatalf("non-account reaction failure applied %d lifecycle transitions, want 0", got)
+			}
+		})
+	}
+}
+
+func TestSendReactionRoutesLocalAccountFailureThroughGuardedLifecycleReporting(t *testing.T) {
+	poller := newFakePoller()
+	poller.status = signallive.StatusSnapshot{
+		Connected: true,
+		Paired:    true,
+		Account:   "+15551230000",
+	}
+	poller.reactionErr = signallive.NewCommandError("send Signal reaction: authorization failed")
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	run, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "signal-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	receiveValue(t, poller.started, "retained poller start")
+
+	if _, err := adapter.SendReaction(context.Background(), bridge.ReactionRequest{}); err == nil {
+		t.Fatal("SendReaction() error = nil, want local-account command failure")
+	}
+	terminal := receiveValue(t, run.Done(), "guarded reaction-send terminal")
+	assertOpError(t, terminal, bridge.FailureTransient, "signal_send_account_check")
+	if got := poller.appliedCount(); got != 1 {
+		t.Fatalf("local-account reaction failure status projections = %d, want one transient projection", got)
 	}
 }
 
@@ -996,6 +1275,8 @@ type fakePoller struct {
 	textCalls      []fakeTextRequest
 	textTimestamp  int64
 	textErr        error
+	reactionCalls  []fakeReactionRequest
+	reactionErr    error
 	mediaCalls     []fakeMediaRequest
 	mediaTimestamp int64
 	mediaErr       error
@@ -1005,6 +1286,14 @@ type fakeTextRequest struct {
 	conversationID string
 	body           string
 	replyToID      string
+}
+
+type fakeReactionRequest struct {
+	conversationID string
+	targetRemoteID string
+	targetAuthorID string
+	emoji          string
+	action         string
 }
 
 type fakeMediaRequest struct {
@@ -1094,6 +1383,37 @@ func (p *fakePoller) lastTextRequest() fakeTextRequest {
 		return fakeTextRequest{}
 	}
 	return p.textCalls[len(p.textCalls)-1]
+}
+
+func (p *fakePoller) SendReactionRequest(
+	conversationID, targetRemoteID, targetAuthorID, emoji, action string,
+) error {
+	p.mu.Lock()
+	p.reactionCalls = append(p.reactionCalls, fakeReactionRequest{
+		conversationID: conversationID,
+		targetRemoteID: targetRemoteID,
+		targetAuthorID: targetAuthorID,
+		emoji:          emoji,
+		action:         action,
+	})
+	err := p.reactionErr
+	p.mu.Unlock()
+	return err
+}
+
+func (p *fakePoller) reactionCallCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.reactionCalls)
+}
+
+func (p *fakePoller) lastReactionRequest() fakeReactionRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.reactionCalls) == 0 {
+		return fakeReactionRequest{}
+	}
+	return p.reactionCalls[len(p.reactionCalls)-1]
 }
 
 func (p *fakePoller) SendMediaRequest(

--- a/internal/bridgeadapters/whatsapp/send_test.go
+++ b/internal/bridgeadapters/whatsapp/send_test.go
@@ -22,6 +22,17 @@ func TestAdapterImplementsTextSender(t *testing.T) {
 	var _ bridge.TextSender = (*Adapter)(nil)
 }
 
+func TestAdapterImplementsReactionSender(t *testing.T) {
+	var _ bridge.ReactionSender = (*Adapter)(nil)
+}
+
+func TestNewWiresReactionRequestSeam(t *testing.T) {
+	a := New("whatsapp-primary", &whatsapplive.Bridge{})
+	if a.sendReactionRequest == nil {
+		t.Fatal("New() did not wire the retained SendReactionRequest method")
+	}
+}
+
 func TestSendTextRequiresReadyTransportWithoutLifecycleAction(t *testing.T) {
 	var connectCalls, sendCalls int
 	a := &Adapter{
@@ -247,6 +258,238 @@ func TestSendTextFailureDoesNotRetireReceiveGeneration(t *testing.T) {
 			select {
 			case reported := <-r.finish:
 				t.Fatalf("SendText() retired the receive generation with %v", reported)
+			default:
+			}
+		})
+	}
+}
+
+func TestSendReactionRequiresReadyTransportWithoutLifecycleAction(t *testing.T) {
+	var connectCalls, sendCalls int
+	a := &Adapter{
+		accountID: "whatsapp-primary",
+		connect: func(context.Context) error {
+			connectCalls++
+			return nil
+		},
+		mediaReady: func() bool { return false },
+		sendReactionRequest: func(string, string, string, string, string, string) error {
+			sendCalls++
+			return nil
+		},
+	}
+
+	result, err := a.SendReaction(context.Background(), bridge.ReactionRequest{})
+	if result != (bridge.SendResult{}) {
+		t.Fatalf("SendReaction() result = %+v, want zero result", result)
+	}
+	failure, ok := asOpError(err)
+	if !ok {
+		t.Fatalf("SendReaction() error = %T %v, want bridge.OpError", err, err)
+	}
+	if failure.Class != bridge.FailureTransient ||
+		failure.Dispatch != bridge.DispatchNotCalled ||
+		failure.Operation != "send_reaction" ||
+		failure.Fingerprint != "whatsapp_not_connected" ||
+		!errors.Is(failure.Cause, whatsmeow.ErrNotConnected) {
+		t.Fatalf("SendReaction() failure = %+v, want classified not-connected pre-call failure", failure)
+	}
+	if connectCalls != 0 {
+		t.Fatalf("connect calls = %d, want zero", connectCalls)
+	}
+	if sendCalls != 0 {
+		t.Fatalf("transport send calls = %d, want zero", sendCalls)
+	}
+}
+
+func TestSendReactionContextGuardsRunBeforeTransport(t *testing.T) {
+	tests := []struct {
+		name            string
+		ctx             context.Context
+		wantFingerprint string
+		wantCause       error
+	}{
+		{
+			name:            "nil context",
+			ctx:             nil,
+			wantFingerprint: "whatsapp_reaction_context_missing",
+		},
+		{
+			name:            "done context",
+			ctx:             canceledTextSendContext(),
+			wantFingerprint: "whatsapp_reaction_context_done",
+			wantCause:       context.Canceled,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var sendCalls int
+			a := &Adapter{
+				mediaReady: func() bool { return true },
+				sendReactionRequest: func(string, string, string, string, string, string) error {
+					sendCalls++
+					return nil
+				},
+			}
+
+			_, err := a.SendReaction(test.ctx, bridge.ReactionRequest{})
+			failure, ok := asOpError(err)
+			if !ok || failure.Class != bridge.FailureTransient ||
+				failure.Dispatch != bridge.DispatchNotCalled ||
+				failure.Operation != "send_reaction" ||
+				failure.Fingerprint != test.wantFingerprint {
+				t.Fatalf("SendReaction() error = %v, want context pre-call failure %q", err, test.wantFingerprint)
+			}
+			if test.wantCause != nil && !errors.Is(failure.Cause, test.wantCause) {
+				t.Fatalf("SendReaction() cause = %v, want %v", failure.Cause, test.wantCause)
+			}
+			if sendCalls != 0 {
+				t.Fatalf("transport send calls = %d, want zero", sendCalls)
+			}
+		})
+	}
+}
+
+func TestSendReactionSuccessAndActionMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		action     bridge.ReactionAction
+		wantAction string
+		authorID   string
+	}{
+		{name: "add", action: bridge.ReactionAdd, wantAction: "add", authorID: "+15557654321"},
+		{name: "remove", action: bridge.ReactionRemove, wantAction: "remove", authorID: "+15557654321"},
+		{name: "switch", action: bridge.ReactionSwitch, wantAction: "switch", authorID: "+15557654321"},
+		{name: "empty author remains self target", action: bridge.ReactionAdd, wantAction: "add"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var gotConversationID, gotTargetRemoteID, gotTargetAuthorID, gotEmoji, gotAction, gotRequestID string
+			a := &Adapter{
+				accountID:  "whatsapp-primary",
+				mediaReady: func() bool { return true },
+				sendReactionRequest: func(conversationID, targetRemoteID, targetAuthorID, emoji, action, requestID string) error {
+					gotConversationID = conversationID
+					gotTargetRemoteID = targetRemoteID
+					gotTargetAuthorID = targetAuthorID
+					gotEmoji = emoji
+					gotAction = action
+					gotRequestID = requestID
+					return nil
+				},
+			}
+
+			result, err := a.SendReaction(context.Background(), bridge.ReactionRequest{
+				AccountID: "whatsapp-primary",
+				Conversation: bridge.ConversationRef{
+					RemoteID: "whatsapp:120363019999999999@g.us",
+				},
+				Target: bridge.MessageRef{
+					RemoteID: "target-remote-id",
+					AuthorID: test.authorID,
+				},
+				Emoji:     "🔥",
+				Action:    test.action,
+				RequestID: "outbox-reaction-123",
+			})
+			if err != nil {
+				t.Fatalf("SendReaction() error = %v", err)
+			}
+			if result != (bridge.SendResult{}) {
+				t.Fatalf("SendReaction() result = %+v, want empty result for ConfirmWithoutResult", result)
+			}
+			if gotConversationID != "whatsapp:120363019999999999@g.us" ||
+				gotTargetRemoteID != "target-remote-id" ||
+				gotTargetAuthorID != test.authorID ||
+				gotEmoji != "🔥" ||
+				gotAction != test.wantAction ||
+				gotRequestID != "outbox-reaction-123" {
+				t.Fatalf("SendReactionRequest args = conversation=%q target=%q author=%q emoji=%q action=%q request=%q",
+					gotConversationID, gotTargetRemoteID, gotTargetAuthorID, gotEmoji, gotAction, gotRequestID)
+			}
+		})
+	}
+}
+
+func TestSendReactionTransportErrorClassification(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantDispatch bridge.DispatchCertainty
+	}{
+		{
+			name:         "pre-send failure is safe to retry",
+			err:          fmt.Errorf("%w: %w", whatsapplive.ErrSendNotDispatched, whatsmeow.ErrNotConnected),
+			wantDispatch: bridge.DispatchNotCalled,
+		},
+		{
+			name:         "send-boundary failure stays uncertain",
+			err:          fmt.Errorf("send WhatsApp reaction: %w", whatsmeow.ErrNotConnected),
+			wantDispatch: "",
+		},
+		{
+			name:         "ambiguous acknowledgement failure stays uncertain",
+			err:          errors.New("reaction acknowledgement lost"),
+			wantDispatch: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := &Adapter{
+				mediaReady: func() bool { return true },
+				sendReactionRequest: func(string, string, string, string, string, string) error {
+					return test.err
+				},
+			}
+
+			_, err := a.SendReaction(context.Background(), bridge.ReactionRequest{})
+			failure, ok := asOpError(err)
+			if !ok || failure.Class != bridge.FailureTransient ||
+				failure.Dispatch != test.wantDispatch ||
+				failure.Operation != "send_reaction" ||
+				failure.Fingerprint != "whatsapp_reaction_failed" ||
+				!errors.Is(failure.Cause, test.err) {
+				t.Fatalf("SendReaction() error = %v, want dispatch=%q reaction failure", err, test.wantDispatch)
+			}
+		})
+	}
+}
+
+// The retained transport core owns its guarded reconnect report. The adapter
+// shim must not independently retire the active receive generation for either
+// a known disconnect or an otherwise ambiguous reaction failure.
+func TestSendReactionFailureDoesNotRetireReceiveGeneration(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{"ambiguous send failure", errors.New("ambiguous reaction send failure")},
+		{"not connected", fmt.Errorf("send WhatsApp reaction: %w", whatsmeow.ErrNotConnected)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ready := make(chan struct{})
+			close(ready)
+			r := &run{
+				ready:     ready,
+				finish:    make(chan error, 1),
+				admitting: true,
+			}
+			a := &Adapter{
+				current:    r,
+				mediaReady: func() bool { return true },
+				sendReactionRequest: func(string, string, string, string, string, string) error {
+					return test.err
+				},
+			}
+
+			_, err := a.SendReaction(context.Background(), bridge.ReactionRequest{})
+			returnedFailure, ok := asOpError(err)
+			if !ok || !errors.Is(returnedFailure.Cause, test.err) {
+				t.Fatalf("SendReaction() error = %v, want classified transport failure", err)
+			}
+			select {
+			case reported := <-r.finish:
+				t.Fatalf("SendReaction() retired the receive generation with %v", reported)
 			default:
 			}
 		})

--- a/internal/bridgeadapters/whatsapp/whatsapp.go
+++ b/internal/bridgeadapters/whatsapp/whatsapp.go
@@ -25,20 +25,21 @@ type Adapter struct {
 	accountID string
 	host      *whatsapplive.Bridge
 
-	connect          func(context.Context) error
-	disconnect       func()
-	probe            func(context.Context) error
-	accountInfo      func() whatsapplive.AccountInfo
-	cooldown         func() time.Time
-	prepareQR        func(context.Context) (<-chan whatsmeow.QRChannelItem, error)
-	connectPairing   func(context.Context) error
-	applyQR          func(whatsmeow.QRChannelItem) whatsapplive.QRSnapshot
-	pairPhone        func(context.Context, string) (string, error)
-	unpair           func() error
-	now              func() time.Time
-	mediaReady       func() bool // Shared connection gate; it does no media-specific work.
-	sendTextRequest  func(string, string, string, string) (string, time.Time, error)
-	sendMediaRequest func(string, []byte, string, string, string, string, string) (string, time.Time, error)
+	connect             func(context.Context) error
+	disconnect          func()
+	probe               func(context.Context) error
+	accountInfo         func() whatsapplive.AccountInfo
+	cooldown            func() time.Time
+	prepareQR           func(context.Context) (<-chan whatsmeow.QRChannelItem, error)
+	connectPairing      func(context.Context) error
+	applyQR             func(whatsmeow.QRChannelItem) whatsapplive.QRSnapshot
+	pairPhone           func(context.Context, string) (string, error)
+	unpair              func() error
+	now                 func() time.Time
+	mediaReady          func() bool // Shared connection gate; it does no media-specific work.
+	sendTextRequest     func(string, string, string, string) (string, time.Time, error)
+	sendReactionRequest func(string, string, string, string, string, string) error
+	sendMediaRequest    func(string, []byte, string, string, string, string, string) (string, time.Time, error)
 
 	mu       sync.Mutex
 	current  *run
@@ -65,6 +66,7 @@ func New(accountID string, host *whatsapplive.Bridge) *Adapter {
 		a.unpair = host.Unpair
 		a.mediaReady = func() bool { return host.Status().Connected }
 		a.sendTextRequest = host.SendTextRequest
+		a.sendReactionRequest = host.SendReactionRequest
 		a.sendMediaRequest = host.SendMediaRequest
 		host.ObserveLifecycle(a.handleLifecycleEvent)
 	}
@@ -149,6 +151,59 @@ func whatsappTextPreCallFailure(fingerprint string, cause error) bridge.OpError 
 }
 
 var _ bridge.TextSender = (*Adapter)(nil)
+
+// SendReaction bridges the v2 reaction request to the existing whatsmeow
+// transport without loading or updating the legacy stored reaction target.
+func (a *Adapter) SendReaction(ctx context.Context, req bridge.ReactionRequest) (bridge.SendResult, error) {
+	if a == nil || a.mediaReady == nil || !a.mediaReady() || a.sendReactionRequest == nil {
+		return bridge.SendResult{}, whatsappReactionPreCallFailure(
+			"whatsapp_not_connected",
+			whatsmeow.ErrNotConnected,
+		)
+	}
+	if ctx == nil {
+		return bridge.SendResult{}, whatsappReactionPreCallFailure(
+			"whatsapp_reaction_context_missing",
+			errors.New("WhatsApp reaction send context is nil"),
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.SendResult{}, whatsappReactionPreCallFailure("whatsapp_reaction_context_done", err)
+	}
+
+	err := a.sendReactionRequest(
+		req.Conversation.RemoteID,
+		req.Target.RemoteID,
+		req.Target.AuthorID,
+		req.Emoji,
+		string(req.Action),
+		req.RequestID,
+	)
+	if err != nil {
+		// Deliberately no adapter-level lifecycle report. The retained core's
+		// guarded reportConnectionError path owns reconnect-worthy failures.
+		failure := a.classifyError(err, "send_reaction", "whatsapp_reaction_failed")
+		if errors.Is(err, whatsapplive.ErrSendNotDispatched) {
+			failure.Dispatch = bridge.DispatchNotCalled
+		}
+		return bridge.SendResult{}, failure
+	}
+
+	// Reaction dispatch intentionally confirms without a transport result.
+	return bridge.SendResult{}, nil
+}
+
+func whatsappReactionPreCallFailure(fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "send_reaction",
+		Fingerprint: fingerprint,
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       cause,
+	}
+}
+
+var _ bridge.ReactionSender = (*Adapter)(nil)
 
 // SendMedia bridges the v2 request contract to the already-owned whatsmeow
 // transport. Readiness is checked without constructing or connecting a client.

--- a/internal/signallive/client.go
+++ b/internal/signallive/client.go
@@ -1254,6 +1254,70 @@ func signalSendAllRecipientsFailed(err error) bool {
 	return errors.As(err, &resultErr) && resultErr.allRecipientsFailed
 }
 
+// SendReactionRequest sends a reaction using only the durable request's remote
+// references. Unlike the legacy SendReaction path, it neither reads nor updates
+// locally stored message state.
+func (b *Bridge) SendReactionRequest(
+	conversationID, targetRemoteID, targetAuthorID, emoji, action string,
+) error {
+	targetRemoteID = strings.TrimSpace(targetRemoteID)
+	if targetRemoteID == "" {
+		return errors.New("signal target message is required")
+	}
+	emoji = strings.TrimSpace(emoji)
+	if emoji == "" {
+		return errors.New("signal reaction emoji is required")
+	}
+	action = strings.ToLower(strings.TrimSpace(action))
+	if action == "" {
+		action = "add"
+	}
+
+	account, err := b.usableAccount()
+	if err != nil {
+		return err
+	}
+	recipient, isGroup, err := parseConversationTarget(conversationID)
+	if err != nil {
+		return err
+	}
+	targetAuthor := strings.TrimSpace(targetAuthorID)
+	if targetAuthor == "" {
+		// An empty author identifies a message sent by this account.
+		targetAuthor = account
+	}
+
+	args := []string{
+		"-a", account,
+		"sendReaction",
+		"-e", emoji,
+		"-a", targetAuthor,
+		"-t", targetRemoteID,
+	}
+	if action == "remove" {
+		args = append(args, "-r")
+	}
+	// Signal has no native switch action: sending the new emoji without -r
+	// overwrites the account's existing reaction.
+	if isGroup {
+		args = append(args, "--group-id", recipient)
+	} else {
+		args = append(args, recipient)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
+	defer cancel()
+	b.commandMu.Lock()
+	output, err := runSignalCLI(ctx, b.configDir, args...)
+	b.commandMu.Unlock()
+	if err != nil {
+		// There is no structured reaction result that can prove a signal-cli
+		// boundary failure was not dispatched, so it remains uncertain.
+		return commandError("send Signal reaction", err, output)
+	}
+	return nil
+}
+
 func (b *Bridge) SendReaction(conversationID, targetMessageID, emoji, action string) error {
 	targetMessageID = strings.TrimSpace(targetMessageID)
 	if targetMessageID == "" {

--- a/internal/signallive/client_test.go
+++ b/internal/signallive/client_test.go
@@ -1979,7 +1979,136 @@ func TestHandleReceiveOutputAppliesSentSyncSignalGroupEditWithoutDestination(t *
 	}
 }
 
-func TestBridgeSendReactionRunsSignalCLIAndUpdatesLocalState(t *testing.T) {
+func TestBridgeSendReactionRequestMapsActionsWithoutStoredState(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		wantR  bool
+	}{
+		{name: "add", action: "add"},
+		{name: "remove", action: "remove", wantR: true},
+		{name: "switch", action: "switch"},
+	}
+
+	originalRun := runSignalCLI
+	defer func() { runSignalCLI = originalRun }()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bridge := &Bridge{
+				account:   "+15551230000",
+				connected: true,
+				configDir: t.TempDir(),
+				logger:    zerolog.Nop(),
+			}
+			var captured []string
+			runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+				captured = append([]string(nil), args...)
+				return []byte("ok"), nil
+			}
+
+			err := bridge.SendReactionRequest(
+				"signal:+15551234567",
+				"1700000000123",
+				"+15551234567",
+				"😂",
+				tc.action,
+			)
+			if err != nil {
+				t.Fatalf("SendReactionRequest(): %v", err)
+			}
+			want := []string{
+				"-a", "+15551230000",
+				"sendReaction",
+				"-e", "😂",
+				"-a", "+15551234567",
+				"-t", "1700000000123",
+			}
+			if tc.wantR {
+				want = append(want, "-r")
+			}
+			want = append(want, "+15551234567")
+			if !slices.Equal(captured, want) {
+				t.Fatalf("signal-cli args = %q, want %q", captured, want)
+			}
+			if slices.Contains(captured, "--output=json") || slices.Contains(captured, "--output") {
+				t.Fatalf("reaction requested unused structured output: %q", captured)
+			}
+		})
+	}
+}
+
+func TestBridgeSendReactionRequestMapsEmptyAuthorToSelfForGroup(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		connected: true,
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+
+	originalRun := runSignalCLI
+	defer func() { runSignalCLI = originalRun }()
+	var captured []string
+	runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		captured = append([]string(nil), args...)
+		return []byte("ok"), nil
+	}
+
+	if err := bridge.SendReactionRequest(
+		"signal-group:test-group",
+		"1700000000123",
+		"",
+		"👍",
+		"switch",
+	); err != nil {
+		t.Fatalf("SendReactionRequest(): %v", err)
+	}
+	want := []string{
+		"-a", "+15551230000",
+		"sendReaction",
+		"-e", "👍",
+		"-a", "+15551230000",
+		"-t", "1700000000123",
+		"--group-id", "test-group",
+	}
+	if !slices.Equal(captured, want) {
+		t.Fatalf("signal-cli args = %q, want self-authored group target %q", captured, want)
+	}
+}
+
+func TestBridgeSendReactionRequestSeparatesPreCallAndCommandFailures(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		connected: true,
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+
+	originalRun := runSignalCLI
+	defer func() { runSignalCLI = originalRun }()
+	calls := 0
+	runSignalCLI = func(context.Context, string, ...string) ([]byte, error) {
+		calls++
+		return nil, errors.New("exit status 1")
+	}
+
+	err := bridge.SendReactionRequest("invalid-conversation", "1700000000123", "", "👍", "add")
+	if err == nil || IsCommandError(err) || IsSendNotDispatchedError(err) {
+		t.Fatalf("pre-call error = %v (%T), want unmarked validation error", err, err)
+	}
+	if calls != 0 {
+		t.Fatalf("signal-cli calls after pre-call failure = %d, want 0", calls)
+	}
+
+	err = bridge.SendReactionRequest("signal:+15551234567", "1700000000123", "", "👍", "add")
+	if err == nil || !IsCommandError(err) || IsSendNotDispatchedError(err) {
+		t.Fatalf("send-boundary error = %v (%T), want uncertain CommandError", err, err)
+	}
+	if calls != 1 {
+		t.Fatalf("signal-cli calls after send-boundary failure = %d, want 1", calls)
+	}
+}
+
+func TestLegacySendReactionCharacterizationPreservesTransportAndLocalState(t *testing.T) {
 	dataDir := t.TempDir()
 	store, err := db.New(filepath.Join(dataDir, "messages.db"))
 	if err != nil {

--- a/internal/whatsapplive/client.go
+++ b/internal/whatsapplive/client.go
@@ -1408,6 +1408,51 @@ func (e sendNotDispatchedError) Is(target error) bool {
 	return target == ErrSendNotDispatched
 }
 
+// SendReactionRequest sends a reaction from the v2 request data without
+// loading or updating the locally stored target message.
+func (b *Bridge) SendReactionRequest(conversationID, targetRemoteID, targetAuthorID, emoji, action, requestID string) error {
+	chatJID, err := parseConversationJID(conversationID)
+	if err != nil {
+		return markSendNotDispatched(err, true)
+	}
+	chatJID = b.normalizeConversationJID(chatJID)
+
+	targetSenderJID := watypes.EmptyJID
+	if strings.TrimSpace(targetAuthorID) != "" {
+		targetSenderJID = b.canonicalJID(parseWhatsAppSenderJID(targetAuthorID))
+	}
+
+	reactionText := emoji
+	switch action {
+	case "remove":
+		reactionText = ""
+	case "switch":
+		// WhatsApp has no distinct switch action: sending the new emoji
+		// overwrites the actor's existing reaction, just like an add.
+		reactionText = emoji
+	}
+	reqID := deriveWebMessageID(requestID)
+
+	cli, err := b.ensureSendClient()
+	if err != nil {
+		return markSendNotDispatched(err, true)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	_, err = sendTextMessage(cli, ctx, chatJID, cli.BuildReaction(
+		chatJID,
+		targetSenderJID,
+		watypes.MessageID(targetRemoteID),
+		reactionText,
+	), whatsmeow.SendRequestExtra{ID: reqID})
+	if err != nil {
+		b.reportConnectionError(err)
+		return fmt.Errorf("send WhatsApp reaction: %w", err)
+	}
+	return nil
+}
+
 func (b *Bridge) SendReaction(conversationID, targetMessageID, emoji, action string) error {
 	targetMessageID = strings.TrimSpace(targetMessageID)
 	if targetMessageID == "" {

--- a/internal/whatsapplive/send_reaction_request_test.go
+++ b/internal/whatsapplive/send_reaction_request_test.go
@@ -1,0 +1,178 @@
+package whatsapplive
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+	watypes "go.mau.fi/whatsmeow/types"
+)
+
+func TestSendReactionRequestMapsActionsAndTargetSender(t *testing.T) {
+	tests := []struct {
+		name            string
+		action          string
+		targetAuthorID  string
+		wantText        string
+		wantFromMe      bool
+		wantParticipant string
+	}{
+		{
+			name:            "add from another group participant",
+			action:          "add",
+			targetAuthorID:  "+15557654321",
+			wantText:        "🔥",
+			wantParticipant: "15557654321@s.whatsapp.net",
+		},
+		{
+			name:            "switch overwrites with another emoji",
+			action:          "switch",
+			targetAuthorID:  "+15557654321",
+			wantText:        "🔥",
+			wantParticipant: "15557654321@s.whatsapp.net",
+		},
+		{
+			name:            "remove sends empty reaction text",
+			action:          "remove",
+			targetAuthorID:  "+15557654321",
+			wantText:        "",
+			wantParticipant: "15557654321@s.whatsapp.net",
+		},
+		{
+			name:       "empty author targets own message",
+			action:     "add",
+			wantText:   "🔥",
+			wantFromMe: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bridge := connectedMediaTestBridge()
+			originalSend := sendTextMessage
+			originalIsConnected := clientIsConnected
+			defer func() {
+				sendTextMessage = originalSend
+				clientIsConnected = originalIsConnected
+			}()
+			clientIsConnected = func(*whatsmeow.Client) bool { return true }
+
+			var gotTo watypes.JID
+			var gotMessage *waE2E.Message
+			var gotRequestID watypes.MessageID
+			sendTextMessage = func(_ *whatsmeow.Client, _ context.Context, to watypes.JID, message *waE2E.Message, extra ...whatsmeow.SendRequestExtra) (whatsmeow.SendResponse, error) {
+				gotTo = to
+				gotMessage = message
+				if len(extra) != 1 {
+					t.Fatalf("SendMessage extras = %d, want exactly one", len(extra))
+				}
+				gotRequestID = extra[0].ID
+				return whatsmeow.SendResponse{}, nil
+			}
+
+			err := bridge.SendReactionRequest(
+				"whatsapp:120363019999999999@g.us",
+				"target-remote-id",
+				test.targetAuthorID,
+				"🔥",
+				test.action,
+				"outbox-request-123",
+			)
+			if err != nil {
+				t.Fatalf("SendReactionRequest() error = %v", err)
+			}
+			if gotTo.String() != "120363019999999999@g.us" {
+				t.Fatalf("recipient = %q, want group JID", gotTo.String())
+			}
+			if gotRequestID != deriveWebMessageID("outbox-request-123") {
+				t.Fatalf("request ID = %q, want derived ID %q", gotRequestID, deriveWebMessageID("outbox-request-123"))
+			}
+			reaction := extractReactionMessage(gotMessage)
+			if reaction == nil {
+				t.Fatal("expected outgoing reaction message")
+			}
+			if reaction.GetKey().GetID() != "target-remote-id" {
+				t.Fatalf("target ID = %q, want target-remote-id", reaction.GetKey().GetID())
+			}
+			if reaction.GetText() != test.wantText {
+				t.Fatalf("reaction text = %q, want %q", reaction.GetText(), test.wantText)
+			}
+			if reaction.GetKey().GetFromMe() != test.wantFromMe {
+				t.Fatalf("target FromMe = %t, want %t", reaction.GetKey().GetFromMe(), test.wantFromMe)
+			}
+			if reaction.GetKey().GetParticipant() != test.wantParticipant {
+				t.Fatalf("target participant = %q, want %q", reaction.GetKey().GetParticipant(), test.wantParticipant)
+			}
+		})
+	}
+}
+
+func TestSendReactionRequestMarksOnlyPreDispatchFailures(t *testing.T) {
+	t.Run("invalid conversation", func(t *testing.T) {
+		err := connectedMediaTestBridge().SendReactionRequest(
+			"invalid",
+			"target-remote-id",
+			"+15557654321",
+			"🔥",
+			"add",
+			"request-1",
+		)
+		if err == nil || !errors.Is(err, ErrSendNotDispatched) {
+			t.Fatalf("SendReactionRequest() error = %v, want not-dispatched marker", err)
+		}
+		if err.Error() != "invalid WhatsApp conversation id: invalid" {
+			t.Fatalf("error text = %q, want parse error", err.Error())
+		}
+	})
+
+	t.Run("transport disconnected before send", func(t *testing.T) {
+		err := (&Bridge{}).SendReactionRequest(
+			"whatsapp:15551234567@s.whatsapp.net",
+			"target-remote-id",
+			"",
+			"🔥",
+			"add",
+			"request-1",
+		)
+		if !errors.Is(err, whatsmeow.ErrNotConnected) || !errors.Is(err, ErrSendNotDispatched) {
+			t.Fatalf("SendReactionRequest() error = %v, want not-connected cause and not-dispatched marker", err)
+		}
+	})
+
+	t.Run("send-boundary failure is uncertain and reported by retained core", func(t *testing.T) {
+		bridge := connectedMediaTestBridge()
+		originalSend := sendTextMessage
+		originalIsConnected := clientIsConnected
+		defer func() {
+			sendTextMessage = originalSend
+			clientIsConnected = originalIsConnected
+		}()
+		clientIsConnected = func(*whatsmeow.Client) bool { return true }
+		want := whatsmeow.ErrNotConnected
+		sendTextMessage = func(*whatsmeow.Client, context.Context, watypes.JID, *waE2E.Message, ...whatsmeow.SendRequestExtra) (whatsmeow.SendResponse, error) {
+			return whatsmeow.SendResponse{}, want
+		}
+		var reported error
+		bridge.callbacks.OnConnectionError = func(err error) { reported = err }
+
+		err := bridge.SendReactionRequest(
+			"whatsapp:15551234567@s.whatsapp.net",
+			"target-remote-id",
+			"",
+			"🔥",
+			"add",
+			"request-1",
+		)
+		if !errors.Is(err, want) {
+			t.Fatalf("SendReactionRequest() error = %v, want send cause", err)
+		}
+		if errors.Is(err, ErrSendNotDispatched) {
+			t.Fatalf("SendReactionRequest() error = %v, send-boundary failure must stay uncertain", err)
+		}
+		if !errors.Is(reported, want) {
+			t.Fatalf("retained lifecycle report = %v, want send cause", reported)
+		}
+	})
+}


### PR DESCRIPTION
## Rebuild T5a — reaction adapter shims (Google, WhatsApp, Signal)

Each lifecycle adapter now implements `bridge.ReactionSender`. **Still no production wiring.**

### Design
- **Uniform result mapping** — all three return an empty `SendResult` on success: reactions are fire-and-confirm (`dispatchReactionLease` routes the empty id to `ConfirmWithoutResult`; Google's transport returns only a success bool anyway).
- **Self-target contract** — empty `Target.AuthorID` means *self* on every platform (WhatsApp `EmptyJID` → whatsmeow `FromMe=true`, verified against the pinned whatsmeow source; Signal → own account, mirroring the quote path; Google needs no author).
- **Action mapping per platform reality** — Google passes add/remove/switch natively; WhatsApp realizes remove as empty reaction text, switch as overwrite-add; Signal appends `-r` for remove only.
- **Store-free retained variants** on WhatsApp/Signal with the legacy argv/boundary layouts; both legacy `SendReaction` bodies byte-identical to main (characterization-pinned).

### Verification
- Adversarial review verdict **mergeable, zero required fixes**: D1/D2 lifecycle isolation both directions on all three platforms; the two targeted likely-bug sites (Google action-string case semantics; Signal's double `-a` argv) proven clean against the real `gm.go` mapping and the extracted legacy argv; legacy bodies byte-diffed.
- Full `go test -race ./...` green — 24 packages, shuffled in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
