### PR TITLE
Add read-receipt adapter shims and reconcile capability honesty (rebuild T5b)

### DIFF
--- a/internal/bridgeadapters/google/mark_read_test.go
+++ b/internal/bridgeadapters/google/mark_read_test.go
@@ -1,0 +1,305 @@
+package google
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/client"
+)
+
+var _ bridge.ReadReceiptSender = (*Adapter)(nil)
+
+func TestMarkReadNotConnectedDoesNotReachClientOrTransport(t *testing.T) {
+	host := newTestApp(t)
+	legacy := newLegacyClient(t)
+	generation := host.BeginGoogleGeneration(legacy)
+	t.Cleanup(generation.Release)
+	fake := &fakeReadSendClient{}
+	seam := installReadSendClient(t, legacy, fake)
+	a := New("google-primary", host, func() bool { return true })
+	a.newClient = func() (*client.Client, transportClient, error) {
+		t.Fatal("MarkRead must not construct a Google transport")
+		return nil, nil, nil
+	}
+
+	err := a.MarkRead(context.Background(), bridge.ReadReceiptRequest{
+		AccountID: "google-primary",
+		Conversation: bridge.ConversationRef{
+			RemoteID: "conversation-id",
+		},
+		Messages: []bridge.MessageRef{{RemoteID: "message-id"}},
+	})
+	failure := requireMarkReadOpError(t, err)
+	if failure.Class != bridge.FailureTransient ||
+		failure.Dispatch != bridge.DispatchNotCalled ||
+		failure.Operation != "mark_read" ||
+		failure.Fingerprint != "google_not_connected" {
+		t.Fatalf("failure = %+v, want transient pre-call google_not_connected", failure)
+	}
+	if seam.calls != 0 || fake.calls != 0 {
+		t.Fatalf("seam/transport calls = (%d, %d), want (0, 0)", seam.calls, fake.calls)
+	}
+}
+
+func TestMarkReadContextGuardsDoNotReachTransport(t *testing.T) {
+	doneCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	tests := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{name: "nil", ctx: nil},
+		{name: "done", ctx: doneCtx},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeReadSendClient{}
+			a := newReadSendTestAdapter(t, fake)
+
+			err := a.MarkRead(test.ctx, bridge.ReadReceiptRequest{
+				Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+				Messages:     []bridge.MessageRef{{RemoteID: "message-id"}},
+			})
+			failure := requireMarkReadOpError(t, err)
+			if failure.Class != bridge.FailureTransient ||
+				failure.Dispatch != bridge.DispatchNotCalled ||
+				failure.Operation != "mark_read" {
+				t.Fatalf("failure = %+v, want transient pre-call mark_read", failure)
+			}
+			if fake.calls != 0 {
+				t.Fatalf("MarkRead transport calls = %d, want 0", fake.calls)
+			}
+		})
+	}
+}
+
+func TestMarkReadEmptyMessagesIsClassifiedPreCall(t *testing.T) {
+	fake := &fakeReadSendClient{}
+	a := newReadSendTestAdapter(t, fake)
+
+	err := a.MarkRead(context.Background(), bridge.ReadReceiptRequest{
+		Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+	})
+	failure := requireMarkReadOpError(t, err)
+	if failure.Class != bridge.FailureTransient ||
+		failure.Dispatch != bridge.DispatchNotCalled ||
+		failure.Operation != "mark_read" {
+		t.Fatalf("failure = %+v, want transient pre-call mark_read", failure)
+	}
+	if fake.calls != 0 {
+		t.Fatalf("MarkRead transport calls = %d, want 0", fake.calls)
+	}
+}
+
+func TestMarkReadSuccessUsesConversationAndLastMessageAsCursor(t *testing.T) {
+	fake := &fakeReadSendClient{}
+	a := newReadSendTestAdapter(t, fake)
+
+	err := a.MarkRead(context.Background(), bridge.ReadReceiptRequest{
+		AccountID: "google-primary",
+		Conversation: bridge.ConversationRef{
+			RemoteID: "remote-conversation-id",
+		},
+		Messages: []bridge.MessageRef{
+			{RemoteID: "older-message-id", AuthorID: "older-author"},
+			{RemoteID: "read-cursor-message-id", AuthorID: "cursor-author"},
+		},
+		ReadAt: time.Date(2026, time.July, 15, 13, 14, 15, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("MarkRead() error = %v", err)
+	}
+	if fake.calls != 1 {
+		t.Fatalf("MarkRead transport calls = %d, want 1", fake.calls)
+	}
+	if fake.conversationID != "remote-conversation-id" ||
+		fake.messageID != "read-cursor-message-id" {
+		t.Fatalf(
+			"MarkRead transport args = (%q, %q), want (remote-conversation-id, read-cursor-message-id)",
+			fake.conversationID,
+			fake.messageID,
+		)
+	}
+}
+
+func TestMarkReadTransientTransportFailureIsRetryableNotUncertain(t *testing.T) {
+	fake := &fakeReadSendClient{err: errors.New("transport timeout")}
+	a := newReadSendTestAdapter(t, fake)
+
+	err := a.MarkRead(context.Background(), bridge.ReadReceiptRequest{
+		Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+		Messages:     []bridge.MessageRef{{RemoteID: "message-id"}},
+	})
+	failure := requireMarkReadOpError(t, err)
+	if failure.Class != bridge.FailureTransient ||
+		failure.Operation != "mark_read" ||
+		failure.Fingerprint != "google_mark_read_failed" ||
+		failure.Dispatch != bridge.DispatchNotCalled {
+		t.Fatalf(
+			"failure = %+v, want transient google_mark_read_failed with DispatchNotCalled (never uncertain)",
+			failure,
+		)
+	}
+	if failure.Dispatch == bridge.DispatchUncertain {
+		t.Fatalf("failure dispatch = %q, idempotent read receipt must never be uncertain", failure.Dispatch)
+	}
+	if fake.calls != 1 {
+		t.Fatalf("MarkRead transport calls = %d, want 1", fake.calls)
+	}
+}
+
+func TestMarkReadTransientFailureDoesNotRetireGeneration(t *testing.T) {
+	host := newTestApp(t)
+	lifecycleTransport := &fakeTransport{}
+	a := newTestAdapter(t, host, lifecycleTransport)
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+	lifecycleTransport.emit(&gmproto.Conversation{ConversationID: "ready"})
+	<-run.Ready()
+
+	fake := &fakeReadSendClient{err: errors.New("transport timeout")}
+	installReadSendClient(t, host.GetClient(), fake)
+	err = a.MarkRead(context.Background(), bridge.ReadReceiptRequest{
+		Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+		Messages:     []bridge.MessageRef{{RemoteID: "message-id"}},
+	})
+	failure := requireMarkReadOpError(t, err)
+	if failure.Class != bridge.FailureTransient ||
+		failure.Operation != "mark_read" ||
+		failure.Fingerprint != "google_mark_read_failed" ||
+		failure.Dispatch != bridge.DispatchNotCalled {
+		t.Fatalf("failure = %+v, want retryable google_mark_read_failed", failure)
+	}
+	if !host.Connected.Load() {
+		t.Fatal("transient read failure marked the connected receive generation lost")
+	}
+	select {
+	case terminal := <-run.Done():
+		t.Fatalf("transient read failure retired the receive generation with %v", terminal)
+	default:
+	}
+	if host.GoogleStatus().NeedsRepair {
+		t.Fatal("transient read failure parked the Google lifecycle")
+	}
+}
+
+func TestMarkReadAuthExpiryReportsToLifecycleAndRemainsRetryable(t *testing.T) {
+	host := newTestApp(t)
+	lifecycleTransport := &fakeTransport{}
+	a := newTestAdapter(t, host, lifecycleTransport)
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	lifecycleTransport.emit(&gmproto.Conversation{ConversationID: "ready"})
+	<-run.Ready()
+
+	fake := &fakeReadSendClient{err: errors.New("google returned HTTP 401 for MarkRead")}
+	installReadSendClient(t, host.GetClient(), fake)
+	err = a.MarkRead(context.Background(), bridge.ReadReceiptRequest{
+		Conversation: bridge.ConversationRef{RemoteID: "conversation-id"},
+		Messages:     []bridge.MessageRef{{RemoteID: "message-id"}},
+	})
+	failure := requireMarkReadOpError(t, err)
+	if failure.Class != bridge.FailureCredentialsExpired ||
+		failure.Fingerprint != "google_auth_expired" ||
+		failure.Dispatch != bridge.DispatchNotCalled {
+		t.Fatalf(
+			"failure = %+v, want credentials-expired google_auth_expired retaining DispatchNotCalled",
+			failure,
+		)
+	}
+
+	select {
+	case terminal := <-run.Done():
+		terminalFailure, ok := asOpError(terminal)
+		if !ok || (terminalFailure.Class != bridge.FailureCredentialsExpired &&
+			terminalFailure.Class != bridge.FailureUpgradeRequired) {
+			t.Fatalf("terminal = %v, want credentials_expired/upgrade_required", terminal)
+		}
+		if terminalFailure.Dispatch != bridge.DispatchNotCalled {
+			t.Fatalf(
+				"terminal dispatch = %q, want retained DispatchNotCalled",
+				terminalFailure.Dispatch,
+			)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("auth-expired read failure did not reach the lifecycle owner")
+	}
+}
+
+func newReadSendTestAdapter(t *testing.T, fake *fakeReadSendClient) *Adapter {
+	t.Helper()
+	host := newTestApp(t)
+	legacy := newLegacyClient(t)
+	generation := host.BeginGoogleGeneration(legacy)
+	t.Cleanup(generation.Release)
+	host.Connected.Store(true)
+	installReadSendClient(t, legacy, fake)
+	return New("google-primary", host, func() bool { return true })
+}
+
+type readSendClientSeamProbe struct {
+	calls int
+}
+
+func installReadSendClient(
+	t *testing.T,
+	want *client.Client,
+	fake readSendClient,
+) *readSendClientSeamProbe {
+	t.Helper()
+	probe := &readSendClientSeamProbe{}
+	previous := readSendClientFor
+	readSendClientFor = func(got *client.Client) readSendClient {
+		probe.calls++
+		if got != want {
+			t.Fatalf("read client source = %p, want App.GetClient() %p", got, want)
+		}
+		return fake
+	}
+	t.Cleanup(func() { readSendClientFor = previous })
+	return probe
+}
+
+func requireMarkReadOpError(t *testing.T, err error) bridge.OpError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("MarkRead() error = nil, want classified failure")
+	}
+	failure, ok := asOpError(err)
+	if !ok {
+		t.Fatalf("MarkRead() error = %T %v, want bridge.OpError", err, err)
+	}
+	return failure
+}
+
+type fakeReadSendClient struct {
+	err error
+
+	calls          int
+	conversationID string
+	messageID      string
+}
+
+func (f *fakeReadSendClient) MarkRead(conversationID, messageID string) error {
+	f.calls++
+	f.conversationID = conversationID
+	f.messageID = messageID
+	return f.err
+}

--- a/internal/bridgeadapters/google/send.go
+++ b/internal/bridgeadapters/google/send.go
@@ -33,6 +33,14 @@ var reactionSendClientFor = func(cli *client.Client) reactionSendClient {
 	return cli.GM
 }
 
+type readSendClient interface {
+	MarkRead(conversationID, messageID string) error
+}
+
+var readSendClientFor = func(cli *client.Client) readSendClient {
+	return cli.GM
+}
+
 type mediaSendClient interface {
 	UploadMedia(data []byte, filename, mime string) (*gmproto.MediaContent, error)
 	GetConversation(conversationID string) (*gmproto.Conversation, error)
@@ -218,6 +226,46 @@ func (a *Adapter) SendReaction(
 	// Reaction dispatch confirms an empty result via ConfirmWithoutResult;
 	// there is no reaction-message ID or echo-reconciliation consumer.
 	return bridge.SendResult{}, nil
+}
+
+// MarkRead advances the remote Google Messages read cursor through the
+// connected libgm client retained by the lifecycle-owned App generation.
+func (a *Adapter) MarkRead(ctx context.Context, req bridge.ReadReceiptRequest) error {
+	if a == nil || a.host == nil || !a.host.Connected.Load() {
+		return notConnectedReadError()
+	}
+	cli := a.host.GetClient()
+	if cli == nil || cli.GM == nil {
+		return notConnectedReadError()
+	}
+	transport := readSendClientFor(cli)
+	if transport == nil {
+		return notConnectedReadError()
+	}
+	if ctx == nil {
+		return preDispatchReadError(
+			"google_mark_read_context_invalid",
+			errors.New("Google mark-read context is nil"),
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return preDispatchReadError("google_mark_read_context_done", err)
+	}
+	if len(req.Messages) == 0 {
+		return preDispatchReadError(
+			"google_mark_read_no_messages",
+			errors.New("Google mark-read request has no messages"),
+		)
+	}
+
+	messageID := req.Messages[len(req.Messages)-1].RemoteID
+	if err := transport.MarkRead(req.Conversation.RemoteID, messageID); err != nil {
+		return a.classifyReadTransportError(
+			fmt.Errorf("mark Google conversation read: %w", err),
+			"google_mark_read_failed",
+		)
+	}
+	return nil
 }
 
 // SendMedia adapts the durable media outbox request to the connected libgm
@@ -464,6 +512,36 @@ func (a *Adapter) classifyReactionTransportError(
 	return failure
 }
 
+func notConnectedReadError() bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "mark_read",
+		Fingerprint: "google_not_connected",
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       errors.New("Google Messages is not connected"),
+	}
+}
+
+func preDispatchReadError(fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "mark_read",
+		Fingerprint: fingerprint,
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       cause,
+	}
+}
+
+func (a *Adapter) classifyReadTransportError(err error, fingerprint string) bridge.OpError {
+	failure := a.classifyTransportError(err, "mark_read", fingerprint)
+	// Deliberate idempotent-read divergence: even after libgm's transport call,
+	// repeating a read receipt is harmless, so failures stay retryable as
+	// DispatchNotCalled instead of becoming uncertain like text/media sends.
+	failure.Dispatch = bridge.DispatchNotCalled
+	a.reportIfAuthIndicting(failure)
+	return failure
+}
+
 func notConnectedMediaError() bridge.OpError {
 	return bridge.OpError{
 		Class:       bridge.FailureTransient,
@@ -513,4 +591,5 @@ func (a *Adapter) reportIfAuthIndicting(failure bridge.OpError) {
 
 var _ bridge.TextSender = (*Adapter)(nil)
 var _ bridge.ReactionSender = (*Adapter)(nil)
+var _ bridge.ReadReceiptSender = (*Adapter)(nil)
 var _ bridge.MediaSender = (*Adapter)(nil)

--- a/internal/bridgeadapters/signal/signal.go
+++ b/internal/bridgeadapters/signal/signal.go
@@ -52,6 +52,9 @@ func (a *Adapter) AccountID() string { return a.accountID }
 func (a *Adapter) Platform() bridge.Platform { return bridge.PlatformSignal }
 
 func (a *Adapter) DeclaredCapabilities() bridge.CapabilitySet {
+	// ReadReceipts deliberately remains undeclared. A 1:1 signal-cli
+	// sendReceipt adapter is deferred to a follow-up because sendReceipt has no
+	// --group-id and group receipt semantics cannot yet be served honestly.
 	return bridge.CapabilitySet{
 		TextSend:      true,
 		MediaSend:     true,

--- a/internal/bridgeadapters/signal/signal_test.go
+++ b/internal/bridgeadapters/signal/signal_test.go
@@ -28,6 +28,28 @@ func TestAdapterImplementsReactionSender(t *testing.T) {
 	var _ bridge.ReactionSender = (*Adapter)(nil)
 }
 
+func TestAdapterDoesNotImplementReadReceiptSender(t *testing.T) {
+	var adapter bridge.Adapter = (*Adapter)(nil)
+	if _, ok := adapter.(bridge.ReadReceiptSender); ok {
+		t.Fatal("Signal adapter unexpectedly implements bridge.ReadReceiptSender")
+	}
+}
+
+func TestRegistryKeepsSignalReadReceiptsUndeclared(t *testing.T) {
+	const accountID = "signal-primary"
+
+	registry := bridge.NewRegistry()
+	if err := registry.Register(New(accountID, nil)); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	if _, ok := registry.Snapshot(accountID); !ok {
+		t.Fatal("registered Signal account was not discovered")
+	}
+	if got := registry.Capabilities(accountID).ReadReceipts; got {
+		t.Fatal("Signal ReadReceipts capability = true, want false")
+	}
+}
+
 func TestSendTextRequiresReadyRetainedBridge(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/bridgeadapters/whatsapp/mark_read_test.go
+++ b/internal/bridgeadapters/whatsapp/mark_read_test.go
@@ -1,0 +1,297 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/whatsapplive"
+)
+
+func TestAdapterImplementsReadReceiptSender(t *testing.T) {
+	var _ bridge.ReadReceiptSender = (*Adapter)(nil)
+}
+
+func TestNewWiresMarkReadRequestSeam(t *testing.T) {
+	a := New("whatsapp-primary", &whatsapplive.Bridge{})
+	if a.markReadRequest == nil {
+		t.Fatal("New() did not wire the retained MarkReadRequest method")
+	}
+}
+
+func TestMarkReadRequiresReadyTransportWithoutLifecycleAction(t *testing.T) {
+	var connectCalls, transportCalls int
+	a := &Adapter{
+		accountID: "whatsapp-primary",
+		connect: func(context.Context) error {
+			connectCalls++
+			return nil
+		},
+		mediaReady: func() bool { return false },
+		markReadRequest: func(string, []string, string, time.Time) error {
+			transportCalls++
+			return nil
+		},
+	}
+
+	err := a.MarkRead(context.Background(), bridge.ReadReceiptRequest{})
+	failure, ok := asOpError(err)
+	if !ok {
+		t.Fatalf("MarkRead() error = %T %v, want bridge.OpError", err, err)
+	}
+	if failure.Class != bridge.FailureTransient ||
+		failure.Dispatch != bridge.DispatchNotCalled ||
+		failure.Operation != "mark_read" ||
+		failure.Fingerprint != "whatsapp_not_connected" ||
+		!errors.Is(failure.Cause, whatsmeow.ErrNotConnected) {
+		t.Fatalf("MarkRead() failure = %+v, want classified not-connected pre-call failure", failure)
+	}
+	if connectCalls != 0 {
+		t.Fatalf("connect calls = %d, want zero", connectCalls)
+	}
+	if transportCalls != 0 {
+		t.Fatalf("MarkRead transport calls = %d, want zero", transportCalls)
+	}
+}
+
+func TestMarkReadContextGuardsRunBeforeTransport(t *testing.T) {
+	tests := []struct {
+		name            string
+		ctx             context.Context
+		wantFingerprint string
+		wantCause       error
+	}{
+		{
+			name:            "nil context",
+			ctx:             nil,
+			wantFingerprint: "whatsapp_mark_read_context_missing",
+		},
+		{
+			name:            "done context",
+			ctx:             canceledTextSendContext(),
+			wantFingerprint: "whatsapp_mark_read_context_done",
+			wantCause:       context.Canceled,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var transportCalls int
+			a := &Adapter{
+				mediaReady: func() bool { return true },
+				markReadRequest: func(string, []string, string, time.Time) error {
+					transportCalls++
+					return nil
+				},
+			}
+
+			err := a.MarkRead(test.ctx, bridge.ReadReceiptRequest{
+				Messages: []bridge.MessageRef{{RemoteID: "message-one"}},
+			})
+			failure, ok := asOpError(err)
+			if !ok || failure.Class != bridge.FailureTransient ||
+				failure.Dispatch != bridge.DispatchNotCalled ||
+				failure.Operation != "mark_read" ||
+				failure.Fingerprint != test.wantFingerprint {
+				t.Fatalf("MarkRead() error = %v, want context pre-call failure %q", err, test.wantFingerprint)
+			}
+			if test.wantCause != nil && !errors.Is(failure.Cause, test.wantCause) {
+				t.Fatalf("MarkRead() cause = %v, want %v", failure.Cause, test.wantCause)
+			}
+			if transportCalls != 0 {
+				t.Fatalf("MarkRead transport calls = %d, want zero", transportCalls)
+			}
+		})
+	}
+}
+
+func TestMarkReadRejectsEmptyMessagesBeforeTransport(t *testing.T) {
+	var transportCalls int
+	a := &Adapter{
+		mediaReady: func() bool { return true },
+		markReadRequest: func(string, []string, string, time.Time) error {
+			transportCalls++
+			return nil
+		},
+	}
+
+	err := a.MarkRead(context.Background(), bridge.ReadReceiptRequest{})
+	failure, ok := asOpError(err)
+	if !ok || failure.Class != bridge.FailureTransient ||
+		failure.Dispatch != bridge.DispatchNotCalled ||
+		failure.Operation != "mark_read" ||
+		failure.Fingerprint != "whatsapp_mark_read_no_messages" ||
+		failure.Cause == nil {
+		t.Fatalf("MarkRead(empty Messages) error = %v, want no-messages pre-call failure", err)
+	}
+	if transportCalls != 0 {
+		t.Fatalf("MarkRead transport calls = %d, want zero", transportCalls)
+	}
+}
+
+func TestMarkReadSuccessMapsAllMessagesAndFirstAuthor(t *testing.T) {
+	readAt := time.Date(2026, time.July, 15, 14, 4, 5, 0, time.UTC)
+	var (
+		gotConversationID string
+		gotMessageIDs     []string
+		gotSenderID       string
+		gotReadAt         time.Time
+		transportCalls    int
+	)
+	a := &Adapter{
+		accountID:  "whatsapp-primary",
+		mediaReady: func() bool { return true },
+		markReadRequest: func(conversationID string, messageIDs []string, senderID string, timestamp time.Time) error {
+			transportCalls++
+			gotConversationID = conversationID
+			gotMessageIDs = append([]string(nil), messageIDs...)
+			gotSenderID = senderID
+			gotReadAt = timestamp
+			return nil
+		},
+	}
+
+	err := a.MarkRead(context.Background(), bridge.ReadReceiptRequest{
+		AccountID: "whatsapp-primary",
+		Conversation: bridge.ConversationRef{
+			RemoteID: "whatsapp:120363019999999999@g.us",
+		},
+		Messages: []bridge.MessageRef{
+			{RemoteID: "message-one", AuthorID: "+15557654321"},
+			{RemoteID: "message-two", AuthorID: "+15550000000"},
+		},
+		ReadAt: readAt,
+	})
+	if err != nil {
+		t.Fatalf("MarkRead() error = %v", err)
+	}
+	if transportCalls != 1 {
+		t.Fatalf("MarkRead transport calls = %d, want one", transportCalls)
+	}
+	if gotConversationID != "whatsapp:120363019999999999@g.us" {
+		t.Fatalf("MarkReadRequest conversation = %q", gotConversationID)
+	}
+	if len(gotMessageIDs) != 2 || gotMessageIDs[0] != "message-one" || gotMessageIDs[1] != "message-two" {
+		t.Fatalf("MarkReadRequest message IDs = %q, want both request IDs in order", gotMessageIDs)
+	}
+	if gotSenderID != "+15557654321" {
+		t.Fatalf("MarkReadRequest sender = %q, want first message author", gotSenderID)
+	}
+	if !gotReadAt.Equal(readAt) {
+		t.Fatalf("MarkReadRequest timestamp = %s, want %s", gotReadAt, readAt)
+	}
+}
+
+func TestMarkReadTransientTransportFailuresAreAlwaysRetryable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "plain transport error", err: errors.New("read receipt acknowledgement lost")},
+		{name: "disconnect at transport boundary", err: fmt.Errorf("mark WhatsApp messages read: %w", whatsmeow.ErrNotConnected)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := &Adapter{
+				mediaReady: func() bool { return true },
+				markReadRequest: func(string, []string, string, time.Time) error {
+					return test.err
+				},
+			}
+
+			err := a.MarkRead(context.Background(), bridge.ReadReceiptRequest{
+				Messages: []bridge.MessageRef{{RemoteID: "message-one"}},
+			})
+			failure, ok := asOpError(err)
+			if !ok || failure.Class != bridge.FailureTransient ||
+				failure.Dispatch != bridge.DispatchNotCalled ||
+				failure.Dispatch == bridge.DispatchUncertain ||
+				failure.Operation != "mark_read" ||
+				failure.Fingerprint != "whatsapp_mark_read_failed" ||
+				!errors.Is(failure.Cause, test.err) {
+				t.Fatalf("MarkRead() error = %v, want retryable not-dispatched read failure", err)
+			}
+		})
+	}
+}
+
+func TestMarkReadPreservesAuthenticationClassification(t *testing.T) {
+	want := whatsmeow.ErrNotLoggedIn
+	a := &Adapter{
+		mediaReady: func() bool { return true },
+		markReadRequest: func(string, []string, string, time.Time) error {
+			return want
+		},
+	}
+
+	err := a.MarkRead(context.Background(), bridge.ReadReceiptRequest{
+		Messages: []bridge.MessageRef{{RemoteID: "message-one"}},
+	})
+	failure, ok := asOpError(err)
+	if !ok || failure.Class != bridge.FailureReauthRequired ||
+		failure.Operation != "mark_read" ||
+		failure.Fingerprint != "whatsapp_session_invalid" ||
+		!errors.Is(failure.Cause, want) {
+		t.Fatalf("MarkRead() error = %v, want WhatsApp reauth classification", err)
+	}
+}
+
+// The adapter shim must not forward either retryable read failures or terminal
+// authentication failures into the receive lifecycle. The retained core owns
+// its guarded connection-error report at the actual transport boundary.
+func TestMarkReadFailureDoesNotRetireReceiveGeneration(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantClass bridge.FailureClass
+	}{
+		{
+			name:      "transient transport failure",
+			err:       errors.New("read receipt failed"),
+			wantClass: bridge.FailureTransient,
+		},
+		{
+			name:      "authentication failure",
+			err:       whatsmeow.ErrNotLoggedIn,
+			wantClass: bridge.FailureReauthRequired,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ready := make(chan struct{})
+			close(ready)
+			r := &run{
+				ready:     ready,
+				finish:    make(chan error, 1),
+				admitting: true,
+			}
+			a := &Adapter{
+				current:    r,
+				mediaReady: func() bool { return true },
+				markReadRequest: func(string, []string, string, time.Time) error {
+					return test.err
+				},
+			}
+
+			err := a.MarkRead(context.Background(), bridge.ReadReceiptRequest{
+				Messages: []bridge.MessageRef{{RemoteID: "message-one"}},
+			})
+			failure, ok := asOpError(err)
+			if !ok || failure.Class != test.wantClass || !errors.Is(failure.Cause, test.err) {
+				t.Fatalf("MarkRead() error = %v, want class %q with transport cause", err, test.wantClass)
+			}
+			select {
+			case reported := <-r.finish:
+				t.Fatalf("MarkRead() retired the receive generation with %v", reported)
+			default:
+			}
+		})
+	}
+}

