### PR TITLE
Add the openmessage backup command with a verified manifest (rebuild Wave 4 / R1)

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -1,0 +1,1022 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/app"
+
+	_ "modernc.org/sqlite"
+)
+
+const (
+	backupManifestFormat = 1
+	instanceLockName     = "instance.lock"
+	legacyDatabaseName   = "messages.db"
+	manifestName         = "manifest.json"
+
+	refusedRunningExitCode      = 2
+	preflightExitCode           = 3
+	backupFailureExitCode       = 4
+	verificationFailureExitCode = 5
+)
+
+func defaultBackendProbeURL() string {
+	host := strings.TrimSpace(os.Getenv("OPENMESSAGES_HOST"))
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	port := strings.TrimSpace(os.Getenv("OPENMESSAGES_PORT"))
+	if port == "" {
+		port = "7007"
+	}
+	return "http://" + net.JoinHostPort(host, port) + "/api/status"
+}
+
+var errInstanceLockHeld = errors.New("instance lock is held")
+
+// backupError carries the stable operator-facing exit status required by the
+// migration runbook. Other commands retain the historical exit status 1.
+type backupError struct {
+	code int
+	err  error
+}
+
+func (e *backupError) Error() string { return e.err.Error() }
+func (e *backupError) Unwrap() error { return e.err }
+func (e *backupError) ExitCode() int { return e.code }
+
+func newBackupError(code int, format string, args ...any) error {
+	return &backupError{code: code, err: fmt.Errorf(format, args...)}
+}
+
+// ExitCode returns the stable status carried by an error, or 1 for ordinary
+// command failures. A nil error represents success.
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var coded interface{ ExitCode() int }
+	if errors.As(err, &coded) {
+		return coded.ExitCode()
+	}
+	return 1
+}
+
+type backupOptions struct {
+	dataDir     string
+	destination string
+}
+
+type backupDependencies struct {
+	now            func() time.Time
+	version        string
+	commit         string
+	modified       bool
+	probeURL       string
+	httpClient     *http.Client
+	availableBytes func(string) (uint64, error)
+	quickCheck     func(string) (string, error)
+	beforeManifest func() error
+}
+
+type backupResult struct {
+	BackupPath   string
+	ManifestPath string
+	Manifest     backupManifest
+}
+
+type backupManifest struct {
+	Format         int                  `json:"format"`
+	CreatedAt      string               `json:"created_at"`
+	AppVersion     string               `json:"app_version"`
+	Tool           backupTool           `json:"tool"`
+	Source         backupSource         `json:"source"`
+	Target         backupTarget         `json:"target"`
+	Files          []backupFile         `json:"files"`
+	Counts         legacyCounts         `json:"counts"`
+	AuxiliaryState backupAuxiliaryState `json:"auxiliary_state"`
+	Warnings       []string             `json:"warnings"`
+}
+
+type backupTool struct {
+	Version  string `json:"version"`
+	Commit   string `json:"commit"`
+	Modified bool   `json:"modified,omitempty"`
+}
+
+type backupSource struct {
+	Path              string `json:"path"`
+	DatabasePath      string `json:"database_path"`
+	SchemaFingerprint string `json:"schema_fingerprint"`
+	SchemaUserVersion int64  `json:"schema_user_version"`
+	QuickCheck        string `json:"quick_check"`
+}
+
+type backupTarget struct {
+	Path         string `json:"path"`
+	DatabasePath string `json:"database_path"`
+}
+
+type backupFile struct {
+	Path       string `json:"path"`
+	SourcePath string `json:"source_path"`
+	Size       int64  `json:"size"`
+	SHA256     string `json:"sha256"`
+	Mode       string `json:"mode"`
+}
+
+type legacyCounts struct {
+	Conversations             int64            `json:"conversations"`
+	Messages                  int64            `json:"messages"`
+	Contacts                  int64            `json:"contacts"`
+	UnifiedContacts           int64            `json:"unified_contacts"`
+	Drafts                    int64            `json:"drafts"`
+	ScheduledMessages         int64            `json:"scheduled_messages"`
+	ScheduledMessagesByStatus map[string]int64 `json:"scheduled_messages_by_status"`
+	ContactMeta               int64            `json:"contact_meta"`
+}
+
+type backupAuxiliaryState struct {
+	Included   []string `json:"included"`
+	NotPresent []string `json:"not_present"`
+}
+
+type backupCommandOutput struct {
+	OK           bool          `json:"ok"`
+	ExitCode     int           `json:"exit_code"`
+	BackupPath   string        `json:"backup_path,omitempty"`
+	ManifestPath string        `json:"manifest_path,omitempty"`
+	Counts       *legacyCounts `json:"counts,omitempty"`
+	Error        string        `json:"error,omitempty"`
+}
+
+type auxiliaryFile struct {
+	sourcePath   string
+	relativePath string
+	isSQLite     bool
+}
+
+type auxiliaryPlan struct {
+	files          []auxiliaryFile
+	included       []string
+	notPresent     []string
+	signalDirFound bool
+}
+
+// RunBackup handles "openmessage backup [--to <directory>] [--json]".
+//
+// It deliberately does not construct app.App: app.New opens and repairs the
+// live database, whereas a backup must leave its source untouched.
+func RunBackup(_ zerolog.Logger, args ...string) error {
+	return runBackupCommand(context.Background(), args, defaultBackupDependencies(), os.Stdout, os.Stderr)
+}
+
+func runBackupCommand(ctx context.Context, args []string, deps backupDependencies, stdout, stderr io.Writer) error {
+	asJSON := hasFlag(args, "--json")
+	fs := flag.NewFlagSet("backup", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: openmessage backup [--to <directory>] [--json]")
+		fmt.Fprintln(stderr, "  --to defaults to <data-dir>/migration-backups/<UTC-stamp>")
+	}
+	var destination string
+	fs.StringVar(&destination, "to", "", "backup destination directory")
+	fs.BoolVar(&asJSON, "json", asJSON, "write one machine-readable JSON object")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		err = newBackupError(preflightExitCode, "parse backup options: %w", err)
+		return writeBackupCommandError(stdout, asJSON, err)
+	}
+	if fs.NArg() != 0 {
+		err := newBackupError(preflightExitCode, "unexpected backup argument %q; use --to <directory>", fs.Arg(0))
+		return writeBackupCommandError(stdout, asJSON, err)
+	}
+
+	result, err := executeBackup(ctx, backupOptions{
+		dataDir:     app.DefaultDataDir(),
+		destination: destination,
+	}, deps)
+	if err != nil {
+		return writeBackupCommandError(stdout, asJSON, err)
+	}
+
+	if asJSON {
+		output := backupCommandOutput{
+			OK:           true,
+			ExitCode:     0,
+			BackupPath:   result.BackupPath,
+			ManifestPath: result.ManifestPath,
+			Counts:       &result.Manifest.Counts,
+		}
+		if err := json.NewEncoder(stdout).Encode(output); err != nil {
+			return newBackupError(backupFailureExitCode, "write JSON output: %w", err)
+		}
+		return nil
+	}
+
+	fmt.Fprintf(stdout, "Backup complete: %s\n", result.BackupPath)
+	fmt.Fprintf(stdout, "Manifest: %s\n", result.ManifestPath)
+	fmt.Fprintln(stdout, "The legacy source was not modified. Keep this directory for rollback.")
+	return nil
+}
+
+func writeBackupCommandError(stdout io.Writer, asJSON bool, commandErr error) error {
+	if !asJSON {
+		return commandErr
+	}
+	output := backupCommandOutput{
+		OK:       false,
+		ExitCode: ExitCode(commandErr),
+		Error:    commandErr.Error(),
+	}
+	if err := json.NewEncoder(stdout).Encode(output); err != nil {
+		return newBackupError(backupFailureExitCode, "write JSON error output: %w", err)
+	}
+	return commandErr
+}
+
+func defaultBackupDependencies() backupDependencies {
+	commit, modified := buildRevision()
+	return backupDependencies{
+		now:      time.Now,
+		version:  Version(),
+		commit:   commit,
+		modified: modified,
+		probeURL: defaultBackendProbeURL(),
+		httpClient: &http.Client{
+			Timeout: 750 * time.Millisecond,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		availableBytes: filesystemAvailableBytes,
+		quickCheck:     sqliteQuickCheck,
+	}
+}
+
+func buildRevision() (string, bool) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown", false
+	}
+	commit := "unknown"
+	modified := false
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if setting.Value != "" {
+				commit = setting.Value
+			}
+		case "vcs.modified":
+			modified = setting.Value == "true"
+		}
+	}
+	return commit, modified
+}
+
+func executeBackup(ctx context.Context, opts backupOptions, deps backupDependencies) (backupResult, error) {
+	if deps.now == nil || deps.availableBytes == nil || deps.quickCheck == nil || deps.httpClient == nil {
+		return backupResult{}, newBackupError(preflightExitCode, "backup dependencies are incomplete")
+	}
+
+	createdAt := deps.now().UTC().Truncate(time.Second)
+	dataDir, err := canonicalExistingDirectory(opts.dataDir)
+	if err != nil {
+		return backupResult{}, newBackupError(preflightExitCode, "resolve OpenMessage data directory %q: %w", opts.dataDir, err)
+	}
+	sourceDB := filepath.Join(dataDir, legacyDatabaseName)
+	sourceInfo, err := os.Stat(sourceDB)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return backupResult{}, newBackupError(preflightExitCode, "legacy database not found at %s", sourceDB)
+		}
+		return backupResult{}, newBackupError(preflightExitCode, "inspect legacy database %s: %w", sourceDB, err)
+	}
+	if !sourceInfo.Mode().IsRegular() {
+		return backupResult{}, newBackupError(preflightExitCode, "legacy database path is not a regular file: %s", sourceDB)
+	}
+
+	lock, err := acquireInstanceLock(filepath.Join(dataDir, instanceLockName), instanceLockRecord{
+		PID:           os.Getpid(),
+		Process:       "openmessage backup",
+		StartedAt:     createdAt.Format(time.RFC3339),
+		BuildID:       deps.version,
+		Commit:        deps.commit,
+		CanonicalPath: dataDir,
+		ProbeURL:      deps.probeURL,
+	})
+	if err != nil {
+		if errors.Is(err, errInstanceLockHeld) {
+			return backupResult{}, newBackupError(refusedRunningExitCode, "OpenMessage state is in use: %s is locked; stop the backend and retry", filepath.Join(dataDir, instanceLockName))
+		}
+		return backupResult{}, newBackupError(preflightExitCode, "acquire OpenMessage instance lock: %w", err)
+	}
+	defer lock.Close()
+
+	running, probeErr := probeBackend(ctx, deps.httpClient, deps.probeURL)
+	if probeErr != nil {
+		return backupResult{}, newBackupError(refusedRunningExitCode, "cannot safely rule out a running OpenMessage backend at %s: %w; stop the backend and retry", deps.probeURL, probeErr)
+	}
+	if running {
+		return backupResult{}, newBackupError(refusedRunningExitCode, "OpenMessage backend is running at %s; stop it before creating a migration backup", deps.probeURL)
+	}
+
+	destination, err := resolveBackupDestination(dataDir, opts.destination, createdAt)
+	if err != nil {
+		return backupResult{}, newBackupError(preflightExitCode, "resolve backup destination: %w", err)
+	}
+	if pathWithin(destination, filepath.Join(dataDir, "signal-cli")) {
+		return backupResult{}, newBackupError(preflightExitCode, "backup destination %s cannot be inside the signal-cli source directory", destination)
+	}
+	if _, err := os.Lstat(destination); err == nil {
+		return backupResult{}, newBackupError(preflightExitCode, "backup destination already exists: %s (choose a new --to directory; existing backups are never overwritten)", destination)
+	} else if !os.IsNotExist(err) {
+		return backupResult{}, newBackupError(preflightExitCode, "inspect backup destination %s: %w", destination, err)
+	}
+
+	auxiliary, err := discoverAuxiliaryState(dataDir)
+	if err != nil {
+		return backupResult{}, newBackupError(preflightExitCode, "inspect auxiliary state: %w", err)
+	}
+
+	spacePath, err := nearestExistingDirectory(filepath.Dir(destination))
+	if err != nil {
+		return backupResult{}, newBackupError(preflightExitCode, "resolve destination filesystem for %s: %w", destination, err)
+	}
+	available, err := deps.availableBytes(spacePath)
+	if err != nil {
+		return backupResult{}, newBackupError(preflightExitCode, "check free space at %s: %w", spacePath, err)
+	}
+	if sourceInfo.Size() < 0 || uint64(sourceInfo.Size()) > math.MaxUint64/2 {
+		return backupResult{}, newBackupError(preflightExitCode, "legacy database size cannot be represented safely: %d", sourceInfo.Size())
+	}
+	required := uint64(sourceInfo.Size()) * 2
+	if available < required {
+		return backupResult{}, newBackupError(preflightExitCode,
+			"insufficient free space at %s: backup requires approximately %s (2x the %s legacy database), but only %s is available",
+			spacePath, formatByteCount(required), formatByteCount(uint64(sourceInfo.Size())), formatByteCount(available))
+	}
+
+	if err := os.MkdirAll(destination, 0o700); err != nil {
+		return backupResult{}, newBackupError(backupFailureExitCode, "create backup directory %s: %w", destination, err)
+	}
+	if err := os.Chmod(destination, 0o700); err != nil {
+		return backupResult{}, newBackupError(backupFailureExitCode, "secure backup directory %s: %w", destination, err)
+	}
+
+	backupDB := filepath.Join(destination, legacyDatabaseName)
+	if err := vacuumInto(ctx, sourceDB, backupDB); err != nil {
+		return backupResult{}, newBackupError(backupFailureExitCode, "back up legacy database with SQLite VACUUM INTO: %w", err)
+	}
+	if err := os.Chmod(backupDB, 0o600); err != nil {
+		return backupResult{}, newBackupError(backupFailureExitCode, "secure copied legacy database: %w", err)
+	}
+
+	quickCheck, err := deps.quickCheck(backupDB)
+	if err != nil {
+		return backupResult{}, newBackupError(verificationFailureExitCode, "run PRAGMA quick_check on copied database: %w", err)
+	}
+	if quickCheck != "ok" {
+		return backupResult{}, newBackupError(verificationFailureExitCode, "copied database failed PRAGMA quick_check: %s", quickCheck)
+	}
+
+	fingerprint, userVersion, counts, err := inspectLegacySnapshot(backupDB)
+	if err != nil {
+		return backupResult{}, newBackupError(verificationFailureExitCode, "inspect copied legacy database: %w", err)
+	}
+
+	files := make([]backupFile, 0, len(auxiliary.files)+1)
+	dbFile, err := describeBackupFile(backupDB, sourceDB, legacyDatabaseName)
+	if err != nil {
+		return backupResult{}, newBackupError(verificationFailureExitCode, "hash copied legacy database: %w", err)
+	}
+	files = append(files, dbFile)
+
+	if auxiliary.signalDirFound {
+		if err := os.MkdirAll(filepath.Join(destination, "signal-cli"), 0o700); err != nil {
+			return backupResult{}, newBackupError(backupFailureExitCode, "create Signal backup directory: %w", err)
+		}
+	}
+	for _, source := range auxiliary.files {
+		destinationPath := filepath.Join(destination, filepath.FromSlash(source.relativePath))
+		if source.isSQLite {
+			// SQLite databases must be snapshotted transactionally: a plain file
+			// copy silently drops hot WAL/journal content (a crashed daemon can
+			// hold the ENTIRE database in the WAL), producing a valid-looking but
+			// empty or mid-transaction backup that quick_check cannot flag.
+			if err := vacuumInto(ctx, source.sourcePath, destinationPath); err != nil {
+				return backupResult{}, newBackupError(backupFailureExitCode, "snapshot auxiliary database %s: %w", source.sourcePath, err)
+			}
+			if result, err := sqliteQuickCheck(destinationPath); err != nil {
+				return backupResult{}, newBackupError(verificationFailureExitCode, "verify auxiliary database %s: %w", source.relativePath, err)
+			} else if result != "ok" {
+				return backupResult{}, newBackupError(verificationFailureExitCode, "auxiliary database %s quick_check: %s", source.relativePath, result)
+			}
+			if err := os.Chmod(destinationPath, 0o600); err != nil {
+				return backupResult{}, newBackupError(backupFailureExitCode, "harden auxiliary database %s: %w", source.relativePath, err)
+			}
+		} else if err := copyPlainFile(source.sourcePath, destinationPath); err != nil {
+			return backupResult{}, newBackupError(backupFailureExitCode, "copy auxiliary state %s: %w", source.sourcePath, err)
+		}
+		file, err := describeBackupFile(destinationPath, source.sourcePath, source.relativePath)
+		if err != nil {
+			return backupResult{}, newBackupError(verificationFailureExitCode, "hash copied auxiliary state %s: %w", source.relativePath, err)
+		}
+		files = append(files, file)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+
+	manifest := backupManifest{
+		Format:     backupManifestFormat,
+		CreatedAt:  createdAt.Format(time.RFC3339),
+		AppVersion: deps.version,
+		Tool: backupTool{
+			Version: deps.version, Commit: deps.commit, Modified: deps.modified,
+		},
+		Source: backupSource{
+			Path: dataDir, DatabasePath: sourceDB, SchemaFingerprint: fingerprint,
+			SchemaUserVersion: userVersion, QuickCheck: quickCheck,
+		},
+		Target: backupTarget{
+			Path: destination, DatabasePath: backupDB,
+		},
+		Files:  files,
+		Counts: counts,
+		AuxiliaryState: backupAuxiliaryState{
+			Included: auxiliary.included, NotPresent: auxiliary.notPresent,
+		},
+		Warnings: []string{},
+	}
+
+	if deps.beforeManifest != nil {
+		if err := deps.beforeManifest(); err != nil {
+			return backupResult{}, newBackupError(backupFailureExitCode, "backup interrupted before manifest completion: %w", err)
+		}
+	}
+	manifestPath := filepath.Join(destination, manifestName)
+	if err := writeManifestAtomically(manifestPath, manifest); err != nil {
+		return backupResult{}, newBackupError(backupFailureExitCode, "write final backup manifest: %w", err)
+	}
+
+	return backupResult{
+		BackupPath: destination, ManifestPath: manifestPath, Manifest: manifest,
+	}, nil
+}
+
+func canonicalExistingDirectory(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	realPath, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(realPath)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("not a directory")
+	}
+	return filepath.Clean(realPath), nil
+}
+
+func resolveBackupDestination(dataDir, override string, createdAt time.Time) (string, error) {
+	path := override
+	if path == "" {
+		path = filepath.Join(dataDir, "migration-backups", createdAt.Format("20060102T150405Z"))
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	existing, err := nearestExistingDirectory(filepath.Dir(abs))
+	if err != nil {
+		return "", err
+	}
+	realExisting, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return "", err
+	}
+	remainder, err := filepath.Rel(existing, abs)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(filepath.Join(realExisting, remainder)), nil
+}
+
+func nearestExistingDirectory(path string) (string, error) {
+	current := filepath.Clean(path)
+	for {
+		info, err := os.Stat(current)
+		if err == nil {
+			if !info.IsDir() {
+				return "", fmt.Errorf("%s is not a directory", current)
+			}
+			return current, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("no existing parent directory for %s", path)
+		}
+		current = parent
+	}
+}
+
+func pathWithin(path, parent string) bool {
+	rel, err := filepath.Rel(filepath.Clean(parent), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func probeBackend(ctx context.Context, client *http.Client, probeURL string) (bool, error) {
+	if strings.TrimSpace(probeURL) == "" {
+		return false, fmt.Errorf("backend probe URL is empty")
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		return false, err
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+	// Any HTTP response is conservative evidence that something owns the
+	// configured OpenMessage endpoint, even if it is unhealthy or unauthorized.
+	return true, nil
+}
+
+// instanceLockRecord is diagnostic only. The advisory OS lock held on the file
+// descriptor is authoritative; stale JSON after a crash never blocks a run.
+type instanceLockRecord struct {
+	PID           int    `json:"pid"`
+	Process       string `json:"process"`
+	StartedAt     string `json:"started_at,omitempty"`
+	BuildID       string `json:"build_id,omitempty"`
+	Commit        string `json:"commit,omitempty"`
+	CanonicalPath string `json:"canonical_path,omitempty"`
+	ProbeURL      string `json:"probe_url,omitempty"`
+}
+
+type instanceLock struct {
+	file *os.File
+}
+
+func acquireInstanceLock(path string, record instanceLockRecord) (*instanceLock, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	closeWithError := func(lockErr error) (*instanceLock, error) {
+		_ = file.Close()
+		return nil, lockErr
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return closeWithError(err)
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return closeWithError(fmt.Errorf("%w: %s", errInstanceLockHeld, path))
+		}
+		return closeWithError(err)
+	}
+
+	payload, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		return closeWithError(err)
+	}
+	payload = append(payload, '\n')
+	if err := file.Truncate(0); err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		return closeWithError(err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		return closeWithError(err)
+	}
+	if _, err := file.Write(payload); err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		return closeWithError(err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		return closeWithError(err)
+	}
+	return &instanceLock{file: file}, nil
+}
+
+func (l *instanceLock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	unlockErr := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	closeErr := l.file.Close()
+	l.file = nil
+	return errors.Join(unlockErr, closeErr)
+}
+
+func filesystemAvailableBytes(path string) (uint64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	blockSize := uint64(stat.Bsize)
+	availableBlocks := uint64(stat.Bavail)
+	if blockSize == 0 || availableBlocks > math.MaxUint64/blockSize {
+		return 0, fmt.Errorf("filesystem free-space value overflows uint64")
+	}
+	return availableBlocks * blockSize, nil
+}
+
+func vacuumInto(ctx context.Context, sourcePath, destinationPath string) error {
+	database, err := sql.Open("sqlite", sqliteReadOnlyDSN(sourcePath))
+	if err != nil {
+		return err
+	}
+	database.SetMaxOpenConns(1)
+	defer database.Close()
+	if _, err := database.ExecContext(ctx, "PRAGMA busy_timeout=5000"); err != nil {
+		return err
+	}
+	if _, err := database.ExecContext(ctx, "VACUUM INTO ?", destinationPath); err != nil {
+		return err
+	}
+	return database.Close()
+}
+
+func sqliteReadOnlyDSN(path string) string {
+	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(path), RawQuery: "mode=ro"}).String()
+}
+
+func sqliteQuickCheck(path string) (string, error) {
+	database, err := sql.Open("sqlite", sqliteReadOnlyDSN(path))
+	if err != nil {
+		return "", err
+	}
+	database.SetMaxOpenConns(1)
+	defer database.Close()
+	rows, err := database.Query("PRAGMA quick_check")
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	var results []string
+	for rows.Next() {
+		var result string
+		if err := rows.Scan(&result); err != nil {
+			return "", err
+		}
+		results = append(results, result)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if len(results) == 0 {
+		return "", fmt.Errorf("PRAGMA quick_check returned no rows")
+	}
+	return strings.Join(results, "; "), nil
+}
+
+func inspectLegacySnapshot(path string) (string, int64, legacyCounts, error) {
+	database, err := sql.Open("sqlite", sqliteReadOnlyDSN(path))
+	if err != nil {
+		return "", 0, legacyCounts{}, err
+	}
+	database.SetMaxOpenConns(1)
+	defer database.Close()
+
+	fingerprint, err := schemaFingerprint(database)
+	if err != nil {
+		return "", 0, legacyCounts{}, err
+	}
+	var userVersion int64
+	if err := database.QueryRow("PRAGMA user_version").Scan(&userVersion); err != nil {
+		return "", 0, legacyCounts{}, err
+	}
+
+	counts := legacyCounts{ScheduledMessagesByStatus: map[string]int64{
+		"pending": 0, "sending": 0, "sent": 0, "failed": 0, "canceled": 0,
+	}}
+	queries := []struct {
+		table string
+		value *int64
+	}{
+		{"conversations", &counts.Conversations},
+		{"messages", &counts.Messages},
+		{"contacts", &counts.Contacts},
+		{"unified_contacts", &counts.UnifiedContacts},
+		{"drafts", &counts.Drafts},
+		{"scheduled_messages", &counts.ScheduledMessages},
+		{"contact_meta", &counts.ContactMeta},
+	}
+	for _, query := range queries {
+		if err := database.QueryRow("SELECT COUNT(*) FROM " + query.table).Scan(query.value); err != nil {
+			return "", 0, legacyCounts{}, fmt.Errorf("count %s: %w", query.table, err)
+		}
+	}
+	rows, err := database.Query("SELECT status, COUNT(*) FROM scheduled_messages GROUP BY status ORDER BY status")
+	if err != nil {
+		return "", 0, legacyCounts{}, fmt.Errorf("count scheduled messages by status: %w", err)
+	}
+	var statusTotal int64
+	for rows.Next() {
+		var status string
+		var count int64
+		if err := rows.Scan(&status, &count); err != nil {
+			rows.Close()
+			return "", 0, legacyCounts{}, err
+		}
+		counts.ScheduledMessagesByStatus[status] = count
+		statusTotal += count
+	}
+	if err := rows.Close(); err != nil {
+		return "", 0, legacyCounts{}, err
+	}
+	if err := rows.Err(); err != nil {
+		return "", 0, legacyCounts{}, err
+	}
+	if statusTotal != counts.ScheduledMessages {
+		return "", 0, legacyCounts{}, fmt.Errorf("scheduled status counts sum to %d, want %d", statusTotal, counts.ScheduledMessages)
+	}
+	return fingerprint, userVersion, counts, nil
+}
+
+func schemaFingerprint(database *sql.DB) (string, error) {
+	rows, err := database.Query(`
+		SELECT type, name, tbl_name, IFNULL(sql, '')
+		FROM sqlite_schema
+		WHERE name NOT LIKE 'sqlite_%'
+		ORDER BY type, name, tbl_name
+	`)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	hash := sha256.New()
+	for rows.Next() {
+		var kind, name, table, statement string
+		if err := rows.Scan(&kind, &name, &table, &statement); err != nil {
+			return "", err
+		}
+		for _, field := range []string{kind, name, table, statement} {
+			_, _ = io.WriteString(hash, field)
+			_, _ = hash.Write([]byte{0x1f})
+		}
+		_, _ = hash.Write([]byte{'\n'})
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func discoverAuxiliaryState(dataDir string) (auxiliaryPlan, error) {
+	plan := auxiliaryPlan{included: []string{}, notPresent: []string{}}
+	fileNames := []string{"session.json", "whatsapp-session.db", "openmessage.db"}
+	for _, name := range fileNames {
+		path := filepath.Join(dataDir, name)
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			plan.notPresent = append(plan.notPresent, name)
+			continue
+		}
+		if err != nil {
+			return auxiliaryPlan{}, err
+		}
+		if !info.Mode().IsRegular() {
+			return auxiliaryPlan{}, fmt.Errorf("%s is not a regular file", path)
+		}
+		plan.included = append(plan.included, name)
+		plan.files = append(plan.files, auxiliaryFile{
+			sourcePath:   path,
+			relativePath: name,
+			isSQLite:     strings.HasSuffix(name, ".db"),
+		})
+	}
+
+	signalPath := filepath.Join(dataDir, "signal-cli")
+	info, err := os.Lstat(signalPath)
+	if os.IsNotExist(err) {
+		plan.notPresent = append(plan.notPresent, "signal-cli/")
+	} else if err != nil {
+		return auxiliaryPlan{}, err
+	} else {
+		if !info.IsDir() {
+			return auxiliaryPlan{}, fmt.Errorf("%s is not a directory", signalPath)
+		}
+		plan.signalDirFound = true
+		plan.included = append(plan.included, "signal-cli/")
+		if err := filepath.WalkDir(signalPath, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if path == signalPath {
+				return nil
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				return fmt.Errorf("signal-cli state contains unsupported symbolic link: %s", path)
+			}
+			if entry.IsDir() {
+				return nil
+			}
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("signal-cli state contains unsupported non-regular file: %s", path)
+			}
+			relative, err := filepath.Rel(dataDir, path)
+			if err != nil {
+				return err
+			}
+			plan.files = append(plan.files, auxiliaryFile{
+				sourcePath: path, relativePath: filepath.ToSlash(relative),
+			})
+			return nil
+		}); err != nil {
+			return auxiliaryPlan{}, err
+		}
+	}
+
+	sort.Slice(plan.files, func(i, j int) bool { return plan.files[i].relativePath < plan.files[j].relativePath })
+	sort.Strings(plan.included)
+	sort.Strings(plan.notPresent)
+	return plan, nil
+}
+
+func copyPlainFile(sourcePath, destinationPath string) (returnErr error) {
+	info, err := os.Lstat(sourcePath)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("source is not a regular file")
+	}
+	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o700); err != nil {
+		return err
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	destination, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := destination.Close(); returnErr == nil {
+			returnErr = closeErr
+		}
+	}()
+	if _, err := io.Copy(destination, source); err != nil {
+		return err
+	}
+	if err := destination.Sync(); err != nil {
+		return err
+	}
+	if err := os.Chmod(destinationPath, 0o600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func describeBackupFile(path, sourcePath, relativePath string) (backupFile, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return backupFile{}, err
+	}
+	hash := sha256.New()
+	size, copyErr := io.Copy(hash, file)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return backupFile{}, copyErr
+	}
+	if closeErr != nil {
+		return backupFile{}, closeErr
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return backupFile{}, err
+	}
+	if !info.Mode().IsRegular() || info.Size() != size {
+		return backupFile{}, fmt.Errorf("file changed while hashing")
+	}
+	sourceAbs, err := filepath.Abs(sourcePath)
+	if err != nil {
+		return backupFile{}, err
+	}
+	return backupFile{
+		Path:       filepath.ToSlash(relativePath),
+		SourcePath: filepath.Clean(sourceAbs),
+		Size:       size,
+		SHA256:     hex.EncodeToString(hash.Sum(nil)),
+		Mode:       fmt.Sprintf("%04o", info.Mode().Perm()),
+	}, nil
+}
+
+func writeManifestAtomically(path string, manifest backupManifest) (returnErr error) {
+	payload, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	temporary := filepath.Join(filepath.Dir(path), ".manifest.json.tmp")
+	_ = os.Remove(temporary)
+	file, err := os.OpenFile(temporary, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	renamed := false
+	defer func() {
+		if closeErr := file.Close(); returnErr == nil && !renamed {
+			returnErr = closeErr
+		}
+		if !renamed {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if _, err := file.Write(payload); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		return err
+	}
+	renamed = true
+	directory, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+	syncErr := directory.Sync()
+	closeErr := directory.Close()
+	if err := errors.Join(syncErr, closeErr); err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+	return nil
+}
+
+func formatByteCount(bytes uint64) string {
+	const (
+		kiB = uint64(1024)
+		miB = 1024 * kiB
+		giB = 1024 * miB
+	)
+	switch {
+	case bytes >= giB:
+		return fmt.Sprintf("%.2f GiB", float64(bytes)/float64(giB))
+	case bytes >= miB:
+		return fmt.Sprintf("%.2f MiB", float64(bytes)/float64(miB))
+	case bytes >= kiB:
+		return fmt.Sprintf("%.2f KiB", float64(bytes)/float64(kiB))
+	default:
+		return fmt.Sprintf("%d bytes", bytes)
+	}
+}

--- a/cmd/backup_test.go
+++ b/cmd/backup_test.go
@@ -1,0 +1,547 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+var fixtureCounts = legacyCounts{
+	Conversations:     2,
+	Messages:          3,
+	Contacts:          2,
+	UnifiedContacts:   1,
+	Drafts:            1,
+	ScheduledMessages: 7,
+	ScheduledMessagesByStatus: map[string]int64{
+		db.ScheduleStatusPending:  2,
+		db.ScheduleStatusSending:  1,
+		db.ScheduleStatusSent:     1,
+		db.ScheduleStatusFailed:   1,
+		db.ScheduleStatusCanceled: 1,
+		"future-status":           1,
+	},
+	ContactMeta: 2,
+}
+
+func TestBackupHappyPathWritesVerifiedManifestLast(t *testing.T) {
+	dataDir := buildLegacyBackupFixture(t)
+	writeBackupAuxiliaryFixture(t, dataDir)
+
+	now := time.Date(2026, 7, 16, 12, 34, 56, 987000000, time.FixedZone("EDT", -4*60*60))
+	deps := testBackupDependencies(t, now)
+	result, err := executeBackup(context.Background(), backupOptions{dataDir: dataDir}, deps)
+	if err != nil {
+		t.Fatalf("executeBackup: %v", err)
+	}
+
+	canonicalDataDir, err := filepath.EvalSymlinks(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDir := filepath.Join(canonicalDataDir, "migration-backups", "20260716T163456Z")
+	if result.BackupPath != wantDir {
+		t.Fatalf("BackupPath = %q, want %q", result.BackupPath, wantDir)
+	}
+	if result.ManifestPath != filepath.Join(wantDir, "manifest.json") {
+		t.Fatalf("ManifestPath = %q", result.ManifestPath)
+	}
+
+	manifest := readBackupManifest(t, result.ManifestPath)
+	if manifest.Format != backupManifestFormat {
+		t.Fatalf("manifest format = %d, want %d", manifest.Format, backupManifestFormat)
+	}
+	if manifest.CreatedAt != "2026-07-16T16:34:56Z" {
+		t.Fatalf("created_at = %q", manifest.CreatedAt)
+	}
+	if manifest.AppVersion != "test-version" || manifest.Tool.Version != "test-version" || manifest.Tool.Commit != "test-commit" {
+		t.Fatalf("tool metadata = %+v, app_version = %q", manifest.Tool, manifest.AppVersion)
+	}
+	if manifest.Source.Path != canonicalDataDir || manifest.Source.DatabasePath != filepath.Join(canonicalDataDir, "messages.db") {
+		t.Fatalf("source = %+v", manifest.Source)
+	}
+	if manifest.Source.SchemaFingerprint == "" {
+		t.Fatal("schema fingerprint is empty")
+	}
+	if manifest.Source.QuickCheck != "ok" {
+		t.Fatalf("source.quick_check = %q, want ok", manifest.Source.QuickCheck)
+	}
+	assertLegacyCounts(t, manifest.Counts, fixtureCounts)
+
+	wantFiles := map[string]bool{
+		"messages.db":                 false,
+		"session.json":                false,
+		"signal-cli/accounts/account": false,
+		"signal-cli/config.json":      false,
+		"whatsapp-session.db":         false,
+		"openmessage.db":              false,
+	}
+	for _, file := range manifest.Files {
+		if _, ok := wantFiles[file.Path]; !ok {
+			t.Errorf("unexpected manifest file %q", file.Path)
+			continue
+		}
+		wantFiles[file.Path] = true
+		backupPath := filepath.Join(result.BackupPath, filepath.FromSlash(file.Path))
+		info, err := os.Stat(backupPath)
+		if err != nil {
+			t.Errorf("stat %q: %v", file.Path, err)
+			continue
+		}
+		if file.Size != info.Size() {
+			t.Errorf("%s size = %d, stat = %d", file.Path, file.Size, info.Size())
+		}
+		if file.SHA256 != fileSHA256(t, backupPath) {
+			t.Errorf("%s sha256 does not match copied bytes", file.Path)
+		}
+		if !filepath.IsAbs(file.SourcePath) {
+			t.Errorf("%s source_path = %q, want absolute", file.Path, file.SourcePath)
+		}
+	}
+	for path, found := range wantFiles {
+		if !found {
+			t.Errorf("manifest missing %q", path)
+		}
+	}
+
+	copyDB, err := sql.Open("sqlite", filepath.Join(result.BackupPath, "messages.db"))
+	if err != nil {
+		t.Fatalf("open copied database: %v", err)
+	}
+	defer copyDB.Close()
+	var quickCheck string
+	if err := copyDB.QueryRow("PRAGMA quick_check").Scan(&quickCheck); err != nil {
+		t.Fatalf("quick_check copied database: %v", err)
+	}
+	if quickCheck != "ok" {
+		t.Fatalf("copied database quick_check = %q", quickCheck)
+	}
+}
+
+func TestBackupInterruptedBeforeManifestLeavesIncompleteDirectory(t *testing.T) {
+	dataDir := buildLegacyBackupFixture(t)
+	now := time.Date(2026, 7, 16, 1, 2, 3, 0, time.UTC)
+	deps := testBackupDependencies(t, now)
+	deps.beforeManifest = func() error { return errors.New("simulated interruption") }
+
+	_, err := executeBackup(context.Background(), backupOptions{dataDir: dataDir}, deps)
+	if err == nil {
+		t.Fatal("executeBackup succeeded, want interruption")
+	}
+	if got := ExitCode(err); got != backupFailureExitCode {
+		t.Fatalf("ExitCode = %d, want %d (%v)", got, backupFailureExitCode, err)
+	}
+
+	backupDir := filepath.Join(dataDir, "migration-backups", "20260716T010203Z")
+	if _, statErr := os.Stat(filepath.Join(backupDir, "messages.db")); statErr != nil {
+		t.Fatalf("partial database copy should remain for diagnosis: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(backupDir, "manifest.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("manifest exists after interrupted run: %v", statErr)
+	}
+}
+
+func TestBackupRefusesWhenDaemonHealthEndpointResponds(t *testing.T) {
+	dataDir := buildLegacyBackupFixture(t)
+	requested := make(chan string, 1)
+
+	deps := testBackupDependencies(t, time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC))
+	deps.probeURL = "http://127.0.0.1:7007/api/status"
+	deps.httpClient = &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		requested <- request.URL.Path
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"connected":true}`)),
+			Request:    request,
+		}, nil
+	})}
+	_, err := executeBackup(context.Background(), backupOptions{dataDir: dataDir}, deps)
+	if err == nil {
+		t.Fatal("executeBackup succeeded while daemon responded")
+	}
+	if got := ExitCode(err); got != refusedRunningExitCode {
+		t.Fatalf("ExitCode = %d, want %d (%v)", got, refusedRunningExitCode, err)
+	}
+	if !strings.Contains(err.Error(), "running") || !strings.Contains(err.Error(), "127.0.0.1:7007") {
+		t.Fatalf("refusal error is not actionable: %v", err)
+	}
+	select {
+	case path := <-requested:
+		if path != "/api/status" {
+			t.Fatalf("probe path = %q", path)
+		}
+	default:
+		t.Fatal("daemon endpoint was not probed")
+	}
+	if _, statErr := os.Stat(filepath.Join(dataDir, "migration-backups")); !os.IsNotExist(statErr) {
+		t.Fatalf("backup directory created despite refusal: %v", statErr)
+	}
+}
+
+func TestBackupRefusesWhenInstanceLockIsHeld(t *testing.T) {
+	dataDir := buildLegacyBackupFixture(t)
+	lock, err := acquireInstanceLock(filepath.Join(dataDir, instanceLockName), instanceLockRecord{
+		PID: 4242, Process: "test-daemon",
+	})
+	if err != nil {
+		t.Fatalf("acquire first lock: %v", err)
+	}
+	defer lock.Close()
+
+	deps := testBackupDependencies(t, time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC))
+	_, err = executeBackup(context.Background(), backupOptions{dataDir: dataDir}, deps)
+	if err == nil {
+		t.Fatal("executeBackup succeeded while instance lock held")
+	}
+	if got := ExitCode(err); got != refusedRunningExitCode {
+		t.Fatalf("ExitCode = %d, want %d (%v)", got, refusedRunningExitCode, err)
+	}
+}
+
+func TestBackupRejectsInsufficientDestinationSpace(t *testing.T) {
+	dataDir := buildLegacyBackupFixture(t)
+	info, err := os.Stat(filepath.Join(dataDir, "messages.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	available := uint64(info.Size()*2 - 1)
+	var checkedPath string
+	deps := testBackupDependencies(t, time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC))
+	deps.availableBytes = func(path string) (uint64, error) {
+		checkedPath = path
+		return available, nil
+	}
+
+	_, err = executeBackup(context.Background(), backupOptions{dataDir: dataDir}, deps)
+	if err == nil {
+		t.Fatal("executeBackup succeeded without required free space")
+	}
+	if got := ExitCode(err); got != preflightExitCode {
+		t.Fatalf("ExitCode = %d, want %d (%v)", got, preflightExitCode, err)
+	}
+	if checkedPath == "" || !strings.Contains(err.Error(), "free space") || !strings.Contains(err.Error(), "requires") {
+		t.Fatalf("space error is not actionable: checked=%q err=%v", checkedPath, err)
+	}
+	backupDB := filepath.Join(dataDir, "migration-backups", "20260716T000000Z", "messages.db")
+	if _, statErr := os.Stat(backupDB); !os.IsNotExist(statErr) {
+		t.Fatalf("database copied despite failed space preflight: %v", statErr)
+	}
+}
+
+func TestBackupManifestRowCountsIncludeEveryScheduledStatus(t *testing.T) {
+	dataDir := buildLegacyBackupFixture(t)
+	deps := testBackupDependencies(t, time.Date(2026, 7, 16, 5, 6, 7, 0, time.UTC))
+	result, err := executeBackup(context.Background(), backupOptions{dataDir: dataDir}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := readBackupManifest(t, result.ManifestPath)
+	assertLegacyCounts(t, manifest.Counts, fixtureCounts)
+
+	var statusTotal int64
+	for _, count := range manifest.Counts.ScheduledMessagesByStatus {
+		statusTotal += count
+	}
+	if statusTotal != manifest.Counts.ScheduledMessages {
+		t.Fatalf("scheduled status total = %d, scheduled_messages = %d", statusTotal, manifest.Counts.ScheduledMessages)
+	}
+}
+
+func TestBackupJSONOutputIsMachineReadable(t *testing.T) {
+	dataDir := buildLegacyBackupFixture(t)
+	t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
+	destination := filepath.Join(t.TempDir(), "operator-selected-backup")
+	deps := testBackupDependencies(t, time.Date(2026, 7, 16, 5, 6, 7, 0, time.UTC))
+	var stdout, stderr bytes.Buffer
+
+	err := runBackupCommand(context.Background(), []string{"--json", "--to", destination}, deps, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runBackupCommand: %v\nstderr: %s", err, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var output backupCommandOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	canonicalParent, err := filepath.EvalSymlinks(filepath.Dir(destination))
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalDestination := filepath.Join(canonicalParent, filepath.Base(destination))
+	if !output.OK || output.ExitCode != 0 || output.BackupPath != canonicalDestination {
+		t.Fatalf("JSON output = %+v", output)
+	}
+	if output.ManifestPath != filepath.Join(canonicalDestination, "manifest.json") {
+		t.Fatalf("manifest_path = %q", output.ManifestPath)
+	}
+}
+
+func TestBackupVerificationFailureUsesExitCodeFive(t *testing.T) {
+	dataDir := buildLegacyBackupFixture(t)
+	deps := testBackupDependencies(t, time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC))
+	deps.quickCheck = func(string) (string, error) { return "database disk image is malformed", nil }
+
+	_, err := executeBackup(context.Background(), backupOptions{dataDir: dataDir}, deps)
+	if err == nil {
+		t.Fatal("executeBackup succeeded with failed quick_check")
+	}
+	if got := ExitCode(err); got != verificationFailureExitCode {
+		t.Fatalf("ExitCode = %d, want %d (%v)", got, verificationFailureExitCode, err)
+	}
+	manifestPath := filepath.Join(dataDir, "migration-backups", "20260716T000000Z", "manifest.json")
+	if _, statErr := os.Stat(manifestPath); !os.IsNotExist(statErr) {
+		t.Fatalf("manifest exists after verification failure: %v", statErr)
+	}
+}
+
+func buildLegacyBackupFixture(t *testing.T) string {
+	t.Helper()
+	dataDir := t.TempDir()
+	store, err := db.New(filepath.Join(dataDir, "messages.db"))
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+
+	fail := func(label string, err error) {
+		t.Helper()
+		if err != nil {
+			_ = store.Close()
+			t.Fatalf("%s: %v", label, err)
+		}
+	}
+	fail("conversation 1", store.UpsertConversation(&db.Conversation{
+		ConversationID: "conv-1", Name: "Alice", Participants: `[{"name":"Alice","number":"+15550000001"}]`, SourcePlatform: "sms",
+	}))
+	fail("conversation 2", store.UpsertConversation(&db.Conversation{
+		ConversationID: "conv-2", Name: "Group", IsGroup: true, Participants: `[]`, SourcePlatform: "signal",
+	}))
+	for i, message := range []db.Message{
+		{MessageID: "message-1", ConversationID: "conv-1", SenderName: "Alice", SenderNumber: "+15550000001", Body: "hello", TimestampMS: 1, Status: "delivered", SourcePlatform: "sms"},
+		{MessageID: "message-2", ConversationID: "conv-1", SenderName: "Me", Body: "hi", TimestampMS: 2, Status: "sent", IsFromMe: true, SourcePlatform: "sms"},
+		{MessageID: "signal:3", ConversationID: "conv-2", SenderName: "Bob", SenderNumber: "aci", Body: "signal", TimestampMS: 3, Status: "delivered", SourcePlatform: "signal"},
+	} {
+		m := message
+		fail("message "+string(rune('1'+i)), store.UpsertMessage(&m))
+	}
+	fail("contact 1", store.UpsertContact(&db.Contact{ContactID: "contact-1", Name: "Alice", Number: "+15550000001"}))
+	fail("contact 2", store.UpsertContact(&db.Contact{ContactID: "contact-2", Name: "Bob", Number: "+15550000002"}))
+	fail("unified contact", store.UpsertUnifiedContact(&db.UnifiedContact{
+		UnifiedID: "person-1", DisplayName: "Alice", Identifiers: `[{"platform":"sms","value":"+15550000001"}]`,
+	}))
+	fail("draft", store.UpsertDraft(&db.Draft{DraftID: "draft-1", ConversationID: "conv-1", Body: "later", CreatedAt: 4}))
+
+	statuses := []string{
+		db.ScheduleStatusPending,
+		db.ScheduleStatusPending,
+		db.ScheduleStatusSending,
+		db.ScheduleStatusSent,
+		db.ScheduleStatusFailed,
+		db.ScheduleStatusCanceled,
+		"future-status",
+	}
+	for i, status := range statuses {
+		fail("scheduled message", store.CreateScheduledMessage(&db.ScheduledMessage{
+			ID: "scheduled-" + string(rune('a'+i)), ConversationID: "conv-1", Body: status,
+			SendAt: int64(100 + i), Status: status, CreatedAt: int64(10 + i),
+		}))
+	}
+	fail("contact meta 1", store.SetContactTags("alice", "Alice", []string{"friend"}))
+	fail("contact meta 2", store.SetContactTags("bob", "Bob", []string{"work"}))
+	if err := store.Close(); err != nil {
+		t.Fatalf("close fixture store: %v", err)
+	}
+	return dataDir
+}
+
+func writeBackupAuxiliaryFixture(t *testing.T, dataDir string) {
+	t.Helper()
+	writeFixtureFile(t, filepath.Join(dataDir, "session.json"), []byte(`{"token":"secret"}`), 0o600)
+	writeFixtureSQLite(t, filepath.Join(dataDir, "whatsapp-session.db"), "whatsmeow_device")
+	writeFixtureSQLite(t, filepath.Join(dataDir, "openmessage.db"), "openmessage_state")
+	writeFixtureFile(t, filepath.Join(dataDir, "signal-cli", "config.json"), []byte(`{"account":"+15550000000"}`), 0o600)
+	writeFixtureFile(t, filepath.Join(dataDir, "signal-cli", "accounts", "account"), []byte("signal account"), 0o600)
+}
+
+func writeFixtureFile(t *testing.T, path string, contents []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, contents, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeFixtureSQLite creates a real, checkpointed SQLite database with one
+// table so the aux-database snapshot path has valid input (production aux
+// files -- whatsapp-session.db, openmessage.db -- are SQLite).
+func writeFixtureSQLite(t *testing.T, path, table string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+filepath.ToSlash(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("CREATE TABLE " + table + " (id INTEGER PRIMARY KEY, v TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("INSERT INTO " + table + " (v) VALUES ('seed')"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testBackupDependencies(t *testing.T, now time.Time) backupDependencies {
+	t.Helper()
+	deps := defaultBackupDependencies()
+	deps.now = func() time.Time { return now }
+	deps.version = "test-version"
+	deps.commit = "test-commit"
+	deps.probeURL = "http://127.0.0.1:7007/api/status"
+	deps.httpClient = &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, syscall.ECONNREFUSED
+	})}
+	deps.availableBytes = func(string) (uint64, error) { return ^uint64(0), nil }
+	return deps
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func readBackupManifest(t *testing.T, path string) backupManifest {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest backupManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	return manifest
+}
+
+func assertLegacyCounts(t *testing.T, got, want legacyCounts) {
+	t.Helper()
+	if got.Conversations != want.Conversations || got.Messages != want.Messages || got.Contacts != want.Contacts ||
+		got.UnifiedContacts != want.UnifiedContacts || got.Drafts != want.Drafts ||
+		got.ScheduledMessages != want.ScheduledMessages || got.ContactMeta != want.ContactMeta {
+		t.Fatalf("counts = %+v, want %+v", got, want)
+	}
+	if len(got.ScheduledMessagesByStatus) != len(want.ScheduledMessagesByStatus) {
+		t.Fatalf("scheduled status counts = %#v, want %#v", got.ScheduledMessagesByStatus, want.ScheduledMessagesByStatus)
+	}
+	for status, count := range want.ScheduledMessagesByStatus {
+		if got.ScheduledMessagesByStatus[status] != count {
+			t.Errorf("scheduled status %q = %d, want %d", status, got.ScheduledMessagesByStatus[status], count)
+		}
+	}
+}
+
+func fileSHA256(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// A crashed daemon can hold an auxiliary database's ENTIRE content in a hot
+// WAL. A plain file copy silently produces a valid-looking empty database, so
+// the backup must snapshot SQLite auxiliaries transactionally. This test fails
+// under the plain-copy design.
+func TestBackupCapturesAuxiliaryDatabaseHotWAL(t *testing.T) {
+	dataDir := buildLegacyBackupFixture(t)
+	writeBackupAuxiliaryFixture(t, dataDir)
+
+	// Rebuild whatsapp-session.db so all of its content lives only in the WAL:
+	// open in WAL mode, write, and DO NOT checkpoint or close cleanly enough to
+	// merge (skip the close-checkpoint by leaving the -wal in place via a
+	// second reader hold... simplest reliable approach: write, then copy the
+	// -wal aside, checkpoint, restore the pre-checkpoint main file + wal).
+	auxPath := filepath.Join(dataDir, "whatsapp-session.db")
+	if err := os.Remove(auxPath); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+filepath.ToSlash(auxPath)+"?_pragma=journal_mode(WAL)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("CREATE TABLE hot (id INTEGER PRIMARY KEY, v TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	// Snapshot the main file while it is still empty (pre-checkpoint).
+	preCheckpointMain, err := os.ReadFile(auxPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("INSERT INTO hot (v) VALUES ('only-in-wal-1'), ('only-in-wal-2')"); err != nil {
+		t.Fatal(err)
+	}
+	walBytes, err := os.ReadFile(auxPath + "-wal")
+	if err != nil {
+		t.Fatalf("expected a hot WAL: %v", err)
+	}
+	if len(walBytes) == 0 {
+		t.Fatal("fixture WAL is empty; test cannot discriminate")
+	}
+	if err := db.Close(); err != nil { // close checkpoints; restore the hot state below
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(auxPath, preCheckpointMain, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(auxPath+"-wal", walBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	deps := testBackupDependencies(t, now)
+	result, err := executeBackup(context.Background(), backupOptions{dataDir: dataDir}, deps)
+	if err != nil {
+		t.Fatalf("executeBackup: %v", err)
+	}
+
+	copyDB, err := sql.Open("sqlite", "file:"+filepath.ToSlash(filepath.Join(result.BackupPath, "whatsapp-session.db"))+"?mode=ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer copyDB.Close()
+	var count int
+	if err := copyDB.QueryRow("SELECT COUNT(*) FROM hot").Scan(&count); err != nil {
+		t.Fatalf("hot table missing from backup copy (WAL content dropped): %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("backup copy hot rows = %d, want 2 (WAL content dropped)", count)
+	}
+}

--- a/cmd/binary_test.go
+++ b/cmd/binary_test.go
@@ -96,6 +96,27 @@ func TestBuiltBinaryRejectsSendGroupNoArgs(t *testing.T) {
 	}
 }
 
+func TestBuiltBinaryBackupUsesPreflightExitCode(t *testing.T) {
+	binary, dataDir := buildTestBinary(t)
+
+	command := exec.Command(binary, "backup")
+	command.Env = append(os.Environ(), "OPENMESSAGES_DATA_DIR="+dataDir)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatal("backup succeeded without messages.db")
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("backup error type = %T, want *exec.ExitError: %v", err, err)
+	}
+	if exitErr.ExitCode() != 3 {
+		t.Fatalf("backup exit code = %d, want 3\n%s", exitErr.ExitCode(), output)
+	}
+	if !strings.Contains(string(output), "legacy database not found") {
+		t.Fatalf("backup error is not actionable:\n%s", output)
+	}
+}
+
 func TestBuiltBinaryDemoServesSeededDataWithoutTouchingConfiguredDataDir(t *testing.T) {
 	binary, dataDir := buildTestBinary(t)
 	port := reserveTCPPort(t)

--- a/docs/migration-backup.md
+++ b/docs/migration-backup.md
@@ -1,0 +1,45 @@
+# Migration backup (Wave 4, R1)
+
+The first cutover step is an offline, verified backup of the legacy data:
+
+```sh
+openmessage backup
+```
+
+The command uses the same data-directory resolution as the app:
+`OPENMESSAGES_DATA_DIR` when set, otherwise
+`~/.local/share/openmessage`. By default it writes
+`<data-dir>/migration-backups/<UTC-stamp>/`; use `--to <directory>` to choose
+an unused destination. `--json` emits one JSON object for automation.
+
+Stop the OpenMessage backend before running the command. R1 checks the current
+daemon endpoint at `http://127.0.0.1:7007/api/status` and holds an exclusive,
+non-blocking advisory lock on `<data-dir>/instance.lock` for the full backup.
+The lock file's JSON body is diagnostic and can remain after a crash; the OS
+lock on the open file descriptor, not that body, is authoritative. R1 creates
+this convention for later offline migration/cutover commands to reuse. The
+current backend predates the convention and does not yet take the lock, so its
+default HTTP health endpoint is the running-backend authority in this release;
+a backend deliberately started on another port or without HTTP must be stopped
+by the operator.
+
+The command requires free space equal to at least twice the legacy
+`messages.db` size. It creates `messages.db` with SQLite `VACUUM INTO`, runs
+`PRAGMA quick_check` on that copy, and copies any present `session.json`,
+`signal-cli/`, `whatsapp-session.db`, and `openmessage.db` state. All copied
+files are recorded with source path, byte size, mode, and SHA-256.
+
+`manifest.json` is atomically written last. Its presence marks a complete,
+verified backup; a timestamped directory without it is incomplete and must not
+be used as cutover evidence.
+
+Stable exit codes are:
+
+- `0`: backup complete
+- `2`: refused because a backend may be running or the instance lock is held
+- `3`: path/free-space preflight failed
+- `4`: backup or copy failed
+- `5`: copied database verification failed
+
+The command never transforms or deletes the source database. Migration is a
+separate later step.

--- a/main.go
+++ b/main.go
@@ -22,10 +22,11 @@ func main() {
 		With().Timestamp().Logger().Level(level)
 
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "Usage: openmessage <pair|serve|demo|read|thread|threads|send|import>")
+		fmt.Fprintln(os.Stderr, "Usage: openmessage <pair|serve|demo|backup|read|thread|threads|send|import>")
 		fmt.Fprintln(os.Stderr, "  pair [--google|--google-file path]       - Pair with your phone via QR or Google account cookies")
 		fmt.Fprintln(os.Stderr, "  serve [--demo] [--web|--no-web] [--mcp-sse|--no-mcp-sse] [--mcp-stdio] - Start explicit web/MCP transports")
 		fmt.Fprintln(os.Stderr, "  demo                                     - Start a seeded fake-data UI with live transports disabled")
+		fmt.Fprintln(os.Stderr, "  backup [--to dir] [--json]               - Create a verified legacy migration backup and manifest")
 		fmt.Fprintln(os.Stderr, "  read <query> [--limit N] [--phone X] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--json] - Search the local store")
 		fmt.Fprintln(os.Stderr, "  thread <name|number|conversation_id> [--limit N] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--json] - Print a full conversation chronologically")
 		fmt.Fprintln(os.Stderr, "  threads [--limit N] [--json]             - List recent conversations (find an id/name for thread)")
@@ -48,6 +49,8 @@ func main() {
 		err = cmd.RunServe(logger, os.Args[2:]...)
 	case "demo":
 		err = cmd.RunDemo(logger)
+	case "backup":
+		err = cmd.RunBackup(logger, os.Args[2:]...)
 	case "read", "search":
 		if len(os.Args) < 3 {
 			fmt.Fprintln(os.Stderr, "Usage: openmessage read <query> [--limit N] [--phone NUMBER] [--json]")
@@ -91,11 +94,15 @@ func main() {
 		err = cmd.RunDebugMedia(logger, os.Args[2])
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1])
-		fmt.Fprintln(os.Stderr, "Usage: openmessage <pair|serve|demo|read|thread|threads|send|import>")
+		fmt.Fprintln(os.Stderr, "Usage: openmessage <pair|serve|demo|backup|read|thread|threads|send|import>")
 		os.Exit(1)
 	}
 
 	if err != nil {
+		if exitCode := cmd.ExitCode(err); exitCode != 1 {
+			logger.Error().Err(err).Msg("Command failed")
+			os.Exit(exitCode)
+		}
 		logger.Fatal().Err(err).Msg("Fatal error")
 	}
 }


### PR DESCRIPTION
First PR of the data-cutover sequence: a hermetic, operator-run backup that snapshots the legacy store + aux state and writes the manifest that becomes the cutover's pre-registered evidence. Refuses a live backend (health probe + exclusive flock, establishing the instance-lock convention R2/R5 reuse); VACUUM INTO + quick_check for every SQLite database (aux DBs too — a plain copy silently drops hot-WAL content); manifest written last. Adversarially reviewed against a scratch fixture with hot WALs (never the live dir); all four review fixes folded in, including a discriminating hot-WAL regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)