### PR TITLE
Add media-download adapter shims and the versioned Opaque wire-format (rebuild M4b)

### DIFF
--- a/internal/bridgeadapters/google/download_test.go
+++ b/internal/bridgeadapters/google/download_test.go
@@ -1,0 +1,413 @@
+package google
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/client"
+)
+
+var _ bridge.MediaDownloader = (*Adapter)(nil)
+
+func TestDownloadMediaGoogleOpaqueV1RoundTripAndStreamWrapping(t *testing.T) {
+	opaque, err := json.Marshal(googleDownloadOpaqueV1{
+		V:             1,
+		MediaID:       "media-id/with:punctuation",
+		DecryptionKey: "0001aBff",
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if want := `{"v":1,"media_id":"media-id/with:punctuation","decryption_key":"0001aBff"}`; string(opaque) != want {
+		t.Fatalf("opaque = %s, want %s", opaque, want)
+	}
+
+	fake := &fakeDownloadClient{
+		data: []byte("downloaded Google media"),
+		mime: " image/transport ",
+	}
+	a := newDownloadTestAdapter(t, fake)
+	stream, err := a.DownloadMedia(context.Background(), "google-primary", bridge.MediaRef{
+		RemoteID: "attachment-row-id-is-not-the-transport-id",
+		Opaque:   opaque,
+		Filename: "photo.jpg",
+		MIME:     "image/from-ref",
+	})
+	if err != nil {
+		t.Fatalf("DownloadMedia() error = %v", err)
+	}
+	if fake.calls != 1 || fake.mediaID != "media-id/with:punctuation" {
+		t.Fatalf("transport calls/media ID = (%d, %q), want (1, media-id/with:punctuation)", fake.calls, fake.mediaID)
+	}
+	if want := []byte{0x00, 0x01, 0xab, 0xff}; !bytes.Equal(fake.key, want) {
+		t.Fatalf("transport decryption key = %x, want %x", fake.key, want)
+	}
+	if stream.ReadCloser == nil {
+		t.Fatal("MediaStream.ReadCloser = nil on success")
+	}
+	defer stream.Close()
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("ReadAll(MediaStream) error = %v", err)
+	}
+	if string(data) != "downloaded Google media" || stream.Size != int64(len(data)) {
+		t.Fatalf("stream bytes/size = (%q, %d), want downloaded bytes/%d", data, stream.Size, len(data))
+	}
+	if stream.Filename != "photo.jpg" || stream.MIME != "image/transport" {
+		t.Fatalf("stream metadata = (%q, %q), want (photo.jpg, image/transport)", stream.Filename, stream.MIME)
+	}
+}
+
+func TestDownloadMediaMIMEFallbackOrder(t *testing.T) {
+	tests := []struct {
+		name          string
+		transportMIME string
+		refMIME       string
+		want          string
+	}{
+		{name: "transport wins", transportMIME: " image/transport ", refMIME: "image/ref", want: "image/transport"},
+		{name: "reference fallback", refMIME: " image/ref ", want: "image/ref"},
+		{name: "both empty"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeDownloadClient{data: []byte("x"), mime: test.transportMIME}
+			a := newDownloadTestAdapter(t, fake)
+			stream, err := a.DownloadMedia(context.Background(), "google-primary", bridge.MediaRef{
+				Opaque: googleDownloadOpaque(t, 1, "media-id", "00"),
+				MIME:   test.refMIME,
+			})
+			if err != nil {
+				t.Fatalf("DownloadMedia() error = %v", err)
+			}
+			defer stream.Close()
+			if stream.MIME != test.want {
+				t.Fatalf("MediaStream.MIME = %q, want %q", stream.MIME, test.want)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaNilDataStillReturnsNonNilReadCloser(t *testing.T) {
+	fake := &fakeDownloadClient{}
+	a := newDownloadTestAdapter(t, fake)
+	stream, err := a.DownloadMedia(context.Background(), "google-primary", bridge.MediaRef{
+		Opaque: googleDownloadOpaque(t, 1, "media-id", "00"),
+	})
+	if err != nil {
+		t.Fatalf("DownloadMedia() error = %v", err)
+	}
+	if stream.ReadCloser == nil {
+		t.Fatal("DownloadMedia() returned nil ReadCloser with nil error")
+	}
+	defer stream.Close()
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("ReadAll(MediaStream) error = %v", err)
+	}
+	if len(data) != 0 || stream.Size != 0 {
+		t.Fatalf("nil transport data wrapped as (%d bytes, size %d), want empty stream", len(data), stream.Size)
+	}
+}
+
+func TestDownloadMediaUnsupportedOpaqueVersionFailsClosed(t *testing.T) {
+	fake := &fakeDownloadClient{}
+	a := newDownloadTestAdapter(t, fake)
+	_, err := a.DownloadMedia(context.Background(), "google-primary", bridge.MediaRef{
+		Opaque: googleDownloadOpaque(t, 2, "media-id", "00"),
+	})
+	failure := requireDownloadOpError(t, err)
+	if failure.Class != bridge.FailureUnsupported ||
+		failure.Operation != "download_media" ||
+		failure.Fingerprint != "opaque_version_unsupported" ||
+		failure.Dispatch != "" {
+		t.Fatalf("failure = %+v, want terminal unsupported opaque_version_unsupported", failure)
+	}
+	if fake.calls != 0 {
+		t.Fatalf("DownloadMedia transport calls = %d, want 0", fake.calls)
+	}
+}
+
+func TestDownloadMediaMalformedOpaqueIsTerminalPreCall(t *testing.T) {
+	tests := []struct {
+		name   string
+		opaque []byte
+	}{
+		{name: "malformed JSON", opaque: []byte(`{"v":1`)},
+		{name: "invalid UTF-8", opaque: []byte{'{', '"', 'v', '"', ':', '1', ',', '"', 'x', '"', ':', '"', 0xff, '"', '}'}},
+		{name: "wrong JSON shape", opaque: []byte(`[1,2,3]`)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeDownloadClient{}
+			a := newDownloadTestAdapter(t, fake)
+			_, err := a.DownloadMedia(context.Background(), "google-primary", bridge.MediaRef{Opaque: test.opaque})
+			failure := requireDownloadOpError(t, err)
+			if failure.Class != bridge.FailureUnsupported ||
+				failure.Operation != "download_media" ||
+				failure.Fingerprint != "google_opaque_malformed" ||
+				failure.Dispatch != "" {
+				t.Fatalf("failure = %+v, want terminal unsupported google_opaque_malformed", failure)
+			}
+			if fake.calls != 0 {
+				t.Fatalf("DownloadMedia transport calls = %d, want 0", fake.calls)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaInvalidOpaqueFieldsAreTerminalPreCall(t *testing.T) {
+	tests := []struct {
+		name        string
+		mediaID     string
+		key         string
+		fingerprint string
+	}{
+		{name: "missing media id", key: "00", fingerprint: "google_opaque_media_id_missing"},
+		{name: "blank media id", mediaID: "  ", key: "00", fingerprint: "google_opaque_media_id_missing"},
+		{name: "missing key", mediaID: "media-id", fingerprint: "google_opaque_decryption_key_missing"},
+		{name: "non-hex key", mediaID: "media-id", key: "not-hex", fingerprint: "google_opaque_decryption_key_invalid"},
+		{name: "odd-length key", mediaID: "media-id", key: "abc", fingerprint: "google_opaque_decryption_key_invalid"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeDownloadClient{}
+			a := newDownloadTestAdapter(t, fake)
+			_, err := a.DownloadMedia(context.Background(), "google-primary", bridge.MediaRef{
+				Opaque: googleDownloadOpaque(t, 1, test.mediaID, test.key),
+			})
+			failure := requireDownloadOpError(t, err)
+			if failure.Class != bridge.FailureUnsupported ||
+				failure.Operation != "download_media" ||
+				failure.Fingerprint != test.fingerprint ||
+				failure.Dispatch != "" {
+				t.Fatalf("failure = %+v, want terminal unsupported %s", failure, test.fingerprint)
+			}
+			if fake.calls != 0 {
+				t.Fatalf("DownloadMedia transport calls = %d, want 0", fake.calls)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaNotReadyDoesNotConstructOrReachTransport(t *testing.T) {
+	host := newTestApp(t)
+	legacy := newLegacyClient(t)
+	generation := host.BeginGoogleGeneration(legacy)
+	t.Cleanup(generation.Release)
+	fake := &fakeDownloadClient{}
+	probe := installDownloadClient(t, legacy, fake)
+	a := New("google-primary", host, func() bool { return true })
+	a.newClient = func() (*client.Client, transportClient, error) {
+		t.Fatal("DownloadMedia must not construct a Google transport")
+		return nil, nil, nil
+	}
+
+	stream, err := a.DownloadMedia(context.Background(), "google-primary", bridge.MediaRef{
+		Opaque: googleDownloadOpaque(t, 1, "media-id", "00"),
+	})
+	if stream.ReadCloser != nil {
+		stream.Close()
+		t.Fatal("failed DownloadMedia returned a non-zero stream")
+	}
+	failure := requireDownloadOpError(t, err)
+	if failure.Class != bridge.FailureTransient ||
+		failure.Operation != "download_media" ||
+		failure.Fingerprint != "google_not_connected" ||
+		failure.Dispatch != "" {
+		t.Fatalf("failure = %+v, want transient google_not_connected", failure)
+	}
+	if probe.calls != 0 || fake.calls != 0 {
+		t.Fatalf("seam/transport calls = (%d, %d), want (0, 0)", probe.calls, fake.calls)
+	}
+}
+
+func TestDownloadMediaContextGuardsAreClassifiedPreCall(t *testing.T) {
+	done, cancel := context.WithCancel(context.Background())
+	cancel()
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		fingerprint string
+	}{
+		{name: "nil", fingerprint: "google_download_context_invalid"},
+		{name: "done", ctx: done, fingerprint: "google_download_context_done"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeDownloadClient{}
+			a := newDownloadTestAdapter(t, fake)
+			_, err := a.DownloadMedia(test.ctx, "google-primary", bridge.MediaRef{
+				Opaque: googleDownloadOpaque(t, 1, "media-id", "00"),
+			})
+			failure := requireDownloadOpError(t, err)
+			if failure.Class != bridge.FailureTransient ||
+				failure.Operation != "download_media" ||
+				failure.Fingerprint != test.fingerprint ||
+				failure.Dispatch != "" {
+				t.Fatalf("failure = %+v, want transient pre-call %s", failure, test.fingerprint)
+			}
+			if fake.calls != 0 {
+				t.Fatalf("DownloadMedia transport calls = %d, want 0", fake.calls)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaTransientFailureDoesNotRetireGeneration(t *testing.T) {
+	host := newTestApp(t)
+	lifecycleTransport := &fakeTransport{}
+	a := newTestAdapter(t, host, lifecycleTransport)
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+	lifecycleTransport.emit(&gmproto.Conversation{ConversationID: "ready"})
+	<-run.Ready()
+
+	fake := &fakeDownloadClient{err: errors.New("media server timeout")}
+	installDownloadClient(t, host.GetClient(), fake)
+	_, err = a.DownloadMedia(context.Background(), "google-primary", bridge.MediaRef{
+		Opaque: googleDownloadOpaque(t, 1, "media-id", "00"),
+	})
+	failure := requireDownloadOpError(t, err)
+	if failure.Class != bridge.FailureTransient ||
+		failure.Operation != "download_media" ||
+		failure.Fingerprint != "google_media_download_failed" ||
+		failure.Dispatch != "" {
+		t.Fatalf("failure = %+v, want plain transient google_media_download_failed", failure)
+	}
+	if !host.Connected.Load() {
+		t.Fatal("transient download failure marked the receive generation disconnected")
+	}
+	select {
+	case terminal := <-run.Done():
+		t.Fatalf("transient download failure retired the receive generation with %v", terminal)
+	default:
+	}
+	if host.GoogleStatus().NeedsRepair {
+		t.Fatal("transient download failure parked the Google lifecycle")
+	}
+}
+
+func TestDownloadMediaAuthExpiryReportsToLifecycle(t *testing.T) {
+	host := newTestApp(t)
+	lifecycleTransport := &fakeTransport{}
+	a := newTestAdapter(t, host, lifecycleTransport)
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	lifecycleTransport.emit(&gmproto.Conversation{ConversationID: "ready"})
+	<-run.Ready()
+
+	fake := &fakeDownloadClient{err: errors.New("Google returned HTTP 401 for DownloadMedia")}
+	installDownloadClient(t, host.GetClient(), fake)
+	_, err = a.DownloadMedia(context.Background(), "google-primary", bridge.MediaRef{
+		Opaque: googleDownloadOpaque(t, 1, "media-id", "00"),
+	})
+	failure := requireDownloadOpError(t, err)
+	if failure.Class != bridge.FailureCredentialsExpired ||
+		failure.Fingerprint != "google_auth_expired" ||
+		failure.Operation != "download_media" ||
+		failure.Dispatch != "" {
+		t.Fatalf("failure = %+v, want credentials-expired google_auth_expired", failure)
+	}
+	select {
+	case terminal := <-run.Done():
+		terminalFailure, ok := asOpError(terminal)
+		if !ok || (terminalFailure.Class != bridge.FailureCredentialsExpired &&
+			terminalFailure.Class != bridge.FailureUpgradeRequired) {
+			t.Fatalf("terminal = %v, want credentials_expired/upgrade_required", terminal)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("auth-expired download failure did not reach the lifecycle owner")
+	}
+}
+
+func googleDownloadOpaque(t *testing.T, version int, mediaID, key string) []byte {
+	t.Helper()
+	opaque, err := json.Marshal(googleDownloadOpaqueV1{
+		V:             version,
+		MediaID:       mediaID,
+		DecryptionKey: key,
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return opaque
+}
+
+func newDownloadTestAdapter(t *testing.T, fake *fakeDownloadClient) *Adapter {
+	t.Helper()
+	host := newTestApp(t)
+	legacy := newLegacyClient(t)
+	generation := host.BeginGoogleGeneration(legacy)
+	t.Cleanup(generation.Release)
+	host.Connected.Store(true)
+	installDownloadClient(t, legacy, fake)
+	return New("google-primary", host, func() bool { return true })
+}
+
+type downloadClientSeamProbe struct {
+	calls int
+}
+
+func installDownloadClient(t *testing.T, want *client.Client, fake downloadClient) *downloadClientSeamProbe {
+	t.Helper()
+	probe := &downloadClientSeamProbe{}
+	previous := downloadClientFor
+	downloadClientFor = func(got *client.Client) downloadClient {
+		probe.calls++
+		if got != want {
+			t.Fatalf("download client source = %p, want App.GetClient() %p", got, want)
+		}
+		return fake
+	}
+	t.Cleanup(func() { downloadClientFor = previous })
+	return probe
+}
+
+func requireDownloadOpError(t *testing.T, err error) bridge.OpError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("DownloadMedia() error = nil, want classified failure")
+	}
+	failure, ok := asOpError(err)
+	if !ok {
+		t.Fatalf("DownloadMedia() error = %T %v, want bridge.OpError", err, err)
+	}
+	return failure
+}
+
+type fakeDownloadClient struct {
+	data []byte
+	mime string
+	err  error
+
+	calls   int
+	mediaID string
+	key     []byte
+}
+
+func (f *fakeDownloadClient) DownloadMedia(mediaID string, key []byte) ([]byte, string, error) {
+	f.calls++
+	f.mediaID = mediaID
+	f.key = append([]byte(nil), key...)
+	return f.data, f.mime, f.err
+}

--- a/internal/bridgeadapters/google/send.go
+++ b/internal/bridgeadapters/google/send.go
@@ -1,12 +1,16 @@
 package google
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"strings"
+	"unicode/utf8"
 
 	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
 
@@ -39,6 +43,98 @@ type readSendClient interface {
 
 var readSendClientFor = func(cli *client.Client) readSendClient {
 	return cli.GM
+}
+
+type downloadClient interface {
+	DownloadMedia(mediaID string, key []byte) ([]byte, string, error)
+}
+
+type downloadClientFunc func(mediaID string, key []byte) ([]byte, string, error)
+
+func (f downloadClientFunc) DownloadMedia(mediaID string, key []byte) ([]byte, string, error) {
+	return f(mediaID, key)
+}
+
+var downloadClientFor = func(cli *client.Client) downloadClient {
+	if cli == nil || cli.GM == nil {
+		return nil
+	}
+	// The pinned libgm fork exposes DownloadMedia(string, []byte)
+	// ([]byte, error), with no MIME result. Adapt that actual return shape to
+	// the lifecycle seam; the shim consequently falls back to MediaRef.MIME.
+	return downloadClientFunc(func(mediaID string, key []byte) ([]byte, string, error) {
+		data, err := cli.GM.DownloadMedia(mediaID, key)
+		return data, "", err
+	})
+}
+
+// googleDownloadOpaqueV1 is Google's versioned Wave-4-to-M4b wire contract.
+// The future Google decoder must pack these transport inputs into
+// message_attachments.remote_ref. No decoder does so yet, so this shim is
+// unit-testable but remains production-inert until Wave-4 ingest lands.
+type googleDownloadOpaqueV1 struct {
+	V             int    `json:"v"`
+	MediaID       string `json:"media_id"`
+	DecryptionKey string `json:"decryption_key"`
+}
+
+type googleDownloadRef struct {
+	mediaID string
+	key     []byte
+}
+
+func decodeGoogleDownloadOpaque(opaque []byte) (googleDownloadRef, error) {
+	if !utf8.Valid(opaque) {
+		return googleDownloadRef{}, unsupportedGoogleOpaqueError(
+			"google_opaque_malformed",
+			errors.New("Google media opaque payload is not valid UTF-8"),
+		)
+	}
+	var payload googleDownloadOpaqueV1
+	if err := json.Unmarshal(opaque, &payload); err != nil {
+		return googleDownloadRef{}, unsupportedGoogleOpaqueError(
+			"google_opaque_malformed",
+			fmt.Errorf("decode Google media opaque payload: %w", err),
+		)
+	}
+	if payload.V != 1 {
+		return googleDownloadRef{}, unsupportedGoogleOpaqueError(
+			"opaque_version_unsupported",
+			fmt.Errorf("Google media opaque version %d is unsupported", payload.V),
+		)
+	}
+	if strings.TrimSpace(payload.MediaID) == "" {
+		return googleDownloadRef{}, unsupportedGoogleOpaqueError(
+			"google_opaque_media_id_missing",
+			errors.New("Google media opaque payload has no media_id"),
+		)
+	}
+	if payload.DecryptionKey == "" {
+		return googleDownloadRef{}, unsupportedGoogleOpaqueError(
+			"google_opaque_decryption_key_missing",
+			errors.New("Google media opaque payload has no decryption_key"),
+		)
+	}
+	key, err := hex.DecodeString(payload.DecryptionKey)
+	if err != nil {
+		return googleDownloadRef{}, unsupportedGoogleOpaqueError(
+			"google_opaque_decryption_key_invalid",
+			fmt.Errorf("decode Google media decryption key: %w", err),
+		)
+	}
+	return googleDownloadRef{mediaID: payload.MediaID, key: key}, nil
+}
+
+// Structural opaque failures are terminal unsupported errors: remote_ref is
+// immutable input, so retrying the same malformed or incomplete payload can
+// never make the download succeed.
+func unsupportedGoogleOpaqueError(fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureUnsupported,
+		Operation:   "download_media",
+		Fingerprint: fingerprint,
+		Cause:       cause,
+	}
 }
 
 type mediaSendClient interface {
@@ -266,6 +362,57 @@ func (a *Adapter) MarkRead(ctx context.Context, req bridge.ReadReceiptRequest) e
 		)
 	}
 	return nil
+}
+
+// DownloadMedia adapts Google's versioned remote media reference to the
+// connected libgm client retained by the lifecycle-owned App generation.
+func (a *Adapter) DownloadMedia(
+	ctx context.Context,
+	accountID string,
+	ref bridge.MediaRef,
+) (bridge.MediaStream, error) {
+	if a == nil || a.host == nil || !a.host.Connected.Load() {
+		return bridge.MediaStream{}, notConnectedDownloadError()
+	}
+	cli := a.host.GetClient()
+	if cli == nil || cli.GM == nil {
+		return bridge.MediaStream{}, notConnectedDownloadError()
+	}
+	transport := downloadClientFor(cli)
+	if transport == nil {
+		return bridge.MediaStream{}, notConnectedDownloadError()
+	}
+	if ctx == nil {
+		return bridge.MediaStream{}, preDownloadError(
+			"google_download_context_invalid",
+			errors.New("Google media download context is nil"),
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.MediaStream{}, preDownloadError("google_download_context_done", err)
+	}
+
+	decoded, err := decodeGoogleDownloadOpaque(ref.Opaque)
+	if err != nil {
+		return bridge.MediaStream{}, err
+	}
+	data, transportMIME, err := transport.DownloadMedia(decoded.mediaID, decoded.key)
+	if err != nil {
+		return bridge.MediaStream{}, a.classifyDownloadTransportError(
+			fmt.Errorf("download Google media: %w", err),
+			"google_media_download_failed",
+		)
+	}
+
+	// libgm's retained downloader is fully buffered. This NopCloser adaptation
+	// intentionally forfeits true streaming until the transport exposes a
+	// reader, while still guaranteeing every nil-error result has a ReadCloser.
+	return bridge.MediaStream{
+		ReadCloser: io.NopCloser(bytes.NewReader(data)),
+		Size:       int64(len(data)),
+		Filename:   ref.Filename,
+		MIME:       firstNonEmpty(transportMIME, ref.MIME),
+	}, nil
 }
 
 // SendMedia adapts the durable media outbox request to the connected libgm
@@ -542,6 +689,33 @@ func (a *Adapter) classifyReadTransportError(err error, fingerprint string) brid
 	return failure
 }
 
+func notConnectedDownloadError() bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "download_media",
+		Fingerprint: "google_not_connected",
+		Cause:       errors.New("Google Messages is not connected"),
+	}
+}
+
+func preDownloadError(fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "download_media",
+		Fingerprint: fingerprint,
+		Cause:       cause,
+	}
+}
+
+func (a *Adapter) classifyDownloadTransportError(err error, fingerprint string) bridge.OpError {
+	failure := a.classifyTransportError(err, "download_media", fingerprint)
+	// Downloads are idempotent reads. The media service simply retries on a
+	// later request, so the send-path Dispatch certainty does not apply here.
+	failure.Dispatch = ""
+	a.reportIfAuthIndicting(failure)
+	return failure
+}
+
 func notConnectedMediaError() bridge.OpError {
 	return bridge.OpError{
 		Class:       bridge.FailureTransient,
@@ -589,7 +763,17 @@ func (a *Adapter) reportIfAuthIndicting(failure bridge.OpError) {
 	}
 }
 
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
 var _ bridge.TextSender = (*Adapter)(nil)
 var _ bridge.ReactionSender = (*Adapter)(nil)
 var _ bridge.ReadReceiptSender = (*Adapter)(nil)
 var _ bridge.MediaSender = (*Adapter)(nil)
+var _ bridge.MediaDownloader = (*Adapter)(nil)

--- a/internal/bridgeadapters/signal/download_test.go
+++ b/internal/bridgeadapters/signal/download_test.go
@@ -1,0 +1,429 @@
+package signal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/signallive"
+)
+
+func TestAdapterImplementsMediaDownloader(t *testing.T) {
+	var _ bridge.MediaDownloader = (*Adapter)(nil)
+}
+
+func TestSignalDownloadOpaqueV1PinsWaveFourWireShape(t *testing.T) {
+	opaque, err := json.Marshal(signalDownloadOpaqueV1{
+		Version:        1,
+		Kind:           "remote",
+		AttachmentID:   "attachment-1",
+		Path:           "",
+		ConversationID: "signal:+15551234567",
+	})
+	if err != nil {
+		t.Fatalf("marshal Signal v1 Opaque: %v", err)
+	}
+	const want = `{"v":1,"kind":"remote","att_id":"attachment-1","path":"","conversation_id":"signal:+15551234567"}`
+	if string(opaque) != want {
+		t.Fatalf("Signal v1 Opaque = %s, want %s", opaque, want)
+	}
+
+	poller := readyDownloadPoller()
+	poller.downloadData = []byte("wire-contract")
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	stream, err := adapter.DownloadMedia(context.Background(), "signal-primary", bridge.MediaRef{Opaque: opaque})
+	if err != nil {
+		t.Fatalf("DownloadMedia(v1 Opaque): %v", err)
+	}
+	defer stream.Close()
+	if got := poller.lastDownloadRequest(); got != (fakeDownloadRequest{
+		account:      "+15551230000",
+		kind:         "remote",
+		attachmentID: "attachment-1",
+		target:       "+15551234567",
+	}) {
+		t.Fatalf("DownloadMediaRef request = %+v, want decoded v1 fields", got)
+	}
+}
+
+func TestDownloadMediaRoutesVersionOneOpaqueReferences(t *testing.T) {
+	tests := []struct {
+		name      string
+		opaque    map[string]any
+		refMIME   string
+		transport string
+		want      fakeDownloadRequest
+		wantMIME  string
+	}{
+		{
+			name: "remote recipient",
+			opaque: map[string]any{
+				"v":               1,
+				"kind":            "remote",
+				"att_id":          "attachment-recipient",
+				"conversation_id": "signal:+15551234567",
+			},
+			refMIME:   " image/png ",
+			transport: " image/transport ",
+			want: fakeDownloadRequest{
+				account:      "+15551230000",
+				kind:         "remote",
+				attachmentID: "attachment-recipient",
+				target:       "+15551234567",
+			},
+			wantMIME: "image/transport",
+		},
+		{
+			name: "remote group",
+			opaque: map[string]any{
+				"v":               1,
+				"kind":            "remote",
+				"att_id":          "attachment-group",
+				"conversation_id": "signal-group:group-token",
+			},
+			refMIME:   " video/mp4 ",
+			transport: "   ",
+			want: fakeDownloadRequest{
+				account:      "+15551230000",
+				kind:         "remote",
+				attachmentID: "attachment-group",
+				target:       "group-token",
+				isGroup:      true,
+			},
+			wantMIME: "video/mp4",
+		},
+		{
+			name: "local path",
+			opaque: map[string]any{
+				"v":    1,
+				"kind": "local",
+				"path": "/tmp/local Signal attachment",
+			},
+			refMIME: "audio/ogg",
+			want: fakeDownloadRequest{
+				account: "+15551230000",
+				kind:    "local",
+				path:    "/tmp/local Signal attachment",
+			},
+			wantMIME: "audio/ogg",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opaque, err := json.Marshal(tc.opaque)
+			if err != nil {
+				t.Fatalf("marshal v1 opaque payload: %v", err)
+			}
+			poller := readyDownloadPoller()
+			poller.downloadData = []byte("signal attachment bytes")
+			poller.downloadMIME = tc.transport
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+			stream, err := adapter.DownloadMedia(context.Background(), "signal-primary", bridge.MediaRef{
+				RemoteID: "remote-row-id",
+				Opaque:   opaque,
+				Filename: "attachment.bin",
+				MIME:     tc.refMIME,
+			})
+			if err != nil {
+				t.Fatalf("DownloadMedia() error = %v", err)
+			}
+			if stream.ReadCloser == nil {
+				t.Fatal("DownloadMedia() returned a nil ReadCloser with nil error")
+			}
+			t.Cleanup(func() { _ = stream.Close() })
+			data, err := io.ReadAll(stream)
+			if err != nil {
+				t.Fatalf("read MediaStream: %v", err)
+			}
+			if !bytes.Equal(data, poller.downloadData) {
+				t.Fatalf("MediaStream bytes = %q, want %q", data, poller.downloadData)
+			}
+			if stream.Size != int64(len(poller.downloadData)) ||
+				stream.Filename != "attachment.bin" || stream.MIME != tc.wantMIME {
+				t.Fatalf("MediaStream metadata = {Size:%d Filename:%q MIME:%q}", stream.Size, stream.Filename, stream.MIME)
+			}
+			if got := poller.downloadCallCount(); got != 1 {
+				t.Fatalf("DownloadMediaRef calls = %d, want 1", got)
+			}
+			if got := poller.lastDownloadRequest(); got != tc.want {
+				t.Fatalf("DownloadMediaRef request = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaRejectsUnsupportedOpaqueVersionBeforeTransport(t *testing.T) {
+	poller := readyDownloadPoller()
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+	_, err := adapter.DownloadMedia(context.Background(), "signal-primary", bridge.MediaRef{
+		Opaque: []byte(`{"v":2,"kind":"local","path":"/tmp/attachment"}`),
+	})
+	assertDownloadOpError(t, err, bridge.FailureUnsupported, "opaque_version_unsupported")
+	if got := poller.downloadCallCount(); got != 0 {
+		t.Fatalf("DownloadMediaRef calls = %d, want 0 for unsupported version", got)
+	}
+}
+
+func TestDownloadMediaRejectsStructurallyInvalidOpaqueBeforeTransport(t *testing.T) {
+	tests := []struct {
+		name            string
+		opaque          []byte
+		wantFingerprint string
+	}{
+		{
+			name:            "invalid UTF-8",
+			opaque:          []byte{'{', '"', 'v', '"', ':', '1', ',', '"', 'x', '"', ':', '"', 0xff, '"', '}'},
+			wantFingerprint: "signal_download_media_opaque_invalid_utf8",
+		},
+		{
+			name:            "malformed JSON",
+			opaque:          []byte(`{"v":1`),
+			wantFingerprint: "signal_download_media_opaque_malformed",
+		},
+		{
+			name:            "version is not an integer",
+			opaque:          []byte(`{"v":"1","kind":"local","path":"/tmp/a"}`),
+			wantFingerprint: "signal_download_media_opaque_malformed",
+		},
+		{
+			name:            "kind missing",
+			opaque:          []byte(`{"v":1,"path":"/tmp/a"}`),
+			wantFingerprint: "signal_download_media_kind_missing",
+		},
+		{
+			name:            "unknown kind",
+			opaque:          []byte(`{"v":1,"kind":"archive","path":"/tmp/a"}`),
+			wantFingerprint: "signal_download_media_kind_unsupported",
+		},
+		{
+			name:            "whitespace-wrapped kind",
+			opaque:          []byte(`{"v":1,"kind":" remote ","att_id":"attachment","conversation_id":"signal:+15551234567"}`),
+			wantFingerprint: "signal_download_media_kind_unsupported",
+		},
+		{
+			name:            "remote attachment missing",
+			opaque:          []byte(`{"v":1,"kind":"remote","conversation_id":"signal:+15551234567"}`),
+			wantFingerprint: "signal_download_media_remote_missing_field",
+		},
+		{
+			name:            "remote conversation missing",
+			opaque:          []byte(`{"v":1,"kind":"remote","att_id":"attachment"}`),
+			wantFingerprint: "signal_download_media_remote_missing_field",
+		},
+		{
+			name:            "remote conversation invalid",
+			opaque:          []byte(`{"v":1,"kind":"remote","att_id":"attachment","conversation_id":"whatsapp:+15551234567"}`),
+			wantFingerprint: "signal_download_media_conversation_invalid",
+		},
+		{
+			name:            "local path missing",
+			opaque:          []byte(`{"v":1,"kind":"local"}`),
+			wantFingerprint: "signal_download_media_local_missing_field",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := readyDownloadPoller()
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+			_, err := adapter.DownloadMedia(context.Background(), "signal-primary", bridge.MediaRef{Opaque: tc.opaque})
+			assertDownloadOpError(t, err, bridge.FailureUnsupported, tc.wantFingerprint)
+			if got := poller.downloadCallCount(); got != 0 {
+				t.Fatalf("DownloadMediaRef calls = %d, want 0 for invalid Opaque", got)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaRequiresReadyRetainedBridge(t *testing.T) {
+	tests := []struct {
+		name   string
+		poller poller
+	}{
+		{name: "nil retained bridge"},
+		{name: "not connected", poller: newFakePoller()},
+		{
+			name: "connected without account",
+			poller: &fakePoller{
+				started: make(chan *fakePollerRun, 1),
+				status:  signallive.StatusSnapshot{Connected: true},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := &Adapter{accountID: "signal-primary", poller: tc.poller}
+			stream, err := adapter.DownloadMedia(context.Background(), "signal-primary", bridge.MediaRef{
+				Opaque: []byte(`{"v":1,"kind":"remote","att_id":"attachment","conversation_id":"signal:+15551234567"}`),
+			})
+			if stream.ReadCloser != nil {
+				t.Fatal("DownloadMedia() failure returned a non-nil ReadCloser")
+			}
+			assertDownloadOpError(t, err, bridge.FailureTransient, "signal_not_connected")
+			if fake, ok := tc.poller.(*fakePoller); ok && fake.downloadCallCount() != 0 {
+				t.Fatalf("DownloadMediaRef calls = %d, want 0 while not ready", fake.downloadCallCount())
+			}
+		})
+	}
+}
+
+func TestDownloadMediaRejectsInvalidContextBeforeTransport(t *testing.T) {
+	tests := []struct {
+		name            string
+		context         func() context.Context
+		wantFingerprint string
+	}{
+		{
+			name:            "nil context",
+			context:         func() context.Context { return nil },
+			wantFingerprint: "signal_download_media_context_missing",
+		},
+		{
+			name: "done context",
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantFingerprint: "signal_download_media_context_done",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := readyDownloadPoller()
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+			_, err := adapter.DownloadMedia(tc.context(), "signal-primary", bridge.MediaRef{
+				Opaque: []byte(`{"v":1,"kind":"local","path":"/tmp/attachment"}`),
+			})
+			assertDownloadOpError(t, err, bridge.FailureTransient, tc.wantFingerprint)
+			if got := poller.downloadCallCount(); got != 0 {
+				t.Fatalf("DownloadMediaRef calls = %d, want 0 after context failure", got)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaClassifiesTransportFailureWithoutWideningC6(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "local read failure", err: errors.New("read local Signal attachment: unavailable")},
+		{name: "recipient failure", err: signallive.NewCommandError("download Signal attachment: recipient is not registered")},
+		{name: "network failure", err: signallive.NewCommandError("download Signal attachment: Connection reset by peer")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poller := readyDownloadPoller()
+			poller.downloadErr = tc.err
+			adapter := &Adapter{accountID: "signal-primary", poller: poller}
+			run, err := adapter.Start(context.Background(), bridge.StartRequest{
+				AccountID: "signal-primary", Generation: 1,
+			}, nil)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			receiveValue(t, poller.started, "retained poller start")
+			t.Cleanup(func() { stopAdapterRun(t, run) })
+
+			_, err = adapter.DownloadMedia(context.Background(), "signal-primary", bridge.MediaRef{
+				Opaque: []byte(`{"v":1,"kind":"remote","att_id":"attachment","conversation_id":"signal:+15551234567"}`),
+			})
+			failure := assertDownloadOpError(t, err, bridge.FailureTransient, "signal_download_media_failed")
+			if !errors.Is(failure.Cause, tc.err) {
+				t.Fatalf("DownloadMedia() cause = %v, want %v", failure.Cause, tc.err)
+			}
+			select {
+			case terminal := <-run.Done():
+				t.Fatalf("non-account download failure retired receive generation: %v", terminal)
+			default:
+			}
+			if got := poller.appliedCount(); got != 0 {
+				t.Fatalf("non-account download failure applied %d lifecycle transitions, want 0", got)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaReportsOnlyUnambiguousLocalAccountFailure(t *testing.T) {
+	poller := readyDownloadPoller()
+	poller.downloadErr = signallive.NewCommandError("download Signal attachment: authorization failed")
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	run, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID: "signal-primary", Generation: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	receiveValue(t, poller.started, "retained poller start")
+
+	_, err = adapter.DownloadMedia(context.Background(), "signal-primary", bridge.MediaRef{
+		Opaque: []byte(`{"v":1,"kind":"remote","att_id":"attachment","conversation_id":"signal:+15551234567"}`),
+	})
+	assertDownloadOpError(t, err, bridge.FailureTransient, "signal_download_media_failed")
+	terminal := receiveValue(t, run.Done(), "local-account download terminal")
+	assertOpError(t, terminal, bridge.FailureTransient, "signal_send_account_check")
+	if got := poller.appliedCount(); got != 1 {
+		t.Fatalf("local-account download status projections = %d, want 1", got)
+	}
+}
+
+func TestDownloadMediaAlwaysReturnsReaderOnSuccess(t *testing.T) {
+	poller := readyDownloadPoller()
+	poller.downloadData = nil
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+	stream, err := adapter.DownloadMedia(context.Background(), "signal-primary", bridge.MediaRef{
+		Opaque: []byte(`{"v":1,"kind":"local","path":"/tmp/empty"}`),
+	})
+	if err != nil {
+		t.Fatalf("DownloadMedia() error = %v", err)
+	}
+	if stream.ReadCloser == nil {
+		t.Fatal("DownloadMedia() returned nil ReadCloser with nil error")
+	}
+	defer stream.Close()
+	if stream.Size != 0 {
+		t.Fatalf("MediaStream.Size = %d, want 0", stream.Size)
+	}
+}
+
+func readyDownloadPoller() *fakePoller {
+	poller := newFakePoller()
+	poller.status = signallive.StatusSnapshot{
+		Connected: true,
+		Paired:    true,
+		Account:   "+15551230000",
+	}
+	return poller
+}
+
+func assertDownloadOpError(
+	t *testing.T,
+	err error,
+	wantClass bridge.FailureClass,
+	wantFingerprint string,
+) bridge.OpError {
+	t.Helper()
+	var failure bridge.OpError
+	if !errors.As(err, &failure) {
+		t.Fatalf("DownloadMedia() error = %v (%T), want bridge.OpError", err, err)
+	}
+	if failure.Class != wantClass || failure.Operation != "download_media" ||
+		failure.Fingerprint != wantFingerprint || failure.Dispatch != "" {
+		t.Fatalf("DownloadMedia() OpError = %+v, want class %q operation download_media fingerprint %q", failure, wantClass, wantFingerprint)
+	}
+	return failure
+}

--- a/internal/bridgeadapters/signal/signal.go
+++ b/internal/bridgeadapters/signal/signal.go
@@ -4,7 +4,9 @@
 package signal
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/maxghenis/openmessage/internal/bridge"
 	"github.com/maxghenis/openmessage/internal/signallive"
@@ -22,10 +25,31 @@ type poller interface {
 	SendTextRequest(string, string, string) (int64, error)
 	SendReactionRequest(string, string, string, string, string) error
 	SendMediaRequest(string, io.Reader, int64, string, string, string, string) (int64, error)
+	DownloadMediaRef(string, string, string, string, string, bool) ([]byte, string, error)
 	Status() signallive.StatusSnapshot
 	ApplyPollerFailure(signallive.PollerExit)
 	InputFingerprint() string
 	UnpairContext(context.Context) error
+}
+
+// signalDownloadOpaqueV1 is the Signal-owned Wave-4 -> M4b wire contract.
+// The Wave-4 Signal decoder MUST pack conversation_id for every remote
+// attachment: getAttachment needs a recipient or group target, while
+// bridge.MediaDownloader intentionally carries no conversation argument.
+// No v2 decoder writes remote_ref yet, so this adapter is unit-testable but the
+// production path remains inert until Wave-4 ingest starts packing this shape.
+type signalDownloadOpaqueV1 struct {
+	Version        int    `json:"v"`
+	Kind           string `json:"kind"`
+	AttachmentID   string `json:"att_id"`
+	Path           string `json:"path"`
+	ConversationID string `json:"conversation_id"`
+}
+
+type decodedSignalDownloadRef struct {
+	payload signalDownloadOpaqueV1
+	target  string
+	isGroup bool
 }
 
 // Adapter owns Signal connection generations while retaining signallive's
@@ -244,6 +268,169 @@ func (a *Adapter) SendMedia(
 		RemoteMessageID: strconv.FormatInt(timestampMS, 10),
 		EchoExpected:    false,
 	}, nil
+}
+
+// DownloadMedia adapts Signal's retained fully-buffered attachment downloader
+// to bridge.MediaStream. This forfeits true streaming, matching the retained
+// signal-cli boundary until a future transport exposes a streaming response.
+func (a *Adapter) DownloadMedia(
+	ctx context.Context,
+	accountID string,
+	ref bridge.MediaRef,
+) (bridge.MediaStream, error) {
+	_ = accountID // Logical registry ID; the ready status owns the Signal account.
+	if ctx == nil {
+		return bridge.MediaStream{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "download_media",
+			Fingerprint: "signal_download_media_context_missing",
+			Cause:       errors.New("Signal media download context is nil"),
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.MediaStream{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "download_media",
+			Fingerprint: "signal_download_media_context_done",
+			Cause:       err,
+		}
+	}
+	if a == nil || a.poller == nil {
+		return bridge.MediaStream{}, signalDownloadNotConnectedError()
+	}
+	status := a.poller.Status()
+	account := strings.TrimSpace(status.Account)
+	if !status.Connected || account == "" {
+		return bridge.MediaStream{}, signalDownloadNotConnectedError()
+	}
+
+	decoded, err := decodeSignalDownloadOpaque(ref.Opaque)
+	if err != nil {
+		return bridge.MediaStream{}, err
+	}
+	data, transportMIME, err := a.poller.DownloadMediaRef(
+		account,
+		decoded.payload.Kind,
+		decoded.payload.AttachmentID,
+		decoded.payload.Path,
+		decoded.target,
+		decoded.isGroup,
+	)
+	if err != nil {
+		// Preserve C6: ReportError only acts on unambiguous local-account
+		// CommandErrors and never widens recipient/network failures into receive
+		// lifecycle transitions.
+		a.ReportError(err)
+		return bridge.MediaStream{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "download_media",
+			Fingerprint: "signal_download_media_failed",
+			Cause:       err,
+		}
+	}
+
+	return bridge.MediaStream{
+		ReadCloser: io.NopCloser(bytes.NewReader(data)),
+		Size:       int64(len(data)),
+		Filename:   ref.Filename,
+		MIME:       firstNonEmpty(transportMIME, ref.MIME),
+	}, nil
+}
+
+func decodeSignalDownloadOpaque(raw []byte) (decodedSignalDownloadRef, error) {
+	if !utf8.Valid(raw) {
+		return decodedSignalDownloadRef{}, signalDownloadOpaqueError(
+			"signal_download_media_opaque_invalid_utf8",
+			errors.New("Signal media Opaque is not valid UTF-8"),
+		)
+	}
+	var payload signalDownloadOpaqueV1
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return decodedSignalDownloadRef{}, signalDownloadOpaqueError(
+			"signal_download_media_opaque_malformed",
+			fmt.Errorf("decode Signal media Opaque JSON: %w", err),
+		)
+	}
+	if payload.Version != 1 {
+		return decodedSignalDownloadRef{}, signalDownloadOpaqueError(
+			"opaque_version_unsupported",
+			fmt.Errorf("unsupported Signal media Opaque version %d", payload.Version),
+		)
+	}
+	if payload.Kind == "" {
+		return decodedSignalDownloadRef{}, signalDownloadOpaqueError(
+			"signal_download_media_kind_missing",
+			errors.New("Signal media Opaque requires kind"),
+		)
+	}
+
+	switch payload.Kind {
+	case "remote":
+		payload.AttachmentID = strings.TrimSpace(payload.AttachmentID)
+		payload.ConversationID = strings.TrimSpace(payload.ConversationID)
+		if payload.AttachmentID == "" || payload.ConversationID == "" {
+			return decodedSignalDownloadRef{}, signalDownloadOpaqueError(
+				"signal_download_media_remote_missing_field",
+				errors.New("Signal remote media Opaque requires att_id and conversation_id"),
+			)
+		}
+		target, isGroup, err := signallive.ParseConversationTarget(payload.ConversationID)
+		if err != nil {
+			return decodedSignalDownloadRef{}, signalDownloadOpaqueError(
+				"signal_download_media_conversation_invalid",
+				fmt.Errorf("parse Signal media conversation_id: %w", err),
+			)
+		}
+		return decodedSignalDownloadRef{
+			payload: payload,
+			target:  target,
+			isGroup: isGroup,
+		}, nil
+	case "local":
+		if strings.TrimSpace(payload.Path) == "" {
+			return decodedSignalDownloadRef{}, signalDownloadOpaqueError(
+				"signal_download_media_local_missing_field",
+				errors.New("Signal local media Opaque requires path"),
+			)
+		}
+		return decodedSignalDownloadRef{payload: payload}, nil
+	default:
+		return decodedSignalDownloadRef{}, signalDownloadOpaqueError(
+			"signal_download_media_kind_unsupported",
+			fmt.Errorf("unsupported Signal media Opaque kind %q", payload.Kind),
+		)
+	}
+}
+
+// Structural Opaque failures are terminal unsupported errors: retrying the
+// same persisted bytes can never make invalid UTF-8/JSON or missing fields
+// decodable. Each structural category has its own fingerprint; version skew
+// uses the cross-platform opaque_version_unsupported contract.
+func signalDownloadOpaqueError(fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureUnsupported,
+		Operation:   "download_media",
+		Fingerprint: fingerprint,
+		Cause:       cause,
+	}
+}
+
+func signalDownloadNotConnectedError() bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "download_media",
+		Fingerprint: "signal_not_connected",
+		Cause:       errors.New("Signal is not connected"),
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func signalNotConnectedError(operation string) bridge.OpError {
@@ -689,5 +876,6 @@ var (
 	_ bridge.TextSender         = (*Adapter)(nil)
 	_ bridge.ReactionSender     = (*Adapter)(nil)
 	_ bridge.MediaSender        = (*Adapter)(nil)
+	_ bridge.MediaDownloader    = (*Adapter)(nil)
 	_ bridge.Run                = (*run)(nil)
 )

--- a/internal/bridgeadapters/signal/signal_test.go
+++ b/internal/bridgeadapters/signal/signal_test.go
@@ -1302,6 +1302,10 @@ type fakePoller struct {
 	mediaCalls     []fakeMediaRequest
 	mediaTimestamp int64
 	mediaErr       error
+	downloadCalls  []fakeDownloadRequest
+	downloadData   []byte
+	downloadMIME   string
+	downloadErr    error
 }
 
 type fakeTextRequest struct {
@@ -1326,6 +1330,15 @@ type fakeMediaRequest struct {
 	mime           string
 	caption        string
 	replyToID      string
+}
+
+type fakeDownloadRequest struct {
+	account      string
+	kind         string
+	attachmentID string
+	path         string
+	target       string
+	isGroup      bool
 }
 
 type fakeSignalSendNotDispatchedError struct {
@@ -1476,6 +1489,40 @@ func (p *fakePoller) lastMediaRequest() fakeMediaRequest {
 		return fakeMediaRequest{}
 	}
 	return p.mediaCalls[len(p.mediaCalls)-1]
+}
+
+func (p *fakePoller) DownloadMediaRef(
+	account, kind, attachmentID, path, target string,
+	isGroup bool,
+) ([]byte, string, error) {
+	p.mu.Lock()
+	p.downloadCalls = append(p.downloadCalls, fakeDownloadRequest{
+		account:      account,
+		kind:         kind,
+		attachmentID: attachmentID,
+		path:         path,
+		target:       target,
+		isGroup:      isGroup,
+	})
+	data := append([]byte(nil), p.downloadData...)
+	mimeType, err := p.downloadMIME, p.downloadErr
+	p.mu.Unlock()
+	return data, mimeType, err
+}
+
+func (p *fakePoller) downloadCallCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.downloadCalls)
+}
+
+func (p *fakePoller) lastDownloadRequest() fakeDownloadRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.downloadCalls) == 0 {
+		return fakeDownloadRequest{}
+	}
+	return p.downloadCalls[len(p.downloadCalls)-1]
 }
 
 func (p *fakePoller) ApplyPollerFailure(exit signallive.PollerExit) {

--- a/internal/bridgeadapters/whatsapp/download.go
+++ b/internal/bridgeadapters/whatsapp/download.go
@@ -1,0 +1,227 @@
+package whatsapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	"go.mau.fi/whatsmeow"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/whatsapplive"
+	"github.com/maxghenis/openmessage/internal/whatsappmedia"
+)
+
+// whatsappMediaOpaqueV1 is the WhatsApp-owned Wave-4 -> M4b wire contract.
+// The future WhatsApp decoder must pack message_attachments.remote_ref with
+// this exact versioned JSON shape. Until Wave-4 does so, this production path
+// is intentionally inert even though crafted payloads make it unit-testable.
+type whatsappMediaOpaqueV1 struct {
+	V             int    `json:"v"`
+	Kind          string `json:"kind"`
+	DirectPath    string `json:"direct_path"`
+	FileSHA256    string `json:"file_sha256"`
+	FileEncSHA256 string `json:"file_enc_sha256"`
+	MediaKey      string `json:"media_key"`
+	FileLength    uint64 `json:"file_length"`
+	LocalRef      string `json:"local_ref"`
+}
+
+func marshalWhatsAppMediaOpaqueV1(payload whatsappMediaOpaqueV1) ([]byte, error) {
+	payload.V = 1
+	return json.Marshal(payload)
+}
+
+func unmarshalWhatsAppMediaOpaque(raw []byte) (whatsappMediaOpaqueV1, error) {
+	var payload whatsappMediaOpaqueV1
+	if !utf8.Valid(raw) {
+		return payload, whatsappOpaqueUnsupported(
+			"whatsapp_opaque_malformed",
+			errors.New("WhatsApp media Opaque is not valid UTF-8"),
+		)
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return payload, whatsappOpaqueUnsupported(
+			"whatsapp_opaque_malformed",
+			fmt.Errorf("decode WhatsApp media Opaque JSON: %w", err),
+		)
+	}
+	if payload.V != 1 {
+		return payload, whatsappOpaqueUnsupported(
+			"opaque_version_unsupported",
+			fmt.Errorf("unsupported WhatsApp media Opaque version %d", payload.V),
+		)
+	}
+
+	switch payload.Kind {
+	case "remote":
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			// The typed unmarshal above already succeeded. Keep this defensive
+			// branch classified as immutable structural input if that changes.
+			return payload, whatsappOpaqueUnsupported(
+				"whatsapp_opaque_malformed",
+				fmt.Errorf("inspect WhatsApp media Opaque fields: %w", err),
+			)
+		}
+		fileLength, hasFileLength := fields["file_length"]
+		if strings.TrimSpace(payload.DirectPath) == "" ||
+			strings.TrimSpace(payload.FileEncSHA256) == "" ||
+			strings.TrimSpace(payload.MediaKey) == "" ||
+			!hasFileLength || strings.TrimSpace(string(fileLength)) == "null" {
+			return payload, whatsappOpaqueUnsupported(
+				"whatsapp_opaque_remote_invalid",
+				errors.New("WhatsApp remote media Opaque requires direct_path, file_enc_sha256, media_key, and file_length"),
+			)
+		}
+		for _, field := range []struct {
+			name  string
+			value string
+		}{
+			{name: "file_enc_sha256", value: payload.FileEncSHA256},
+			{name: "file_sha256", value: payload.FileSHA256},
+			{name: "media_key", value: payload.MediaKey},
+		} {
+			name, value := field.name, field.value
+			value = strings.TrimSpace(value)
+			if value == "" && name == "file_sha256" {
+				// Empty plaintext hash is an intentional compatibility mode;
+				// the retained downloader maps it to allowNoHash=true.
+				continue
+			}
+			if _, err := hex.DecodeString(value); err != nil {
+				return payload, whatsappOpaqueUnsupported(
+					"whatsapp_opaque_hex_invalid",
+					fmt.Errorf("decode WhatsApp media Opaque %s: %w", name, err),
+				)
+			}
+		}
+	case "local":
+		// Local refs intentionally ignore all remote-only fields; the retained
+		// local route needs only the encoded desktop reference. The adapter's
+		// uniform passive readiness gate still runs before decoding.
+		if strings.TrimSpace(payload.LocalRef) == "" {
+			return payload, whatsappOpaqueUnsupported(
+				"whatsapp_opaque_local_invalid",
+				errors.New("WhatsApp local media Opaque requires local_ref"),
+			)
+		}
+		localPath, err := whatsappmedia.DecodeLocalMediaRef(payload.LocalRef)
+		if err != nil || strings.TrimSpace(localPath) == "" {
+			if err == nil {
+				err = errors.New("WhatsApp local media reference has an empty path")
+			}
+			return payload, whatsappOpaqueUnsupported(
+				"whatsapp_opaque_local_invalid",
+				fmt.Errorf("decode WhatsApp local media Opaque local_ref: %w", err),
+			)
+		}
+		if _, err := whatsappmedia.ResolveLocalMediaPath("whatsapp-media-validation-root", payload.LocalRef); err != nil {
+			return payload, whatsappOpaqueUnsupported(
+				"whatsapp_opaque_local_invalid",
+				fmt.Errorf("validate WhatsApp local media Opaque local_ref: %w", err),
+			)
+		}
+	default:
+		return payload, whatsappOpaqueUnsupported(
+			"whatsapp_opaque_kind_unsupported",
+			fmt.Errorf("unsupported WhatsApp media Opaque kind %q", payload.Kind),
+		)
+	}
+	return payload, nil
+}
+
+// DownloadMedia adapts the fully-buffered retained WhatsApp download path to
+// bridge.MediaStream. This necessarily forfeits true streaming until a future
+// transport-native streaming API replaces the retained []byte boundary.
+func (a *Adapter) DownloadMedia(ctx context.Context, _ string, ref bridge.MediaRef) (bridge.MediaStream, error) {
+	if a == nil || a.mediaReady == nil || !a.mediaReady() || a.downloadMediaRef == nil {
+		return bridge.MediaStream{}, whatsappDownloadPreCallFailure(
+			"whatsapp_not_connected",
+			whatsmeow.ErrNotConnected,
+		)
+	}
+	if ctx == nil {
+		return bridge.MediaStream{}, whatsappDownloadPreCallFailure(
+			"whatsapp_download_context_missing",
+			errors.New("WhatsApp media download context is nil"),
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.MediaStream{}, whatsappDownloadPreCallFailure("whatsapp_download_context_done", err)
+	}
+
+	payload, err := unmarshalWhatsAppMediaOpaque(ref.Opaque)
+	if err != nil {
+		return bridge.MediaStream{}, err
+	}
+	data, transportMIME, err := a.downloadMediaRef(
+		payload.Kind,
+		whatsapplive.StoredMediaRef{
+			DirectPath:    payload.DirectPath,
+			FileSHA256:    payload.FileSHA256,
+			FileEncSHA256: payload.FileEncSHA256,
+			FileLength:    payload.FileLength,
+		},
+		payload.MediaKey,
+		ref.MIME,
+		payload.LocalRef,
+	)
+	if err != nil {
+		// Deliberately no adapter-level lifecycle report (D1). The retained
+		// WhatsApp core remains the sole owner of guarded reconnect reporting.
+		failure := a.classifyError(
+			err,
+			"download_media",
+			"whatsapp_download_media_failed",
+		)
+		// Downloads are idempotent reads, not dispatches. Do not let a wrapped
+		// OpError from a lower layer leak send certainty into this path.
+		failure.Dispatch = ""
+		return bridge.MediaStream{}, failure
+	}
+
+	return bridge.MediaStream{
+		ReadCloser: io.NopCloser(bytes.NewReader(data)),
+		Size:       int64(len(data)),
+		Filename:   ref.Filename,
+		MIME:       firstNonEmpty(transportMIME, ref.MIME),
+	}, nil
+}
+
+func whatsappDownloadPreCallFailure(fingerprint string, cause error) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "download_media",
+		Fingerprint: fingerprint,
+		Cause:       cause,
+	}
+}
+
+func whatsappOpaqueUnsupported(fingerprint string, cause error) bridge.OpError {
+	// Opaque bytes are persisted immutable input. Malformed or structurally
+	// incomplete payloads cannot heal on retry, so fail closed as terminal.
+	return bridge.OpError{
+		Class:       bridge.FailureUnsupported,
+		Operation:   "download_media",
+		Fingerprint: fingerprint,
+		Cause:       cause,
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+var _ bridge.MediaDownloader = (*Adapter)(nil)

--- a/internal/bridgeadapters/whatsapp/download_test.go
+++ b/internal/bridgeadapters/whatsapp/download_test.go
@@ -1,0 +1,379 @@
+package whatsapp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+	wastore "go.mau.fi/whatsmeow/store"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/whatsapplive"
+)
+
+func TestAdapterImplementsMediaDownloader(t *testing.T) {
+	var _ bridge.MediaDownloader = (*Adapter)(nil)
+}
+
+func TestNewWiresDownloadMediaRefSeam(t *testing.T) {
+	a := New("whatsapp-primary", &whatsapplive.Bridge{})
+	if a.downloadMediaRef == nil {
+		t.Fatal("New() did not wire the retained DownloadMediaRef method")
+	}
+}
+
+func TestWhatsAppMediaOpaqueV1RoundTrip(t *testing.T) {
+	want := whatsappMediaOpaqueV1{
+		Kind:          "remote",
+		DirectPath:    "/mms/image",
+		FileSHA256:    "0506",
+		FileEncSHA256: "0304",
+		MediaKey:      "0102",
+		FileLength:    9,
+		LocalRef:      "",
+	}
+	raw, err := marshalWhatsAppMediaOpaqueV1(want)
+	if err != nil {
+		t.Fatalf("marshalWhatsAppMediaOpaqueV1(): %v", err)
+	}
+	const wantJSON = `{"v":1,"kind":"remote","direct_path":"/mms/image","file_sha256":"0506","file_enc_sha256":"0304","media_key":"0102","file_length":9,"local_ref":""}`
+	if string(raw) != wantJSON {
+		t.Fatalf("opaque JSON = %s, want %s", raw, wantJSON)
+	}
+
+	got, err := unmarshalWhatsAppMediaOpaque(raw)
+	if err != nil {
+		t.Fatalf("unmarshalWhatsAppMediaOpaque(): %v", err)
+	}
+	want.V = 1
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round-trip payload = %#v, want %#v", got, want)
+	}
+}
+
+func TestWhatsAppMediaOpaqueV1AcceptsExplicitZeroFileLength(t *testing.T) {
+	got, err := unmarshalWhatsAppMediaOpaque([]byte(`{"v":1,"kind":"remote","direct_path":"/mms/empty","file_sha256":"","file_enc_sha256":"03","media_key":"01","file_length":0,"local_ref":""}`))
+	if err != nil {
+		t.Fatalf("unmarshalWhatsAppMediaOpaque() explicit zero file_length: %v", err)
+	}
+	if got.FileLength != 0 {
+		t.Fatalf("file_length = %d, want explicit zero preserved", got.FileLength)
+	}
+}
+
+func TestDownloadMediaRemoteRoutesExactOpaqueFieldsAndWrapsStream(t *testing.T) {
+	opaque, err := marshalWhatsAppMediaOpaqueV1(whatsappMediaOpaqueV1{
+		Kind:          "remote",
+		DirectPath:    "/mms/image",
+		FileSHA256:    "0506",
+		FileEncSHA256: "0304",
+		MediaKey:      "0102",
+		FileLength:    9,
+		LocalRef:      "unused-local-ref",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotKind, gotMediaKey, gotMIME, gotLocalRef string
+	var gotRef whatsapplive.StoredMediaRef
+	a := &Adapter{
+		mediaReady: func() bool { return true },
+		downloadMediaRef: func(kind string, ref whatsapplive.StoredMediaRef, mediaKeyHex, mime, localRef string) ([]byte, string, error) {
+			gotKind, gotRef, gotMediaKey, gotMIME, gotLocalRef = kind, ref, mediaKeyHex, mime, localRef
+			return []byte("image-bytes"), "image/transport", nil
+		},
+	}
+
+	stream, err := a.DownloadMedia(context.Background(), "whatsapp-primary", bridge.MediaRef{
+		Opaque:   opaque,
+		Filename: "photo.jpg",
+		MIME:     "image/fallback",
+	})
+	if err != nil {
+		t.Fatalf("DownloadMedia(): %v", err)
+	}
+	defer stream.Close()
+	data, err := io.ReadAll(stream.ReadCloser)
+	if err != nil {
+		t.Fatalf("read MediaStream: %v", err)
+	}
+	if !bytes.Equal(data, []byte("image-bytes")) || stream.Size != 11 || stream.Filename != "photo.jpg" || stream.MIME != "image/transport" {
+		t.Fatalf("MediaStream = bytes=%q size=%d filename=%q mime=%q", data, stream.Size, stream.Filename, stream.MIME)
+	}
+	if gotKind != "remote" || gotMediaKey != "0102" || gotMIME != "image/fallback" || gotLocalRef != "unused-local-ref" {
+		t.Fatalf("DownloadMediaRef scalar args = kind=%q key=%q mime=%q local=%q", gotKind, gotMediaKey, gotMIME, gotLocalRef)
+	}
+	if gotRef.DirectPath != "/mms/image" || gotRef.FileSHA256 != "0506" || gotRef.FileEncSHA256 != "0304" || gotRef.FileLength != 9 {
+		t.Fatalf("DownloadMediaRef stored ref = %#v", gotRef)
+	}
+}
+
+func TestDownloadMediaLocalRoutingAndMIMEFallback(t *testing.T) {
+	opaque, err := marshalWhatsAppMediaOpaqueV1(whatsappMediaOpaqueV1{
+		Kind:     "local",
+		LocalRef: "walocal:dGVzdA",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotKind, gotLocalRef string
+	a := &Adapter{
+		mediaReady: func() bool { return true },
+		downloadMediaRef: func(kind string, _ whatsapplive.StoredMediaRef, _ string, _ string, localRef string) ([]byte, string, error) {
+			gotKind, gotLocalRef = kind, localRef
+			return []byte("local-bytes"), "", nil
+		},
+	}
+
+	stream, err := a.DownloadMedia(context.Background(), "whatsapp-primary", bridge.MediaRef{
+		Opaque:   opaque,
+		Filename: "voice.opus",
+		MIME:     "audio/ogg",
+	})
+	if err != nil {
+		t.Fatalf("DownloadMedia(): %v", err)
+	}
+	defer stream.Close()
+	if gotKind != "local" || gotLocalRef != "walocal:dGVzdA" {
+		t.Fatalf("DownloadMediaRef routing = kind=%q local=%q", gotKind, gotLocalRef)
+	}
+	if stream.MIME != "audio/ogg" {
+		t.Fatalf("MediaStream MIME = %q, want ref fallback audio/ogg", stream.MIME)
+	}
+}
+
+func TestDownloadMediaAlwaysReturnsNonNilReadCloserOnSuccess(t *testing.T) {
+	opaque, err := marshalWhatsAppMediaOpaqueV1(whatsappMediaOpaqueV1{Kind: "local", LocalRef: "walocal:dGVzdA"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := &Adapter{
+		mediaReady: func() bool { return true },
+		downloadMediaRef: func(string, whatsapplive.StoredMediaRef, string, string, string) ([]byte, string, error) {
+			return nil, "", nil
+		},
+	}
+	stream, err := a.DownloadMedia(context.Background(), "whatsapp-primary", bridge.MediaRef{Opaque: opaque})
+	if err != nil {
+		t.Fatalf("DownloadMedia(): %v", err)
+	}
+	if stream.ReadCloser == nil {
+		t.Fatal("DownloadMedia() returned nil ReadCloser with nil error")
+	}
+	defer stream.Close()
+	if stream.Size != 0 {
+		t.Fatalf("MediaStream size = %d, want zero", stream.Size)
+	}
+}
+
+func TestDownloadMediaRequiresReadyTransportWithoutLifecycleAction(t *testing.T) {
+	var connectCalls, downloadCalls int
+	a := &Adapter{
+		connect: func(context.Context) error {
+			connectCalls++
+			return nil
+		},
+		mediaReady: func() bool { return false },
+		downloadMediaRef: func(string, whatsapplive.StoredMediaRef, string, string, string) ([]byte, string, error) {
+			downloadCalls++
+			return nil, "", nil
+		},
+	}
+
+	stream, err := a.DownloadMedia(context.Background(), "whatsapp-primary", bridge.MediaRef{})
+	if stream.ReadCloser != nil {
+		t.Fatal("DownloadMedia() returned a stream on readiness failure")
+	}
+	failure, ok := asOpError(err)
+	if !ok || failure.Class != bridge.FailureTransient || failure.Operation != "download_media" ||
+		failure.Fingerprint != "whatsapp_not_connected" || failure.Dispatch != "" ||
+		!errors.Is(failure.Cause, whatsmeow.ErrNotConnected) {
+		t.Fatalf("DownloadMedia() error = %v, want passive not-connected failure", err)
+	}
+	if connectCalls != 0 || downloadCalls != 0 {
+		t.Fatalf("connect/download calls = %d/%d, want zero/zero", connectCalls, downloadCalls)
+	}
+}
+
+func TestDownloadMediaContextGuardsRunBeforeDecodeAndTransport(t *testing.T) {
+	done, cancel := context.WithCancel(context.Background())
+	cancel()
+	tests := []struct {
+		name            string
+		ctx             context.Context
+		wantFingerprint string
+		wantCause       error
+	}{
+		{name: "nil", ctx: nil, wantFingerprint: "whatsapp_download_context_missing"},
+		{name: "done", ctx: done, wantFingerprint: "whatsapp_download_context_done", wantCause: context.Canceled},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var calls int
+			a := &Adapter{
+				mediaReady: func() bool { return true },
+				downloadMediaRef: func(string, whatsapplive.StoredMediaRef, string, string, string) ([]byte, string, error) {
+					calls++
+					return nil, "", nil
+				},
+			}
+			_, err := a.DownloadMedia(test.ctx, "whatsapp-primary", bridge.MediaRef{Opaque: []byte("not-json")})
+			failure, ok := asOpError(err)
+			if !ok || failure.Class != bridge.FailureTransient || failure.Operation != "download_media" ||
+				failure.Fingerprint != test.wantFingerprint || failure.Dispatch != "" {
+				t.Fatalf("DownloadMedia() error = %v, want context failure %q", err, test.wantFingerprint)
+			}
+			if test.wantCause != nil && !errors.Is(failure.Cause, test.wantCause) {
+				t.Fatalf("failure cause = %v, want %v", failure.Cause, test.wantCause)
+			}
+			if calls != 0 {
+				t.Fatalf("transport calls = %d, want zero", calls)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaRejectsUnsupportedOpaqueVersion(t *testing.T) {
+	for _, raw := range [][]byte{
+		[]byte(`{"v":2,"kind":"local","local_ref":"walocal:dGVzdA"}`),
+		[]byte(`{"kind":"local","local_ref":"walocal:dGVzdA"}`),
+	} {
+		a := &Adapter{
+			mediaReady: func() bool { return true },
+			downloadMediaRef: func(string, whatsapplive.StoredMediaRef, string, string, string) ([]byte, string, error) {
+				t.Fatal("transport called for unsupported Opaque version")
+				return nil, "", nil
+			},
+		}
+		_, err := a.DownloadMedia(context.Background(), "whatsapp-primary", bridge.MediaRef{Opaque: raw})
+		failure, ok := asOpError(err)
+		if !ok || failure.Class != bridge.FailureUnsupported || failure.Operation != "download_media" ||
+			failure.Fingerprint != "opaque_version_unsupported" || failure.Dispatch != "" {
+			t.Fatalf("DownloadMedia() error = %v, want terminal unsupported version", err)
+		}
+	}
+}
+
+func TestDownloadMediaRejectsMalformedOrIncompleteOpaqueBeforeTransport(t *testing.T) {
+	invalidUTF8 := append([]byte(`{"v":1,"kind":"local","local_ref":"`), 0xff)
+	invalidUTF8 = append(invalidUTF8, []byte(`"}`)...)
+	tests := []struct {
+		name            string
+		raw             []byte
+		wantFingerprint string
+	}{
+		{name: "malformed JSON", raw: []byte(`{"v":1`), wantFingerprint: "whatsapp_opaque_malformed"},
+		{name: "invalid UTF-8", raw: invalidUTF8, wantFingerprint: "whatsapp_opaque_malformed"},
+		{name: "unknown kind", raw: []byte(`{"v":1,"kind":"future"}`), wantFingerprint: "whatsapp_opaque_kind_unsupported"},
+		{name: "whitespace-wrapped kind", raw: []byte(`{"v":1,"kind":" remote ","direct_path":"/mms","file_enc_sha256":"03","media_key":"01","file_length":1}`), wantFingerprint: "whatsapp_opaque_kind_unsupported"},
+		{name: "remote direct path missing", raw: []byte(`{"v":1,"kind":"remote","file_enc_sha256":"03","media_key":"01","file_length":1}`), wantFingerprint: "whatsapp_opaque_remote_invalid"},
+		{name: "remote encrypted hash missing", raw: []byte(`{"v":1,"kind":"remote","direct_path":"/mms","media_key":"01","file_length":1}`), wantFingerprint: "whatsapp_opaque_remote_invalid"},
+		{name: "remote media key missing", raw: []byte(`{"v":1,"kind":"remote","direct_path":"/mms","file_enc_sha256":"03","file_length":1}`), wantFingerprint: "whatsapp_opaque_remote_invalid"},
+		{name: "remote file length missing", raw: []byte(`{"v":1,"kind":"remote","direct_path":"/mms","file_enc_sha256":"03","media_key":"01"}`), wantFingerprint: "whatsapp_opaque_remote_invalid"},
+		{name: "invalid encrypted hash hex", raw: []byte(`{"v":1,"kind":"remote","direct_path":"/mms","file_enc_sha256":"xyz","media_key":"01","file_length":1}`), wantFingerprint: "whatsapp_opaque_hex_invalid"},
+		{name: "invalid optional plaintext hash hex", raw: []byte(`{"v":1,"kind":"remote","direct_path":"/mms","file_sha256":"xyz","file_enc_sha256":"03","media_key":"01","file_length":1}`), wantFingerprint: "whatsapp_opaque_hex_invalid"},
+		{name: "invalid media key hex", raw: []byte(`{"v":1,"kind":"remote","direct_path":"/mms","file_enc_sha256":"03","media_key":"xyz","file_length":1}`), wantFingerprint: "whatsapp_opaque_hex_invalid"},
+		{name: "local ref missing", raw: []byte(`{"v":1,"kind":"local"}`), wantFingerprint: "whatsapp_opaque_local_invalid"},
+		{name: "local ref encoding malformed", raw: []byte(`{"v":1,"kind":"local","local_ref":"walocal:not*base64"}`), wantFingerprint: "whatsapp_opaque_local_invalid"},
+		{name: "local ref escapes root", raw: []byte(`{"v":1,"kind":"local","local_ref":"walocal:Li4vLi4vZXNjYXBl"}`), wantFingerprint: "whatsapp_opaque_local_invalid"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var calls int
+			a := &Adapter{
+				mediaReady: func() bool { return true },
+				downloadMediaRef: func(string, whatsapplive.StoredMediaRef, string, string, string) ([]byte, string, error) {
+					calls++
+					return nil, "", nil
+				},
+			}
+			_, err := a.DownloadMedia(context.Background(), "whatsapp-primary", bridge.MediaRef{Opaque: test.raw})
+			failure, ok := asOpError(err)
+			if !ok || failure.Class != bridge.FailureUnsupported || failure.Operation != "download_media" ||
+				failure.Fingerprint != test.wantFingerprint || failure.Dispatch != "" {
+				t.Fatalf("DownloadMedia() error = %v, want terminal structural failure %q", err, test.wantFingerprint)
+			}
+			if calls != 0 {
+				t.Fatalf("transport calls = %d, want zero", calls)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaClearsDispatchCertaintyFromWrappedOpError(t *testing.T) {
+	opaque, err := marshalWhatsAppMediaOpaqueV1(whatsappMediaOpaqueV1{Kind: "local", LocalRef: "walocal:dGVzdA"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cause := errors.New("lower-layer failure")
+	wrapped := fmt.Errorf("wrapped retained error: %w", bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "lower_operation",
+		Fingerprint: "lower_fingerprint",
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       cause,
+	})
+	a := &Adapter{
+		mediaReady: func() bool { return true },
+		downloadMediaRef: func(string, whatsapplive.StoredMediaRef, string, string, string) ([]byte, string, error) {
+			return nil, "", wrapped
+		},
+	}
+
+	_, err = a.DownloadMedia(context.Background(), "whatsapp-primary", bridge.MediaRef{Opaque: opaque})
+	failure, ok := asOpError(err)
+	if !ok || failure.Class != bridge.FailureTransient || failure.Operation != "lower_operation" ||
+		failure.Fingerprint != "lower_fingerprint" || failure.Dispatch != "" || !errors.Is(failure.Cause, cause) {
+		t.Fatalf("DownloadMedia() error = %v, want wrapped classification with empty dispatch certainty", err)
+	}
+}
+
+func TestDownloadMediaTransportClassificationDoesNotRetireReceiveGeneration(t *testing.T) {
+	opaque, err := marshalWhatsAppMediaOpaqueV1(whatsappMediaOpaqueV1{Kind: "local", LocalRef: "walocal:dGVzdA"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name            string
+		err             error
+		wantClass       bridge.FailureClass
+		wantFingerprint string
+	}{
+		{name: "plain transient", err: errors.New("media CDN unavailable"), wantClass: bridge.FailureTransient, wantFingerprint: "whatsapp_download_media_failed"},
+		{name: "terminal session error", err: wastore.ErrDeviceDeleted, wantClass: bridge.FailureReauthRequired, wantFingerprint: "whatsapp_session_invalid"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ready := make(chan struct{})
+			close(ready)
+			r := &run{ready: ready, finish: make(chan error, 1), admitting: true}
+			a := &Adapter{
+				current:    r,
+				mediaReady: func() bool { return true },
+				downloadMediaRef: func(string, whatsapplive.StoredMediaRef, string, string, string) ([]byte, string, error) {
+					return nil, "", test.err
+				},
+			}
+			stream, err := a.DownloadMedia(context.Background(), "whatsapp-primary", bridge.MediaRef{Opaque: opaque})
+			if stream.ReadCloser != nil {
+				t.Fatal("DownloadMedia() returned stream on transport error")
+			}
+			failure, ok := asOpError(err)
+			if !ok || failure.Class != test.wantClass || failure.Operation != "download_media" ||
+				failure.Fingerprint != test.wantFingerprint || failure.Dispatch != "" || !errors.Is(failure.Cause, test.err) {
+				t.Fatalf("DownloadMedia() error = %v, want class=%q fingerprint=%q", err, test.wantClass, test.wantFingerprint)
+			}
+			select {
+			case reported := <-r.finish:
+				t.Fatalf("DownloadMedia() retired the receive generation with %v", reported)
+			default:
+			}
+		})
+	}
+}

--- a/internal/bridgeadapters/whatsapp/whatsapp.go
+++ b/internal/bridgeadapters/whatsapp/whatsapp.go
@@ -41,6 +41,7 @@ type Adapter struct {
 	sendReactionRequest func(string, string, string, string, string, string) error
 	markReadRequest     func(string, []string, string, time.Time) error
 	sendMediaRequest    func(string, []byte, string, string, string, string, string) (string, time.Time, error)
+	downloadMediaRef    func(string, whatsapplive.StoredMediaRef, string, string, string) ([]byte, string, error)
 
 	mu       sync.Mutex
 	current  *run
@@ -70,6 +71,7 @@ func New(accountID string, host *whatsapplive.Bridge) *Adapter {
 		a.sendReactionRequest = host.SendReactionRequest
 		a.markReadRequest = host.MarkReadRequest
 		a.sendMediaRequest = host.SendMediaRequest
+		a.downloadMediaRef = host.DownloadMediaRef
 		host.ObserveLifecycle(a.handleLifecycleEvent)
 	}
 	return a

--- a/internal/signallive/client.go
+++ b/internal/signallive/client.go
@@ -3346,6 +3346,14 @@ func parseConversationTarget(conversationID string) (target string, isGroup bool
 	return
 }
 
+// ParseConversationTarget exposes the retained Signal conversation parser to
+// lifecycle adapters that must turn a Wave-4 media remote_ref into the exact
+// getAttachment recipient/group arguments. Keep parsing centralized here so
+// send and download paths cannot drift on signal:/signal-group: semantics.
+func ParseConversationTarget(conversationID string) (target string, isGroup bool, err error) {
+	return parseConversationTarget(conversationID)
+}
+
 func signalConversationID(address, groupID string) string {
 	if groupID = strings.TrimSpace(groupID); groupID != "" {
 		return "signal-group:" + groupID
@@ -3827,12 +3835,58 @@ func (b *Bridge) DownloadMedia(msg *db.Message) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-
-	args := []string{"-a", account, "getAttachment", "--id", attachmentID}
 	target, isGroup, err := parseConversationTarget(msg.ConversationID)
 	if err != nil {
 		return nil, "", err
 	}
+	data, err := b.downloadSignalAttachment(account, attachmentID, target, isGroup)
+	if err != nil {
+		return nil, "", err
+	}
+	return data, msg.MimeType, nil
+}
+
+// DownloadMediaRef is the store-free retained entry point used by the M4b
+// lifecycle adapter. Signal's transport reports no MIME, so the adapter falls
+// back to bridge.MediaRef.MIME after this returns an empty MIME string.
+func (b *Bridge) DownloadMediaRef(
+	account, kind, attachmentID, path, target string,
+	isGroup bool,
+) ([]byte, string, error) {
+	switch strings.TrimSpace(kind) {
+	case "local":
+		if strings.TrimSpace(path) == "" {
+			return nil, "", errors.New("Signal local attachment path is required")
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, "", fmt.Errorf("read local Signal attachment: %w", err)
+		}
+		return data, "", nil
+	case "remote":
+		account = strings.TrimSpace(account)
+		attachmentID = strings.TrimSpace(attachmentID)
+		target = strings.TrimSpace(target)
+		if account == "" || attachmentID == "" || target == "" {
+			return nil, "", errors.New("Signal remote attachment account, id, and target are required")
+		}
+		data, err := b.downloadSignalAttachment(account, attachmentID, target, isGroup)
+		if err != nil {
+			return nil, "", err
+		}
+		return data, "", nil
+	default:
+		return nil, "", fmt.Errorf("unsupported Signal attachment kind %q", kind)
+	}
+}
+
+// downloadSignalAttachment is the store-free signal-cli getAttachment core
+// shared by the legacy db.Message downloader and the ref-shaped M4b path.
+func (b *Bridge) downloadSignalAttachment(
+	account, attachmentID, target string,
+	isGroup bool,
+) ([]byte, error) {
+	args := []string{"-a", account, "getAttachment", "--id", attachmentID}
 	if isGroup {
 		args = append(args, "--group-id", target)
 	} else {
@@ -3845,20 +3899,20 @@ func (b *Bridge) DownloadMedia(msg *db.Message) ([]byte, string, error) {
 	output, err := runSignalCLI(ctx, b.configDir, args...)
 	b.commandMu.Unlock()
 	if err != nil {
-		return nil, "", commandError("download Signal attachment", err, output)
+		return nil, commandError("download Signal attachment", err, output)
 	}
 	payload := strings.TrimSpace(string(output))
 	if payload == "" {
-		return nil, "", errors.New("signal attachment is empty")
+		return nil, errors.New("signal attachment is empty")
 	}
 	data, err := base64.StdEncoding.DecodeString(payload)
 	if err != nil {
 		data, err = base64.RawStdEncoding.DecodeString(payload)
 		if err != nil {
-			return nil, "", fmt.Errorf("decode Signal attachment: %w", err)
+			return nil, fmt.Errorf("decode Signal attachment: %w", err)
 		}
 	}
-	return data, msg.MimeType, nil
+	return data, nil
 }
 
 func (b *Bridge) signalQuoteArgs(replyToID, account string) ([]string, error) {

--- a/internal/signallive/download_ref_test.go
+++ b/internal/signallive/download_ref_test.go
@@ -1,0 +1,181 @@
+package signallive
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/rs/zerolog"
+)
+
+func TestBridgeDownloadMediaRefRoutesRemoteRecipientAndGroup(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		isGroup  bool
+		wantTail []string
+	}{
+		{
+			name:     "recipient",
+			target:   "+15551234567",
+			wantTail: []string{"--recipient", "+15551234567"},
+		},
+		{
+			name:     "group",
+			target:   "group-token",
+			isGroup:  true,
+			wantTail: []string{"--group-id", "group-token"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bridge := &Bridge{configDir: t.TempDir(), logger: zerolog.Nop()}
+			originalRun := runSignalCLI
+			t.Cleanup(func() { runSignalCLI = originalRun })
+
+			var captured []string
+			runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+				captured = append([]string{configDir}, args...)
+				return []byte("cmVtb3RlLWJ5dGVz"), nil
+			}
+
+			data, mimeType, err := bridge.DownloadMediaRef(
+				"+15551230000",
+				"remote",
+				"attachment-123",
+				"",
+				tc.target,
+				tc.isGroup,
+			)
+			if err != nil {
+				t.Fatalf("DownloadMediaRef(remote): %v", err)
+			}
+			if string(data) != "remote-bytes" || mimeType != "" {
+				t.Fatalf("DownloadMediaRef(remote) = (%q, %q), want remote-bytes and empty transport MIME", data, mimeType)
+			}
+			want := []string{
+				bridge.configDir,
+				"-a", "+15551230000",
+				"getAttachment", "--id", "attachment-123",
+			}
+			want = append(want, tc.wantTail...)
+			if !slices.Equal(captured, want) {
+				t.Fatalf("signal-cli call = %q, want %q", captured, want)
+			}
+		})
+	}
+}
+
+func TestBridgeDownloadMediaRefRoutesLocalPathWithoutSignalCLI(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local attachment.bin")
+	if err := os.WriteFile(path, []byte("local-bytes"), 0o600); err != nil {
+		t.Fatalf("write local attachment: %v", err)
+	}
+	bridge := &Bridge{configDir: t.TempDir(), logger: zerolog.Nop()}
+	originalRun := runSignalCLI
+	t.Cleanup(func() { runSignalCLI = originalRun })
+	called := false
+	runSignalCLI = func(context.Context, string, ...string) ([]byte, error) {
+		called = true
+		return nil, errors.New("signal-cli must not run for local attachment")
+	}
+
+	data, mimeType, err := bridge.DownloadMediaRef(
+		"+15551230000",
+		"local",
+		"",
+		path,
+		"",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("DownloadMediaRef(local): %v", err)
+	}
+	if string(data) != "local-bytes" || mimeType != "" {
+		t.Fatalf("DownloadMediaRef(local) = (%q, %q), want local-bytes and empty transport MIME", data, mimeType)
+	}
+	if called {
+		t.Fatal("DownloadMediaRef(local) invoked signal-cli")
+	}
+}
+
+func TestBridgeDownloadMediaRefClassifiesRemoteCommandFailure(t *testing.T) {
+	bridge := &Bridge{configDir: t.TempDir(), logger: zerolog.Nop()}
+	originalRun := runSignalCLI
+	t.Cleanup(func() { runSignalCLI = originalRun })
+	runSignalCLI = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("authorization failed"), errors.New("exit status 1")
+	}
+
+	_, _, err := bridge.DownloadMediaRef(
+		"+15551230000", "remote", "attachment-123", "", "+15551234567", false,
+	)
+	if err == nil || !IsCommandError(err) {
+		t.Fatalf("DownloadMediaRef(remote) error = %v, want CommandError", err)
+	}
+}
+
+func TestBridgeDownloadMediaRefRejectsUnknownKindBeforeIO(t *testing.T) {
+	bridge := &Bridge{configDir: t.TempDir(), logger: zerolog.Nop()}
+	originalRun := runSignalCLI
+	t.Cleanup(func() { runSignalCLI = originalRun })
+	called := false
+	runSignalCLI = func(context.Context, string, ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	}
+
+	_, _, err := bridge.DownloadMediaRef(
+		"+15551230000", "archive", "attachment-123", "/tmp/a", "+15551234567", false,
+	)
+	if err == nil {
+		t.Fatal("DownloadMediaRef(unknown kind) error = nil")
+	}
+	if called {
+		t.Fatal("DownloadMediaRef(unknown kind) invoked signal-cli")
+	}
+}
+
+func TestBridgeDownloadMediaLegacyGroupBehaviorSurvivesCoreExtraction(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		connected: true,
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+	originalRun := runSignalCLI
+	t.Cleanup(func() { runSignalCLI = originalRun })
+	var captured []string
+	runSignalCLI = func(ctx context.Context, configDir string, args ...string) ([]byte, error) {
+		captured = append([]string{configDir}, args...)
+		// Raw, unpadded base64 preserves the legacy decoder fallback as well as
+		// the recipient/group command shape through the extracted core.
+		return []byte("bGVnYWN5LWdyb3VwIQ"), nil
+	}
+
+	data, mimeType, err := bridge.DownloadMedia(&db.Message{
+		ConversationID: "signal-group:group-token",
+		MediaID:        "signalatt:attachment-legacy",
+		MimeType:       "image/gif",
+	})
+	if err != nil {
+		t.Fatalf("DownloadMedia(legacy group): %v", err)
+	}
+	if string(data) != "legacy-group!" || mimeType != "image/gif" {
+		t.Fatalf("DownloadMedia(legacy group) = (%q, %q), want legacy-group!/image-gif", data, mimeType)
+	}
+	want := []string{
+		bridge.configDir,
+		"-a", "+15551230000",
+		"getAttachment", "--id", "attachment-legacy",
+		"--group-id", "group-token",
+	}
+	if !slices.Equal(captured, want) {
+		t.Fatalf("legacy signal-cli call = %q, want %q", captured, want)
+	}
+}

--- a/internal/whatsapplive/client.go
+++ b/internal/whatsapplive/client.go
@@ -150,6 +150,12 @@ type storedMediaRef struct {
 	FileLength    uint64 `json:"file_length,omitempty"`
 }
 
+// StoredMediaRef is an exported alias solely so the lifecycle adapter can
+// pass its platform-owned Opaque fields into DownloadMediaRef. The wire codec
+// remains in bridgeadapters/whatsapp; this type is only the retained transport
+// input that already backed legacy stored-media downloads.
+type StoredMediaRef = storedMediaRef
+
 type Callbacks struct {
 	OnConversationsChange func()
 	OnIncomingMessage     func(*db.Message)
@@ -1670,6 +1676,59 @@ func (b *Bridge) DownloadStoredMedia(msg *db.Message) ([]byte, string, error) {
 		return nil, "", fmt.Errorf("download WhatsApp media: %w", err)
 	}
 	return data, msg.MimeType, nil
+}
+
+// DownloadMediaRef is the store-free counterpart to DownloadStoredMedia. It
+// accepts the ref-shaped fields supplied by the lifecycle adapter and reuses
+// the same remote/local transport helpers without loading a legacy db.Message.
+func (b *Bridge) DownloadMediaRef(kind string, ref storedMediaRef, mediaKeyHex, mime, localRef string) ([]byte, string, error) {
+	switch kind {
+	case "local":
+		return downloadLocalWhatsAppMedia(localRef, mime)
+	case "remote":
+		// Continue below.
+	default:
+		return nil, "", fmt.Errorf("unsupported WhatsApp media ref kind %q", kind)
+	}
+
+	mediaType, err := mediaTypeForMIME(mime)
+	if err != nil {
+		return nil, "", err
+	}
+	mediaKey, err := decodeHexBytes(mediaKeyHex)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid WhatsApp media key: %w", err)
+	}
+	fileEncSHA256, err := decodeHexBytes(ref.FileEncSHA256)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid WhatsApp media enc hash: %w", err)
+	}
+	fileSHA256, err := decodeHexBytes(ref.FileSHA256)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid WhatsApp media hash: %w", err)
+	}
+
+	b.mu.RLock()
+	cli := b.client
+	connected := b.connected
+	b.mu.RUnlock()
+	if cli == nil || !connected || !clientIsConnected(cli) {
+		return nil, "", errors.New("whatsapp live sync is not connected")
+	}
+	if ref.DirectPath == "" {
+		return nil, "", errors.New("whatsapp media is missing a download path")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// An empty plaintext hash is an intentional legacy-compatible mode. The
+	// adapter preserves that distinction from the versioned Opaque payload.
+	data, err := downloadMediaWithPath(cli, ctx, ref.DirectPath, fileEncSHA256, fileSHA256, mediaKey, mediaType, "", len(fileSHA256) == 0)
+	if err != nil {
+		return nil, "", fmt.Errorf("download WhatsApp media: %w", err)
+	}
+	return data, mime, nil
 }
 
 func downloadLocalWhatsAppMedia(mediaID, currentMIME string) ([]byte, string, error) {

--- a/internal/whatsapplive/download_media_ref_test.go
+++ b/internal/whatsapplive/download_media_ref_test.go
@@ -1,0 +1,88 @@
+package whatsapplive
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.mau.fi/whatsmeow"
+
+	"github.com/maxghenis/openmessage/internal/whatsappmedia"
+)
+
+func TestDownloadMediaRefRemoteDecodesHexAndControlsAllowNoHash(t *testing.T) {
+	tests := []struct {
+		name            string
+		fileSHA256      string
+		wantFileSHA256  []byte
+		wantAllowNoHash bool
+	}{
+		{name: "hash present is strict", fileSHA256: "0506", wantFileSHA256: []byte{0x05, 0x06}, wantAllowNoHash: false},
+		{name: "hash absent allows legacy download", fileSHA256: "", wantFileSHA256: nil, wantAllowNoHash: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bridge := &Bridge{connected: true, client: &whatsmeow.Client{}}
+			originalDownload := downloadMediaWithPath
+			originalIsConnected := clientIsConnected
+			t.Cleanup(func() {
+				downloadMediaWithPath = originalDownload
+				clientIsConnected = originalIsConnected
+			})
+			clientIsConnected = func(*whatsmeow.Client) bool { return true }
+			downloadMediaWithPath = func(_ *whatsmeow.Client, _ context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, mediaType whatsmeow.MediaType, mmsType string, allowNoHash bool) ([]byte, error) {
+				if directPath != "/mms/image" || mmsType != "" {
+					t.Fatalf("download path/type = %q/%q", directPath, mmsType)
+				}
+				if string(encFileHash) != string([]byte{0x03, 0x04}) || string(fileHash) != string(test.wantFileSHA256) || string(mediaKey) != string([]byte{0x01, 0x02}) {
+					t.Fatalf("decoded enc/hash/key = %x/%x/%x", encFileHash, fileHash, mediaKey)
+				}
+				if mediaType != whatsmeow.MediaImage || allowNoHash != test.wantAllowNoHash {
+					t.Fatalf("media type/allowNoHash = %v/%v, want image/%v", mediaType, allowNoHash, test.wantAllowNoHash)
+				}
+				return []byte("image-bytes"), nil
+			}
+
+			data, mime, err := bridge.DownloadMediaRef("remote", storedMediaRef{
+				DirectPath:    "/mms/image",
+				FileSHA256:    test.fileSHA256,
+				FileEncSHA256: "0304",
+				FileLength:    11,
+			}, "0102", "image/png", "unused")
+			if err != nil {
+				t.Fatalf("DownloadMediaRef(): %v", err)
+			}
+			if string(data) != "image-bytes" || mime != "image/png" {
+				t.Fatalf("download = %q/%q, want image-bytes/image/png", data, mime)
+			}
+		})
+	}
+}
+
+func TestDownloadMediaRefLocalRoutesWithoutTransport(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	path := filepath.Join(tempHome, "Library", "Group Containers", "group.net.whatsapp.WhatsApp.shared", "Message", "Media", "voice.opus")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("opus-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	bridge := &Bridge{}
+	data, mime, err := bridge.DownloadMediaRef(
+		"local",
+		storedMediaRef{DirectPath: "ignored", FileEncSHA256: "not-hex"},
+		"not-hex",
+		"",
+		whatsappmedia.EncodeLocalMediaRef("Media/voice.opus"),
+	)
+	if err != nil {
+		t.Fatalf("DownloadMediaRef(): %v", err)
+	}
+	if string(data) != "opus-bytes" || mime != "audio/ogg" {
+		t.Fatalf("local download = %q/%q, want opus-bytes/audio/ogg", data, mime)
+	}
+}


### PR DESCRIPTION
## Rebuild M4b — media-download shims + the versioned Opaque wire-format

Each lifecycle adapter now implements `bridge.MediaDownloader`, **completing the transport-shim phase**. Still no production wiring; downloads become end-to-end runnable when Wave-4 ingest populates `message_attachments.remote_ref` using exactly the versioned Opaque formats defined (and comment-contracted) here.

Review verdict **mergeable, zero blocking defects** — codec fields byte-pinned against the spec, retained-call fidelity pinned position-for-position (the enc-hash/hash transposition trap), the fork's `DownloadMedia` signature verified in the module cache, D1/D2/C6 both directions on all three platforms. The review also attributed a pre-existing whatsapplive test-seam data race to base (clean-export repro) — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)