--- a/internal/bridgeadapters/whatsapp/whatsapp.go
+++ b/internal/bridgeadapters/whatsapp/whatsapp.go
@@ -39,6 +39,7 @@ type Adapter struct {
 	mediaReady          func() bool // Shared connection gate; it does no media-specific work.
 	sendTextRequest     func(string, string, string, string) (string, time.Time, error)
 	sendReactionRequest func(string, string, string, string, string, string) error
+	markReadRequest     func(string, []string, string, time.Time) error
 	sendMediaRequest    func(string, []byte, string, string, string, string, string) (string, time.Time, error)
 
 	mu       sync.Mutex
@@ -67,6 +68,7 @@ func New(accountID string, host *whatsapplive.Bridge) *Adapter {
 		a.mediaReady = func() bool { return host.Status().Connected }
 		a.sendTextRequest = host.SendTextRequest
 		a.sendReactionRequest = host.SendReactionRequest
+		a.markReadRequest = host.MarkReadRequest
 		a.sendMediaRequest = host.SendMediaRequest
 		host.ObserveLifecycle(a.handleLifecycleEvent)
 	}
@@ -204,6 +206,67 @@ func whatsappReactionPreCallFailure(fingerprint string, cause error) bridge.OpEr
 }
 
 var _ bridge.ReactionSender = (*Adapter)(nil)
