### PR TITLE
Add the legacy->v2 migration transformer with an integrity report (rebuild Wave 4 / R2)

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,648 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/migration"
+)
+
+const (
+	migrateSourceExitCode    = 3
+	migrateLockExitCode      = 4
+	migrateTransformExitCode = 5
+
+	v2StoreName        = "store.sqlite3"
+	v2BlobName         = "blobs"
+	v2TempStoreName    = "store.sqlite3.tmp"
+	v2TempBlobName     = "blobs.tmp"
+	v2TempSourceSuffix = ".source"
+	migrateSpaceCopies = uint64(2)
+)
+
+// migrateError carries the stable exit statuses pre-registered for the
+// one-shot migration command. It is deliberately separate from backupError:
+// backup was released first and has different meanings for exit codes 2-4.
+type migrateError struct {
+	code int
+	err  error
+}
+
+func (e *migrateError) Error() string { return e.err.Error() }
+func (e *migrateError) Unwrap() error { return e.err }
+func (e *migrateError) ExitCode() int { return e.code }
+
+func newMigrateError(code int, format string, args ...any) error {
+	return &migrateError{code: code, err: fmt.Errorf(format, args...)}
+}
+
+type migrateOptions struct {
+	sourceDir string
+	targetDir string
+	check     bool
+}
+
+type migrateTransform func(context.Context, migration.Options) (migration.Report, error)
+
+type migrateDependencies struct {
+	now            func() time.Time
+	version        string
+	commit         string
+	probeURL       string
+	httpClient     *http.Client
+	availableBytes func(string) (uint64, error)
+	transform      migrateTransform
+}
+
+type migrateResult struct {
+	report    migration.Report
+	hasReport bool
+}
+
+type migrateFailureOutput struct {
+	OK       bool   `json:"ok"`
+	ExitCode int    `json:"exit_code"`
+	Error    string `json:"error"`
+}
+
+// RunMigrate handles
+// "openmessage migrate [--check] [--from legacy-dir] [--to v2-dir] [--json]".
+//
+// stdout is always exactly one JSON value. The --json flag is accepted for
+// compatibility with the other operator commands, but migration evidence is
+// machine-readable even without it. Human instructions and warnings go only
+// to stderr.
+func RunMigrate(_ zerolog.Logger, args ...string) error {
+	return runMigrateCommand(
+		context.Background(), args, defaultMigrateDependencies(), os.Stdout, os.Stderr,
+	)
+}
+
+func runMigrateCommand(
+	ctx context.Context,
+	args []string,
+	deps migrateDependencies,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	fs := flag.NewFlagSet("migrate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: openmessage migrate [--check] [--from <legacy-dir>] [--to <v2-dir>] [--json]")
+		fmt.Fprintln(stderr, "  --from defaults to the OpenMessage data directory")
+		fmt.Fprintln(stderr, "  --to defaults to <from>/v2")
+		fmt.Fprintln(stderr, "  --check validates a complete staged migration without publishing it")
+		fmt.Fprintln(stderr, "  the integrity report is JSON on stdout; human guidance is on stderr")
+	}
+
+	options := migrateOptions{sourceDir: app.DefaultDataDir()}
+	var explicitJSON bool
+	fs.BoolVar(&options.check, "check", false, "validate without publishing")
+	fs.StringVar(&options.sourceDir, "from", options.sourceDir, "legacy OpenMessage data directory")
+	fs.StringVar(&options.targetDir, "to", "", "v2 target directory")
+	fs.BoolVar(&explicitJSON, "json", false, "emit the integrity report as JSON (always enabled)")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		commandErr := newMigrateError(migrateSourceExitCode, "parse migrate options: %v", err)
+		return writeMigrateFailure(stdout, stderr, commandErr)
+	}
+	_ = explicitJSON
+	if fs.NArg() != 0 {
+		commandErr := newMigrateError(
+			migrateSourceExitCode,
+			"unexpected migrate argument %q; use --from and --to for paths",
+			fs.Arg(0),
+		)
+		return writeMigrateFailure(stdout, stderr, commandErr)
+	}
+
+	result, commandErr := executeMigrate(ctx, options, deps)
+	if result.hasReport {
+		if err := json.NewEncoder(stdout).Encode(result.report); err != nil {
+			return newMigrateError(migrateTransformExitCode, "write migration integrity report: %v", err)
+		}
+		writeHumanMigrationReport(stderr, result.report)
+	} else if commandErr != nil {
+		return writeMigrateFailure(stdout, stderr, commandErr)
+	}
+	if commandErr != nil {
+		fmt.Fprintf(stderr, "Migration failed: %v\n", commandErr)
+	}
+	return commandErr
+}
+
+func writeMigrateFailure(stdout, stderr io.Writer, commandErr error) error {
+	output := migrateFailureOutput{
+		OK: false, ExitCode: ExitCode(commandErr), Error: commandErr.Error(),
+	}
+	if err := json.NewEncoder(stdout).Encode(output); err != nil {
+		return newMigrateError(migrateTransformExitCode, "write migration error report: %v", err)
+	}
+	fmt.Fprintf(stderr, "Migration failed: %v\n", commandErr)
+	return commandErr
+}
+
+func defaultMigrateDependencies() migrateDependencies {
+	commit, _ := buildRevision()
+	return migrateDependencies{
+		now:      time.Now,
+		version:  Version(),
+		commit:   commit,
+		probeURL: defaultBackendProbeURL(),
+		httpClient: &http.Client{
+			Timeout: 750 * time.Millisecond,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		availableBytes: filesystemAvailableBytes,
+		transform:      migration.Transform,
+	}
+}
+
+func executeMigrate(
+	ctx context.Context,
+	options migrateOptions,
+	deps migrateDependencies,
+) (result migrateResult, resultErr error) {
+	if ctx == nil {
+		return result, newMigrateError(migrateTransformExitCode, "migration context is nil")
+	}
+	if deps.now == nil || deps.httpClient == nil || deps.availableBytes == nil || deps.transform == nil {
+		return result, newMigrateError(migrateTransformExitCode, "migration dependencies are incomplete")
+	}
+
+	sourceDir, err := canonicalExistingDirectory(options.sourceDir)
+	if err != nil {
+		return result, newMigrateError(
+			migrateSourceExitCode, "resolve legacy data directory %q: %v", options.sourceDir, err,
+		)
+	}
+	sourceStorePath := filepath.Join(sourceDir, legacyDatabaseName)
+	sourceInfo, err := os.Stat(sourceStorePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return result, newMigrateError(
+				migrateSourceExitCode, "legacy database not found at %s", sourceStorePath,
+			)
+		}
+		return result, newMigrateError(
+			migrateSourceExitCode, "inspect legacy database %s: %v", sourceStorePath, err,
+		)
+	}
+	if !sourceInfo.Mode().IsRegular() {
+		return result, newMigrateError(
+			migrateSourceExitCode, "legacy database path is not a regular file: %s", sourceStorePath,
+		)
+	}
+
+	targetDir, err := resolveMigrationTarget(sourceDir, options.targetDir)
+	if err != nil {
+		return result, newMigrateError(migrateSourceExitCode, "resolve v2 target directory: %v", err)
+	}
+	if pathWithin(targetDir, filepath.Join(sourceDir, "signal-cli")) {
+		return result, newMigrateError(
+			migrateSourceExitCode,
+			"v2 target %s cannot be inside the legacy signal-cli source directory",
+			targetDir,
+		)
+	}
+
+	createdAt := deps.now().UTC().Truncate(time.Second)
+	lockPath := filepath.Join(sourceDir, instanceLockName)
+	lock, err := acquireInstanceLock(lockPath, instanceLockRecord{
+		PID:           os.Getpid(),
+		Process:       "openmessage migrate",
+		StartedAt:     createdAt.Format(time.RFC3339),
+		BuildID:       deps.version,
+		Commit:        deps.commit,
+		CanonicalPath: sourceDir,
+		ProbeURL:      deps.probeURL,
+	})
+	if err != nil {
+		if errors.Is(err, errInstanceLockHeld) {
+			return result, newMigrateError(
+				migrateLockExitCode,
+				"OpenMessage state is in use: %s is locked; stop the backend and retry",
+				lockPath,
+			)
+		}
+		return result, newMigrateError(
+			migrateLockExitCode, "acquire OpenMessage instance lock %s: %v", lockPath, err,
+		)
+	}
+	defer func() {
+		if closeErr := lock.Close(); closeErr != nil && resultErr == nil {
+			resultErr = newMigrateError(
+				migrateTransformExitCode, "release OpenMessage instance lock: %v", closeErr,
+			)
+		}
+	}()
+
+	running, probeErr := probeBackend(ctx, deps.httpClient, deps.probeURL)
+	if probeErr != nil {
+		return result, newMigrateError(
+			migrateLockExitCode,
+			"cannot safely rule out a running OpenMessage backend at %s: %v; stop the backend and retry",
+			deps.probeURL,
+			probeErr,
+		)
+	}
+	if running {
+		return result, newMigrateError(
+			migrateLockExitCode,
+			"OpenMessage backend is running at %s; stop it before migrating",
+			deps.probeURL,
+		)
+	}
+
+	if err := refuseCanonicalV2State(targetDir); err != nil {
+		return result, newMigrateError(migrateSourceExitCode, "%v", err)
+	}
+	tempStorePath := filepath.Join(targetDir, v2TempStoreName)
+	tempBlobPath := filepath.Join(targetDir, v2TempBlobName)
+	// Discard an interrupted prior stage before measuring headroom. Otherwise
+	// a large stale blobs.tmp could make an otherwise resumable retry report a
+	// false insufficient-space failure.
+	if err := removeStagedMigration(tempStorePath, tempBlobPath); err != nil {
+		return result, newMigrateError(
+			migrateTransformExitCode, "remove stale migration staging: %v", err,
+		)
+	}
+	spacePath, err := nearestExistingDirectory(targetDir)
+	if err != nil {
+		return result, newMigrateError(
+			migrateSourceExitCode, "resolve target filesystem for %s: %v", targetDir, err,
+		)
+	}
+	available, err := deps.availableBytes(spacePath)
+	if err != nil {
+		return result, newMigrateError(
+			migrateSourceExitCode, "check free space at %s: %v", spacePath, err,
+		)
+	}
+	sourceBytes, err := migrationSourceFootprint(sourceStorePath, sourceInfo)
+	if err != nil {
+		return result, newMigrateError(
+			migrateSourceExitCode, "inspect legacy database family size: %v", err,
+		)
+	}
+	if sourceBytes > math.MaxUint64/migrateSpaceCopies {
+		return result, newMigrateError(
+			migrateSourceExitCode,
+			"legacy database family size cannot be represented safely: %d",
+			sourceBytes,
+		)
+	}
+	required := sourceBytes * migrateSpaceCopies
+	if available < required {
+		return result, newMigrateError(
+			migrateSourceExitCode,
+			"insufficient free space at %s: migration staging requires approximately %s (2x the %s legacy database family), but only %s is available",
+			spacePath,
+			formatByteCount(required),
+			formatByteCount(sourceBytes),
+			formatByteCount(available),
+		)
+	}
+
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		return result, newMigrateError(
+			migrateSourceExitCode, "create v2 target directory %s: %v", targetDir, err,
+		)
+	}
+	// Re-check after creation. This closes the small preflight race where a
+	// canonical store could appear between the first Lstat and MkdirAll.
+	if err := refuseCanonicalV2State(targetDir); err != nil {
+		return result, newMigrateError(migrateSourceExitCode, "%v", err)
+	}
+
+	// Re-run after MkdirAll to keep Transform's require-absent contract true
+	// even if the target was created through an unusual filesystem alias.
+	if err := removeStagedMigration(tempStorePath, tempBlobPath); err != nil {
+		return result, newMigrateError(
+			migrateTransformExitCode, "remove stale migration staging: %v", err,
+		)
+	}
+	defer func() {
+		if cleanupErr := removeStagedMigration(tempStorePath, tempBlobPath); cleanupErr != nil && resultErr == nil {
+			resultErr = newMigrateError(
+				migrateTransformExitCode, "clean migration staging: %v", cleanupErr,
+			)
+		}
+	}()
+
+	targetStorePath := filepath.Join(targetDir, v2StoreName)
+	report, transformErr := deps.transform(ctx, migration.Options{
+		SourcePath:      sourceStorePath,
+		TempStorePath:   tempStorePath,
+		TempBlobPath:    tempBlobPath,
+		TargetPath:      targetDir,
+		TargetStorePath: targetStorePath,
+		Check:           options.check,
+	})
+	result = migrateResult{report: report, hasReport: true}
+	result.report.Check = options.check
+	result.report.Target.Path = targetDir
+	result.report.Target.DatabasePath = targetStorePath
+	result.report.Target.Published = false
+	if transformErr != nil {
+		result.report.OK = false
+		code := migrateTransformExitCode
+		if errors.Is(transformErr, migration.ErrSource) {
+			code = migrateSourceExitCode
+		}
+		return result, newMigrateError(code, "transform legacy store: %v", transformErr)
+	}
+	if !report.OK || !report.Validation.Passed {
+		result.report.OK = false
+		return result, newMigrateError(
+			migrateTransformExitCode,
+			"transform returned without passing every validation gate",
+		)
+	}
+
+	if options.check {
+		return result, nil
+	}
+	if err := publishStagedMigration(targetDir, tempStorePath, tempBlobPath); err != nil {
+		result.report.OK = false
+		return result, newMigrateError(migrateTransformExitCode, "publish migrated v2 store: %v", err)
+	}
+	result.report.Target.Published = true
+	return result, nil
+}
+
+func migrationSourceFootprint(databasePath string, databaseInfo os.FileInfo) (uint64, error) {
+	if databaseInfo == nil || databaseInfo.Size() < 0 {
+		return 0, fmt.Errorf("legacy database has an invalid size")
+	}
+	total := uint64(databaseInfo.Size())
+	walPath := databasePath + "-wal"
+	walInfo, err := os.Stat(walPath)
+	if os.IsNotExist(err) {
+		return total, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("inspect WAL %s: %w", walPath, err)
+	}
+	if !walInfo.Mode().IsRegular() || walInfo.Size() < 0 {
+		return 0, fmt.Errorf("legacy WAL is not a regular file with a valid size: %s", walPath)
+	}
+	walBytes := uint64(walInfo.Size())
+	if total > math.MaxUint64-walBytes {
+		return 0, fmt.Errorf("legacy database family size overflows")
+	}
+	return total + walBytes, nil
+}
+
+func resolveMigrationTarget(sourceDir, override string) (string, error) {
+	target := override
+	if target == "" {
+		target = filepath.Join(sourceDir, "v2")
+	} else if strings.TrimSpace(target) == "" {
+		return "", fmt.Errorf("target path is empty")
+	}
+
+	// Existing directories need their final symlink component resolved too.
+	// New directories use R1's destination resolver so their deepest existing
+	// ancestor is canonical and an alias cannot silently select another store.
+	info, err := os.Stat(target)
+	switch {
+	case err == nil:
+		if !info.IsDir() {
+			return "", fmt.Errorf("target exists and is not a directory: %s", target)
+		}
+		return canonicalExistingDirectory(target)
+	case !os.IsNotExist(err):
+		return "", err
+	default:
+		return resolveBackupDestination(sourceDir, target, time.Time{})
+	}
+}
+
+func refuseCanonicalV2State(targetDir string) error {
+	for _, name := range []string{
+		v2StoreName, v2StoreName + "-wal", v2StoreName + "-shm", v2BlobName,
+	} {
+		path := filepath.Join(targetDir, name)
+		if _, err := os.Lstat(path); err == nil {
+			return fmt.Errorf(
+				"v2 target already contains canonical state at %s; existing stores and blobs are never overwritten",
+				path,
+			)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect canonical v2 path %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func removeStagedMigration(tempStorePath, tempBlobPath string) error {
+	var errs []error
+	for _, path := range []string{
+		tempStorePath,
+		tempStorePath + "-wal",
+		tempStorePath + "-shm",
+		tempStorePath + v2TempSourceSuffix,
+		tempBlobPath,
+	} {
+		if err := os.RemoveAll(path); err != nil {
+			errs = append(errs, fmt.Errorf("remove %s: %w", path, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func publishStagedMigration(targetDir, tempStorePath, tempBlobPath string) (returnErr error) {
+	storePath := filepath.Join(targetDir, v2StoreName)
+	blobPath := filepath.Join(targetDir, v2BlobName)
+	if err := requireStagedRegularFile(tempStorePath); err != nil {
+		return err
+	}
+	if err := requireStagedDirectory(tempBlobPath); err != nil {
+		return err
+	}
+	if err := refuseCanonicalV2State(targetDir); err != nil {
+		return err
+	}
+
+	blobsPublished := false
+	storePublished := false
+	defer func() {
+		if returnErr == nil {
+			return
+		}
+		// A failed publication must not leave a target that looks cut over. Keep
+		// the database as the commit marker and best-effort roll both paths back.
+		var rollbackErrs []error
+		if storePublished {
+			if err := os.Remove(storePath); err != nil && !os.IsNotExist(err) {
+				rollbackErrs = append(rollbackErrs, fmt.Errorf("remove published store: %w", err))
+			}
+		}
+		if blobsPublished {
+			if err := os.RemoveAll(blobPath); err != nil {
+				rollbackErrs = append(rollbackErrs, fmt.Errorf("remove published blobs: %w", err))
+			}
+		}
+		if err := syncMigrationDirectory(targetDir); err != nil {
+			rollbackErrs = append(rollbackErrs, fmt.Errorf("sync rollback: %w", err))
+		}
+		returnErr = errors.Join(returnErr, errors.Join(rollbackErrs...))
+	}()
+
+	// Blob references in the database cannot become visible before their
+	// files. The store rename is the publication commit point.
+	if err := os.Rename(tempBlobPath, blobPath); err != nil {
+		return fmt.Errorf("publish blobs first: %w", err)
+	}
+	blobsPublished = true
+	if err := syncMigrationDirectory(targetDir); err != nil {
+		return fmt.Errorf("sync target after publishing blobs: %w", err)
+	}
+	if err := os.Rename(tempStorePath, storePath); err != nil {
+		return fmt.Errorf("publish store database: %w", err)
+	}
+	storePublished = true
+	if err := syncMigrationDirectory(targetDir); err != nil {
+		return fmt.Errorf("sync target after publishing store: %w", err)
+	}
+	return nil
+}
+
+func requireStagedRegularFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("inspect staged store %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("staged store is not a regular file: %s", path)
+	}
+	return nil
+}
+
+func requireStagedDirectory(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("inspect staged blob store %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("staged blob store is not a directory: %s", path)
+	}
+	return nil
+}
+
+func syncMigrationDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	syncErr := directory.Sync()
+	closeErr := directory.Close()
+	return errors.Join(syncErr, closeErr)
+}
+
+func writeHumanMigrationReport(writer io.Writer, report migration.Report) {
+	mode := "publish"
+	if report.Check {
+		mode = "check"
+	}
+	status := "FAILED"
+	if report.OK && report.Validation.Passed {
+		status = "PASSED"
+	}
+	fmt.Fprintf(writer, "OpenMessage migration %s: %s\n", mode, status)
+	fmt.Fprintf(writer, "Source: %s (unchanged=%t, quick_check=%s)\n",
+		report.Source.DatabasePath, report.Source.Unchanged, report.Source.QuickCheck)
+	fmt.Fprintf(writer, "Target: %s (schema=%d, published=%t)\n",
+		report.Target.DatabasePath, report.Target.SchemaVersion, report.Target.Published)
+
+	if messages, ok := report.TableCounts["messages"]; ok {
+		fmt.Fprintf(writer, "Messages: legacy=%d v2=%d reconciled=%d ratio=%.6f collisions=%d\n",
+			messages.Legacy, messages.V2, messages.Reconciled,
+			messages.ReconciliationRatio, len(report.MessageCollisions))
+	}
+	platforms := make([]string, 0, len(report.PlatformCounts))
+	for platform := range report.PlatformCounts {
+		platforms = append(platforms, platform)
+	}
+	sort.Strings(platforms)
+	for _, platform := range platforms {
+		counts := report.PlatformCounts[platform]
+		fmt.Fprintf(writer, "  %s (%s): legacy=%d v2=%d ratio=%.6f\n",
+			platform, counts.AccountID, counts.Legacy, counts.V2, counts.ReconciliationRatio)
+	}
+	fmt.Fprintf(writer, "Identity graph: identities=%d people=%d un-unified=%d\n",
+		report.Identities.Created, report.Identities.PeopleCreated,
+		report.Identities.UnunifiedIdentities)
+	fmt.Fprintf(writer, "Scheduled: pending->outbox=%d pending-media=%d sending-ambiguous=%d sent/canceled/failed-skipped=%d/%d/%d\n",
+		report.Schedule.PendingToOutbox, report.Schedule.PendingMedia,
+		report.Schedule.AmbiguousSending, report.Schedule.SkippedSent,
+		report.Schedule.SkippedCanceled, report.Schedule.SkippedFailed)
+	fmt.Fprintf(writer, "Dropped (counted): reactions=%d transcripts=%d avatars=%d drafts=%d contact_meta(CRM)=%d outgoing_send_keys=%d tabs=%d\n",
+		report.Dropped.ReactionsBearingMessages,
+		report.Dropped.TranscriptBearingMessages,
+		report.Dropped.ContactAvatars,
+		report.Dropped.Drafts,
+		report.Dropped.ContactMetaCRM,
+		report.Dropped.OutgoingSendKeys,
+		report.Dropped.Tabs)
+
+	matched := 0
+	for _, sample := range report.SampledHashes {
+		if sample.Matched {
+			matched++
+		}
+	}
+	fmt.Fprintf(writer, "Validation: quick_check=%s foreign_keys=%d orphans=%d sampled_hashes=%d/%d passed=%t\n",
+		report.Validation.QuickCheck,
+		len(report.Validation.ForeignKeyViolations),
+		migrationOrphanTotal(report.Validation.Orphans),
+		matched,
+		len(report.SampledHashes),
+		report.Validation.Passed)
+	if report.ReadState.LossyWarning != "" {
+		fmt.Fprintf(writer, "WARNING: %s (%d conversations had unread_count > 0)\n",
+			report.ReadState.LossyWarning,
+			report.ReadState.ConversationsWithUnreadCount)
+	}
+	for _, warning := range report.Warnings {
+		if warning == report.ReadState.LossyWarning {
+			continue
+		}
+		fmt.Fprintf(writer, "WARNING: %s\n", warning)
+	}
+	if report.Check && report.OK && report.Validation.Passed {
+		fmt.Fprintln(writer, "Check complete; staged files were removed and no v2 store was published.")
+	} else if report.Target.Published {
+		fmt.Fprintln(writer, "Migration published. The legacy source remains available for rollback with the old release.")
+	}
+}
+
+func migrationOrphanTotal(report migration.OrphanReport) int64 {
+	return report.MessageConversations +
+		report.MessageSenders +
+		report.ConversationParticipants +
+		report.MessageAttachments +
+		report.OutboxAccounts +
+		report.OutboxConversations +
+		report.OutboxAttachments +
+		report.ReadCursorMessages
+}

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -1,0 +1,393 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/migration"
+)
+
+func TestMigrateCheckEmitsSplitReportAndCleansStaging(t *testing.T) {
+	sourceDir := newMigrateSourceFixture(t)
+	targetDir := filepath.Join(sourceDir, "v2")
+	if err := os.Mkdir(targetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, v2TempStoreName), []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	staleSource := filepath.Join(targetDir, v2TempStoreName+v2TempSourceSuffix)
+	if err := os.Mkdir(staleSource, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleSource, "messages.db"), []byte("stale private snapshot"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(targetDir, v2TempBlobName), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, v2TempBlobName, "stale"), []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	legacyBefore, err := os.ReadFile(filepath.Join(sourceDir, legacyDatabaseName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deps := testMigrateDependencies(t)
+	deps.transform = successfulTestTransform(t, func(options migration.Options) {
+		if !options.Check {
+			t.Fatal("transform Check = false, want true")
+		}
+		for _, path := range []string{
+			options.TempStorePath,
+			options.TempStorePath + v2TempSourceSuffix,
+			options.TempBlobPath,
+		} {
+			if _, err := os.Lstat(path); !os.IsNotExist(err) {
+				t.Fatalf("stale staging was not removed before Transform: %s (%v)", path, err)
+			}
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	err = runMigrateCommand(
+		context.Background(),
+		[]string{"--check", "--from", sourceDir, "--json"},
+		deps,
+		&stdout,
+		&stderr,
+	)
+	if err != nil {
+		t.Fatalf("runMigrateCommand: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	var report migration.Report
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("stdout is not an integrity report: %v\n%s", err, stdout.String())
+	}
+	if !report.OK || !report.Check || !report.Validation.Passed || report.Target.Published {
+		t.Fatalf("check report = %+v", report)
+	}
+	for _, path := range []string{
+		filepath.Join(targetDir, v2StoreName),
+		filepath.Join(targetDir, v2BlobName),
+		filepath.Join(targetDir, v2TempStoreName),
+		filepath.Join(targetDir, v2TempStoreName+v2TempSourceSuffix),
+		filepath.Join(targetDir, v2TempBlobName),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Errorf("check left migration output %s: %v", path, err)
+		}
+	}
+	legacyAfter, err := os.ReadFile(filepath.Join(sourceDir, legacyDatabaseName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(legacyBefore, legacyAfter) {
+		t.Fatal("legacy database bytes changed during --check")
+	}
+	if got := stderr.String(); !strings.Contains(got, "OpenMessage migration check: PASSED") ||
+		!strings.Contains(got, "contact_meta(CRM)") ||
+		!strings.Contains(got, "no v2 store was published") {
+		t.Fatalf("human report missing required evidence:\n%s", got)
+	}
+}
+
+func TestMigratePublishesBlobsThenStoreAndMarksReport(t *testing.T) {
+	sourceDir := newMigrateSourceFixture(t)
+	targetDir := filepath.Join(sourceDir, "published-v2")
+	deps := testMigrateDependencies(t)
+	deps.transform = successfulTestTransform(t, func(options migration.Options) {
+		if options.Check {
+			t.Fatal("transform Check = true, want false")
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := runMigrateCommand(
+		context.Background(),
+		[]string{"--from", sourceDir, "--to", targetDir},
+		deps,
+		&stdout,
+		&stderr,
+	)
+	if err != nil {
+		t.Fatalf("runMigrateCommand: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	var report migration.Report
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("stdout is not an integrity report: %v\n%s", err, stdout.String())
+	}
+	if !report.OK || report.Check || !report.Validation.Passed || !report.Target.Published {
+		t.Fatalf("publish report = %+v", report)
+	}
+	storeBytes, err := os.ReadFile(filepath.Join(targetDir, v2StoreName))
+	if err != nil {
+		t.Fatalf("read published store: %v", err)
+	}
+	if string(storeBytes) != "validated-v2-store" {
+		t.Fatalf("published store = %q", storeBytes)
+	}
+	blobBytes, err := os.ReadFile(filepath.Join(targetDir, v2BlobName, "sha256", "fixture"))
+	if err != nil {
+		t.Fatalf("read published blob: %v", err)
+	}
+	if string(blobBytes) != "scheduled-media" {
+		t.Fatalf("published blob = %q", blobBytes)
+	}
+	for _, path := range []string{
+		filepath.Join(targetDir, v2TempStoreName),
+		filepath.Join(targetDir, v2TempStoreName+v2TempSourceSuffix),
+		filepath.Join(targetDir, v2TempBlobName),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Errorf("published migration left staging %s: %v", path, err)
+		}
+	}
+	if !strings.Contains(stderr.String(), "Migration published") {
+		t.Fatalf("human report does not describe publication:\n%s", stderr.String())
+	}
+}
+
+func TestMigrateHeldInstanceLockUsesExitCodeFour(t *testing.T) {
+	sourceDir := newMigrateSourceFixture(t)
+	lock, err := acquireInstanceLock(filepath.Join(sourceDir, instanceLockName), instanceLockRecord{
+		PID: 4242, Process: "test backend",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+
+	deps := testMigrateDependencies(t)
+	deps.transform = func(context.Context, migration.Options) (migration.Report, error) {
+		t.Fatal("Transform called while source lock was held")
+		return migration.Report{}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	err = runMigrateCommand(
+		context.Background(), []string{"--from", sourceDir}, deps, &stdout, &stderr,
+	)
+	if err == nil {
+		t.Fatal("runMigrateCommand succeeded while instance lock was held")
+	}
+	if got := ExitCode(err); got != migrateLockExitCode {
+		t.Fatalf("ExitCode = %d, want %d (%v)", got, migrateLockExitCode, err)
+	}
+	var output migrateFailureOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("decode failure output: %v\n%s", err, stdout.String())
+	}
+	if output.OK || output.ExitCode != migrateLockExitCode || !strings.Contains(output.Error, "locked") {
+		t.Fatalf("failure output = %+v", output)
+	}
+	if !strings.Contains(stderr.String(), "stop the backend") {
+		t.Fatalf("stderr is not actionable: %s", stderr.String())
+	}
+}
+
+func TestMigrateRefusesCanonicalTargetState(t *testing.T) {
+	sourceDir := newMigrateSourceFixture(t)
+	targetDir := filepath.Join(sourceDir, "v2")
+	if err := os.Mkdir(targetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, v2StoreName), []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := testMigrateDependencies(t)
+	deps.transform = func(context.Context, migration.Options) (migration.Report, error) {
+		t.Fatal("Transform called for an occupied target")
+		return migration.Report{}, nil
+	}
+	result, err := executeMigrate(context.Background(), migrateOptions{sourceDir: sourceDir}, deps)
+	if err == nil {
+		t.Fatal("executeMigrate succeeded for occupied target")
+	}
+	if result.hasReport {
+		t.Fatalf("occupied target unexpectedly produced transform report: %+v", result.report)
+	}
+	if got := ExitCode(err); got != migrateSourceExitCode {
+		t.Fatalf("ExitCode = %d, want %d (%v)", got, migrateSourceExitCode, err)
+	}
+	if !strings.Contains(err.Error(), "never overwritten") {
+		t.Fatalf("target refusal is not actionable: %v", err)
+	}
+	bytes, readErr := os.ReadFile(filepath.Join(targetDir, v2StoreName))
+	if readErr != nil || string(bytes) != "existing" {
+		t.Fatalf("canonical store changed: %q, %v", bytes, readErr)
+	}
+}
+
+func TestMigrateValidationFailureUsesExitCodeFiveAndCleansStaging(t *testing.T) {
+	sourceDir := newMigrateSourceFixture(t)
+	targetDir := filepath.Join(sourceDir, "v2")
+	deps := testMigrateDependencies(t)
+	deps.transform = func(_ context.Context, options migration.Options) (migration.Report, error) {
+		if err := os.WriteFile(options.TempStorePath, []byte("invalid"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(options.TempBlobPath, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		return migration.Report{
+			Format: migration.ReportFormat,
+			Check:  options.Check,
+			Source: migration.SourceReport{DatabasePath: options.SourcePath, Unchanged: true},
+			Target: migration.TargetReport{DatabasePath: options.TargetStorePath},
+			Validation: migration.ValidationReport{
+				QuickCheck: "row mismatch", Passed: false,
+			},
+		}, migration.ErrValidation
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runMigrateCommand(
+		context.Background(), []string{"--check", "--from", sourceDir}, deps, &stdout, &stderr,
+	)
+	if err == nil {
+		t.Fatal("runMigrateCommand succeeded after validation failure")
+	}
+	if got := ExitCode(err); got != migrateTransformExitCode {
+		t.Fatalf("ExitCode = %d, want %d (%v)", got, migrateTransformExitCode, err)
+	}
+	var report migration.Report
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("stdout is not the failed integrity report: %v\n%s", err, stdout.String())
+	}
+	if report.OK || report.Validation.Passed {
+		t.Fatalf("failed report = %+v", report)
+	}
+	for _, path := range []string{
+		filepath.Join(targetDir, v2TempStoreName),
+		filepath.Join(targetDir, v2TempStoreName+v2TempSourceSuffix),
+		filepath.Join(targetDir, v2TempBlobName),
+		filepath.Join(targetDir, v2StoreName), filepath.Join(targetDir, v2BlobName),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Errorf("validation failure left output %s: %v", path, err)
+		}
+	}
+	if !strings.Contains(stderr.String(), "Migration failed") {
+		t.Fatalf("human failure missing from stderr: %s", stderr.String())
+	}
+}
+
+func TestMigrationSourceFootprintIncludesHotWAL(t *testing.T) {
+	directory := t.TempDir()
+	databasePath := filepath.Join(directory, legacyDatabaseName)
+	if err := os.WriteFile(databasePath, []byte("main"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	databaseInfo, err := os.Stat(databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := migrationSourceFootprint(databasePath, databaseInfo); err != nil || got != 4 {
+		t.Fatalf("footprint without WAL = %d, %v; want 4, nil", got, err)
+	}
+	if err := os.WriteFile(databasePath+"-wal", []byte("hot-wal"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := migrationSourceFootprint(databasePath, databaseInfo); err != nil || got != 11 {
+		t.Fatalf("footprint with WAL = %d, %v; want 11, nil", got, err)
+	}
+}
+
+func newMigrateSourceFixture(t *testing.T) string {
+	t.Helper()
+	directory := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(directory, legacyDatabaseName), []byte("immutable-legacy-fixture"), 0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	return directory
+}
+
+func testMigrateDependencies(t *testing.T) migrateDependencies {
+	t.Helper()
+	return migrateDependencies{
+		now:      func() time.Time { return time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC) },
+		version:  "test-version",
+		commit:   "test-commit",
+		probeURL: "http://127.0.0.1:7007/api/status",
+		httpClient: &http.Client{Transport: migrateRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, syscall.ECONNREFUSED
+		})},
+		availableBytes: func(string) (uint64, error) { return math.MaxUint64, nil },
+		transform: func(context.Context, migration.Options) (migration.Report, error) {
+			t.Fatal("test did not install a Transform fake")
+			return migration.Report{}, nil
+		},
+	}
+}
+
+func successfulTestTransform(
+	t *testing.T,
+	inspect func(migration.Options),
+) migrateTransform {
+	t.Helper()
+	return func(_ context.Context, options migration.Options) (migration.Report, error) {
+		if inspect != nil {
+			inspect(options)
+		}
+		if err := os.WriteFile(options.TempStorePath, []byte("validated-v2-store"), 0o600); err != nil {
+			t.Fatalf("write staged store: %v", err)
+		}
+		blobDir := filepath.Join(options.TempBlobPath, "sha256")
+		if err := os.MkdirAll(blobDir, 0o700); err != nil {
+			t.Fatalf("create staged blob directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(blobDir, "fixture"), []byte("scheduled-media"), 0o600); err != nil {
+			t.Fatalf("write staged blob: %v", err)
+		}
+		return migration.Report{
+			Format: migration.ReportFormat,
+			OK:     true,
+			Check:  options.Check,
+			Source: migration.SourceReport{
+				Path: filepath.Dir(options.SourcePath), DatabasePath: options.SourcePath,
+				QuickCheck: "ok", Unchanged: true,
+			},
+			Target: migration.TargetReport{
+				Path: options.TargetPath, DatabasePath: options.TargetStorePath,
+				SchemaVersion: 9,
+			},
+			TableCounts: map[string]migration.TableReconciliation{
+				"messages": {
+					Legacy: 2, V2: 2, Reconciled: 2, ReconciliationRatio: 1,
+				},
+			},
+			PlatformCounts: map[string]migration.PlatformReconciliation{
+				"signal": {
+					AccountID: "signal-primary", Legacy: 1, V2: 1, ReconciliationRatio: 1,
+				},
+			},
+			ReadState:     migration.ReadStateReport{LossyWarning: "legacy read state was lossy"},
+			SampledHashes: []migration.SampledHash{{Matched: true}},
+			Validation: migration.ValidationReport{
+				QuickCheck: "ok", CountsMatched: true, SampledHashesMatched: true,
+				BlobReferencesValid: true, SourceUnchanged: true, Passed: true,
+			},
+		}, nil
+	}
+}
+
+type migrateRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (function migrateRoundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}

--- a/internal/bridgeadapters/google/send.go
+++ b/internal/bridgeadapters/google/send.go
@@ -83,6 +83,14 @@ type googleDownloadRef struct {
 	key     []byte
 }
 
+// ValidateDownloadOpaque reports whether raw is a well-formed v1 download Opaque this
+// adapter can decode. It is the exported round-trip check the Wave-4
+// migration uses to prove the refs it packs will unpack here.
+func ValidateDownloadOpaque(raw []byte) error {
+	_, err := decodeGoogleDownloadOpaque(raw)
+	return err
+}
+
 func decodeGoogleDownloadOpaque(opaque []byte) (googleDownloadRef, error) {
 	if !utf8.Valid(opaque) {
 		return googleDownloadRef{}, unsupportedGoogleOpaqueError(

--- a/internal/bridgeadapters/signal/signal.go
+++ b/internal/bridgeadapters/signal/signal.go
@@ -337,6 +337,14 @@ func (a *Adapter) DownloadMedia(
 	}, nil
 }
 
+// ValidateDownloadOpaque reports whether raw is a well-formed v1 download Opaque this
+// adapter can decode. It is the exported round-trip check the Wave-4
+// migration uses to prove the refs it packs will unpack here.
+func ValidateDownloadOpaque(raw []byte) error {
+	_, err := decodeSignalDownloadOpaque(raw)
+	return err
+}
+
 func decodeSignalDownloadOpaque(raw []byte) (decodedSignalDownloadRef, error) {
 	if !utf8.Valid(raw) {
 		return decodedSignalDownloadRef{}, signalDownloadOpaqueError(

--- a/internal/bridgeadapters/whatsapp/download.go
+++ b/internal/bridgeadapters/whatsapp/download.go
@@ -38,6 +38,14 @@ func marshalWhatsAppMediaOpaqueV1(payload whatsappMediaOpaqueV1) ([]byte, error)
 	return json.Marshal(payload)
 }
 
+// ValidateDownloadOpaque reports whether raw is a well-formed v1 download Opaque this
+// adapter can decode. It is the exported round-trip check the Wave-4
+// migration uses to prove the refs it packs will unpack here.
+func ValidateDownloadOpaque(raw []byte) error {
+	_, err := unmarshalWhatsAppMediaOpaque(raw)
+	return err
+}
+
 func unmarshalWhatsAppMediaOpaque(raw []byte) (whatsappMediaOpaqueV1, error) {
 	var payload whatsappMediaOpaqueV1
 	if !utf8.Valid(raw) {

--- a/internal/migration/report.go
+++ b/internal/migration/report.go
@@ -1,0 +1,197 @@
+// Package migration transforms the legacy OpenMessage store into the merged
+// v2 SQLite schema. It is intentionally one-shot and never opens the legacy
+// database through internal/db, whose constructor performs writes.
+package migration
+
+import "errors"
+
+const (
+	// ReportFormat is the machine-readable integrity report schema version.
+	ReportFormat = 1
+	// SampleMessagesPerPlatform is the deterministic spot-check sample size.
+	SampleMessagesPerPlatform = 5
+)
+
+var (
+	// ErrSource marks an unsupported, ambiguous, or unreadable legacy source.
+	ErrSource = errors.New("legacy migration source error")
+	// ErrTransform marks a failure while constructing the staged v2 store.
+	ErrTransform = errors.New("legacy migration transform error")
+	// ErrValidation marks a completed transform that failed integrity gates.
+	ErrValidation = errors.New("legacy migration validation error")
+)
+
+// Report is the pre-registered cutover evidence emitted by migrate and
+// migrate --check. Maps have stable JSON ordering under encoding/json.
+type Report struct {
+	Format            int                               `json:"format"`
+	OK                bool                              `json:"ok"`
+	Check             bool                              `json:"check"`
+	Source            SourceReport                      `json:"source"`
+	Target            TargetReport                      `json:"target"`
+	TableCounts       map[string]TableReconciliation    `json:"table_counts"`
+	PlatformCounts    map[string]PlatformReconciliation `json:"platform_counts"`
+	Identities        IdentityReport                    `json:"identities"`
+	Schedule          ScheduleReport                    `json:"schedule"`
+	ReadState         ReadStateReport                   `json:"read_state"`
+	Dropped           DroppedDimensions                 `json:"dropped_dimensions"`
+	SignalLocalRows   int64                             `json:"signal_local_rows"`
+	Media             MediaReport                       `json:"media"`
+	MessageCollisions []MessageCollision                `json:"message_collisions"`
+	SampledHashes     []SampledHash                     `json:"sampled_hashes"`
+	Validation        ValidationReport                  `json:"validation"`
+	Warnings          []string                          `json:"warnings"`
+}
+
+type SourceReport struct {
+	Path              string               `json:"path"`
+	DatabasePath      string               `json:"database_path"`
+	SchemaFingerprint string               `json:"schema_fingerprint"`
+	SchemaUserVersion int64                `json:"schema_user_version"`
+	QuickCheck        string               `json:"quick_check"`
+	SHA256Before      string               `json:"sha256_before"`
+	SHA256After       string               `json:"sha256_after"`
+	Unchanged         bool                 `json:"unchanged"`
+	Files             []SourceFileEvidence `json:"files"`
+}
+
+// SourceFileEvidence records content and mutation-relevant metadata for the
+// SQLite database family. WAL and shared-memory sidecars are part of the
+// source evidence because a stopped legacy WAL store may retain both.
+type SourceFileEvidence struct {
+	Role               string `json:"role"`
+	Path               string `json:"path"`
+	ExistsBefore       bool   `json:"exists_before"`
+	ExistsAfter        bool   `json:"exists_after"`
+	SizeBefore         int64  `json:"size_before"`
+	SizeAfter          int64  `json:"size_after"`
+	SHA256Before       string `json:"sha256_before,omitempty"`
+	SHA256After        string `json:"sha256_after,omitempty"`
+	ModeBefore         string `json:"mode_before,omitempty"`
+	ModeAfter          string `json:"mode_after,omitempty"`
+	ModifiedAtNSBefore int64  `json:"modified_at_ns_before,omitempty"`
+	ModifiedAtNSAfter  int64  `json:"modified_at_ns_after,omitempty"`
+	Unchanged          bool   `json:"unchanged"`
+}
+
+type TargetReport struct {
+	Path               string           `json:"path"`
+	DatabasePath       string           `json:"database_path"`
+	StoreInstanceID    string           `json:"store_instance_id"`
+	SchemaVersion      int64            `json:"schema_version"`
+	MigrationChecksums []string         `json:"migration_checksums"`
+	Counts             map[string]int64 `json:"counts"`
+	Published          bool             `json:"published"`
+}
+
+type TableReconciliation struct {
+	Legacy              int64   `json:"legacy"`
+	V2                  int64   `json:"v2"`
+	Reconciled          int64   `json:"reconciled"`
+	ReconciliationRatio float64 `json:"reconciliation_ratio"`
+	Disposition         string  `json:"disposition,omitempty"`
+}
+
+type PlatformReconciliation struct {
+	AccountID           string  `json:"account_id"`
+	Legacy              int64   `json:"legacy"`
+	V2                  int64   `json:"v2"`
+	ReconciliationRatio float64 `json:"reconciliation_ratio"`
+}
+
+type IdentityReport struct {
+	Created             int64            `json:"created"`
+	PeopleCreated       int64            `json:"people_created"`
+	LinksByProvenance   map[string]int64 `json:"links_by_provenance"`
+	UnunifiedIdentities int64            `json:"ununified_identities"`
+}
+
+type ScheduleReport struct {
+	LegacyTotal        int64            `json:"legacy_total"`
+	ByStatus           map[string]int64 `json:"by_status"`
+	PendingToOutbox    int64            `json:"pending_to_outbox"`
+	PendingMedia       int64            `json:"pending_media"`
+	SkippedSent        int64            `json:"skipped_sent"`
+	SkippedCanceled    int64            `json:"skipped_canceled"`
+	SkippedFailed      int64            `json:"skipped_failed"`
+	AmbiguousSending   int64            `json:"ambiguous_sending"`
+	OptimisticOnlyRows int64            `json:"optimistic_only_rows"`
+}
+
+type ReadStateReport struct {
+	LossyWarning                 string `json:"lossy_warning"`
+	ConversationsWithUnreadCount int64  `json:"conversations_with_unread_count"`
+	CursorsCreated               int64  `json:"cursors_created"`
+}
+
+type DroppedDimensions struct {
+	ReactionsBearingMessages  int64 `json:"reactions_bearing_messages"`
+	TranscriptBearingMessages int64 `json:"transcript_bearing_messages"`
+	ContactAvatars            int64 `json:"contact_avatars"`
+	Drafts                    int64 `json:"drafts"`
+	ContactMetaCRM            int64 `json:"contact_meta_crm"`
+	OutgoingSendKeys          int64 `json:"outgoing_send_keys"`
+	Tabs                      int64 `json:"tabs"`
+}
+
+type MediaReport struct {
+	LegacyAttachments             int64 `json:"legacy_attachments"`
+	PendingAttachments            int64 `json:"pending_attachments"`
+	WhatsAppUnresolvable          int64 `json:"whatsapp_unresolvable"`
+	SignalUnresolvable            int64 `json:"signal_unresolvable"`
+	SignalLocalAttachments        int64 `json:"signal_local_attachments"`
+	UnsupportedArchiveAttachments int64 `json:"unsupported_archive_attachments"`
+	ScheduledBlobsVerified        int64 `json:"scheduled_blobs_verified"`
+}
+
+type MessageCollision struct {
+	AccountID        string   `json:"account_id"`
+	ConversationID   string   `json:"legacy_conversation_id"`
+	RemoteMessageID  string   `json:"remote_message_id"`
+	LegacyMessageIDs []string `json:"legacy_message_ids"`
+}
+
+type SampledHash struct {
+	Platform        string `json:"platform"`
+	LegacyMessageID string `json:"legacy_message_id"`
+	V2MessageID     string `json:"v2_message_id"`
+	ExpectedSHA256  string `json:"expected_sha256"`
+	ActualSHA256    string `json:"actual_sha256"`
+	Matched         bool   `json:"matched"`
+}
+
+type ValidationReport struct {
+	QuickCheck           string                `json:"quick_check"`
+	ForeignKeyViolations []ForeignKeyViolation `json:"foreign_key_check"`
+	Orphans              OrphanReport          `json:"orphans"`
+	CountsMatched        bool                  `json:"counts_matched"`
+	SampledHashesMatched bool                  `json:"sampled_hashes_matched"`
+	BlobReferencesValid  bool                  `json:"blob_references_valid"`
+	SourceUnchanged      bool                  `json:"source_unchanged"`
+	Passed               bool                  `json:"passed"`
+}
+
+type ForeignKeyViolation struct {
+	Table      string `json:"table"`
+	RowID      *int64 `json:"rowid,omitempty"`
+	Parent     string `json:"parent"`
+	Constraint int64  `json:"constraint"`
+}
+
+type OrphanReport struct {
+	MessageConversations     int64 `json:"message_conversations"`
+	MessageSenders           int64 `json:"message_senders"`
+	ConversationParticipants int64 `json:"conversation_participants"`
+	MessageAttachments       int64 `json:"message_attachments"`
+	OutboxAccounts           int64 `json:"outbox_accounts"`
+	OutboxConversations      int64 `json:"outbox_conversations"`
+	OutboxAttachments        int64 `json:"outbox_attachments"`
+	ReadCursorMessages       int64 `json:"read_cursor_messages"`
+}
+
+func reconciliationRatio(reconciled, legacy int64) float64 {
+	if legacy == 0 {
+		return 1
+	}
+	return float64(reconciled) / float64(legacy)
+}

--- a/internal/migration/source.go
+++ b/internal/migration/source.go
@@ -1,0 +1,698 @@
+package migration
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+type legacyConversation struct {
+	ID               string
+	Name             string
+	IsGroup          bool
+	ParticipantsJSON string
+	LastMessageMS    int64
+	UnreadCount      int64
+	Platform         string
+	DisplayProtocol  string
+	NotificationMode string
+	IsFavorite       bool
+	Tab              string
+}
+
+type legacyMessage struct {
+	ID              string
+	ConversationID  string
+	SenderName      string
+	SenderNumber    string
+	Body            string
+	TimestampMS     int64
+	Status          string
+	IsFromMe        bool
+	MentionsMe      bool
+	MediaID         string
+	MIME            string
+	DecryptionKey   string
+	Reactions       string
+	ReplyToID       string
+	Platform        string
+	SourceID        string
+	Transcript      string
+	TranscribedAtMS int64
+	TranscriptModel string
+}
+
+type legacyContact struct {
+	ID     string
+	Name   string
+	Number string
+}
+
+type legacyUnifiedContact struct {
+	ID              string
+	DisplayName     string
+	IdentifiersJSON string
+}
+
+type legacyScheduledMessage struct {
+	ID             string
+	ConversationID string
+	Body           string
+	ReplyToID      string
+	SendAtMS       int64
+	Status         string
+	Attempts       int64
+	LastError      string
+	CreatedAtMS    int64
+	SentMessageID  string
+	MediaData      []byte
+	MediaFilename  string
+	MediaMIME      string
+}
+
+type legacyDataset struct {
+	conversations []legacyConversation
+	messages      []legacyMessage
+	contacts      []legacyContact
+	unified       []legacyUnifiedContact
+	scheduled     []legacyScheduledMessage
+
+	tableCounts      map[string]int64
+	scheduleByStatus map[string]int64
+	platformMessages map[string]int64
+	dropped          DroppedDimensions
+	signalLocalRows  int64
+	unreadRows       int64
+	mediaRows        int64
+}
+
+var requiredLegacyColumns = map[string][]string{
+	"conversations": {
+		"conversation_id", "name", "is_group", "participants", "last_message_ts",
+		"unread_count", "source_platform", "display_protocol", "notification_mode",
+		"is_favorite", "tab",
+	},
+	"messages": {
+		"message_id", "conversation_id", "sender_name", "sender_number", "body",
+		"timestamp_ms", "status", "is_from_me", "mentions_me", "media_id",
+		"mime_type", "decryption_key", "reactions", "reply_to_id", "source_platform",
+		"source_id", "transcript", "transcribed_at", "transcript_model",
+	},
+	"contacts":           {"contact_id", "name", "number"},
+	"contact_avatars":    {"avatar_id"},
+	"drafts":             {"draft_id"},
+	"outgoing_send_keys": {"idempotency_key"},
+	"unified_contacts":   {"unified_id", "display_name", "identifiers"},
+	"scheduled_messages": {
+		"id", "conversation_id", "body", "reply_to_id", "send_at", "status",
+		"attempts", "last_error", "created_at", "sent_message_id", "media_data",
+		"media_filename", "media_mime",
+	},
+	"contact_meta": {"person_key"},
+	"tabs":         {"tab_id"},
+}
+
+func loadLegacySource(
+	ctx context.Context,
+	sourcePath string,
+	snapshotDirectory string,
+) (datasetResult legacyDataset, reportResult SourceReport, returnErr error) {
+	files, err := captureSourceFileEvidence(sourcePath)
+	if err != nil {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: inspect legacy database family: %v", ErrSource, err)
+	}
+	before := files[0].SHA256Before
+	snapshotPath, cleanupSnapshot, err := stageLegacySourceSnapshot(snapshotDirectory, files)
+	if err != nil {
+		cleanupErr := cleanupSnapshot()
+		return legacyDataset{}, SourceReport{}, errors.Join(
+			fmt.Errorf("%w: stage immutable legacy snapshot: %v", ErrSource, err),
+			wrapSnapshotCleanupError(cleanupErr),
+		)
+	}
+	defer func() {
+		if cleanupErr := cleanupSnapshot(); cleanupErr != nil {
+			returnErr = errors.Join(returnErr, fmt.Errorf(
+				"%w: remove staged legacy snapshot: %v", ErrSource, cleanupErr,
+			))
+		}
+	}()
+	database, err := sql.Open("sqlite", readOnlySQLiteDSN(snapshotPath))
+	if err != nil {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: open legacy database: %v", ErrSource, err)
+	}
+	database.SetMaxOpenConns(1)
+	defer func() {
+		if closeErr := database.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, fmt.Errorf(
+				"%w: close staged legacy snapshot: %v", ErrSource, closeErr,
+			))
+		}
+	}()
+	if err := database.PingContext(ctx); err != nil {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: connect to legacy database: %v", ErrSource, err)
+	}
+	if _, err := database.ExecContext(ctx, "PRAGMA query_only=ON"); err != nil {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: make legacy database connection read-only: %v", ErrSource, err)
+	}
+
+	quick, err := quickCheck(ctx, database)
+	if err != nil {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: quick-check legacy database: %v", ErrSource, err)
+	}
+	if quick != "ok" {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: legacy database PRAGMA quick_check: %s", ErrSource, quick)
+	}
+	if err := validateLegacySchema(ctx, database); err != nil {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: %v", ErrSource, err)
+	}
+	fingerprint, err := databaseSchemaFingerprint(ctx, database)
+	if err != nil {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: fingerprint legacy schema: %v", ErrSource, err)
+	}
+	var userVersion int64
+	if err := database.QueryRowContext(ctx, "PRAGMA user_version").Scan(&userVersion); err != nil {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: read legacy user_version: %v", ErrSource, err)
+	}
+
+	dataset := legacyDataset{
+		tableCounts: map[string]int64{},
+		scheduleByStatus: map[string]int64{
+			"pending": 0, "sending": 0, "sent": 0, "failed": 0, "canceled": 0,
+		},
+		platformMessages: map[string]int64{},
+	}
+	if err := loadLegacyRows(ctx, database, &dataset); err != nil {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: %v", ErrSource, err)
+	}
+	if err := validateLegacyRelationships(dataset); err != nil {
+		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: %v", ErrSource, err)
+	}
+
+	report := SourceReport{
+		Path:              filepath.Dir(sourcePath),
+		DatabasePath:      sourcePath,
+		SchemaFingerprint: fingerprint,
+		SchemaUserVersion: userVersion,
+		QuickCheck:        quick,
+		SHA256Before:      before,
+		Files:             files,
+	}
+	return dataset, report, nil
+}
+
+func loadLegacyRows(ctx context.Context, database *sql.DB, dataset *legacyDataset) error {
+	rows, err := database.QueryContext(ctx, `
+		SELECT conversation_id, name, is_group, participants, last_message_ts,
+		       unread_count, source_platform, display_protocol, notification_mode,
+		       is_favorite, tab
+		FROM conversations
+		ORDER BY conversation_id
+	`)
+	if err != nil {
+		return fmt.Errorf("read conversations: %w", err)
+	}
+	for rows.Next() {
+		var row legacyConversation
+		if err := rows.Scan(
+			&row.ID, &row.Name, &row.IsGroup, &row.ParticipantsJSON,
+			&row.LastMessageMS, &row.UnreadCount, &row.Platform,
+			&row.DisplayProtocol, &row.NotificationMode, &row.IsFavorite, &row.Tab,
+		); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan conversation: %w", err)
+		}
+		dataset.conversations = append(dataset.conversations, row)
+		if row.UnreadCount > 0 {
+			dataset.unreadRows++
+		}
+	}
+	if err := closeRows(rows); err != nil {
+		return fmt.Errorf("read conversations: %w", err)
+	}
+
+	rows, err = database.QueryContext(ctx, `
+		SELECT message_id, conversation_id, sender_name, sender_number, body,
+		       timestamp_ms, status, is_from_me, mentions_me, media_id, mime_type,
+		       decryption_key, reactions, reply_to_id, source_platform, source_id,
+		       transcript, transcribed_at, transcript_model
+		FROM messages
+		ORDER BY source_platform, conversation_id, timestamp_ms, message_id
+	`)
+	if err != nil {
+		return fmt.Errorf("read messages: %w", err)
+	}
+	for rows.Next() {
+		var row legacyMessage
+		if err := rows.Scan(
+			&row.ID, &row.ConversationID, &row.SenderName, &row.SenderNumber,
+			&row.Body, &row.TimestampMS, &row.Status, &row.IsFromMe, &row.MentionsMe,
+			&row.MediaID, &row.MIME, &row.DecryptionKey, &row.Reactions, &row.ReplyToID,
+			&row.Platform, &row.SourceID, &row.Transcript, &row.TranscribedAtMS,
+			&row.TranscriptModel,
+		); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan message: %w", err)
+		}
+		dataset.messages = append(dataset.messages, row)
+		platform := normalizeLegacyPlatform(row.Platform)
+		dataset.platformMessages[platform]++
+		if strings.TrimSpace(row.MediaID) != "" {
+			dataset.mediaRows++
+		}
+		if strings.TrimSpace(row.Reactions) != "" &&
+			strings.TrimSpace(row.Reactions) != "null" &&
+			strings.TrimSpace(row.Reactions) != "[]" {
+			dataset.dropped.ReactionsBearingMessages++
+		}
+		if strings.TrimSpace(row.Transcript) != "" || row.TranscribedAtMS != 0 ||
+			strings.TrimSpace(row.TranscriptModel) != "" {
+			dataset.dropped.TranscriptBearingMessages++
+		}
+		if strings.HasPrefix(row.ID, "signal:local:") {
+			dataset.signalLocalRows++
+		}
+	}
+	if err := closeRows(rows); err != nil {
+		return fmt.Errorf("read messages: %w", err)
+	}
+
+	rows, err = database.QueryContext(ctx, `
+		SELECT contact_id, name, number FROM contacts ORDER BY contact_id
+	`)
+	if err != nil {
+		return fmt.Errorf("read contacts: %w", err)
+	}
+	for rows.Next() {
+		var row legacyContact
+		if err := rows.Scan(&row.ID, &row.Name, &row.Number); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan contact: %w", err)
+		}
+		dataset.contacts = append(dataset.contacts, row)
+	}
+	if err := closeRows(rows); err != nil {
+		return fmt.Errorf("read contacts: %w", err)
+	}
+
+	rows, err = database.QueryContext(ctx, `
+		SELECT unified_id, display_name, identifiers
+		FROM unified_contacts ORDER BY unified_id
+	`)
+	if err != nil {
+		return fmt.Errorf("read unified contacts: %w", err)
+	}
+	for rows.Next() {
+		var row legacyUnifiedContact
+		if err := rows.Scan(&row.ID, &row.DisplayName, &row.IdentifiersJSON); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan unified contact: %w", err)
+		}
+		dataset.unified = append(dataset.unified, row)
+	}
+	if err := closeRows(rows); err != nil {
+		return fmt.Errorf("read unified contacts: %w", err)
+	}
+
+	rows, err = database.QueryContext(ctx, `
+		SELECT id, conversation_id, body, reply_to_id, send_at, status, attempts,
+		       last_error, created_at, sent_message_id, media_data, media_filename,
+		       media_mime
+		FROM scheduled_messages
+		ORDER BY id
+	`)
+	if err != nil {
+		return fmt.Errorf("read scheduled messages: %w", err)
+	}
+	for rows.Next() {
+		var row legacyScheduledMessage
+		if err := rows.Scan(
+			&row.ID, &row.ConversationID, &row.Body, &row.ReplyToID, &row.SendAtMS,
+			&row.Status, &row.Attempts, &row.LastError, &row.CreatedAtMS,
+			&row.SentMessageID, &row.MediaData, &row.MediaFilename, &row.MediaMIME,
+		); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan scheduled message: %w", err)
+		}
+		row.Status = strings.ToLower(strings.TrimSpace(row.Status))
+		dataset.scheduled = append(dataset.scheduled, row)
+		dataset.scheduleByStatus[row.Status]++
+	}
+	if err := closeRows(rows); err != nil {
+		return fmt.Errorf("read scheduled messages: %w", err)
+	}
+
+	for _, table := range []string{
+		"conversations", "messages", "contacts", "contact_avatars", "drafts",
+		"outgoing_send_keys", "unified_contacts", "scheduled_messages", "contact_meta", "tabs",
+	} {
+		var count int64
+		if err := database.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&count); err != nil {
+			return fmt.Errorf("count %s: %w", table, err)
+		}
+		dataset.tableCounts[table] = count
+	}
+	dataset.dropped.ContactAvatars = dataset.tableCounts["contact_avatars"]
+	dataset.dropped.Drafts = dataset.tableCounts["drafts"]
+	dataset.dropped.ContactMetaCRM = dataset.tableCounts["contact_meta"]
+	dataset.dropped.OutgoingSendKeys = dataset.tableCounts["outgoing_send_keys"]
+	dataset.dropped.Tabs = dataset.tableCounts["tabs"]
+	return nil
+}
+
+func validateLegacyRelationships(dataset legacyDataset) error {
+	conversations := make(map[string]string, len(dataset.conversations))
+	for _, conversation := range dataset.conversations {
+		if strings.TrimSpace(conversation.ID) == "" {
+			return fmt.Errorf("conversation has an empty primary key")
+		}
+		platform := normalizeLegacyPlatform(conversation.Platform)
+		if _, err := accountForPlatform(platform); err != nil {
+			return err
+		}
+		conversations[conversation.ID] = platform
+	}
+	for _, message := range dataset.messages {
+		if strings.TrimSpace(message.ID) == "" {
+			return fmt.Errorf("message has an empty primary key")
+		}
+		platform := normalizeLegacyPlatform(message.Platform)
+		if _, err := accountForPlatform(platform); err != nil {
+			return err
+		}
+		conversationPlatform, ok := conversations[message.ConversationID]
+		if !ok {
+			return fmt.Errorf("message %q references missing conversation %q", message.ID, message.ConversationID)
+		}
+		if platform != conversationPlatform {
+			return fmt.Errorf(
+				"message %q platform %q does not match conversation %q platform %q",
+				message.ID, platform, message.ConversationID, conversationPlatform,
+			)
+		}
+		if message.TimestampMS <= 0 {
+			return fmt.Errorf("message %q has non-positive timestamp_ms %d", message.ID, message.TimestampMS)
+		}
+		if strings.TrimSpace(deriveRemoteMessageID(message)) == "" {
+			return fmt.Errorf("message %q maps to an empty remote_message_id", message.ID)
+		}
+	}
+	for _, scheduled := range dataset.scheduled {
+		if strings.TrimSpace(scheduled.ID) == "" {
+			return fmt.Errorf("scheduled message has an empty primary key")
+		}
+		if _, ok := conversations[scheduled.ConversationID]; !ok {
+			return fmt.Errorf("scheduled message %q references missing conversation %q", scheduled.ID, scheduled.ConversationID)
+		}
+		switch scheduled.Status {
+		case "pending", "sending", "sent", "failed", "canceled":
+		default:
+			return fmt.Errorf("scheduled message %q has unsupported status %q", scheduled.ID, scheduled.Status)
+		}
+		if (scheduled.Status == "pending" || scheduled.Status == "sending") && scheduled.SendAtMS <= 0 {
+			return fmt.Errorf("scheduled message %q has non-positive send_at %d", scheduled.ID, scheduled.SendAtMS)
+		}
+	}
+	return nil
+}
+
+func validateLegacySchema(ctx context.Context, database *sql.DB) error {
+	tables := make([]string, 0, len(requiredLegacyColumns))
+	for table := range requiredLegacyColumns {
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+	for _, table := range tables {
+		rows, err := database.QueryContext(ctx, "PRAGMA table_info("+table+")")
+		if err != nil {
+			return fmt.Errorf("inspect legacy table %s: %w", table, err)
+		}
+		columns := map[string]bool{}
+		for rows.Next() {
+			var cid, notNull, primaryKey int64
+			var name, dataType string
+			var defaultValue any
+			if err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultValue, &primaryKey); err != nil {
+				rows.Close()
+				return fmt.Errorf("inspect legacy table %s: %w", table, err)
+			}
+			columns[name] = true
+		}
+		if err := closeRows(rows); err != nil {
+			return fmt.Errorf("inspect legacy table %s: %w", table, err)
+		}
+		if len(columns) == 0 {
+			return fmt.Errorf("unsupported legacy schema: table %s is missing", table)
+		}
+		for _, column := range requiredLegacyColumns[table] {
+			if !columns[column] {
+				return fmt.Errorf("unsupported legacy schema: column %s.%s is missing", table, column)
+			}
+		}
+	}
+	return nil
+}
+
+func quickCheck(ctx context.Context, database *sql.DB) (string, error) {
+	rows, err := database.QueryContext(ctx, "PRAGMA quick_check")
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	var results []string
+	for rows.Next() {
+		var result string
+		if err := rows.Scan(&result); err != nil {
+			return "", err
+		}
+		results = append(results, result)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if len(results) == 0 {
+		return "", fmt.Errorf("PRAGMA quick_check returned no rows")
+	}
+	return strings.Join(results, "; "), nil
+}
+
+func databaseSchemaFingerprint(ctx context.Context, database *sql.DB) (string, error) {
+	rows, err := database.QueryContext(ctx, `
+		SELECT type, name, tbl_name, IFNULL(sql, '')
+		FROM sqlite_schema
+		WHERE name NOT LIKE 'sqlite_%'
+		ORDER BY type, name, tbl_name
+	`)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	hash := sha256.New()
+	for rows.Next() {
+		var kind, name, table, statement string
+		if err := rows.Scan(&kind, &name, &table, &statement); err != nil {
+			return "", err
+		}
+		for _, field := range []string{kind, name, table, statement} {
+			_, _ = io.WriteString(hash, field)
+			_, _ = hash.Write([]byte{0x1f})
+		}
+		_, _ = hash.Write([]byte{'\n'})
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func fileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.New()
+	_, copyErr := io.Copy(hash, file)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return "", copyErr
+	}
+	if closeErr != nil {
+		return "", closeErr
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func readOnlySQLiteDSN(path string) string {
+	return (&url.URL{
+		Scheme: "file", Path: filepath.ToSlash(path), RawQuery: "mode=ro",
+	}).String()
+}
+
+func stageLegacySourceSnapshot(
+	directory string,
+	evidence []SourceFileEvidence,
+) (string, func() error, error) {
+	if err := os.Mkdir(directory, 0o700); err != nil {
+		return "", func() error { return nil }, err
+	}
+	cleanup := func() error { return os.RemoveAll(directory) }
+	snapshotPath := filepath.Join(directory, "messages.db")
+	for _, file := range evidence {
+		if !file.ExistsBefore || (file.Role != "database" && file.Role != "wal") {
+			continue
+		}
+		destination := snapshotPath
+		if file.Role == "wal" {
+			destination += "-wal"
+		}
+		if err := copySourceSnapshotFile(file.Path, destination); err != nil {
+			return snapshotStageFailure(cleanup, fmt.Errorf("copy %s: %w", file.Role, err))
+		}
+		copied, err := inspectSourceFile(destination)
+		if err != nil {
+			return snapshotStageFailure(cleanup, fmt.Errorf("verify copied %s: %w", file.Role, err))
+		}
+		if copied.size != file.SizeBefore || copied.sha256 != file.SHA256Before {
+			return snapshotStageFailure(cleanup, fmt.Errorf("%s changed while its snapshot was copied", file.Role))
+		}
+	}
+	return snapshotPath, cleanup, nil
+}
+
+func snapshotStageFailure(
+	cleanup func() error,
+	stageErr error,
+) (string, func() error, error) {
+	cleanupErr := cleanup()
+	return "", cleanup, errors.Join(stageErr, wrapSnapshotCleanupError(cleanupErr))
+}
+
+func wrapSnapshotCleanupError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("remove partial staged legacy snapshot: %w", err)
+}
+
+func copySourceSnapshotFile(sourcePath, destinationPath string) (returnErr error) {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	destination, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := destination.Close(); returnErr == nil {
+			returnErr = closeErr
+		}
+	}()
+	if _, err := io.Copy(destination, source); err != nil {
+		return err
+	}
+	return destination.Sync()
+}
+
+func captureSourceFileEvidence(databasePath string) ([]SourceFileEvidence, error) {
+	files := []SourceFileEvidence{
+		{Role: "database", Path: databasePath},
+		{Role: "wal", Path: databasePath + "-wal"},
+		{Role: "shm", Path: databasePath + "-shm"},
+	}
+	for index := range files {
+		state, err := inspectSourceFile(files[index].Path)
+		if err != nil {
+			return nil, fmt.Errorf("inspect %s %s: %w", files[index].Role, files[index].Path, err)
+		}
+		files[index].ExistsBefore = state.exists
+		files[index].SizeBefore = state.size
+		files[index].SHA256Before = state.sha256
+		files[index].ModeBefore = state.mode
+		files[index].ModifiedAtNSBefore = state.modifiedAtNS
+	}
+	if !files[0].ExistsBefore {
+		return nil, fmt.Errorf("database does not exist: %s", databasePath)
+	}
+	return files, nil
+}
+
+func completeSourceFileEvidence(report *SourceReport) (bool, error) {
+	if report == nil || len(report.Files) != 3 {
+		return false, fmt.Errorf("source database family evidence is incomplete")
+	}
+	allUnchanged := true
+	for index := range report.Files {
+		file := &report.Files[index]
+		state, err := inspectSourceFile(file.Path)
+		if err != nil {
+			return false, fmt.Errorf("inspect %s %s after transform: %w", file.Role, file.Path, err)
+		}
+		file.ExistsAfter = state.exists
+		file.SizeAfter = state.size
+		file.SHA256After = state.sha256
+		file.ModeAfter = state.mode
+		file.ModifiedAtNSAfter = state.modifiedAtNS
+		file.Unchanged = file.ExistsBefore == file.ExistsAfter &&
+			file.SizeBefore == file.SizeAfter &&
+			file.SHA256Before == file.SHA256After &&
+			file.ModeBefore == file.ModeAfter &&
+			file.ModifiedAtNSBefore == file.ModifiedAtNSAfter
+		allUnchanged = allUnchanged && file.Unchanged
+		if file.Role == "database" {
+			report.SHA256After = file.SHA256After
+		}
+	}
+	report.Unchanged = allUnchanged
+	return allUnchanged, nil
+}
+
+type sourceFileState struct {
+	exists       bool
+	size         int64
+	sha256       string
+	mode         string
+	modifiedAtNS int64
+}
+
+func inspectSourceFile(path string) (sourceFileState, error) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return sourceFileState{}, nil
+	}
+	if err != nil {
+		return sourceFileState{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return sourceFileState{}, fmt.Errorf("not a regular file")
+	}
+	hash, err := fileSHA256(path)
+	if err != nil {
+		return sourceFileState{}, err
+	}
+	return sourceFileState{
+		exists: true, size: info.Size(), sha256: hash,
+		mode: fmt.Sprintf("%04o", info.Mode().Perm()), modifiedAtNS: info.ModTime().UnixNano(),
+	}, nil
+}
+
+func closeRows(rows *sql.Rows) error {
+	iterationErr := rows.Err()
+	closeErr := rows.Close()
+	if iterationErr != nil {
+		return iterationErr
+	}
+	return closeErr
+}

--- a/internal/migration/transform.go
+++ b/internal/migration/transform.go
@@ -1,0 +1,1182 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/whatsappmedia"
+)
+
+const scheduledMediaMaxBytes int64 = 128 << 20
+
+const legacySnapshotSuffix = ".source"
+
+// Options names the immutable source and the staged v2 destinations. Transform
+// never publishes the staged paths; the CLI owns the final atomic rename.
+type Options struct {
+	SourcePath      string
+	TempStorePath   string
+	TempBlobPath    string
+	TargetPath      string
+	TargetStorePath string
+	Check           bool
+}
+
+type accountSpec struct {
+	Platform    string
+	AccountID   string
+	BridgeKey   string
+	DisplayName string
+	Mode        sqlite.AccountMode
+}
+
+var platformAccounts = map[string]accountSpec{
+	"sms": {
+		Platform: "sms", AccountID: "google-primary", BridgeKey: "google_messages",
+		DisplayName: "Google Messages", Mode: sqlite.AccountModeLive,
+	},
+	"whatsapp": {
+		Platform: "whatsapp", AccountID: "whatsapp-primary", BridgeKey: "whatsmeow",
+		DisplayName: "WhatsApp", Mode: sqlite.AccountModeLive,
+	},
+	"signal": {
+		Platform: "signal", AccountID: "signal-primary", BridgeKey: "signal_cli",
+		DisplayName: "Signal", Mode: sqlite.AccountModeLive,
+	},
+	"gchat": {
+		Platform: "gchat", AccountID: "gchat-archive", BridgeKey: "gchat",
+		DisplayName: "Google Chat archive", Mode: sqlite.AccountModeArchive,
+	},
+	"imessage": {
+		Platform: "imessage", AccountID: "imessage-archive", BridgeKey: "imessage",
+		DisplayName: "iMessage archive", Mode: sqlite.AccountModeArchive,
+	},
+}
+
+type identityKey struct {
+	AccountID string
+	Kind      string
+	Canonical string
+}
+
+type identityCandidate struct {
+	Key         identityKey
+	Raw         string
+	DisplayName string
+	IsSelf      bool
+	Priority    int
+}
+
+type participantPlan struct {
+	Identity identityKey
+	Name     string
+}
+
+type conversationPlan struct {
+	Legacy       legacyConversation
+	Account      accountSpec
+	V2ID         string
+	Participants []participantPlan
+}
+
+type unifiedIdentifier struct {
+	Platform string `json:"platform"`
+	Value    string `json:"value"`
+}
+
+type unifiedContactPlan struct {
+	Legacy     legacyUnifiedContact
+	PersonID   string
+	Identities []identityKey
+}
+
+type legacyParticipant struct {
+	Name      string `json:"name"`
+	Number    string `json:"number"`
+	Phone     string `json:"phone"`
+	Email     string `json:"email"`
+	ID        string `json:"id"`
+	ContactID string `json:"contact_id"`
+	IsMe      bool   `json:"is_me"`
+	IsMeCamel bool   `json:"isMe"`
+}
+
+type expectedMessage struct {
+	Legacy   legacyMessage
+	Platform string
+	Account  accountSpec
+	V2ID     string
+	RemoteID string
+	MediaID  string
+}
+
+type scheduledBlob struct {
+	OutboxID string
+	Ref      blob.BlobRef
+}
+
+type transformState struct {
+	baseTimestampMS int64
+	accounts        map[string]accountSpec
+	identities      map[identityKey]*identityCandidate
+	conversations   map[string]*conversationPlan
+	unified         []unifiedContactPlan
+
+	contactIdentityKeys       map[identityKey]struct{}
+	contactRowsMapped         int64
+	expectedLinks             int64
+	expectedParticipants      int64
+	expectedHistory           map[string]expectedMessage
+	expectedHistoryByPlatform map[string]map[string]struct{}
+	scheduledMessages         map[string]struct{}
+	expectedCursors           int64
+	expectedPendingMedia      int64
+	scheduledBlobs            []scheduledBlob
+}
+
+// Transform creates and validates a complete staged v2 store using only
+// repository writers. A failed validation returns both the report and an
+// error wrapping ErrValidation so callers can still emit the evidence.
+func Transform(ctx context.Context, options Options) (report Report, returnErr error) {
+	report = Report{
+		Format:            ReportFormat,
+		Check:             options.Check,
+		TableCounts:       map[string]TableReconciliation{},
+		PlatformCounts:    map[string]PlatformReconciliation{},
+		Warnings:          []string{},
+		MessageCollisions: []MessageCollision{},
+		SampledHashes:     []SampledHash{},
+		Target: TargetReport{
+			Path: options.TargetPath, DatabasePath: options.TargetStorePath,
+			Counts: map[string]int64{}, MigrationChecksums: []string{},
+		},
+	}
+	if ctx == nil {
+		return report, fmt.Errorf("%w: context is nil", ErrTransform)
+	}
+	for name, value := range map[string]string{
+		"source path": options.SourcePath, "temporary store path": options.TempStorePath,
+		"temporary blob path": options.TempBlobPath, "target store path": options.TargetStorePath,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return report, fmt.Errorf("%w: %s is empty", ErrTransform, name)
+		}
+	}
+	if err := requireAbsent(options.TempStorePath); err != nil {
+		return report, fmt.Errorf("%w: temporary store: %v", ErrTransform, err)
+	}
+	if err := requireAbsent(options.TempBlobPath); err != nil {
+		return report, fmt.Errorf("%w: temporary blob store: %v", ErrTransform, err)
+	}
+	tempSourcePath := options.TempStorePath + legacySnapshotSuffix
+	if err := requireAbsent(tempSourcePath); err != nil {
+		return report, fmt.Errorf("%w: temporary legacy snapshot: %v", ErrTransform, err)
+	}
+	stageParent := filepath.Dir(options.TempStorePath)
+	if err := os.MkdirAll(stageParent, 0o700); err != nil {
+		return report, fmt.Errorf("%w: create staged store directory: %v", ErrTransform, err)
+	}
+	if err := os.Chmod(stageParent, 0o700); err != nil {
+		return report, fmt.Errorf("%w: secure staged store directory: %v", ErrTransform, err)
+	}
+
+	dataset, sourceReport, err := loadLegacySource(ctx, options.SourcePath, tempSourcePath)
+	report.Source = sourceReport
+	if err != nil {
+		return report, err
+	}
+	report.Dropped = dataset.dropped
+	report.SignalLocalRows = dataset.signalLocalRows
+	report.ReadState = ReadStateReport{
+		LossyWarning:                 "legacy read state was lossy",
+		ConversationsWithUnreadCount: dataset.unreadRows,
+	}
+	report.Schedule = scheduleReport(dataset)
+	report.Media.LegacyAttachments = dataset.mediaRows
+	appendRequiredWarnings(&report)
+
+	state, err := buildTransformState(dataset, &report)
+	if err != nil {
+		return report, fmt.Errorf("%w: plan transform: %v", ErrSource, err)
+	}
+
+	target, err := sqlite.Open(options.TempStorePath)
+	if err != nil {
+		return report, fmt.Errorf("%w: initialize merged v2 schema: %v", ErrTransform, err)
+	}
+	targetOpen := true
+	defer func() {
+		if targetOpen {
+			if closeErr := target.Close(); closeErr != nil && returnErr == nil {
+				returnErr = fmt.Errorf("%w: close staged v2 store: %v", ErrTransform, closeErr)
+			}
+		}
+	}()
+	blobs, err := blob.New(options.TempBlobPath)
+	if err != nil {
+		return report, fmt.Errorf("%w: initialize staged blob store: %v", ErrTransform, err)
+	}
+
+	clockMS := state.baseTimestampMS
+	now := func() time.Time { return time.UnixMilli(clockMS) }
+	messageRepository, err := sqlite.NewMessageRepository(target, now)
+	if err != nil {
+		return report, fmt.Errorf("%w: initialize message importer: %v", ErrTransform, err)
+	}
+	outboxRepository, err := sqlite.NewOutboxRepository(target, now)
+	if err != nil {
+		return report, fmt.Errorf("%w: initialize outbox importer: %v", ErrTransform, err)
+	}
+
+	if err := writeAccounts(target, state); err != nil {
+		return report, fmt.Errorf("%w: %v", ErrTransform, err)
+	}
+	if err := writeIdentities(target, state); err != nil {
+		return report, fmt.Errorf("%w: %v", ErrTransform, err)
+	}
+	if err := writePeople(target, state); err != nil {
+		return report, fmt.Errorf("%w: %v", ErrTransform, err)
+	}
+	if err := writeConversations(target, state); err != nil {
+		return report, fmt.Errorf("%w: %v", ErrTransform, err)
+	}
+	if err := writeHistory(ctx, messageRepository, dataset, state, &clockMS, &report); err != nil {
+		return report, fmt.Errorf("%w: %v", ErrTransform, err)
+	}
+	if err := writeScheduled(
+		ctx, messageRepository, outboxRepository, blobs, dataset, state, &clockMS, &report,
+	); err != nil {
+		return report, fmt.Errorf("%w: %v", ErrTransform, err)
+	}
+	if err := writeReadCursors(target, dataset, state, &report); err != nil {
+		return report, fmt.Errorf("%w: %v", ErrTransform, err)
+	}
+
+	storeID, err := target.StoreInstanceID()
+	if err != nil {
+		return report, fmt.Errorf("%w: read staged store ID: %v", ErrTransform, err)
+	}
+	report.Target.StoreInstanceID = storeID
+	if err := target.Close(); err != nil {
+		return report, fmt.Errorf("%w: close staged v2 store: %v", ErrTransform, err)
+	}
+	targetOpen = false
+	if err := checkpointAndSyncSQLite(ctx, options.TempStorePath); err != nil {
+		return report, fmt.Errorf("%w: finalize staged v2 database: %v", ErrTransform, err)
+	}
+
+	if err := validateTarget(ctx, options, dataset, state, &report); err != nil {
+		return report, err
+	}
+	report.OK = true
+	return report, nil
+}
+
+func buildTransformState(dataset legacyDataset, report *Report) (*transformState, error) {
+	state := &transformState{
+		baseTimestampMS: minLegacyTimestamp(dataset),
+		accounts:        map[string]accountSpec{}, identities: map[identityKey]*identityCandidate{},
+		conversations:             map[string]*conversationPlan{},
+		contactIdentityKeys:       map[identityKey]struct{}{},
+		expectedHistory:           map[string]expectedMessage{},
+		expectedHistoryByPlatform: map[string]map[string]struct{}{},
+		scheduledMessages:         map[string]struct{}{},
+	}
+
+	for _, legacy := range dataset.conversations {
+		account, err := accountForPlatform(normalizeLegacyPlatform(legacy.Platform))
+		if err != nil {
+			return nil, err
+		}
+		state.accounts[account.Platform] = account
+		plan := &conversationPlan{
+			Legacy: legacy, Account: account,
+			V2ID: deriveID("conversation", account.AccountID, legacy.ID),
+		}
+		var participants []legacyParticipant
+		if err := json.Unmarshal([]byte(legacy.ParticipantsJSON), &participants); err != nil {
+			return nil, fmt.Errorf("conversation %q participants JSON: %w", legacy.ID, err)
+		}
+		seen := map[identityKey]bool{}
+		for index, participant := range participants {
+			value := firstNonEmpty(
+				participant.Number, participant.Phone, participant.Email,
+				participant.ID, participant.ContactID,
+			)
+			if strings.TrimSpace(value) == "" {
+				// Never key an identity by display name. A conversation-scoped
+				// synthetic value preserves the participant without merging names.
+				if strings.TrimSpace(participant.Name) == "" {
+					continue
+				}
+				value = fmt.Sprintf("legacy-participant:%s:%d", legacy.ID, index)
+			}
+			key, err := addIdentity(
+				state, account, value, participant.Name,
+				participant.IsMe || participant.IsMeCamel || strings.EqualFold(strings.TrimSpace(value), "me"), 10,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("conversation %q participant %d: %w", legacy.ID, index, err)
+			}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			plan.Participants = append(plan.Participants, participantPlan{Identity: key, Name: participant.Name})
+		}
+		state.expectedParticipants += int64(len(plan.Participants))
+		state.conversations[legacy.ID] = plan
+	}
+
+	for _, message := range dataset.messages {
+		account, _ := accountForPlatform(normalizeLegacyPlatform(message.Platform))
+		state.accounts[account.Platform] = account
+		if strings.TrimSpace(message.SenderNumber) != "" {
+			if _, err := addIdentity(
+				state, account, message.SenderNumber, message.SenderName, message.IsFromMe, 20,
+			); err != nil {
+				return nil, fmt.Errorf("message %q sender: %w", message.ID, err)
+			}
+		}
+	}
+
+	if len(dataset.contacts) > 0 {
+		account, _ := accountForPlatform("sms")
+		state.accounts[account.Platform] = account
+		for _, contact := range dataset.contacts {
+			if strings.TrimSpace(contact.Number) == "" {
+				report.Warnings = append(report.Warnings,
+					fmt.Sprintf("contact %s had no number and could not produce an identity", contact.ID))
+				continue
+			}
+			key, err := addIdentity(state, account, contact.Number, contact.Name, false, 30)
+			if err != nil {
+				return nil, fmt.Errorf("contact %q: %w", contact.ID, err)
+			}
+			state.contactIdentityKeys[key] = struct{}{}
+			state.contactRowsMapped++
+		}
+	}
+
+	identityOwners := map[identityKey]string{}
+	for _, legacy := range dataset.unified {
+		if strings.TrimSpace(legacy.ID) == "" {
+			return nil, fmt.Errorf("unified contact has an empty ID")
+		}
+		plan := unifiedContactPlan{
+			Legacy:   legacy,
+			PersonID: deriveID("person", "", legacy.ID),
+		}
+		var identifiers []unifiedIdentifier
+		if err := json.Unmarshal([]byte(legacy.IdentifiersJSON), &identifiers); err != nil {
+			return nil, fmt.Errorf("unified contact %q identifiers JSON: %w", legacy.ID, err)
+		}
+		seen := map[identityKey]bool{}
+		for index, identifier := range identifiers {
+			if strings.TrimSpace(identifier.Value) == "" {
+				return nil, fmt.Errorf("unified contact %q identifier %d is empty", legacy.ID, index)
+			}
+			account, err := accountForPlatform(normalizeLegacyPlatform(identifier.Platform))
+			if err != nil {
+				return nil, fmt.Errorf("unified contact %q identifier %d: %w", legacy.ID, index, err)
+			}
+			state.accounts[account.Platform] = account
+			key, err := addIdentity(state, account, identifier.Value, legacy.DisplayName, false, 40)
+			if err != nil {
+				return nil, fmt.Errorf("unified contact %q identifier %d: %w", legacy.ID, index, err)
+			}
+			if seen[key] {
+				continue
+			}
+			if owner, exists := identityOwners[key]; exists && owner != legacy.ID {
+				return nil, fmt.Errorf(
+					"explicit identity %q is owned by both unified contacts %q and %q",
+					key.Canonical, owner, legacy.ID,
+				)
+			}
+			identityOwners[key] = legacy.ID
+			seen[key] = true
+			plan.Identities = append(plan.Identities, key)
+			state.expectedLinks++
+		}
+		state.unified = append(state.unified, plan)
+	}
+	return state, nil
+}
+
+func writeAccounts(target *sqlite.Store, state *transformState) error {
+	platforms := sortedAccountPlatforms(state.accounts)
+	for _, platform := range platforms {
+		account := state.accounts[platform]
+		if err := target.UpsertAccount(sqlite.Account{
+			AccountID: account.AccountID, BridgeKey: account.BridgeKey,
+			DisplayName: account.DisplayName, Mode: account.Mode, Enabled: true,
+			ConfigJSON: "{}", CreatedAtMS: state.baseTimestampMS, UpdatedAtMS: state.baseTimestampMS,
+		}); err != nil {
+			return fmt.Errorf("upsert %s account: %w", platform, err)
+		}
+		deviceID := deriveID("device", account.AccountID, account.AccountID+"\x1flocal")
+		if err := target.UpsertDevice(sqlite.Device{
+			DeviceID: deviceID, AccountID: account.AccountID,
+			Kind: sqlite.DeviceKindLocalInstallation, DisplayName: "OpenMessage",
+			State: sqlite.DeviceStateActive, IsCurrent: true,
+			CreatedAtMS: state.baseTimestampMS, UpdatedAtMS: state.baseTimestampMS,
+		}); err != nil {
+			return fmt.Errorf("upsert %s migration device: %w", platform, err)
+		}
+	}
+	return nil
+}
+
+func writeIdentities(target *sqlite.Store, state *transformState) error {
+	keys := make([]identityKey, 0, len(state.identities))
+	for key := range state.identities {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return identityID(keys[i]) < identityID(keys[j]) })
+	for _, key := range keys {
+		candidate := state.identities[key]
+		if err := target.UpsertIdentity(sqlite.Identity{
+			IdentityID: identityID(key), AccountID: key.AccountID,
+			Kind: sqlite.IdentityKind(key.Kind), CanonicalValue: key.Canonical,
+			RawValue: candidate.Raw, DisplayName: candidate.DisplayName,
+			IsSelf: candidate.IsSelf, MetadataJSON: "{}",
+			CreatedAtMS: state.baseTimestampMS, UpdatedAtMS: state.baseTimestampMS,
+		}); err != nil {
+			return fmt.Errorf("upsert identity %q: %w", key.Canonical, err)
+		}
+	}
+	return nil
+}
+
+func writePeople(target *sqlite.Store, state *transformState) error {
+	for _, plan := range state.unified {
+		if err := target.CreatePerson(sqlite.Person{
+			PersonID: plan.PersonID, DisplayName: plan.Legacy.DisplayName,
+			SortName:    strings.ToLower(strings.TrimSpace(plan.Legacy.DisplayName)),
+			CreatedAtMS: state.baseTimestampMS, UpdatedAtMS: state.baseTimestampMS,
+		}); err != nil {
+			return fmt.Errorf("create person for unified contact %q: %w", plan.Legacy.ID, err)
+		}
+		for index, key := range plan.Identities {
+			if err := target.LinkIdentityToPerson(sqlite.PersonIdentity{
+				IdentityID: identityID(key), PersonID: plan.PersonID,
+				Provenance: sqlite.IdentityProvenanceExplicit, Confidence: 1,
+				IsPrimary: index == 0, LinkedAtMS: state.baseTimestampMS,
+			}); err != nil {
+				return fmt.Errorf("link unified contact %q identity %q: %w", plan.Legacy.ID, key.Canonical, err)
+			}
+		}
+	}
+	return nil
+}
+
+func writeConversations(target *sqlite.Store, state *transformState) error {
+	ids := make([]string, 0, len(state.conversations))
+	for id := range state.conversations {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, legacyID := range ids {
+		plan := state.conversations[legacyID]
+		createdAt, lastMessageAt := conversationTimes(plan.Legacy, state.baseTimestampMS)
+		kind := sqlite.ConversationKindDirect
+		if plan.Legacy.IsGroup {
+			kind = sqlite.ConversationKindGroup
+		}
+		notification := sqlite.NotificationMode(strings.ToLower(strings.TrimSpace(plan.Legacy.NotificationMode)))
+		switch notification {
+		case sqlite.NotificationModeAll, sqlite.NotificationModeMentions, sqlite.NotificationModeMuted:
+		default:
+			notification = sqlite.NotificationModeAll
+		}
+		var archivedAt *int64
+		if strings.EqualFold(strings.TrimSpace(plan.Legacy.Tab), "archive") {
+			value := lastMessageAt
+			if value == 0 {
+				value = createdAt
+			}
+			archivedAt = &value
+		}
+		if err := target.UpsertConversation(sqlite.Conversation{
+			ConversationID: plan.V2ID, AccountID: plan.Account.AccountID,
+			RemoteConversationID: normalizeRemoteConversationID(plan.Account.Platform, plan.Legacy.ID),
+			Kind:                 kind, Title: plan.Legacy.Name, NotificationMode: notification,
+			IsFavorite: plan.Legacy.IsFavorite, ArchivedAtMS: archivedAt,
+			LastMessageAtMS: lastMessageAt, MetadataJSON: "{}",
+			CreatedAtMS: createdAt, UpdatedAtMS: maxInt64(createdAt, lastMessageAt),
+		}); err != nil {
+			return fmt.Errorf("upsert conversation %q: %w", legacyID, err)
+		}
+		participants := make([]sqlite.ConversationParticipant, 0, len(plan.Participants))
+		for _, participant := range plan.Participants {
+			participants = append(participants, sqlite.ConversationParticipant{
+				AccountID: plan.Account.AccountID, ConversationID: plan.V2ID,
+				IdentityID: identityID(participant.Identity), Role: sqlite.ParticipantRoleMember,
+				DisplayName: participant.Name, IsActive: true,
+			})
+		}
+		if err := target.ReplaceConversationParticipants(plan.V2ID, participants); err != nil {
+			return fmt.Errorf("replace conversation %q participants: %w", legacyID, err)
+		}
+	}
+	return nil
+}
+
+func writeHistory(
+	ctx context.Context,
+	repository *sqlite.MessageRepository,
+	dataset legacyDataset,
+	state *transformState,
+	clockMS *int64,
+	report *Report,
+) error {
+	remoteByLegacyID := make(map[string]string, len(dataset.messages))
+	for _, message := range dataset.messages {
+		remoteByLegacyID[message.ID] = deriveRemoteMessageID(message)
+	}
+	collisionGroups := map[string][]string{}
+	for _, legacy := range dataset.messages {
+		conversation := state.conversations[legacy.ConversationID]
+		remoteID := deriveRemoteMessageID(legacy)
+		messageID := deriveID(
+			"message", conversation.Account.AccountID,
+			legacy.ConversationID+"\x1f"+remoteID,
+		)
+		collisionKey := conversation.Account.AccountID + "\x1f" + conversation.V2ID + "\x1f" + remoteID
+		collisionGroups[collisionKey] = append(collisionGroups[collisionKey], legacy.ID)
+		state.expectedHistory[messageID] = expectedMessage{
+			Legacy: legacy, Platform: conversation.Account.Platform, Account: conversation.Account,
+			V2ID: messageID, RemoteID: remoteID, MediaID: legacy.MediaID,
+		}
+		if state.expectedHistoryByPlatform[conversation.Account.Platform] == nil {
+			state.expectedHistoryByPlatform[conversation.Account.Platform] = map[string]struct{}{}
+		}
+		state.expectedHistoryByPlatform[conversation.Account.Platform][messageID] = struct{}{}
+
+		var senderID *string
+		if !legacy.IsFromMe && strings.TrimSpace(legacy.SenderNumber) != "" {
+			key, err := identityKeyFor(conversation.Account, legacy.SenderNumber)
+			if err != nil {
+				return fmt.Errorf("message %q sender identity: %w", legacy.ID, err)
+			}
+			value := identityID(key)
+			senderID = &value
+		}
+		var replyTo *string
+		if strings.TrimSpace(legacy.ReplyToID) != "" {
+			value := remoteByLegacyID[legacy.ReplyToID]
+			if value == "" {
+				value = stripPlatformPrefix(legacy.ReplyToID)
+			}
+			if strings.TrimSpace(value) != "" {
+				replyTo = &value
+			}
+		}
+		direction := sqlite.MessageDirectionIncoming
+		if legacy.IsFromMe {
+			direction = sqlite.MessageDirectionOutgoing
+		}
+		projection := sqlite.MessageProjection{Message: sqlite.Message{
+			MessageID: messageID, ConversationID: conversation.V2ID,
+			AccountID: conversation.Account.AccountID, RemoteMessageID: remoteID,
+			SenderIdentityID: senderID, Direction: direction, Body: legacy.Body,
+			ReplyToRemoteID: replyTo, State: sqlite.MessageStateActive,
+			OccurredAtMS: legacy.TimestampMS,
+		}}
+		if strings.TrimSpace(legacy.MediaID) != "" {
+			attachment, err := packLegacyAttachment(legacy, report)
+			if err != nil {
+				return fmt.Errorf("message %q attachment: %w", legacy.ID, err)
+			}
+			projection.Attachments = []sqlite.MessageAttachment{attachment}
+		}
+		*clockMS = legacy.TimestampMS
+		if err := repository.ImportMessage(ctx, projection); err != nil {
+			return fmt.Errorf("import message %q: %w", legacy.ID, err)
+		}
+	}
+
+	for key, ids := range collisionGroups {
+		if len(ids) < 2 {
+			continue
+		}
+		parts := strings.Split(key, "\x1f")
+		sort.Strings(ids)
+		report.MessageCollisions = append(report.MessageCollisions, MessageCollision{
+			AccountID: parts[0], ConversationID: legacyConversationIDForV2(state, parts[1]),
+			RemoteMessageID: parts[2], LegacyMessageIDs: ids,
+		})
+	}
+	sort.Slice(report.MessageCollisions, func(i, j int) bool {
+		left, right := report.MessageCollisions[i], report.MessageCollisions[j]
+		return left.AccountID+left.ConversationID+left.RemoteMessageID <
+			right.AccountID+right.ConversationID+right.RemoteMessageID
+	})
+	return nil
+}
+
+func writeScheduled(
+	ctx context.Context,
+	messages *sqlite.MessageRepository,
+	outbox *sqlite.OutboxRepository,
+	blobs *blob.BlobStore,
+	dataset legacyDataset,
+	state *transformState,
+	clockMS *int64,
+	report *Report,
+) error {
+	remoteByLegacyID := make(map[string]string, len(dataset.messages))
+	for _, message := range dataset.messages {
+		remoteByLegacyID[message.ID] = deriveRemoteMessageID(message)
+	}
+	for _, scheduled := range dataset.scheduled {
+		conversation := state.conversations[scheduled.ConversationID]
+		switch scheduled.Status {
+		case "sent", "failed", "canceled":
+			continue
+		case "pending", "sending":
+		default:
+			return fmt.Errorf("scheduled message %q has unsupported status %q", scheduled.ID, scheduled.Status)
+		}
+		createdAt := scheduled.CreatedAtMS
+		if createdAt <= 0 {
+			createdAt = state.baseTimestampMS
+		}
+		requestID := deriveID("transport_request", conversation.Account.AccountID, scheduled.ID)
+		localMessageID := deriveID(
+			"message", conversation.Account.AccountID,
+			scheduled.ConversationID+"\x1f"+requestID,
+		)
+		var replyTo *string
+		if strings.TrimSpace(scheduled.ReplyToID) != "" {
+			value := remoteByLegacyID[scheduled.ReplyToID]
+			if value == "" {
+				value = stripPlatformPrefix(scheduled.ReplyToID)
+			}
+			if strings.TrimSpace(value) != "" {
+				replyTo = &value
+			}
+		}
+		message := sqlite.Message{
+			MessageID: localMessageID, ConversationID: conversation.V2ID,
+			AccountID: conversation.Account.AccountID, RemoteMessageID: requestID,
+			Direction: sqlite.MessageDirectionOutgoing, Body: scheduled.Body,
+			ReplyToRemoteID: replyTo, State: sqlite.MessageStateActive,
+			OccurredAtMS: createdAt,
+		}
+		*clockMS = createdAt
+		state.scheduledMessages[localMessageID] = struct{}{}
+		if scheduled.Status == "sending" {
+			if err := messages.ImportMessage(ctx, sqlite.MessageProjection{Message: message}); err != nil {
+				return fmt.Errorf("import ambiguous sending message %q: %w", scheduled.ID, err)
+			}
+			continue
+		}
+
+		item := sqlite.NewOutboxItem{
+			OutboxID:  deriveID("outbox", conversation.Account.AccountID, scheduled.ID),
+			AccountID: conversation.Account.AccountID, ConversationID: conversation.V2ID,
+			IdempotencyKey: scheduled.ID, LocalMessageID: localMessageID,
+			TransportRequestID: requestID, ScheduledForMS: scheduled.SendAtMS,
+		}
+		if strings.TrimSpace(scheduled.MediaFilename) == "" {
+			payloadHash, err := textPayloadHash(scheduled.Body, scheduled.ReplyToID)
+			if err != nil {
+				return fmt.Errorf("hash scheduled text %q: %w", scheduled.ID, err)
+			}
+			item.Kind = sqlite.OutboxKindText
+			item.Operation = "send_text"
+			item.PayloadHash = payloadHash
+			if _, disposition, err := outbox.EnqueueOutgoingMessage(ctx, item, message); err != nil {
+				return fmt.Errorf("enqueue scheduled text %q: %w", scheduled.ID, err)
+			} else if disposition != sqlite.EnqueueInserted {
+				return fmt.Errorf("enqueue scheduled text %q returned disposition %q", scheduled.ID, disposition)
+			}
+			continue
+		}
+
+		mime := strings.TrimSpace(scheduled.MediaMIME)
+		if mime == "" {
+			mime = "application/octet-stream"
+		}
+		ref, err := blobs.Put(ctx, bytes.NewReader(scheduled.MediaData), mime, scheduledMediaMaxBytes)
+		if err != nil {
+			return fmt.Errorf("store scheduled media %q: %w", scheduled.ID, err)
+		}
+		if ref.Size <= 0 {
+			return fmt.Errorf("scheduled media %q is empty", scheduled.ID)
+		}
+		payloadHash, err := mediaPayloadHash(
+			ref.Hash, ref.Size, mime, scheduled.MediaFilename, scheduled.Body, scheduled.ReplyToID,
+		)
+		if err != nil {
+			return fmt.Errorf("hash scheduled media %q: %w", scheduled.ID, err)
+		}
+		item.Kind = sqlite.OutboxKindMedia
+		item.Operation = "send_media"
+		item.PayloadHash = payloadHash
+		if _, disposition, err := outbox.EnqueueOutgoingMediaMessage(
+			ctx, item, message, sqlite.OutboxAttachment{
+				BlobHash: ref.Hash, SizeBytes: ref.Size, MIME: mime,
+				Filename: scheduled.MediaFilename,
+			},
+		); err != nil {
+			return fmt.Errorf("enqueue scheduled media %q: %w", scheduled.ID, err)
+		} else if disposition != sqlite.EnqueueInserted {
+			return fmt.Errorf("enqueue scheduled media %q returned disposition %q", scheduled.ID, disposition)
+		}
+		state.expectedPendingMedia++
+		state.scheduledBlobs = append(state.scheduledBlobs, scheduledBlob{
+			OutboxID: item.OutboxID,
+			Ref:      ref,
+		})
+	}
+	return nil
+}
+
+func writeReadCursors(
+	target *sqlite.Store,
+	dataset legacyDataset,
+	state *transformState,
+	report *Report,
+) error {
+	type messagePosition struct {
+		ID string
+		At int64
+	}
+	byConversation := map[string][]messagePosition{}
+	for _, expected := range state.expectedHistory {
+		byConversation[expected.Legacy.ConversationID] = append(
+			byConversation[expected.Legacy.ConversationID],
+			messagePosition{ID: expected.V2ID, At: expected.Legacy.TimestampMS},
+		)
+	}
+	ids := make([]string, 0, len(state.conversations))
+	for id := range state.conversations {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, legacyID := range ids {
+		conversation := state.conversations[legacyID]
+		positions := byConversation[legacyID]
+		sort.Slice(positions, func(i, j int) bool {
+			if positions[i].At != positions[j].At {
+				return positions[i].At < positions[j].At
+			}
+			return positions[i].ID < positions[j].ID
+		})
+		unread := conversation.Legacy.UnreadCount
+		if unread < 0 {
+			unread = 0
+			report.Warnings = append(report.Warnings,
+				fmt.Sprintf("conversation %s had a negative unread_count; treated as zero", legacyID))
+		}
+		var lastReadID *string
+		lastReadAt := int64(0)
+		index := int64(len(positions)) - unread - 1
+		if index >= 0 && index < int64(len(positions)) {
+			value := positions[index].ID
+			lastReadID = &value
+			lastReadAt = positions[index].At
+		}
+		deviceID := deriveID(
+			"device", conversation.Account.AccountID,
+			conversation.Account.AccountID+"\x1flocal",
+		)
+		updatedAt := state.baseTimestampMS
+		if len(positions) > 0 {
+			updatedAt = maxInt64(updatedAt, positions[len(positions)-1].At)
+		}
+		if err := target.UpsertReadCursor(sqlite.ReadCursor{
+			AccountID: conversation.Account.AccountID, DeviceID: deviceID,
+			ConversationID: conversation.V2ID, LastReadMessageID: lastReadID,
+			LastReadAtMS: lastReadAt, UpdatedAtMS: updatedAt,
+		}); err != nil {
+			return fmt.Errorf("upsert read cursor for conversation %q: %w", legacyID, err)
+		}
+		state.expectedCursors++
+	}
+	report.ReadState.CursorsCreated = state.expectedCursors
+	return nil
+}
+
+func packLegacyAttachment(message legacyMessage, report *Report) (sqlite.MessageAttachment, error) {
+	attachment := sqlite.MessageAttachment{
+		Ordinal: 0, RemoteID: message.MediaID, MIME: strings.TrimSpace(message.MIME),
+		State: "pending",
+	}
+	if attachment.MIME == "" {
+		attachment.MIME = "application/octet-stream"
+	}
+	platform := normalizeLegacyPlatform(message.Platform)
+	var payload any
+	switch platform {
+	case "sms":
+		payload = struct {
+			Version       int    `json:"v"`
+			MediaID       string `json:"media_id"`
+			DecryptionKey string `json:"decryption_key"`
+		}{1, message.MediaID, message.DecryptionKey}
+	case "whatsapp":
+		if !whatsappmedia.IsLocalMediaRef(message.MediaID) {
+			report.Media.WhatsAppUnresolvable++
+			return attachment, nil
+		}
+		if _, err := whatsappmedia.DecodeLocalMediaRef(message.MediaID); err != nil {
+			report.Media.WhatsAppUnresolvable++
+			return attachment, nil
+		}
+		payload = struct {
+			Version  int    `json:"v"`
+			Kind     string `json:"kind"`
+			LocalRef string `json:"local_ref"`
+		}{1, "local", message.MediaID}
+	case "signal":
+		const (
+			remotePrefix = "signalatt:"
+			localPrefix  = "signallocal:"
+		)
+		switch {
+		case strings.HasPrefix(message.MediaID, localPrefix):
+			encoded := strings.TrimSpace(strings.TrimPrefix(message.MediaID, localPrefix))
+			decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+			if err != nil || strings.TrimSpace(string(decoded)) == "" {
+				// Symmetric with the WhatsApp unresolvable path: one corrupt
+				// attachment ref in years of history must not abort the whole
+				// migration. The message migrates; the attachment stays pending
+				// with an empty remote_ref and is counted as unresolvable.
+				report.Media.SignalUnresolvable++
+				return attachment, nil
+			}
+			report.Media.SignalLocalAttachments++
+			payload = struct {
+				Version int    `json:"v"`
+				Kind    string `json:"kind"`
+				Path    string `json:"path"`
+			}{1, "local", strings.TrimSpace(string(decoded))}
+		default:
+			attachmentID := strings.TrimSpace(message.MediaID)
+			if strings.HasPrefix(attachmentID, remotePrefix) {
+				attachmentID = strings.TrimSpace(strings.TrimPrefix(attachmentID, remotePrefix))
+			}
+			if attachmentID == "" {
+				report.Media.SignalUnresolvable++
+				return attachment, nil
+			}
+			payload = struct {
+				Version        int    `json:"v"`
+				Kind           string `json:"kind"`
+				AttachmentID   string `json:"att_id"`
+				ConversationID string `json:"conversation_id"`
+			}{1, "remote", attachmentID, message.ConversationID}
+		}
+	case "gchat", "imessage":
+		report.Media.UnsupportedArchiveAttachments++
+		return attachment, nil
+	default:
+		return attachment, fmt.Errorf("unsupported platform %q", platform)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return attachment, err
+	}
+	attachment.RemoteRef = encoded
+	return attachment, nil
+}
+
+func addIdentity(
+	state *transformState,
+	account accountSpec,
+	raw string,
+	displayName string,
+	isSelf bool,
+	priority int,
+) (identityKey, error) {
+	key, err := identityKeyFor(account, raw)
+	if err != nil {
+		return identityKey{}, err
+	}
+	candidate, exists := state.identities[key]
+	if !exists {
+		state.identities[key] = &identityCandidate{
+			Key: key, Raw: strings.TrimSpace(raw), DisplayName: strings.TrimSpace(displayName),
+			IsSelf: isSelf, Priority: priority,
+		}
+		return key, nil
+	}
+	candidate.IsSelf = candidate.IsSelf || isSelf
+	if strings.TrimSpace(displayName) != "" && (candidate.DisplayName == "" || priority > candidate.Priority) {
+		candidate.DisplayName = strings.TrimSpace(displayName)
+		candidate.Priority = priority
+	}
+	return key, nil
+}
+
+var signalACI = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func identityKeyFor(account accountSpec, raw string) (identityKey, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return identityKey{}, fmt.Errorf("identity value is empty")
+	}
+	kind := "username"
+	canonical := value
+	switch {
+	case strings.HasPrefix(value, "+"):
+		var digits strings.Builder
+		for _, character := range value[1:] {
+			if character >= '0' && character <= '9' {
+				digits.WriteRune(character)
+			}
+		}
+		if digits.Len() == 0 {
+			return identityKey{}, fmt.Errorf("invalid E.164 identity %q", value)
+		}
+		kind = "e164"
+		canonical = "+" + digits.String()
+	case account.Platform == "signal" && signalACI.MatchString(value):
+		kind = "signal_aci"
+		canonical = strings.ToLower(value)
+	case strings.Contains(value, "@") && account.Platform == "whatsapp":
+		kind = "jid"
+		canonical = strings.ToLower(value)
+	case strings.Contains(value, "@"):
+		kind = "email"
+		canonical = strings.ToLower(value)
+	case strings.HasPrefix(value, "legacy-participant:"):
+		kind = "legacy_participant"
+	}
+	return identityKey{AccountID: account.AccountID, Kind: kind, Canonical: canonical}, nil
+}
+
+func identityID(key identityKey) string {
+	return deriveID("identity", key.AccountID, key.Kind+"\x1f"+key.Canonical)
+}
+
+func deriveID(entity, accountID, naturalKey string) string {
+	sum := sha256.Sum256([]byte(entity + "\x1f" + accountID + "\x1f" + naturalKey))
+	return hex.EncodeToString(sum[:])[:32]
+}
+
+func deriveRemoteMessageID(message legacyMessage) string {
+	if message.SourceID != "" {
+		return message.SourceID
+	}
+	return stripPlatformPrefix(message.ID)
+}
+
+func stripPlatformPrefix(value string) string {
+	for _, prefix := range []string{"whatsapp:", "signal:", "gchat:", "imessage:"} {
+		if strings.HasPrefix(value, prefix) {
+			return strings.TrimPrefix(value, prefix)
+		}
+	}
+	return value
+}
+
+func normalizeLegacyPlatform(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "sms", "google", "google_messages":
+		return "sms"
+	case "wa", "whatsapp", "whatsmeow":
+		return "whatsapp"
+	case "signal", "signal_cli":
+		return "signal"
+	case "gchat", "google_chat":
+		return "gchat"
+	case "imessage", "apple_messages":
+		return "imessage"
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func accountForPlatform(platform string) (accountSpec, error) {
+	account, ok := platformAccounts[normalizeLegacyPlatform(platform)]
+	if !ok {
+		return accountSpec{}, fmt.Errorf("unsupported legacy source_platform %q", platform)
+	}
+	return account, nil
+}
+
+func normalizeRemoteConversationID(platform, legacyID string) string {
+	value := strings.TrimSpace(legacyID)
+	if platform != "signal" {
+		return value
+	}
+	if strings.HasPrefix(value, "signal-group:") {
+		return "signal-group:" + strings.TrimSpace(strings.TrimPrefix(value, "signal-group:"))
+	}
+	if strings.HasPrefix(value, "signal:") {
+		return "signal:" + strings.TrimSpace(strings.TrimPrefix(value, "signal:"))
+	}
+	return value
+}
+
+func minLegacyTimestamp(dataset legacyDataset) int64 {
+	minimum := int64(0)
+	consider := func(value int64) {
+		if value > 0 && (minimum == 0 || value < minimum) {
+			minimum = value
+		}
+	}
+	for _, conversation := range dataset.conversations {
+		consider(conversation.LastMessageMS)
+	}
+	for _, message := range dataset.messages {
+		consider(message.TimestampMS)
+	}
+	for _, scheduled := range dataset.scheduled {
+		consider(scheduled.CreatedAtMS)
+		consider(scheduled.SendAtMS)
+	}
+	if minimum == 0 {
+		return 1
+	}
+	return minimum
+}
+
+func conversationTimes(conversation legacyConversation, base int64) (int64, int64) {
+	created := base
+	last := conversation.LastMessageMS
+	if last < 0 {
+		last = 0
+	}
+	return created, last
+}
+
+func scheduleReport(dataset legacyDataset) ScheduleReport {
+	return ScheduleReport{
+		LegacyTotal: int64(len(dataset.scheduled)), ByStatus: dataset.scheduleByStatus,
+		PendingToOutbox:    dataset.scheduleByStatus["pending"],
+		SkippedSent:        dataset.scheduleByStatus["sent"],
+		SkippedCanceled:    dataset.scheduleByStatus["canceled"],
+		SkippedFailed:      dataset.scheduleByStatus["failed"],
+		AmbiguousSending:   dataset.scheduleByStatus["sending"],
+		OptimisticOnlyRows: dataset.scheduleByStatus["sending"],
+	}
+}
+
+func appendRequiredWarnings(report *Report) {
+	report.Warnings = append(report.Warnings, report.ReadState.LossyWarning)
+	if count := report.Dropped.ReactionsBearingMessages; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d messages with reactions were counted and dropped: merged v2 has no reaction read model", count))
+	}
+	if count := report.Dropped.TranscriptBearingMessages; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d messages with transcripts were counted and dropped: merged v2 has no transcript columns", count))
+	}
+	if count := report.Dropped.ContactAvatars; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d contact avatars were counted and dropped", count))
+	}
+	if count := report.Dropped.Drafts; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d drafts were counted and dropped", count))
+	}
+	if count := report.Dropped.ContactMetaCRM; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("IMPORTANT: %d contact_meta CRM records (tags/cadence/summaries) were counted and dropped; export them before deleting the legacy store", count))
+	}
+	if count := report.Dropped.OutgoingSendKeys; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d legacy outgoing_send_keys tombstones were counted and dropped", count))
+	}
+	if count := report.Dropped.Tabs; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d custom tabs were counted and dropped", count))
+	}
+	if count := report.Schedule.AmbiguousSending; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d ambiguous in-flight scheduled sends were not auto-resent; optimistic messages were preserved for verify/SendAgain", count))
+	}
+}
+
+func textPayloadHash(body, replyToMessageID string) (string, error) {
+	payload, err := json.Marshal(struct {
+		Body             string `json:"body"`
+		ReplyToMessageID string `json:"reply_to_message_id,omitempty"`
+	}{body, replyToMessageID})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func mediaPayloadHash(
+	blobHash string,
+	size int64,
+	mime string,
+	filename string,
+	caption string,
+	replyToMessageID string,
+) (string, error) {
+	payload, err := json.Marshal(struct {
+		BlobHash         string `json:"blob_hash"`
+		Size             int64  `json:"size"`
+		MIME             string `json:"mime"`
+		Filename         string `json:"filename"`
+		Caption          string `json:"caption,omitempty"`
+		ReplyToMessageID string `json:"reply_to_message_id,omitempty"`
+	}{blobHash, size, mime, filename, caption, replyToMessageID})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func sortedAccountPlatforms(accounts map[string]accountSpec) []string {
+	platforms := make([]string, 0, len(accounts))
+	for platform := range accounts {
+		platforms = append(platforms, platform)
+	}
+	sort.Slice(platforms, func(i, j int) bool {
+		return accounts[platforms[i]].AccountID < accounts[platforms[j]].AccountID
+	})
+	return platforms
+}
+
+func legacyConversationIDForV2(state *transformState, v2ID string) string {
+	for legacyID, conversation := range state.conversations {
+		if conversation.V2ID == v2ID {
+			return legacyID
+		}
+	}
+	return v2ID
+}
+
+func requireAbsent(path string) error {
+	_, err := os.Lstat(path)
+	if err == nil {
+		return fmt.Errorf("path already exists: %s", path)
+	}
+	if !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func maxInt64(left, right int64) int64 {
+	if left > right {
+		return left
+	}
+	return right
+}

--- a/internal/migration/transform_test.go
+++ b/internal/migration/transform_test.go
@@ -1,0 +1,1028 @@
+package migration
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	googleadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/google"
+	signaladapter "github.com/maxghenis/openmessage/internal/bridgeadapters/signal"
+	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
+	legacydb "github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/whatsappmedia"
+)
+
+const (
+	fixtureBaseMS    int64 = 1_700_000_000_000
+	fixtureSignalACI       = "11111111-2222-3333-4444-555555555555"
+)
+
+type migrationFixture struct {
+	sourcePath     string
+	whatsAppRef    string
+	scheduledBytes []byte
+}
+
+func TestTransformLegacyFixtureToMergedV2(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fixture := buildMigrationFixture(t, root)
+	stagedStore := filepath.Join(root, "store.sqlite3.tmp")
+	stagedBlobs := filepath.Join(root, "blobs.tmp")
+	targetStore := filepath.Join(root, "canonical", "store.sqlite3")
+	sourceHashBefore := testFileSHA256(t, fixture.sourcePath)
+	sourceInfoBefore, err := os.Stat(fixture.sourcePath)
+	mustNoError(t, err)
+
+	report, err := Transform(context.Background(), Options{
+		SourcePath:      fixture.sourcePath,
+		TempStorePath:   stagedStore,
+		TempBlobPath:    stagedBlobs,
+		TargetPath:      filepath.Dir(targetStore),
+		TargetStorePath: targetStore,
+		Check:           true,
+	})
+	mustNoError(t, err)
+
+	reportJSON, err := json.MarshalIndent(report, "", "  ")
+	mustNoError(t, err)
+	t.Logf("fixture integrity report:\n%s", reportJSON)
+
+	assertFixtureReport(t, report, sourceHashBefore)
+	assertSourceUnchanged(t, fixture.sourcePath, sourceHashBefore, sourceInfoBefore)
+
+	target := openReadOnlyTestDB(t, stagedStore)
+	assertMergedMessageSchema(t, target)
+	assertFixtureAccounts(t, target)
+	assertFixtureMessages(t, target)
+	assertFixtureAttachments(t, target, fixture.whatsAppRef)
+	assertSignalIdentitiesRemainSeparate(t, target)
+	assertFixtureSchedules(t, target, stagedBlobs, fixture.scheduledBytes)
+	assertFixtureReadCursors(t, target)
+}
+
+func TestTransformReadsHotWALWithoutMutatingSourceFamily(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fixture := buildMigrationFixture(t, root)
+	writer, err := sql.Open("sqlite", fixture.sourcePath)
+	mustNoError(t, err)
+	writer.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		if err := writer.Close(); err != nil {
+			t.Errorf("close hot-WAL writer: %v", err)
+		}
+	})
+	_, err = writer.Exec(`PRAGMA journal_mode=WAL`)
+	mustNoError(t, err)
+	_, err = writer.Exec(`PRAGMA wal_autocheckpoint=0`)
+	mustNoError(t, err)
+	_, err = writer.Exec(`
+		INSERT INTO tabs (tab_id, name, position, created_at)
+		VALUES ('hot-wal-tab', 'Hot WAL tab', 99, ?)
+	`, fixtureBaseMS+40_000)
+	mustNoError(t, err)
+
+	before := snapshotSourceFamilyForTest(t, fixture.sourcePath)
+	if !before["wal"].exists || len(before["wal"].contents) == 0 {
+		t.Fatal("fixture did not retain a non-empty hot WAL")
+	}
+	if !before["shm"].exists {
+		t.Fatal("fixture did not retain a hot shared-memory sidecar")
+	}
+
+	stagedStore := filepath.Join(root, "hot-wal-store.sqlite3.tmp")
+	report, err := Transform(context.Background(), Options{
+		SourcePath:      fixture.sourcePath,
+		TempStorePath:   stagedStore,
+		TempBlobPath:    filepath.Join(root, "hot-wal-blobs.tmp"),
+		TargetPath:      filepath.Join(root, "hot-wal-target"),
+		TargetStorePath: filepath.Join(root, "hot-wal-target", "store.sqlite3"),
+		Check:           true,
+	})
+	if err != nil {
+		t.Fatalf("Transform hot WAL: %v\nsource evidence: %+v\nvalidation: %+v", err, report.Source.Files, report.Validation)
+	}
+	if !report.OK || !report.Validation.SourceUnchanged || !report.Source.Unchanged {
+		t.Fatalf("hot-WAL migration did not pass immutable-source validation: %+v", report.Validation)
+	}
+	if report.Dropped.Tabs != 2 {
+		t.Fatalf("tabs visible through WAL = %d, want 2 (checkpointed + hot-WAL rows)", report.Dropped.Tabs)
+	}
+	if len(report.Source.Files) != 3 {
+		t.Fatalf("source family evidence has %d files, want database/WAL/SHM", len(report.Source.Files))
+	}
+	for _, file := range report.Source.Files {
+		if !file.Unchanged {
+			t.Errorf("source evidence reports mutation for %s: %+v", file.Role, file)
+		}
+	}
+	after := snapshotSourceFamilyForTest(t, fixture.sourcePath)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("source database family changed during migration\nbefore: %#v\nafter:  %#v", before, after)
+	}
+	if _, err := os.Lstat(stagedStore + legacySnapshotSuffix); !os.IsNotExist(err) {
+		t.Fatalf("migration left private source snapshot behind: %v", err)
+	}
+}
+
+func TestDeterministicID(t *testing.T) {
+	t.Parallel()
+
+	const want = "5b66e34164c6cc052fd1dd40eb5975be"
+	got := deriveID(
+		"message",
+		"google-primary",
+		"sms-conversation\x1fgoogle-server-1",
+	)
+	if got != want {
+		t.Fatalf("deriveID() = %q, want %q", got, want)
+	}
+	if again := deriveID("message", "google-primary", "sms-conversation\x1fgoogle-server-1"); again != got {
+		t.Fatalf("deriveID() was not repeatable: first %q, second %q", got, again)
+	}
+	if len(got) != 32 || strings.ToLower(got) != got {
+		t.Fatalf("deriveID() = %q, want 32 lowercase hex characters", got)
+	}
+	if _, err := hex.DecodeString(got); err != nil {
+		t.Fatalf("deriveID() = %q, want lowercase hex: %v", got, err)
+	}
+	if got == deriveID("message", "signal-primary", "sms-conversation\x1fgoogle-server-1") {
+		t.Fatal("deriveID() did not include account_id")
+	}
+	if got == deriveID("conversation", "google-primary", "sms-conversation\x1fgoogle-server-1") {
+		t.Fatal("deriveID() did not include entity")
+	}
+}
+
+func TestDeriveRemoteMessageID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		message  legacyMessage
+		expected string
+	}{
+		{name: "source id wins", message: legacyMessage{ID: "whatsapp:ignored", SourceID: "remote-from-source"}, expected: "remote-from-source"},
+		{name: "google unprefixed", message: legacyMessage{ID: "google-server-id"}, expected: "google-server-id"},
+		{name: "whatsapp prefix", message: legacyMessage{ID: "whatsapp:stanza-id"}, expected: "stanza-id"},
+		{name: "signal timestamp", message: legacyMessage{ID: "signal:1700000000123"}, expected: "1700000000123"},
+		{name: "signal fabricated local", message: legacyMessage{ID: "signal:local:deadbeef"}, expected: "local:deadbeef"},
+		{name: "gchat prefix", message: legacyMessage{ID: "gchat:message-id"}, expected: "message-id"},
+		{name: "imessage prefix", message: legacyMessage{ID: "imessage:message-id"}, expected: "message-id"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := deriveRemoteMessageID(test.message); got != test.expected {
+				t.Fatalf("deriveRemoteMessageID(%q, %q) = %q, want %q", test.message.ID, test.message.SourceID, got, test.expected)
+			}
+		})
+	}
+}
+
+func buildMigrationFixture(t *testing.T, root string) migrationFixture {
+	t.Helper()
+
+	sourcePath := filepath.Join(root, "legacy.sqlite3")
+	store, err := legacydb.New(sourcePath)
+	mustNoError(t, err)
+	closed := false
+	defer func() {
+		if !closed {
+			_ = store.Close()
+		}
+	}()
+
+	conversations := []*legacydb.Conversation{
+		{
+			ConversationID: "sms-conversation", Name: "Unified Friend",
+			Participants:  `[{"name":"Unified Friend","number":"+1 (555) 010-0001"},{"name":"Me","number":"+15550009999","is_me":true}]`,
+			LastMessageTS: fixtureBaseMS + 2_000, UnreadCount: 1,
+			SourcePlatform: "sms", DisplayProtocol: "RCS", IsFavorite: true,
+			NotificationMode: "muted",
+		},
+		{
+			ConversationID: "whatsapp:fixture-group@g.us", Name: "Fixture WhatsApp group", IsGroup: true,
+			Participants:  `[{"name":"Collision Name","number":"15550100002@s.whatsapp.net"},{"name":"Me","number":"15550009999@s.whatsapp.net","is_me":true}]`,
+			LastMessageTS: fixtureBaseMS + 4_000, SourcePlatform: "whatsapp",
+			NotificationMode: "mentions",
+		},
+		{
+			ConversationID: "signal:+16505550100", Name: "Collision Name",
+			Participants:  `[{"name":"Collision Name","number":"+16505550100"}]`,
+			LastMessageTS: fixtureBaseMS + 6_000, SourcePlatform: "signal",
+		},
+		{
+			ConversationID: "signal:" + fixtureSignalACI, Name: "Collision Name",
+			Participants:  `[{"name":"Collision Name","number":"` + fixtureSignalACI + `"}]`,
+			LastMessageTS: fixtureBaseMS + 7_000, UnreadCount: 1, SourcePlatform: "signal",
+		},
+		{
+			ConversationID: "gchat:thread-alpha", Name: "Unified Friend",
+			Participants:  `[{"name":"Unified Friend","email":"friend@example.com"}]`,
+			LastMessageTS: fixtureBaseMS + 9_000, SourcePlatform: "gchat",
+		},
+		{
+			ConversationID: "imessage:chat-alpha", Name: "Collision Name",
+			Participants:  `[{"name":"Collision Name","number":"+15550100003"}]`,
+			LastMessageTS: fixtureBaseMS + 11_000, SourcePlatform: "imessage",
+		},
+	}
+	for _, conversation := range conversations {
+		mustNoError(t, store.UpsertConversation(conversation))
+	}
+
+	tab, err := store.CreateTab("Fixture custom tab")
+	mustNoError(t, err)
+	mustNoError(t, store.SetConversationTab("gchat:thread-alpha", legacydb.TabArchive))
+	mustNoError(t, store.SetConversationTab("imessage:chat-alpha", tab.TabID))
+
+	whatsAppRef := whatsappmedia.EncodeLocalMediaRef("Media/fixture.webp")
+	if whatsAppRef == "" {
+		t.Fatal("EncodeLocalMediaRef returned an empty fixture reference")
+	}
+	messages := []*legacydb.Message{
+		{
+			MessageID: "google-server-1", ConversationID: "sms-conversation",
+			SenderName: "Unified Friend", SenderNumber: "+15550100001",
+			Body: "google incoming media", TimestampMS: fixtureBaseMS + 1_000,
+			Status: "RCS_DELIVERED", MentionsMe: true, SourcePlatform: "sms",
+			MediaID: "google-media-1", MimeType: "image/jpeg", DecryptionKey: "deadbeef",
+			Reactions: `[{"emoji":"👍","count":1,"actors":["+15550100001"]}]`,
+		},
+		{
+			MessageID: "google-server-2", ConversationID: "sms-conversation",
+			SenderName: "Me", SenderNumber: "+15550009999", Body: "google outgoing reply",
+			TimestampMS: fixtureBaseMS + 2_000, Status: "sent", IsFromMe: true,
+			ReplyToID: "google-server-1", SourcePlatform: "sms",
+		},
+		{
+			MessageID: "whatsapp:wa-stanza-1", ConversationID: "whatsapp:fixture-group@g.us",
+			SenderName: "Collision Name", SenderNumber: "15550100002@s.whatsapp.net",
+			Body: "whatsapp incoming media", TimestampMS: fixtureBaseMS + 3_000,
+			Status: "delivered", SourcePlatform: "whatsapp", SourceID: "wa-source-1",
+			MediaID: whatsAppRef, MimeType: "image/webp",
+		},
+		{
+			MessageID: "whatsapp:wa-stanza-2", ConversationID: "whatsapp:fixture-group@g.us",
+			SenderName: "Me", Body: "whatsapp outgoing reply", TimestampMS: fixtureBaseMS + 4_000,
+			Status: "sent", IsFromMe: true, ReplyToID: "whatsapp:wa-stanza-1",
+			SourcePlatform: "whatsapp",
+		},
+		{
+			MessageID: "signal:1700000001000", ConversationID: "signal:+16505550100",
+			SenderName: "Collision Name", SenderNumber: "+16505550100",
+			Body: "signal incoming media", TimestampMS: fixtureBaseMS + 5_000,
+			Status: "delivered", SourcePlatform: "signal", MediaID: "signalatt:att-42",
+			MimeType: "video/mp4",
+		},
+		{
+			MessageID: "signal:local:abc123", ConversationID: "signal:+16505550100",
+			SenderName: "Me", Body: "signal fabricated outgoing", TimestampMS: fixtureBaseMS + 6_000,
+			Status: "sent", IsFromMe: true, SourcePlatform: "signal",
+		},
+		{
+			MessageID: "signal:1700000002000", ConversationID: "signal:" + fixtureSignalACI,
+			SenderName: "Collision Name", SenderNumber: fixtureSignalACI,
+			Body: "signal ACI incoming", TimestampMS: fixtureBaseMS + 7_000,
+			Status: "delivered", SourcePlatform: "signal",
+		},
+		{
+			MessageID: "gchat:message-1", ConversationID: "gchat:thread-alpha",
+			SenderName: "Unified Friend", SenderNumber: "friend@example.com",
+			Body: "gchat incoming", TimestampMS: fixtureBaseMS + 8_000,
+			Status: "delivered", SourcePlatform: "gchat",
+		},
+		{
+			MessageID: "gchat:message-2", ConversationID: "gchat:thread-alpha",
+			SenderName: "Me", Body: "gchat outgoing", TimestampMS: fixtureBaseMS + 9_000,
+			Status: "sent", IsFromMe: true, SourcePlatform: "gchat",
+		},
+		{
+			MessageID: "imessage:message-1", ConversationID: "imessage:chat-alpha",
+			SenderName: "Collision Name", SenderNumber: "+15550100003",
+			Body: "imessage incoming", TimestampMS: fixtureBaseMS + 10_000,
+			Status: "delivered", SourcePlatform: "imessage",
+		},
+		{
+			MessageID: "imessage:message-2", ConversationID: "imessage:chat-alpha",
+			SenderName: "Me", Body: "imessage outgoing", TimestampMS: fixtureBaseMS + 11_000,
+			Status: "sent", IsFromMe: true, ReplyToID: "imessage:message-1",
+			SourcePlatform: "imessage",
+		},
+	}
+	for _, message := range messages {
+		mustNoError(t, store.UpsertMessage(message))
+	}
+	transcriptModel := "fixture-transcriber"
+	mustNoError(t, store.SetMessageTranscript("google-server-1", "fixture transcript", &transcriptModel))
+
+	mustNoError(t, store.UpsertContact(&legacydb.Contact{
+		ContactID: "contact-unified", Name: "Unified Friend", Number: "+15550100001",
+	}))
+	mustNoError(t, store.UpsertUnifiedContact(&legacydb.UnifiedContact{
+		UnifiedID: "unified-friend", DisplayName: "Unified Friend",
+		Identifiers: `[{"platform":"sms","value":"+15550100001"},{"platform":"gchat","value":"friend@example.com"}]`,
+	}))
+	mustNoError(t, store.UpsertContactAvatar(legacydb.ContactAvatarCandidate{
+		SourcePlatform: "sms", ContactID: "contact-unified", PhoneNumber: "+15550100001",
+		DisplayName: "Unified Friend",
+	}, []byte("avatar bytes"), "image/png", "avatar-hash", fixtureBaseMS))
+	mustNoError(t, store.UpsertDraft(&legacydb.Draft{
+		DraftID: "draft-fixture", ConversationID: "sms-conversation",
+		Body: "legacy draft", CreatedAt: fixtureBaseMS + 20_000,
+	}))
+	claimed, _, err := store.ClaimOutgoingSendKey("legacy-send-key", "sms-conversation")
+	mustNoError(t, err)
+	if !claimed {
+		t.Fatal("fixture outgoing send key was not claimed")
+	}
+	mustNoError(t, store.SetContactTags(
+		legacydb.PersonKey("Unified Friend"), "Unified Friend", []string{"friend", "fixture"},
+	))
+
+	scheduledBytes := []byte("scheduled media fixture bytes")
+	scheduled := []*legacydb.ScheduledMessage{
+		{
+			ID: "scheduled-pending-text", ConversationID: "sms-conversation",
+			Body: "pending scheduled text", ReplyToID: "google-server-1",
+			SendAt: fixtureBaseMS + 100_000, Status: legacydb.ScheduleStatusPending,
+			CreatedAt: fixtureBaseMS + 30_000,
+		},
+		{
+			ID: "scheduled-pending-media", ConversationID: "whatsapp:fixture-group@g.us",
+			Body: "pending scheduled caption", ReplyToID: "whatsapp:wa-stanza-1",
+			SendAt: fixtureBaseMS + 200_000, Status: legacydb.ScheduleStatusPending,
+			CreatedAt: fixtureBaseMS + 31_000, MediaData: scheduledBytes,
+			MediaFilename: "scheduled.bin", MediaMime: "application/octet-stream",
+		},
+		{
+			ID: "scheduled-sending", ConversationID: "signal:+16505550100",
+			Body: "ambiguous sending", SendAt: fixtureBaseMS + 300_000,
+			Status: legacydb.ScheduleStatusSending, CreatedAt: fixtureBaseMS + 32_000,
+		},
+		{
+			ID: "scheduled-sent", ConversationID: "sms-conversation", Body: "already sent",
+			SendAt: fixtureBaseMS + 400_000, Status: legacydb.ScheduleStatusSent,
+			CreatedAt: fixtureBaseMS + 33_000, SentMessageID: "google-server-2",
+		},
+		{
+			ID: "scheduled-canceled", ConversationID: "gchat:thread-alpha", Body: "canceled",
+			SendAt: fixtureBaseMS + 500_000, Status: legacydb.ScheduleStatusCanceled,
+			CreatedAt: fixtureBaseMS + 34_000,
+		},
+		{
+			ID: "scheduled-failed", ConversationID: "imessage:chat-alpha", Body: "failed",
+			SendAt: fixtureBaseMS + 600_000, Status: legacydb.ScheduleStatusFailed,
+			Attempts: 5, LastError: "fixture permanent failure", CreatedAt: fixtureBaseMS + 35_000,
+		},
+	}
+	for _, message := range scheduled {
+		mustNoError(t, store.CreateScheduledMessage(message))
+	}
+
+	mustNoError(t, store.Close())
+	closed = true
+	return migrationFixture{
+		sourcePath: sourcePath, whatsAppRef: whatsAppRef, scheduledBytes: scheduledBytes,
+	}
+}
+
+func assertFixtureReport(t *testing.T, report Report, sourceHash string) {
+	t.Helper()
+
+	if report.Format != ReportFormat || !report.OK || !report.Check {
+		t.Fatalf("report header = format %d, ok %v, check %v", report.Format, report.OK, report.Check)
+	}
+	if report.Source.QuickCheck != "ok" || report.Source.SHA256Before != sourceHash ||
+		report.Source.SHA256After != sourceHash || !report.Source.Unchanged {
+		t.Fatalf("source report did not prove immutability: %+v", report.Source)
+	}
+	if len(report.Source.Files) != 3 {
+		t.Fatalf("source report files = %d, want database/WAL/SHM evidence", len(report.Source.Files))
+	}
+	for _, file := range report.Source.Files {
+		if !file.Unchanged || file.ExistsBefore != file.ExistsAfter {
+			t.Errorf("source file evidence did not reconcile: %+v", file)
+		}
+	}
+	if report.Target.SchemaVersion != 9 || len(report.Target.MigrationChecksums) != 9 {
+		t.Fatalf("target schema = version %d with %d checksums, want version 9 with 9 checksums", report.Target.SchemaVersion, len(report.Target.MigrationChecksums))
+	}
+	wantTargetCounts := map[string]int64{
+		"accounts": 5, "devices": 5, "people": 1, "person_identities": 2,
+		"conversations": 6, "inbox": 0, "messages": 14,
+		"message_attachments": 3, "outbox": 2, "outbox_attachments": 1,
+		"read_cursors": 6,
+	}
+	for table, want := range wantTargetCounts {
+		if got := report.Target.Counts[table]; got != want {
+			t.Errorf("target count %s = %d, want %d", table, got, want)
+		}
+	}
+	if report.Identities.Created != report.Target.Counts["identities"] ||
+		report.Identities.PeopleCreated != 1 || report.Identities.LinksByProvenance["explicit"] != 2 ||
+		report.Identities.UnunifiedIdentities != report.Identities.Created-2 {
+		t.Errorf("identity report = %+v", report.Identities)
+	}
+
+	messages := report.TableCounts["messages"]
+	if messages.Legacy != 11 || messages.V2 != 11 || messages.Reconciled != 11 || messages.ReconciliationRatio != 1 {
+		t.Errorf("message reconciliation = %+v, want 11/11 and ratio 1", messages)
+	}
+	if len(report.MessageCollisions) != 0 {
+		t.Errorf("message collisions = %+v, want none", report.MessageCollisions)
+	}
+	wantPlatformMessages := map[string]int64{
+		"sms": 2, "whatsapp": 2, "signal": 3, "gchat": 2, "imessage": 2,
+	}
+	for platform, want := range wantPlatformMessages {
+		got := report.PlatformCounts[platform]
+		if got.Legacy != want || got.V2 != want || got.ReconciliationRatio != 1 {
+			t.Errorf("platform reconciliation %s = %+v, want %d/%d and ratio 1", platform, got, want, want)
+		}
+	}
+
+	if report.Schedule.LegacyTotal != 6 || report.Schedule.ByStatus["pending"] != 2 ||
+		report.Schedule.PendingToOutbox != 2 || report.Schedule.PendingMedia != 1 ||
+		report.Schedule.AmbiguousSending != 1 || report.Schedule.OptimisticOnlyRows != 1 ||
+		report.Schedule.SkippedSent != 1 || report.Schedule.SkippedCanceled != 1 ||
+		report.Schedule.SkippedFailed != 1 {
+		t.Errorf("schedule report = %+v", report.Schedule)
+	}
+	if report.ReadState.LossyWarning != "legacy read state was lossy" ||
+		report.ReadState.ConversationsWithUnreadCount != 2 || report.ReadState.CursorsCreated != 6 {
+		t.Errorf("read state report = %+v", report.ReadState)
+	}
+	wantDropped := DroppedDimensions{
+		ReactionsBearingMessages: 1, TranscriptBearingMessages: 1,
+		ContactAvatars: 1, Drafts: 1, ContactMetaCRM: 1,
+		OutgoingSendKeys: 1, Tabs: 1,
+	}
+	if !reflect.DeepEqual(report.Dropped, wantDropped) {
+		t.Errorf("dropped dimensions = %+v, want %+v", report.Dropped, wantDropped)
+	}
+	if report.SignalLocalRows != 1 {
+		t.Errorf("signal local rows = %d, want 1", report.SignalLocalRows)
+	}
+	if report.Media.LegacyAttachments != 3 || report.Media.PendingAttachments != 3 ||
+		report.Media.WhatsAppUnresolvable != 0 || report.Media.SignalLocalAttachments != 0 ||
+		report.Media.UnsupportedArchiveAttachments != 0 || report.Media.ScheduledBlobsVerified != 1 {
+		t.Errorf("media report = %+v", report.Media)
+	}
+	if len(report.SampledHashes) != 11 {
+		t.Errorf("sampled hashes = %d, want all 11 fixture messages", len(report.SampledHashes))
+	}
+	for _, sample := range report.SampledHashes {
+		if !sample.Matched || sample.ExpectedSHA256 != sample.ActualSHA256 {
+			t.Errorf("sample hash mismatch: %+v", sample)
+		}
+	}
+	if report.Validation.QuickCheck != "ok" || len(report.Validation.ForeignKeyViolations) != 0 ||
+		orphanTotal(report.Validation.Orphans) != 0 || !report.Validation.CountsMatched ||
+		!report.Validation.SampledHashesMatched || !report.Validation.BlobReferencesValid ||
+		!report.Validation.SourceUnchanged || !report.Validation.Passed {
+		t.Errorf("validation report = %+v", report.Validation)
+	}
+	for _, required := range []string{
+		"legacy read state was lossy", "reactions", "transcripts", "contact avatars",
+		"drafts", "IMPORTANT: 1 contact_meta CRM", "outgoing_send_keys", "custom tabs",
+		"ambiguous in-flight scheduled sends",
+	} {
+		if !containsWarning(report.Warnings, required) {
+			t.Errorf("warnings did not contain %q: %v", required, report.Warnings)
+		}
+	}
+}
+
+func assertSourceUnchanged(t *testing.T, path, beforeHash string, before os.FileInfo) {
+	t.Helper()
+
+	if got := testFileSHA256(t, path); got != beforeHash {
+		t.Fatalf("source hash changed: got %s, want %s", got, beforeHash)
+	}
+	after, err := os.Stat(path)
+	mustNoError(t, err)
+	if after.Size() != before.Size() || !after.ModTime().Equal(before.ModTime()) || after.Mode() != before.Mode() {
+		t.Fatalf("source metadata changed: before size/mod/mode %d/%v/%v, after %d/%v/%v", before.Size(), before.ModTime(), before.Mode(), after.Size(), after.ModTime(), after.Mode())
+	}
+}
+
+func assertMergedMessageSchema(t *testing.T, database *sql.DB) {
+	t.Helper()
+
+	rows, err := database.Query(`PRAGMA table_info(messages)`)
+	mustNoError(t, err)
+	defer rows.Close()
+	type column struct {
+		name    string
+		notNull bool
+	}
+	columns := map[string]column{}
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, dataType string
+		var defaultValue any
+		mustNoError(t, rows.Scan(&cid, &name, &dataType, &notNull, &defaultValue, &primaryKey))
+		columns[name] = column{name: name, notNull: notNull != 0}
+	}
+	mustNoError(t, rows.Err())
+	want := []string{
+		"message_id", "conversation_id", "account_id", "remote_message_id",
+		"sender_identity_id", "direction", "body", "reply_to_remote_id", "state",
+		"occurred_at_ms", "created_at_ms", "updated_at_ms",
+	}
+	for _, name := range want {
+		if _, ok := columns[name]; !ok {
+			t.Errorf("merged messages schema is missing %q", name)
+		}
+	}
+	if !columns["remote_message_id"].notNull {
+		t.Error("merged messages.remote_message_id is nullable")
+	}
+	for _, forbidden := range []string{"status", "kind", "client_request_id", "content_json", "mentions_self", "source_inbox_id", "reply_to_message_id"} {
+		if _, ok := columns[forbidden]; ok {
+			t.Errorf("messages unexpectedly contains aspirational column %q", forbidden)
+		}
+	}
+}
+
+func assertFixtureAccounts(t *testing.T, database *sql.DB) {
+	t.Helper()
+
+	want := map[string][2]string{
+		"google-primary":   {"google_messages", "live"},
+		"whatsapp-primary": {"whatsmeow", "live"},
+		"signal-primary":   {"signal_cli", "live"},
+		"gchat-archive":    {"gchat", "archive"},
+		"imessage-archive": {"imessage", "archive"},
+	}
+	rows, err := database.Query(`SELECT account_id, bridge_key, mode FROM accounts ORDER BY account_id`)
+	mustNoError(t, err)
+	defer rows.Close()
+	got := map[string][2]string{}
+	for rows.Next() {
+		var accountID, bridgeKey, mode string
+		mustNoError(t, rows.Scan(&accountID, &bridgeKey, &mode))
+		got[accountID] = [2]string{bridgeKey, mode}
+	}
+	mustNoError(t, rows.Err())
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("accounts = %#v, want %#v", got, want)
+	}
+	if got := mustQueryInt64(t, database, `SELECT COUNT(*) FROM people`); got != 1 {
+		t.Errorf("people count = %d, want only the one unified_contact", got)
+	}
+}
+
+func assertFixtureMessages(t *testing.T, database *sql.DB) {
+	t.Helper()
+
+	type expectedMessage struct {
+		legacyConversation string
+		accountID          string
+		remoteID           string
+		body               string
+		direction          string
+		occurredAt         int64
+		replyTo            string
+		senderIdentityID   string
+	}
+	wants := []expectedMessage{
+		{
+			legacyConversation: "sms-conversation", accountID: "google-primary",
+			remoteID: "google-server-1", body: "google incoming media", direction: "incoming",
+			occurredAt:       fixtureBaseMS + 1_000,
+			senderIdentityID: deriveID("identity", "google-primary", "e164\x1f+15550100001"),
+		},
+		{
+			legacyConversation: "sms-conversation", accountID: "google-primary",
+			remoteID: "google-server-2", body: "google outgoing reply", direction: "outgoing",
+			occurredAt: fixtureBaseMS + 2_000, replyTo: "google-server-1",
+		},
+		{
+			legacyConversation: "whatsapp:fixture-group@g.us", accountID: "whatsapp-primary",
+			remoteID: "wa-source-1", body: "whatsapp incoming media", direction: "incoming",
+			occurredAt:       fixtureBaseMS + 3_000,
+			senderIdentityID: deriveID("identity", "whatsapp-primary", "jid\x1f15550100002@s.whatsapp.net"),
+		},
+		{
+			legacyConversation: "whatsapp:fixture-group@g.us", accountID: "whatsapp-primary",
+			remoteID: "wa-stanza-2", body: "whatsapp outgoing reply", direction: "outgoing",
+			occurredAt: fixtureBaseMS + 4_000, replyTo: "wa-source-1",
+		},
+		{
+			legacyConversation: "signal:+16505550100", accountID: "signal-primary",
+			remoteID: "1700000001000", body: "signal incoming media", direction: "incoming",
+			occurredAt:       fixtureBaseMS + 5_000,
+			senderIdentityID: deriveID("identity", "signal-primary", "e164\x1f+16505550100"),
+		},
+		{
+			legacyConversation: "signal:+16505550100", accountID: "signal-primary",
+			remoteID: "local:abc123", body: "signal fabricated outgoing", direction: "outgoing",
+			occurredAt: fixtureBaseMS + 6_000,
+		},
+	}
+	for _, want := range wants {
+		messageID := deriveID(
+			"message", want.accountID, want.legacyConversation+"\x1f"+want.remoteID,
+		)
+		conversationID := deriveID("conversation", want.accountID, want.legacyConversation)
+		var gotConversationID, gotAccountID, remoteID, body, direction, state string
+		var replyTo, sender sql.NullString
+		var occurredAt, createdAt, updatedAt int64
+		err := database.QueryRow(`
+			SELECT conversation_id, account_id, remote_message_id, sender_identity_id,
+			       direction, body, reply_to_remote_id, state, occurred_at_ms,
+			       created_at_ms, updated_at_ms
+			FROM messages WHERE message_id = ?
+		`, messageID).Scan(
+			&gotConversationID, &gotAccountID, &remoteID, &sender, &direction, &body,
+			&replyTo, &state, &occurredAt, &createdAt, &updatedAt,
+		)
+		mustNoError(t, err)
+		if gotConversationID != conversationID || gotAccountID != want.accountID ||
+			remoteID != want.remoteID || body != want.body || direction != want.direction ||
+			state != "active" || occurredAt != want.occurredAt || createdAt != want.occurredAt ||
+			updatedAt != want.occurredAt {
+			t.Errorf("message %s = conv/account/remote/body/direction/state/times %q/%q/%q/%q/%q/%q/%d/%d/%d", messageID, gotConversationID, gotAccountID, remoteID, body, direction, state, occurredAt, createdAt, updatedAt)
+		}
+		if replyTo.Valid != (want.replyTo != "") || replyTo.String != want.replyTo {
+			t.Errorf("message %s reply_to_remote_id = %+v, want %q", messageID, replyTo, want.replyTo)
+		}
+		if sender.Valid != (want.senderIdentityID != "") || sender.String != want.senderIdentityID {
+			t.Errorf("message %s sender_identity_id = %+v, want %q", messageID, sender, want.senderIdentityID)
+		}
+	}
+	if got := mustQueryInt64(t, database, `SELECT COUNT(*) FROM inbox`); got != 0 {
+		t.Errorf("inbox rows = %d, want ImportMessage to leave historical inbox empty", got)
+	}
+}
+
+func assertFixtureAttachments(t *testing.T, database *sql.DB, whatsAppRef string) {
+	t.Helper()
+
+	tests := []struct {
+		name               string
+		legacyConversation string
+		accountID          string
+		remoteMessageID    string
+		remoteID           string
+		mime               string
+		opaque             string
+		validate           func([]byte) error
+	}{
+		{
+			name: "google", legacyConversation: "sms-conversation", accountID: "google-primary",
+			remoteMessageID: "google-server-1", remoteID: "google-media-1", mime: "image/jpeg",
+			opaque:   `{"v":1,"media_id":"google-media-1","decryption_key":"deadbeef"}`,
+			validate: googleadapter.ValidateDownloadOpaque,
+		},
+		{
+			name: "whatsapp", legacyConversation: "whatsapp:fixture-group@g.us", accountID: "whatsapp-primary",
+			remoteMessageID: "wa-source-1", remoteID: whatsAppRef, mime: "image/webp",
+			opaque:   `{"v":1,"kind":"local","local_ref":"` + whatsAppRef + `"}`,
+			validate: whatsappadapter.ValidateDownloadOpaque,
+		},
+		{
+			name: "signal", legacyConversation: "signal:+16505550100", accountID: "signal-primary",
+			remoteMessageID: "1700000001000", remoteID: "signalatt:att-42", mime: "video/mp4",
+			opaque:   `{"v":1,"kind":"remote","att_id":"att-42","conversation_id":"signal:+16505550100"}`,
+			validate: signaladapter.ValidateDownloadOpaque,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			messageID := deriveID(
+				"message", test.accountID,
+				test.legacyConversation+"\x1f"+test.remoteMessageID,
+			)
+			var ordinal int64
+			var remoteID, mime, state string
+			var remoteRef []byte
+			var blobHash sql.NullString
+			err := database.QueryRow(`
+				SELECT ordinal, remote_id, remote_ref, mime, state, blob_hash
+				FROM message_attachments WHERE message_id = ?
+			`, messageID).Scan(&ordinal, &remoteID, &remoteRef, &mime, &state, &blobHash)
+			mustNoError(t, err)
+			if ordinal != 0 || remoteID != test.remoteID || string(remoteRef) != test.opaque ||
+				mime != test.mime || state != "pending" || blobHash.Valid {
+				t.Fatalf("attachment = ordinal/remote/ref/mime/state/blob %d/%q/%q/%q/%q/%+v", ordinal, remoteID, remoteRef, mime, state, blobHash)
+			}
+			if !json.Valid(remoteRef) {
+				t.Fatalf("attachment opaque is not valid JSON: %q", remoteRef)
+			}
+			// The remote_ref this migration packs must round-trip through the
+			// REAL adapter download codec (string equality alone would miss
+			// struct-tag drift between the packer and the Wave-4 unpacker).
+			if err := test.validate(remoteRef); err != nil {
+				t.Fatalf("packed remote_ref does not decode with the %s download codec: %v", test.name, err)
+			}
+		})
+	}
+}
+
+func assertSignalIdentitiesRemainSeparate(t *testing.T, database *sql.DB) {
+	t.Helper()
+
+	rows, err := database.Query(`
+		SELECT identity_id, kind, canonical_value
+		FROM identities
+		WHERE account_id = 'signal-primary'
+		  AND canonical_value IN ('+16505550100', ?)
+		ORDER BY canonical_value
+	`, fixtureSignalACI)
+	mustNoError(t, err)
+	defer rows.Close()
+	type identity struct {
+		id, kind, canonical string
+	}
+	var identities []identity
+	for rows.Next() {
+		var got identity
+		mustNoError(t, rows.Scan(&got.id, &got.kind, &got.canonical))
+		identities = append(identities, got)
+	}
+	mustNoError(t, rows.Err())
+	if len(identities) != 2 {
+		t.Fatalf("signal phone/ACI identities = %+v, want two separate rows", identities)
+	}
+	kinds := []string{identities[0].kind, identities[1].kind}
+	sort.Strings(kinds)
+	if !reflect.DeepEqual(kinds, []string{"e164", "signal_aci"}) || identities[0].id == identities[1].id {
+		t.Fatalf("signal phone/ACI identities = %+v, want distinct e164 and signal_aci rows", identities)
+	}
+	for _, identity := range identities {
+		if got := mustQueryInt64(t, database, `SELECT COUNT(*) FROM person_identities WHERE identity_id = ?`, identity.id); got != 0 {
+			t.Errorf("signal identity %s was suspiciously unified (%d links)", identity.canonical, got)
+		}
+	}
+}
+
+func assertFixtureSchedules(t *testing.T, database *sql.DB, blobRoot string, scheduledBytes []byte) {
+	t.Helper()
+
+	type expectedOutbox struct {
+		id, accountID, legacyConversation, kind string
+		scheduledFor                            int64
+	}
+	wants := []expectedOutbox{
+		{"scheduled-pending-text", "google-primary", "sms-conversation", "text", fixtureBaseMS + 100_000},
+		{"scheduled-pending-media", "whatsapp-primary", "whatsapp:fixture-group@g.us", "media", fixtureBaseMS + 200_000},
+	}
+	for _, want := range wants {
+		outboxID := deriveID("outbox", want.accountID, want.id)
+		requestID := deriveID("transport_request", want.accountID, want.id)
+		messageID := deriveID(
+			"message", want.accountID, want.legacyConversation+"\x1f"+requestID,
+		)
+		conversationID := deriveID("conversation", want.accountID, want.legacyConversation)
+		var gotOutboxID, accountID, gotConversationID, kind, idempotencyKey, state string
+		var localMessageID, transportRequestID string
+		var scheduledFor, attempts int64
+		err := database.QueryRow(`
+			SELECT outbox_id, account_id, conversation_id, kind, idempotency_key,
+			       state, local_message_id, transport_request_id, scheduled_for_ms,
+			       attempt_count
+			FROM outbox WHERE idempotency_key = ?
+		`, want.id).Scan(
+			&gotOutboxID, &accountID, &gotConversationID, &kind, &idempotencyKey,
+			&state, &localMessageID, &transportRequestID, &scheduledFor, &attempts,
+		)
+		mustNoError(t, err)
+		if gotOutboxID != outboxID || accountID != want.accountID ||
+			gotConversationID != conversationID || kind != want.kind || idempotencyKey != want.id ||
+			state != "queued" || localMessageID != messageID || transportRequestID != requestID ||
+			scheduledFor != want.scheduledFor || attempts != 0 {
+			t.Errorf("outbox %s = id/account/conv/kind/key/state/message/request/schedule/attempts %q/%q/%q/%q/%q/%q/%q/%q/%d/%d", want.id, gotOutboxID, accountID, gotConversationID, kind, idempotencyKey, state, localMessageID, transportRequestID, scheduledFor, attempts)
+		}
+		var optimisticRemote, direction string
+		mustNoError(t, database.QueryRow(`SELECT remote_message_id, direction FROM messages WHERE message_id = ?`, messageID).Scan(&optimisticRemote, &direction))
+		if optimisticRemote != requestID || direction != "outgoing" {
+			t.Errorf("optimistic message %s = remote/direction %q/%q, want %q/outgoing", messageID, optimisticRemote, direction, requestID)
+		}
+	}
+
+	for _, skipped := range []string{"scheduled-sending", "scheduled-sent", "scheduled-canceled", "scheduled-failed"} {
+		if got := mustQueryInt64(t, database, `SELECT COUNT(*) FROM outbox WHERE idempotency_key = ?`, skipped); got != 0 {
+			t.Errorf("outbox contains %d rows for skipped schedule %q", got, skipped)
+		}
+	}
+	sendingRequestID := deriveID("transport_request", "signal-primary", "scheduled-sending")
+	sendingMessageID := deriveID(
+		"message", "signal-primary", "signal:+16505550100\x1f"+sendingRequestID,
+	)
+	var sendingBody, sendingDirection string
+	mustNoError(t, database.QueryRow(`SELECT body, direction FROM messages WHERE message_id = ?`, sendingMessageID).Scan(&sendingBody, &sendingDirection))
+	if sendingBody != "ambiguous sending" || sendingDirection != "outgoing" {
+		t.Errorf("ambiguous sending optimistic row = %q/%q", sendingBody, sendingDirection)
+	}
+
+	mediaOutboxID := deriveID("outbox", "whatsapp-primary", "scheduled-pending-media")
+	var hash, mime, filename string
+	var size int64
+	mustNoError(t, database.QueryRow(`
+		SELECT blob_hash, size_bytes, mime, filename
+		FROM outbox_attachments WHERE outbox_id = ? AND ordinal = 0
+	`, mediaOutboxID).Scan(&hash, &size, &mime, &filename))
+	wantHashBytes := sha256.Sum256(scheduledBytes)
+	wantHash := hex.EncodeToString(wantHashBytes[:])
+	if hash != wantHash || size != int64(len(scheduledBytes)) ||
+		mime != "application/octet-stream" || filename != "scheduled.bin" {
+		t.Errorf("scheduled attachment = hash/size/mime/name %q/%d/%q/%q", hash, size, mime, filename)
+	}
+	blobStore, err := blob.New(blobRoot)
+	mustNoError(t, err)
+	reader, err := blobStore.Open(blob.BlobRef{Hash: hash, Size: size, MIME: mime})
+	mustNoError(t, err)
+	contents, readErr := io.ReadAll(reader)
+	closeErr := reader.Close()
+	mustNoError(t, readErr)
+	mustNoError(t, closeErr)
+	if string(contents) != string(scheduledBytes) {
+		t.Errorf("scheduled blob = %q, want %q", contents, scheduledBytes)
+	}
+}
+
+func assertFixtureReadCursors(t *testing.T, database *sql.DB) {
+	t.Helper()
+
+	smsConversationID := deriveID("conversation", "google-primary", "sms-conversation")
+	smsDeviceID := deriveID(
+		"device", "google-primary", "google-primary\x1flocal",
+	)
+	smsLastReadMessageID := deriveID(
+		"message", "google-primary", "sms-conversation\x1fgoogle-server-1",
+	)
+	var lastRead sql.NullString
+	var lastReadAt int64
+	mustNoError(t, database.QueryRow(`
+		SELECT last_read_message_id, last_read_at_ms
+		FROM read_cursors WHERE device_id = ? AND conversation_id = ?
+	`, smsDeviceID, smsConversationID).Scan(&lastRead, &lastReadAt))
+	if !lastRead.Valid || lastRead.String != smsLastReadMessageID || lastReadAt != fixtureBaseMS+1_000 {
+		t.Errorf("SMS lossy read cursor = %+v at %d, want %s at %d", lastRead, lastReadAt, smsLastReadMessageID, fixtureBaseMS+1_000)
+	}
+
+	aciConversation := "signal:" + fixtureSignalACI
+	aciConversationID := deriveID("conversation", "signal-primary", aciConversation)
+	signalDeviceID := deriveID("device", "signal-primary", "signal-primary\x1flocal")
+	mustNoError(t, database.QueryRow(`
+		SELECT last_read_message_id, last_read_at_ms
+		FROM read_cursors WHERE device_id = ? AND conversation_id = ?
+	`, signalDeviceID, aciConversationID).Scan(&lastRead, &lastReadAt))
+	if lastRead.Valid || lastReadAt != 0 {
+		t.Errorf("fully unread one-message Signal cursor = %+v at %d, want NULL at 0", lastRead, lastReadAt)
+	}
+}
+
+func openReadOnlyTestDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+
+	database, err := sql.Open("sqlite", readOnlySQLiteDSN(path))
+	mustNoError(t, err)
+	database.SetMaxOpenConns(1)
+	mustNoError(t, database.Ping())
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close target database: %v", err)
+		}
+	})
+	return database
+}
+
+func mustQueryInt64(t *testing.T, database *sql.DB, query string, args ...any) int64 {
+	t.Helper()
+
+	var value int64
+	mustNoError(t, database.QueryRow(query, args...).Scan(&value))
+	return value
+}
+
+func testFileSHA256(t *testing.T, path string) string {
+	t.Helper()
+
+	file, err := os.Open(path)
+	mustNoError(t, err)
+	hash := sha256.New()
+	_, copyErr := io.Copy(hash, file)
+	closeErr := file.Close()
+	mustNoError(t, copyErr)
+	mustNoError(t, closeErr)
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+type testSourceFileState struct {
+	exists       bool
+	contents     string
+	size         int64
+	mode         os.FileMode
+	modifiedAtNS int64
+}
+
+func snapshotSourceFamilyForTest(t *testing.T, databasePath string) map[string]testSourceFileState {
+	t.Helper()
+
+	paths := map[string]string{
+		"database": databasePath,
+		"wal":      databasePath + "-wal",
+		"shm":      databasePath + "-shm",
+	}
+	result := make(map[string]testSourceFileState, len(paths))
+	for role, path := range paths {
+		info, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			result[role] = testSourceFileState{}
+			continue
+		}
+		mustNoError(t, err)
+		contents, err := os.ReadFile(path)
+		mustNoError(t, err)
+		result[role] = testSourceFileState{
+			exists: true, contents: string(contents), size: info.Size(),
+			mode: info.Mode(), modifiedAtNS: info.ModTime().UnixNano(),
+		}
+	}
+	return result
+}
+
+func containsWarning(warnings []string, substring string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, substring) {
+			return true
+		}
+	}
+	return false
+}
+
+func mustNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A single corrupt Signal attachment ref must NOT abort the whole migration
+// (symmetric with the WhatsApp unresolvable path): the message migrates, the
+// attachment is dropped to pending/empty-ref, and the report counts it. One
+// unreadable ref in years of history cannot block the cutover go/no-go gate.
+func TestTransformToleratesMalformedSignalMedia(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "messages.db")
+	store, err := legacydb.New(sourcePath)
+	mustNoError(t, err)
+
+	base := int64(1700000000000)
+	mustNoError(t, store.UpsertConversation(&legacydb.Conversation{
+		ConversationID: "signal:+16505550199", Name: "Signal Self", SourcePlatform: "signal",
+		Participants: `[{"name":"Peer","number":"+16505550199"}]`,
+	}))
+	// A message carrying a corrupt signallocal: ref (invalid base64) and one
+	// carrying an empty signalatt: ref — both previously aborted the transform.
+	for i, mediaID := range []string{"signallocal:@@@not-base64@@@", "signalatt:"} {
+		mustNoError(t, store.UpsertMessage(&legacydb.Message{
+			MessageID:      "signal:170000009900" + string(rune('0'+i)),
+			ConversationID: "signal:+16505550199",
+			SenderName:     "Peer", SenderNumber: "+16505550199",
+			Body: "signal media with broken ref", TimestampMS: base + int64(i)*1000,
+			Status: "delivered", SourcePlatform: "signal", MediaID: mediaID, MimeType: "image/png",
+		}))
+	}
+	mustNoError(t, store.Close())
+
+	report, err := Transform(context.Background(), Options{
+		SourcePath:      sourcePath,
+		TempStorePath:   filepath.Join(root, "store.sqlite3.tmp"),
+		TempBlobPath:    filepath.Join(root, "blobs.tmp"),
+		TargetPath:      filepath.Join(root, "canonical"),
+		TargetStorePath: filepath.Join(root, "canonical", "store.sqlite3"),
+		Check:           true,
+	})
+	mustNoError(t, err) // must NOT abort
+	if report.Media.SignalUnresolvable != 2 {
+		t.Fatalf("signal_unresolvable = %d, want 2", report.Media.SignalUnresolvable)
+	}
+	// Both messages still migrated (ratio must stay 1.0 for the go/no-go gate).
+	target := openReadOnlyTestDB(t, filepath.Join(root, "store.sqlite3.tmp"))
+	if got := mustQueryInt64(t, target, `SELECT COUNT(*) FROM messages`); got != 2 {
+		t.Fatalf("migrated messages = %d, want 2", got)
+	}
+	// Attachments were dropped (no pending row with a ref), not fabricated.
+	if got := mustQueryInt64(t, target, `SELECT COUNT(*) FROM message_attachments WHERE remote_ref != x''`); got != 0 {
+		t.Fatalf("attachment rows with a ref = %d, want 0 (unresolvable)", got)
+	}
+}