+
+// MarkRead bridges the v2 read-receipt request to the already-owned whatsmeow
+// transport. Readiness is checked without constructing or connecting a client.
+func (a *Adapter) MarkRead(ctx context.Context, req bridge.ReadReceiptRequest) error {
+	if a == nil || a.mediaReady == nil || !a.mediaReady() || a.markReadRequest == nil {
+		return whatsappReadPreCallFailure(
+			"whatsapp_not_connected",
+			whatsmeow.ErrNotConnected,
+		)
+	}
+	if ctx == nil {
+		return whatsappReadPreCallFailure(
+			"whatsapp_mark_read_context_missing",
+			errors.New("WhatsApp mark-read context is nil"),
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return whatsappReadPreCallFailure("whatsapp_mark_read_context_done", err)
+	}
+	if len(req.Messages) == 0 {
+		return whatsappReadPreCallFailure(
+			"whatsapp_mark_read_no_messages",
+			errors.New("WhatsApp mark-read request has no messages"),
+		)
+	}
+
+	messageIDs := make([]string, len(req.Messages))
+	for i, message := range req.Messages {
+		messageIDs[i] = message.RemoteID
+	}
+	err := a.markReadRequest(
+		req.Conversation.RemoteID,
+		messageIDs,
+		req.Messages[0].AuthorID,
+		req.ReadAt,
+	)
+	if err != nil {
+		// Deliberately no adapter-level lifecycle report: the retained core owns
+		// reconnect reporting through its guarded reportConnectionError path.
+		failure := a.classifyError(err, "mark_read", "whatsapp_mark_read_failed")
+		// Deliberate idempotent-read divergence: even after whatsmeow's transport
+		// call, repeating a read receipt is harmless. Preserve every retryable
+		// class as DispatchNotCalled instead of uncertain; terminal classes are
+		// still rejected by their classification before certainty is consulted.
+		failure.Dispatch = bridge.DispatchNotCalled
+		return failure
+	}
+	return nil
+}
+
+func whatsappReadPreCallFailure(fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "mark_read",
+		Fingerprint: fingerprint,
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       cause,
+	}
+}
+
+var _ bridge.ReadReceiptSender = (*Adapter)(nil)
 
 // SendMedia bridges the v2 request contract to the already-owned whatsmeow
 // transport. Readiness is checked without constructing or connecting a client.

--- a/internal/whatsapplive/client.go
+++ b/internal/whatsapplive/client.go
@@ -70,6 +70,10 @@ var sendTextMessage = func(cli *whatsmeow.Client, ctx context.Context, to watype
 	return cli.SendMessage(ctx, to, message, extra...)
 }
 
+var markReadMessages = func(cli *whatsmeow.Client, ctx context.Context, ids []watypes.MessageID, timestamp time.Time, chat, sender watypes.JID, receiptTypeExtra ...watypes.ReceiptType) error {
+	return cli.MarkRead(ctx, ids, timestamp, chat, sender, receiptTypeExtra...)
+}
+
 var uploadMedia = func(cli *whatsmeow.Client, ctx context.Context, plaintext []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error) {
 	return cli.Upload(ctx, plaintext, mediaType)
 }
@@ -1406,6 +1410,42 @@ func (e sendNotDispatchedError) Unwrap() error { return e.cause }
 
 func (e sendNotDispatchedError) Is(target error) bool {
 	return target == ErrSendNotDispatched
+}
+
+// MarkReadRequest sends read receipts from v2 request data without loading
+// locally stored messages.
+func (b *Bridge) MarkReadRequest(conversationID string, messageIDs []string, senderID string, readAt time.Time) error {
+	if len(messageIDs) == 0 {
+		return markSendNotDispatched(errors.New("at least one WhatsApp message ID is required"), true)
+	}
+
+	chatJID, err := parseConversationJID(conversationID)
+	if err != nil {
+		return markSendNotDispatched(err, true)
+	}
+	chatJID = b.normalizeConversationJID(chatJID)
+
+	ids := make([]watypes.MessageID, len(messageIDs))
+	for i, messageID := range messageIDs {
+		ids[i] = watypes.MessageID(messageID)
+	}
+	senderJID := watypes.EmptyJID
+	if strings.TrimSpace(senderID) != "" {
+		senderJID = b.canonicalJID(parseWhatsAppSenderJID(senderID))
+	}
+
+	cli, err := b.ensureSendClient()
+	if err != nil {
+		return markSendNotDispatched(err, true)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	if err := markReadMessages(cli, ctx, ids, readAt, chatJID, senderJID); err != nil {
+		b.reportConnectionError(err)
+		return fmt.Errorf("mark WhatsApp messages read: %w", err)
+	}
+	return nil
 }
 
 // SendReactionRequest sends a reaction from the v2 request data without

--- a/internal/whatsapplive/mark_read_request_test.go
+++ b/internal/whatsapplive/mark_read_request_test.go
@@ -1,0 +1,231 @@
+package whatsapplive
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	watypes "go.mau.fi/whatsmeow/types"
+)
+
+func TestMarkReadRequestMapsTransportArguments(t *testing.T) {
+	readAt := time.Date(2026, time.July, 15, 14, 3, 2, 123, time.UTC)
+	tests := []struct {
+		name           string
+		conversationID string
+		messageIDs     []string
+		senderID       string
+		wantChat       string
+		wantSender     string
+	}{
+		{
+			name:           "group messages from participant",
+			conversationID: "whatsapp:120363019999999999@g.us",
+			messageIDs:     []string{"message-one", "message-two"},
+			senderID:       "+15557654321",
+			wantChat:       "120363019999999999@g.us",
+			wantSender:     "15557654321@s.whatsapp.net",
+		},
+		{
+			name:           "empty sender remains self",
+			conversationID: "whatsapp:15551234567@s.whatsapp.net",
+			messageIDs:     []string{"message-three"},
+			wantChat:       "15551234567@s.whatsapp.net",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			host := connectedMediaTestBridge()
+			originalMarkRead := markReadMessages
+			originalIsConnected := clientIsConnected
+			defer func() {
+				markReadMessages = originalMarkRead
+				clientIsConnected = originalIsConnected
+			}()
+			clientIsConnected = func(*whatsmeow.Client) bool { return true }
+
+			var (
+				gotClient    *whatsmeow.Client
+				gotContext   context.Context
+				gotIDs       []watypes.MessageID
+				gotReadAt    time.Time
+				gotChat      watypes.JID
+				gotSender    watypes.JID
+				gotExtra     []watypes.ReceiptType
+				transportHit int
+			)
+			markReadMessages = func(
+				cli *whatsmeow.Client,
+				ctx context.Context,
+				ids []watypes.MessageID,
+				timestamp time.Time,
+				chat, sender watypes.JID,
+				extra ...watypes.ReceiptType,
+			) error {
+				transportHit++
+				gotClient = cli
+				gotContext = ctx
+				gotIDs = append([]watypes.MessageID(nil), ids...)
+				gotReadAt = timestamp
+				gotChat = chat
+				gotSender = sender
+				gotExtra = append([]watypes.ReceiptType(nil), extra...)
+				return nil
+			}
+
+			err := host.MarkReadRequest(
+				test.conversationID,
+				test.messageIDs,
+				test.senderID,
+				readAt,
+			)
+			if err != nil {
+				t.Fatalf("MarkReadRequest() error = %v", err)
+			}
+			if transportHit != 1 {
+				t.Fatalf("MarkRead transport calls = %d, want one", transportHit)
+			}
+			if gotClient != host.client {
+				t.Fatalf("MarkRead client = %p, want host client %p", gotClient, host.client)
+			}
+			if gotContext == nil {
+				t.Fatal("MarkRead context is nil")
+			}
+			if len(gotIDs) != len(test.messageIDs) {
+				t.Fatalf("MarkRead IDs = %q, want %q", gotIDs, test.messageIDs)
+			}
+			for i, want := range test.messageIDs {
+				if gotIDs[i] != watypes.MessageID(want) {
+					t.Fatalf("MarkRead ID[%d] = %q, want %q", i, gotIDs[i], want)
+				}
+			}
+			if !gotReadAt.Equal(readAt) {
+				t.Fatalf("MarkRead timestamp = %s, want %s", gotReadAt, readAt)
+			}
+			if gotChat.String() != test.wantChat {
+				t.Fatalf("MarkRead chat = %q, want %q", gotChat.String(), test.wantChat)
+			}
+			if test.wantSender == "" {
+				if !gotSender.IsEmpty() {
+					t.Fatalf("MarkRead sender = %q, want EmptyJID for self", gotSender.String())
+				}
+			} else if gotSender.String() != test.wantSender {
+				t.Fatalf("MarkRead sender = %q, want %q", gotSender.String(), test.wantSender)
+			}
+			if len(gotExtra) != 0 {
+				t.Fatalf("MarkRead receipt extras = %v, want none so whatsmeow defaults to read", gotExtra)
+			}
+		})
+	}
+}
+
+func TestMarkReadRequestRejectsEmptyIDsBeforeTransport(t *testing.T) {
+	originalMarkRead := markReadMessages
+	defer func() { markReadMessages = originalMarkRead }()
+
+	var transportCalls int
+	markReadMessages = func(
+		*whatsmeow.Client,
+		context.Context,
+		[]watypes.MessageID,
+		time.Time,
+		watypes.JID,
+		watypes.JID,
+		...watypes.ReceiptType,
+	) error {
+		transportCalls++
+		return nil
+	}
+
+	err := connectedMediaTestBridge().MarkReadRequest(
+		"whatsapp:15551234567@s.whatsapp.net",
+		nil,
+		"",
+		time.Now(),
+	)
+	if err == nil || !errors.Is(err, ErrSendNotDispatched) {
+		t.Fatalf("MarkReadRequest(empty IDs) error = %v, want not-dispatched marker", err)
+	}
+	if transportCalls != 0 {
+		t.Fatalf("MarkRead transport calls = %d, want zero", transportCalls)
+	}
+}
+
+func TestMarkReadRequestMarksOtherPreDispatchFailures(t *testing.T) {
+	t.Run("invalid conversation", func(t *testing.T) {
+		err := connectedMediaTestBridge().MarkReadRequest(
+			"invalid",
+			[]string{"message-one"},
+			"",
+			time.Now(),
+		)
+		if err == nil || !errors.Is(err, ErrSendNotDispatched) {
+			t.Fatalf("MarkReadRequest(invalid conversation) error = %v, want not-dispatched marker", err)
+		}
+	})
+
+	t.Run("transport disconnected before call", func(t *testing.T) {
+		err := (&Bridge{}).MarkReadRequest(
+			"whatsapp:15551234567@s.whatsapp.net",
+			[]string{"message-one"},
+			"",
+			time.Now(),
+		)
+		if !errors.Is(err, whatsmeow.ErrNotConnected) || !errors.Is(err, ErrSendNotDispatched) {
+			t.Fatalf("MarkReadRequest(disconnected) error = %v, want not-connected cause and not-dispatched marker", err)
+		}
+	})
+}
+
+func TestMarkReadRequestTransportErrorIsWrappedAndReported(t *testing.T) {
+	host := connectedMediaTestBridge()
+	originalMarkRead := markReadMessages
+	originalIsConnected := clientIsConnected
+	defer func() {
+		markReadMessages = originalMarkRead
+		clientIsConnected = originalIsConnected
+	}()
+	clientIsConnected = func(*whatsmeow.Client) bool { return true }
+
+	want := whatsmeow.ErrNotConnected
+	var transportCalls int
+	markReadMessages = func(
+		*whatsmeow.Client,
+		context.Context,
+		[]watypes.MessageID,
+		time.Time,
+		watypes.JID,
+		watypes.JID,
+		...watypes.ReceiptType,
+	) error {
+		transportCalls++
+		return want
+	}
+	var reported error
+	host.callbacks.OnConnectionError = func(err error) { reported = err }
+
+	err := host.MarkReadRequest(
+		"whatsapp:15551234567@s.whatsapp.net",
+		[]string{"message-one"},
+		"",
+		time.Now(),
+	)
+	if !errors.Is(err, want) {
+		t.Fatalf("MarkReadRequest() error = %v, want wrapped transport cause", err)
+	}
+	if err == want {
+		t.Fatalf("MarkReadRequest() returned raw transport error %v, want contextual wrapper", err)
+	}
+	if errors.Is(err, ErrSendNotDispatched) {
+		t.Fatalf("MarkReadRequest() error = %v, transport-call failure must not carry predispatch marker", err)
+	}
+	if transportCalls != 1 {
+		t.Fatalf("MarkRead transport calls = %d, want one", transportCalls)
+	}
+	if !errors.Is(reported, want) {
+		t.Fatalf("retained lifecycle report = %v, want transport cause %v", reported, want)
+	}
+}