--- a/internal/migration/validate.go
+++ b/internal/migration/validate.go
@@ -1,0 +1,570 @@
+package migration
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+
+	_ "modernc.org/sqlite"
+)
+
+var targetCountTables = []string{
+	"accounts", "devices", "identities", "people", "person_identities",
+	"conversations", "conversation_participants", "inbox", "messages",
+	"message_attachments", "outbox", "outbox_attachments", "read_cursors",
+}
+
+func checkpointAndSyncSQLite(ctx context.Context, path string) error {
+	database, err := sql.Open("sqlite", path)
+	if err != nil {
+		return err
+	}
+	database.SetMaxOpenConns(1)
+	var busy, logFrames, checkpointed int64
+	if err := database.QueryRowContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)").Scan(
+		&busy, &logFrames, &checkpointed,
+	); err != nil {
+		_ = database.Close()
+		return err
+	}
+	if busy != 0 || logFrames != checkpointed {
+		_ = database.Close()
+		return fmt.Errorf(
+			"WAL checkpoint incomplete: busy=%d log=%d checkpointed=%d",
+			busy, logFrames, checkpointed,
+		)
+	}
+	if err := database.Close(); err != nil {
+		return err
+	}
+	for _, sidecar := range []string{path + "-wal", path + "-shm"} {
+		if err := os.Remove(sidecar); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove SQLite sidecar %s: %w", sidecar, err)
+		}
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	syncErr := file.Sync()
+	closeErr := file.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}
+
+func validateTarget(
+	ctx context.Context,
+	options Options,
+	dataset legacyDataset,
+	state *transformState,
+	report *Report,
+) error {
+	database, err := sql.Open("sqlite", readOnlySQLiteDSN(options.TempStorePath))
+	if err != nil {
+		return fmt.Errorf("%w: open staged database for validation: %v", ErrValidation, err)
+	}
+	database.SetMaxOpenConns(1)
+	defer database.Close()
+	if _, err := database.ExecContext(ctx, "PRAGMA query_only=ON"); err != nil {
+		return fmt.Errorf("%w: make validation connection read-only: %v", ErrValidation, err)
+	}
+
+	quick, err := quickCheck(ctx, database)
+	if err != nil {
+		return fmt.Errorf("%w: quick-check staged database: %v", ErrValidation, err)
+	}
+	report.Validation.QuickCheck = quick
+	if err := database.QueryRowContext(ctx, "PRAGMA user_version").Scan(&report.Target.SchemaVersion); err != nil {
+		return fmt.Errorf("%w: read staged schema version: %v", ErrValidation, err)
+	}
+	if err := loadMigrationChecksums(ctx, database, &report.Target.MigrationChecksums); err != nil {
+		return fmt.Errorf("%w: read staged migration ledger: %v", ErrValidation, err)
+	}
+	for _, table := range targetCountTables {
+		count, err := queryCount(ctx, database, "SELECT COUNT(*) FROM "+table)
+		if err != nil {
+			return fmt.Errorf("%w: count staged %s: %v", ErrValidation, table, err)
+		}
+		report.Target.Counts[table] = count
+	}
+
+	actualHistoryByPlatform, actualHistory, actualScheduled, err := classifyTargetMessages(ctx, database, state)
+	if err != nil {
+		return fmt.Errorf("%w: classify staged messages: %v", ErrValidation, err)
+	}
+	fillTableReconciliations(dataset, state, report, actualHistory)
+	fillPlatformReconciliations(dataset, state, report, actualHistoryByPlatform)
+	if err := fillIdentityReport(ctx, database, report); err != nil {
+		return fmt.Errorf("%w: inspect staged identity graph: %v", ErrValidation, err)
+	}
+
+	fkViolations, err := foreignKeyCheck(ctx, database)
+	if err != nil {
+		return fmt.Errorf("%w: run foreign_key_check: %v", ErrValidation, err)
+	}
+	report.Validation.ForeignKeyViolations = fkViolations
+	orphans, err := detectOrphans(ctx, database)
+	if err != nil {
+		return fmt.Errorf("%w: detect staged orphans: %v", ErrValidation, err)
+	}
+	report.Validation.Orphans = orphans
+
+	report.SampledHashes, err = sampledHashChecks(ctx, database, dataset, state)
+	if err != nil {
+		return fmt.Errorf("%w: sample staged message hashes: %v", ErrValidation, err)
+	}
+	report.Validation.SampledHashesMatched = true
+	for _, sample := range report.SampledHashes {
+		if !sample.Matched {
+			report.Validation.SampledHashesMatched = false
+			break
+		}
+	}
+
+	report.Validation.BlobReferencesValid, report.Media.ScheduledBlobsVerified =
+		validateScheduledBlobs(ctx, database, options.TempBlobPath, state.scheduledBlobs)
+	report.Media.PendingAttachments = report.Target.Counts["message_attachments"]
+	report.Schedule.PendingMedia = state.expectedPendingMedia
+
+	unchanged, evidenceErr := completeSourceFileEvidence(&report.Source)
+	if evidenceErr != nil {
+		return fmt.Errorf("%w: complete legacy source evidence: %v", ErrValidation, evidenceErr)
+	}
+	report.Validation.SourceUnchanged = unchanged
+
+	countsMatched := countsMatch(dataset, state, report, actualHistory, actualScheduled, actualHistoryByPlatform)
+	report.Validation.CountsMatched = countsMatched
+	report.Validation.Passed = quick == "ok" &&
+		report.Target.SchemaVersion == 9 && len(report.Target.MigrationChecksums) == 9 &&
+		len(fkViolations) == 0 && orphanTotal(orphans) == 0 &&
+		countsMatched && report.Validation.SampledHashesMatched &&
+		report.Validation.BlobReferencesValid && report.Validation.SourceUnchanged &&
+		len(report.MessageCollisions) == 0
+
+	appendMediaWarnings(report)
+	if !report.Validation.Passed {
+		return fmt.Errorf("%w: staged v2 store failed one or more integrity gates", ErrValidation)
+	}
+	return nil
+}
+
+func fillTableReconciliations(
+	dataset legacyDataset,
+	state *transformState,
+	report *Report,
+	actualHistory int64,
+) {
+	add := func(name string, legacy, v2, reconciled int64, disposition string) {
+		report.TableCounts[name] = TableReconciliation{
+			Legacy: legacy, V2: v2, Reconciled: reconciled,
+			ReconciliationRatio: reconciliationRatio(reconciled, legacy),
+			Disposition:         disposition,
+		}
+	}
+	add("accounts", int64(len(state.accounts)), report.Target.Counts["accounts"], report.Target.Counts["accounts"], "derived")
+	add("devices", int64(len(state.accounts)), report.Target.Counts["devices"], report.Target.Counts["devices"], "derived")
+	add("identities", int64(len(state.identities)), report.Target.Counts["identities"], report.Target.Counts["identities"], "derived")
+	add("people", int64(len(dataset.unified)), report.Target.Counts["people"], report.Target.Counts["people"], "unified_contacts")
+	add("person_identities", state.expectedLinks, report.Target.Counts["person_identities"], report.Target.Counts["person_identities"], "explicit")
+	add("conversations", int64(len(dataset.conversations)), report.Target.Counts["conversations"], report.Target.Counts["conversations"], "migrated")
+	add("conversation_participants", state.expectedParticipants, report.Target.Counts["conversation_participants"], report.Target.Counts["conversation_participants"], "derived")
+	add("messages", int64(len(dataset.messages)), actualHistory, actualHistory, "migrated_history")
+	add("message_attachments", dataset.mediaRows, report.Target.Counts["message_attachments"], report.Target.Counts["message_attachments"], "pending_remote_ref")
+	add("contacts", int64(len(dataset.contacts)), int64(len(state.contactIdentityKeys)), state.contactRowsMapped, "address_book_identities")
+	add("unified_contacts", int64(len(dataset.unified)), report.Target.Counts["people"], report.Target.Counts["people"], "people")
+	add("scheduled_messages", int64(len(dataset.scheduled)), report.Target.Counts["outbox"], int64(len(dataset.scheduled)), "mapped_or_counted_skip")
+	add("outbox", dataset.scheduleByStatus["pending"], report.Target.Counts["outbox"], report.Target.Counts["outbox"], "pending_only")
+	add("outbox_attachments", state.expectedPendingMedia, report.Target.Counts["outbox_attachments"], report.Target.Counts["outbox_attachments"], "scheduled_media_blob")
+	add("read_cursors", int64(len(dataset.conversations)), report.Target.Counts["read_cursors"], report.Target.Counts["read_cursors"], "lossy_approximation")
+
+	for _, dropped := range []struct {
+		name  string
+		count int64
+	}{
+		{"reactions", dataset.dropped.ReactionsBearingMessages},
+		{"transcripts", dataset.dropped.TranscriptBearingMessages},
+		{"contact_avatars", dataset.dropped.ContactAvatars},
+		{"drafts", dataset.dropped.Drafts},
+		{"contact_meta", dataset.dropped.ContactMetaCRM},
+		{"outgoing_send_keys", dataset.dropped.OutgoingSendKeys},
+		{"tabs", dataset.dropped.Tabs},
+	} {
+		add(dropped.name, dropped.count, 0, dropped.count, "dropped_with_count")
+	}
+}
+
+func fillPlatformReconciliations(
+	dataset legacyDataset,
+	state *transformState,
+	report *Report,
+	actual map[string]int64,
+) {
+	platforms := map[string]bool{}
+	for platform := range dataset.platformMessages {
+		platforms[platform] = true
+	}
+	for platform := range actual {
+		platforms[platform] = true
+	}
+	for platform := range platforms {
+		legacy := dataset.platformMessages[platform]
+		account := state.accounts[platform]
+		report.PlatformCounts[platform] = PlatformReconciliation{
+			AccountID: account.AccountID, Legacy: legacy, V2: actual[platform],
+			ReconciliationRatio: reconciliationRatio(actual[platform], legacy),
+		}
+	}
+}
+
+func fillIdentityReport(ctx context.Context, database *sql.DB, report *Report) error {
+	report.Identities.Created = report.Target.Counts["identities"]
+	report.Identities.PeopleCreated = report.Target.Counts["people"]
+	report.Identities.LinksByProvenance = map[string]int64{
+		"explicit": 0, "address_book": 0, "bridge_alias": 0, "import": 0, "heuristic": 0,
+	}
+	rows, err := database.QueryContext(ctx, `
+		SELECT provenance, COUNT(*)
+		FROM person_identities
+		GROUP BY provenance
+		ORDER BY provenance
+	`)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var provenance string
+		var count int64
+		if err := rows.Scan(&provenance, &count); err != nil {
+			rows.Close()
+			return err
+		}
+		report.Identities.LinksByProvenance[provenance] = count
+	}
+	if err := closeRows(rows); err != nil {
+		return err
+	}
+	return database.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM identities AS i
+		LEFT JOIN person_identities AS pi ON pi.identity_id = i.identity_id
+		WHERE pi.identity_id IS NULL
+	`).Scan(&report.Identities.UnunifiedIdentities)
+}
+
+func classifyTargetMessages(
+	ctx context.Context,
+	database *sql.DB,
+	state *transformState,
+) (map[string]int64, int64, int64, error) {
+	accountPlatforms := map[string]string{}
+	for platform, account := range state.accounts {
+		accountPlatforms[account.AccountID] = platform
+	}
+	actualByPlatform := map[string]int64{}
+	var actualHistory, actualScheduled int64
+	rows, err := database.QueryContext(ctx, "SELECT account_id, message_id FROM messages ORDER BY message_id")
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	for rows.Next() {
+		var accountID, messageID string
+		if err := rows.Scan(&accountID, &messageID); err != nil {
+			rows.Close()
+			return nil, 0, 0, err
+		}
+		if _, ok := state.expectedHistory[messageID]; ok {
+			actualHistory++
+			actualByPlatform[accountPlatforms[accountID]]++
+			continue
+		}
+		if _, ok := state.scheduledMessages[messageID]; ok {
+			actualScheduled++
+		}
+	}
+	if err := closeRows(rows); err != nil {
+		return nil, 0, 0, err
+	}
+	return actualByPlatform, actualHistory, actualScheduled, nil
+}
+
+func countsMatch(
+	dataset legacyDataset,
+	state *transformState,
+	report *Report,
+	actualHistory int64,
+	actualScheduled int64,
+	actualHistoryByPlatform map[string]int64,
+) bool {
+	if actualHistory != int64(len(dataset.messages)) ||
+		actualScheduled != dataset.scheduleByStatus["pending"]+dataset.scheduleByStatus["sending"] ||
+		report.Target.Counts["messages"] != actualHistory+actualScheduled ||
+		report.Target.Counts["accounts"] != int64(len(state.accounts)) ||
+		report.Target.Counts["devices"] != int64(len(state.accounts)) ||
+		report.Target.Counts["identities"] != int64(len(state.identities)) ||
+		report.Target.Counts["people"] != int64(len(dataset.unified)) ||
+		report.Target.Counts["person_identities"] != state.expectedLinks ||
+		report.Target.Counts["conversations"] != int64(len(dataset.conversations)) ||
+		report.Target.Counts["conversation_participants"] != state.expectedParticipants ||
+		report.Target.Counts["message_attachments"] != dataset.mediaRows ||
+		report.Target.Counts["outbox"] != dataset.scheduleByStatus["pending"] ||
+		report.Target.Counts["outbox_attachments"] != state.expectedPendingMedia ||
+		report.Target.Counts["read_cursors"] != state.expectedCursors ||
+		report.Target.Counts["inbox"] != 0 {
+		return false
+	}
+	for platform, legacy := range dataset.platformMessages {
+		if actualHistoryByPlatform[platform] != legacy {
+			return false
+		}
+	}
+	return true
+}
+
+func loadMigrationChecksums(ctx context.Context, database *sql.DB, destination *[]string) error {
+	rows, err := database.QueryContext(ctx, `
+		SELECT checksum_sha256 FROM schema_migrations ORDER BY version
+	`)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var checksum string
+		if err := rows.Scan(&checksum); err != nil {
+			rows.Close()
+			return err
+		}
+		*destination = append(*destination, checksum)
+	}
+	return closeRows(rows)
+}
+
+func foreignKeyCheck(ctx context.Context, database *sql.DB) ([]ForeignKeyViolation, error) {
+	rows, err := database.QueryContext(ctx, "PRAGMA foreign_key_check")
+	if err != nil {
+		return nil, err
+	}
+	violations := []ForeignKeyViolation{}
+	for rows.Next() {
+		var violation ForeignKeyViolation
+		var rowID sql.NullInt64
+		if err := rows.Scan(&violation.Table, &rowID, &violation.Parent, &violation.Constraint); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		if rowID.Valid {
+			value := rowID.Int64
+			violation.RowID = &value
+		}
+		violations = append(violations, violation)
+	}
+	if err := closeRows(rows); err != nil {
+		return nil, err
+	}
+	return violations, nil
+}
+
+func detectOrphans(ctx context.Context, database *sql.DB) (OrphanReport, error) {
+	queries := []struct {
+		destination *int64
+		query       string
+	}{
+		{query: `SELECT COUNT(*) FROM messages m LEFT JOIN conversations c ON c.account_id=m.account_id AND c.conversation_id=m.conversation_id WHERE c.conversation_id IS NULL`},
+		{query: `SELECT COUNT(*) FROM messages m LEFT JOIN identities i ON i.account_id=m.account_id AND i.identity_id=m.sender_identity_id WHERE m.sender_identity_id IS NOT NULL AND i.identity_id IS NULL`},
+		{query: `SELECT COUNT(*) FROM conversation_participants cp LEFT JOIN identities i ON i.account_id=cp.account_id AND i.identity_id=cp.identity_id WHERE i.identity_id IS NULL`},
+		{query: `SELECT COUNT(*) FROM message_attachments a LEFT JOIN messages m ON m.message_id=a.message_id WHERE m.message_id IS NULL`},
+		{query: `SELECT COUNT(*) FROM outbox o LEFT JOIN accounts a ON a.account_id=o.account_id WHERE a.account_id IS NULL`},
+		{query: `SELECT COUNT(*) FROM outbox o LEFT JOIN conversations c ON c.account_id=o.account_id AND c.conversation_id=o.conversation_id WHERE c.conversation_id IS NULL`},
+		{query: `SELECT COUNT(*) FROM outbox_attachments a LEFT JOIN outbox o ON o.outbox_id=a.outbox_id WHERE o.outbox_id IS NULL`},
+		{query: `SELECT COUNT(*) FROM read_cursors r LEFT JOIN messages m ON m.conversation_id=r.conversation_id AND m.message_id=r.last_read_message_id WHERE r.last_read_message_id IS NOT NULL AND m.message_id IS NULL`},
+	}
+	var report OrphanReport
+	destinations := []*int64{
+		&report.MessageConversations, &report.MessageSenders,
+		&report.ConversationParticipants, &report.MessageAttachments,
+		&report.OutboxAccounts, &report.OutboxConversations,
+		&report.OutboxAttachments, &report.ReadCursorMessages,
+	}
+	for index := range queries {
+		queries[index].destination = destinations[index]
+		if err := database.QueryRowContext(ctx, queries[index].query).Scan(queries[index].destination); err != nil {
+			return OrphanReport{}, err
+		}
+	}
+	return report, nil
+}
+
+func orphanTotal(report OrphanReport) int64 {
+	return report.MessageConversations + report.MessageSenders +
+		report.ConversationParticipants + report.MessageAttachments +
+		report.OutboxAccounts + report.OutboxConversations +
+		report.OutboxAttachments + report.ReadCursorMessages
+}
+
+func sampledHashChecks(
+	ctx context.Context,
+	database *sql.DB,
+	dataset legacyDataset,
+	state *transformState,
+) ([]SampledHash, error) {
+	byPlatform := map[string][]expectedMessage{}
+	for _, expected := range state.expectedHistory {
+		byPlatform[expected.Platform] = append(byPlatform[expected.Platform], expected)
+	}
+	platforms := make([]string, 0, len(byPlatform))
+	for platform := range byPlatform {
+		platforms = append(platforms, platform)
+	}
+	sort.Strings(platforms)
+	checks := []SampledHash{}
+	for _, platform := range platforms {
+		candidates := byPlatform[platform]
+		sort.Slice(candidates, func(i, j int) bool {
+			left := sha256.Sum256([]byte(platform + "\x1f" + candidates[i].Legacy.ID))
+			right := sha256.Sum256([]byte(platform + "\x1f" + candidates[j].Legacy.ID))
+			return hex.EncodeToString(left[:]) < hex.EncodeToString(right[:])
+		})
+		if len(candidates) > SampleMessagesPerPlatform {
+			candidates = candidates[:SampleMessagesPerPlatform]
+		}
+		for _, expected := range candidates {
+			expectedHash, err := messageSpotHash(
+				expected.Legacy.Body, expected.Legacy.TimestampMS,
+				expected.RemoteID, expected.MediaID,
+			)
+			if err != nil {
+				return nil, err
+			}
+			var body, remoteID, attachmentRemoteID string
+			var occurredAt int64
+			err = database.QueryRowContext(ctx, `
+				SELECT m.body, m.occurred_at_ms, m.remote_message_id,
+				       COALESCE(a.remote_id, '')
+				FROM messages AS m
+				LEFT JOIN message_attachments AS a
+				  ON a.message_id = m.message_id AND a.ordinal = 0
+				WHERE m.message_id = ?
+			`, expected.V2ID).Scan(&body, &occurredAt, &remoteID, &attachmentRemoteID)
+			actualHash := "missing"
+			if err == nil {
+				actualHash, err = messageSpotHash(body, occurredAt, remoteID, attachmentRemoteID)
+			}
+			if err != nil && err != sql.ErrNoRows {
+				return nil, err
+			}
+			checks = append(checks, SampledHash{
+				Platform: platform, LegacyMessageID: expected.Legacy.ID,
+				V2MessageID: expected.V2ID, ExpectedSHA256: expectedHash,
+				ActualSHA256: actualHash, Matched: expectedHash == actualHash,
+			})
+		}
+	}
+	return checks, nil
+}
+
+func messageSpotHash(body string, occurredAt int64, remoteID, attachmentRemoteID string) (string, error) {
+	payload, err := json.Marshal(struct {
+		Body               string `json:"body"`
+		OccurredAtMS       int64  `json:"occurred_at_ms"`
+		RemoteMessageID    string `json:"remote_message_id"`
+		AttachmentRemoteID string `json:"attachment_remote_id"`
+	}{body, occurredAt, remoteID, attachmentRemoteID})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func validateScheduledBlobs(
+	ctx context.Context,
+	database *sql.DB,
+	root string,
+	expected []scheduledBlob,
+) (bool, int64) {
+	store, err := blob.New(root)
+	if err != nil {
+		return false, 0
+	}
+	expectedByOutbox := make(map[string]blob.BlobRef, len(expected))
+	for _, item := range expected {
+		if item.OutboxID == "" {
+			return false, 0
+		}
+		if _, duplicate := expectedByOutbox[item.OutboxID]; duplicate {
+			return false, 0
+		}
+		expectedByOutbox[item.OutboxID] = item.Ref
+	}
+	rows, err := database.QueryContext(ctx, `
+		SELECT outbox_id, ordinal, blob_hash, size_bytes, mime
+		FROM outbox_attachments
+		ORDER BY outbox_id, ordinal
+	`)
+	if err != nil {
+		return false, 0
+	}
+	defer rows.Close()
+	var verified int64
+	seen := make(map[string]bool, len(expected))
+	for rows.Next() {
+		var outboxID, hash, mime string
+		var ordinal, size int64
+		if err := rows.Scan(&outboxID, &ordinal, &hash, &size, &mime); err != nil {
+			return false, verified
+		}
+		want, ok := expectedByOutbox[outboxID]
+		if !ok || seen[outboxID] || ordinal != 0 ||
+			hash != want.Hash || size != want.Size || mime != want.MIME {
+			return false, verified
+		}
+		seen[outboxID] = true
+		persisted := blob.BlobRef{Hash: hash, Size: size, MIME: mime}
+		reader, err := store.Open(persisted)
+		if err != nil {
+			return false, verified
+		}
+		digest := sha256.New()
+		actualSize, copyErr := io.Copy(digest, reader)
+		closeErr := reader.Close()
+		if copyErr != nil || closeErr != nil || ctx.Err() != nil ||
+			actualSize != persisted.Size || hex.EncodeToString(digest.Sum(nil)) != persisted.Hash {
+			return false, verified
+		}
+		verified++
+	}
+	if rows.Err() != nil || len(seen) != len(expectedByOutbox) {
+		return false, verified
+	}
+	return true, verified
+}
+
+func appendMediaWarnings(report *Report) {
+	if count := report.Media.WhatsAppUnresolvable; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d WhatsApp attachments lacked a walocal: reference and remain pending but unresolvable", count))
+	}
+	if count := report.Media.UnsupportedArchiveAttachments; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d archive-platform attachments have no merged Opaque codec and remain pending but unresolvable", count))
+	}
+	if count := report.Media.SignalLocalAttachments; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d Signal local attachments were preserved as Opaque v1 local paths without importing bytes", count))
+	}
+}
+
+func queryCount(ctx context.Context, database *sql.DB, query string) (int64, error) {
+	var count int64
+	err := database.QueryRowContext(ctx, query).Scan(&count)
+	return count, err
+}

--- a/internal/migration/validate_test.go
+++ b/internal/migration/validate_test.go
@@ -1,0 +1,68 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+)
+
+func TestValidateScheduledBlobsUsesPersistedOutboxReferences(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	database, err := sql.Open("sqlite", filepath.Join(root, "references.sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close reference database: %v", err)
+		}
+	})
+	if _, err := database.Exec(`
+		CREATE TABLE outbox_attachments (
+			outbox_id TEXT NOT NULL,
+			ordinal INTEGER NOT NULL,
+			blob_hash TEXT NOT NULL,
+			size_bytes INTEGER NOT NULL,
+			mime TEXT NOT NULL
+		)
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	blobRoot := filepath.Join(root, "blobs")
+	blobs, err := blob.New(blobRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := blobs.Put(ctx, bytes.NewReader([]byte("persisted scheduled media")), "application/octet-stream", 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const outboxID = "fixture-outbox"
+	if _, err := database.Exec(`
+		INSERT INTO outbox_attachments (outbox_id, ordinal, blob_hash, size_bytes, mime)
+		VALUES (?, 0, ?, ?, ?)
+	`, outboxID, ref.Hash, ref.Size, ref.MIME); err != nil {
+		t.Fatal(err)
+	}
+	expected := []scheduledBlob{{OutboxID: outboxID, Ref: ref}}
+	if ok, verified := validateScheduledBlobs(ctx, database, blobRoot, expected); !ok || verified != 1 {
+		t.Fatalf("valid persisted reference = ok %v, verified %d; want true, 1", ok, verified)
+	}
+
+	if _, err := database.Exec(`
+		UPDATE outbox_attachments SET size_bytes = size_bytes + 1 WHERE outbox_id = ?
+	`, outboxID); err != nil {
+		t.Fatal(err)
+	}
+	if ok, verified := validateScheduledBlobs(ctx, database, blobRoot, expected); ok || verified != 0 {
+		t.Fatalf("corrupt persisted reference = ok %v, verified %d; want false, 0", ok, verified)
+	}
+}

--- a/internal/storage/sqlite/messages.go
+++ b/internal/storage/sqlite/messages.go
@@ -57,8 +57,9 @@ type Message struct {
 	UpdatedAtMS      int64
 }
 
-// MessageProjection couples a normalized message to the durable inbox frame
-// from which it was decoded.
+// MessageProjection describes a normalized message and its attachments.
+// ProjectMessage requires InboxID to identify the durable frame from which the
+// message was decoded; ImportMessage ignores InboxID for historical imports.
 type MessageProjection struct {
 	InboxID     string
 	Message     Message
@@ -228,6 +229,71 @@ func (r *MessageRepository) GetMessageByRemote(
 		)
 	}
 	return message, nil
+}
+
+// ImportMessage atomically upserts a historical normalized message by remote
+// ID and records its attachments without requiring or modifying an inbox row.
+func (r *MessageRepository) ImportMessage(
+	ctx context.Context,
+	projection MessageProjection,
+) error {
+	message := projection.Message
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("import message %q: begin transaction: %w", message.MessageID, err)
+	}
+	defer tx.Rollback()
+
+	nowMS, err := r.nowMS("import message")
+	if err != nil {
+		return err
+	}
+	if err := r.upsertMessage(ctx, tx, message, nowMS); err != nil {
+		return err
+	}
+	attachmentMessageID := message.MessageID
+	if len(projection.Attachments) > 0 {
+		// upsertMessage preserves the first local message_id on a natural-key
+		// conflict. Resolve that effective parent inside this transaction so a
+		// repeated import cannot point attachments at a discarded ID.
+		if err := tx.QueryRowContext(ctx, `
+			SELECT message_id
+			FROM messages
+			WHERE account_id = ?
+			  AND conversation_id = ?
+			  AND remote_message_id = ?
+		`, message.AccountID, message.ConversationID, message.RemoteMessageID).Scan(
+			&attachmentMessageID,
+		); err != nil {
+			return fmt.Errorf(
+				"import message %q: resolve attachment parent: %w",
+				message.MessageID,
+				err,
+			)
+		}
+	}
+	attachmentRepository := &MessageAttachmentRepository{store: r.store, now: r.now}
+	for _, attachment := range projection.Attachments {
+		// Historical bridge attachments do not carry a trusted v2 message ID.
+		// Bind every row to the parent selected by this import.
+		attachment.MessageID = attachmentMessageID
+		if err := attachmentRepository.RecordInboundAttachment(ctx, tx, attachment); err != nil {
+			return fmt.Errorf(
+				"import message %q: record attachment ordinal %d: %w",
+				message.MessageID,
+				attachment.Ordinal,
+				err,
+			)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		if isSQLiteConstraint(err) {
+			return invalidMessageConstraintError(nil, err, "commit message import")
+		}
+		return fmt.Errorf("import message %q: commit: %w", message.MessageID, err)
+	}
+	return nil
 }
 
 // ProjectMessage atomically upserts a normalized message by remote ID and

--- a/internal/storage/sqlite/messages_test.go
+++ b/internal/storage/sqlite/messages_test.go
@@ -157,6 +157,169 @@ func TestAppendInboxMapsSQLiteConstraints(t *testing.T) {
 	assertRowCount(t, store.db, "inbox", 0)
 }
 
+func TestImportMessageSupportsBothDirectionsWithoutInbox(t *testing.T) {
+	store, repository := openMessageTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
+	)
+	seedMessageProjectionGraph(t, store)
+
+	incoming := messageTestMessage(
+		"message-import-incoming",
+		"conversation-a",
+		"account-a",
+		"remote-import-incoming",
+		pointer("identity-a"),
+	)
+	if err := repository.ImportMessage(context.Background(), MessageProjection{
+		InboxID: "inbox-that-does-not-exist",
+		Message: incoming,
+	}); err != nil {
+		t.Fatalf("ImportMessage(incoming): %v", err)
+	}
+
+	outgoing := messageTestMessage(
+		"message-import-outgoing",
+		"conversation-a",
+		"account-a",
+		"remote-import-outgoing",
+		nil,
+	)
+	outgoing.Direction = MessageDirectionOutgoing
+	outgoing.Body = "historical outgoing message"
+	if err := repository.ImportMessage(context.Background(), MessageProjection{
+		Message: outgoing,
+	}); err != nil {
+		t.Fatalf("ImportMessage(outgoing): %v", err)
+	}
+
+	assertRowCount(t, store.db, "inbox", 0)
+	assertRowCount(t, store.db, "messages", 2)
+	for _, want := range []Message{incoming, outgoing} {
+		got, err := repository.GetMessage(context.Background(), want.MessageID)
+		if err != nil {
+			t.Fatalf("GetMessage(%q): %v", want.MessageID, err)
+		}
+		if got.Direction != want.Direction ||
+			got.Body != want.Body ||
+			!optionalStringEqual(got.SenderIdentityID, want.SenderIdentityID) ||
+			got.CreatedAtMS != messageTestTimeMS ||
+			got.UpdatedAtMS != messageTestTimeMS {
+			t.Fatalf("imported message = %+v, want normalized fields from %+v", got, want)
+		}
+	}
+}
+
+func TestImportMessageIsIdempotentByRemoteIDAndPersistsAttachments(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageProjectionGraph(t, store)
+
+	message := messageTestMessage(
+		"message-import-original",
+		"conversation-a",
+		"account-a",
+		"remote-import-shared",
+		pointer("identity-a"),
+	)
+	firstSize := int64(123)
+	firstAttachment := MessageAttachment{
+		MessageID: "caller-supplied-parent-is-ignored",
+		Ordinal:   0,
+		RemoteID:  "remote-media-first",
+		RemoteRef: []byte("opaque-first"),
+		Filename:  "first.png",
+		MIME:      "image/png",
+		SizeBytes: &firstSize,
+	}
+	if err := repository.ImportMessage(context.Background(), MessageProjection{
+		Message:     message,
+		Attachments: []MessageAttachment{firstAttachment},
+	}); err != nil {
+		t.Fatalf("ImportMessage(first): %v", err)
+	}
+
+	clock.Set(messageTestTimeMS + 100)
+	updated := message
+	updated.MessageID = "message-import-discarded"
+	updated.Body = "edited historical body"
+	updated.ReplyToRemoteID = pointer("remote-parent")
+	updated.State = MessageStateEdited
+	updated.OccurredAtMS++
+	secondSize := int64(456)
+	secondAttachment := MessageAttachment{
+		MessageID: "another-untrusted-parent",
+		Ordinal:   0,
+		RemoteID:  "remote-media-second",
+		RemoteRef: []byte("opaque-second"),
+		Filename:  "second.jpg",
+		MIME:      "image/jpeg",
+		SizeBytes: &secondSize,
+	}
+	if err := repository.ImportMessage(context.Background(), MessageProjection{
+		InboxID:     "still-not-required",
+		Message:     updated,
+		Attachments: []MessageAttachment{secondAttachment},
+	}); err != nil {
+		t.Fatalf("ImportMessage(upsert): %v", err)
+	}
+
+	assertRowCount(t, store.db, "messages", 1)
+	assertRowCount(t, store.db, "message_attachments", 1)
+	got, err := repository.GetMessage(context.Background(), message.MessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(): %v", err)
+	}
+	if got.MessageID != message.MessageID ||
+		got.Body != updated.Body ||
+		got.State != MessageStateEdited ||
+		got.ReplyToRemoteID == nil ||
+		*got.ReplyToRemoteID != *updated.ReplyToRemoteID ||
+		got.CreatedAtMS != messageTestTimeMS ||
+		got.UpdatedAtMS != messageTestTimeMS+100 {
+		t.Fatalf("upserted imported message = %+v, want stable ID/creation and updated content", got)
+	}
+
+	attachmentRepository, err := NewMessageAttachmentRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageAttachmentRepository(): %v", err)
+	}
+	attachment, err := attachmentRepository.GetForDownload(
+		context.Background(), message.MessageID, secondAttachment.Ordinal,
+	)
+	if err != nil {
+		t.Fatalf("GetForDownload(): %v", err)
+	}
+	if attachment.MessageID != message.MessageID ||
+		attachment.State != "pending" ||
+		attachment.BlobHash != nil ||
+		attachment.RemoteID != secondAttachment.RemoteID ||
+		!bytes.Equal(attachment.RemoteRef, secondAttachment.RemoteRef) ||
+		attachment.Filename != secondAttachment.Filename ||
+		attachment.MIME != secondAttachment.MIME ||
+		attachment.SizeBytes == nil ||
+		*attachment.SizeBytes != secondSize {
+		t.Fatalf("imported attachment = %+v, want refreshed metadata %+v", attachment, secondAttachment)
+	}
+
+	clock.Set(messageTestTimeMS + 200)
+	if err := repository.ImportMessage(context.Background(), MessageProjection{Message: updated}); err != nil {
+		t.Fatalf("ImportMessage(idempotent replay): %v", err)
+	}
+	replayed, err := repository.GetMessage(context.Background(), message.MessageID)
+	if err != nil {
+		t.Fatalf("GetMessage() after replay: %v", err)
+	}
+	if replayed.UpdatedAtMS != messageTestTimeMS+100 {
+		t.Fatalf(
+			"idempotent replay updated_at_ms = %d, want unchanged %d",
+			replayed.UpdatedAtMS,
+			messageTestTimeMS+100,
+		)
+	}
+	assertRowCount(t, store.db, "inbox", 0)
+}
+
 func TestProjectMessageIsIdempotentByRemoteID(t *testing.T) {
 	clock := newMessageTestClock(messageTestTimeMS)
 	store, repository := openMessageTestRepository(t, clock.Now)

--- a/main.go
+++ b/main.go
@@ -22,11 +22,12 @@ func main() {
 		With().Timestamp().Logger().Level(level)
 
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "Usage: openmessage <pair|serve|demo|backup|read|thread|threads|send|import>")
+		fmt.Fprintln(os.Stderr, "Usage: openmessage <pair|serve|demo|backup|migrate|read|thread|threads|send|import>")
 		fmt.Fprintln(os.Stderr, "  pair [--google|--google-file path]       - Pair with your phone via QR or Google account cookies")
 		fmt.Fprintln(os.Stderr, "  serve [--demo] [--web|--no-web] [--mcp-sse|--no-mcp-sse] [--mcp-stdio] - Start explicit web/MCP transports")
 		fmt.Fprintln(os.Stderr, "  demo                                     - Start a seeded fake-data UI with live transports disabled")
 		fmt.Fprintln(os.Stderr, "  backup [--to dir] [--json]               - Create a verified legacy migration backup and manifest")
+		fmt.Fprintln(os.Stderr, "  migrate [--check] [--from dir] [--to dir] [--json] - Transform the legacy store into a validated v2 store")
 		fmt.Fprintln(os.Stderr, "  read <query> [--limit N] [--phone X] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--json] - Search the local store")
 		fmt.Fprintln(os.Stderr, "  thread <name|number|conversation_id> [--limit N] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--json] - Print a full conversation chronologically")
 		fmt.Fprintln(os.Stderr, "  threads [--limit N] [--json]             - List recent conversations (find an id/name for thread)")
@@ -51,6 +52,8 @@ func main() {
 		err = cmd.RunDemo(logger)
 	case "backup":
 		err = cmd.RunBackup(logger, os.Args[2:]...)
+	case "migrate":
+		err = cmd.RunMigrate(logger, os.Args[2:]...)
 	case "read", "search":
 		if len(os.Args) < 3 {
 			fmt.Fprintln(os.Stderr, "Usage: openmessage read <query> [--limit N] [--phone NUMBER] [--json]")
@@ -94,7 +97,7 @@ func main() {
 		err = cmd.RunDebugMedia(logger, os.Args[2])
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1])
-		fmt.Fprintln(os.Stderr, "Usage: openmessage <pair|serve|demo|backup|read|thread|threads|send|import>")
+		fmt.Fprintln(os.Stderr, "Usage: openmessage <pair|serve|demo|backup|migrate|read|thread|threads|send|import>")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
The heart of the data cutover: `openmessage migrate` (+`--check`) builds the canonical v2 store from the legacy store and emits the integrity report that is the cutover's pre-registered evidence. Deterministic IDs make it a pure function of the source (idempotent/resumable, proven byte-identical run-twice in review); source never mutated; temp→validate→atomic rename. Every legacy table mapped or counted-drop (incl. the operator's CRM data, surfaced); media refs packed in the PR-D Opaque formats and round-trip-tested through the real adapter codecs. Review verdict **SHIP-ready**; the one substantive fix (corrupt Signal media ref now flags-and-continues instead of aborting the whole migration) is folded in with a regression test. 50k messages migrate+validate in 6.8s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)