### PR DESCRIPTION
## Rebuild T5b — read-receipt shims + capability honesty

WhatsApp and Google now implement `bridge.ReadReceiptSender` with real transport calls; Signal stays honestly undeclared. **Closes a latent lie:** both platforms declared ReadReceipts without implementing `MarkRead`, so a read intent would have queued forever. Declaration now equals reality on all three platforms. Still no production wiring.

### Design
- **WhatsApp** — retained `MarkReadRequest` wraps whatsmeow `MarkRead` (mapping verified against the pinned source: one sender per receipt node; empty sender = self, participant attr correctly omitted in 1:1).
- **Google** — additive shim over the libgm fork's `MarkRead(conversation, message)`, last message ref as the cursor.
- **Signal** — comment + discriminating tests only (the adapter provably does not satisfy the interface; the registry reports the capability false). signal-cli's `sendReceipt` has no group target; declaring would re-create the queue-forever lie. The 1:1 follow-up is named in the code comment.
- **Deliberate, documented divergence** — read shims classify transient transport failures as `DispatchNotCalled` (retryable), never uncertain: receipts are remotely idempotent and the local cursor is already durably advanced at enqueue. Auth-indicting classes still route to repair.

### Verification
- Adversarial review verdict **mergeable, zero required fixes** — the pinned whatsmeow `receipt.go` and libgm `methods.go` sources were read to verify argument mappings (a swap compiles fine and silently sends wrong receipts); D1/D2 pinned both directions; no `MarkRead` enqueuer exists anywhere (production-inert preserved).
- Full `go test -race ./...` green — 24 packages, shuffled in review.
- Wave-3 wiring note: `bridgeadapters/legacy.go` metadata adapters still declare capabilities they don't implement and must never be registered as dispatch adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
