### PR TITLE
MCP send tools via the v2 durable outbox + media-by-URL (rebuild Wave 3 / W3-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ To let a client connect over HTTP, start OpenMessage with `--mcp-sse` (or `--web
 | `list_contacts` | List/search contacts |
 | `resolve_contact_routes` | Resolve a person or phone number to the available SMS/WhatsApp/Signal routes |
 | `get_status` | Google Messages, WhatsApp, and Signal connection status |
-| `download_media` | Download an attachment from a message to a local temp file |
+| `download_media` | Return the local `/api/media/<message-id>` URL and metadata for an attachment |
 | `draft_message` | Save a draft for the local app to review/send later |
 | `import_messages` | Import Google Chat, iMessage, WhatsApp export, or Signal Desktop history |
 | `get_person_messages` | Load messages for conversations matching a person's name |

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -42,6 +42,18 @@ type serveOptions struct {
 	mcpStdio bool
 }
 
+func mcpV2Dependencies(stack *v2Stack) []*tools.V2Dependencies {
+	if stack == nil {
+		return nil
+	}
+	return []*tools.V2Dependencies{{
+		Enabled:  true,
+		Service:  stack.Service,
+		V2Store:  stack.Store,
+		Registry: stack.Registry,
+	}}
+}
+
 // buildVersion is the version string baked in at build time. SetVersion is
 // called from main() with the value of main.version (set via -ldflags).
 var buildVersion = "dev"
@@ -453,7 +465,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		buildVersion,
 		mcpserver.WithToolCapabilities(true),
 	)
-	tools.Register(mcpSrv, a)
+	tools.Register(mcpSrv, a, mcpV2Dependencies(stack)...)
 
 	var mcpHTTPHandler http.Handler
 	if opts.mcpSSE {

--- a/cmd/serve_tools_test.go
+++ b/cmd/serve_tools_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func TestMCPV2Dependencies(t *testing.T) {
+	if got := mcpV2Dependencies(nil); len(got) != 0 {
+		t.Fatalf("mcpV2Dependencies(nil) returned %d dependencies, want zero", len(got))
+	}
+
+	service := &messaging.MessageService{}
+	store := &sqlite.Store{}
+	registry := bridge.NewRegistry()
+	got := mcpV2Dependencies(&v2Stack{
+		Service:  service,
+		Store:    store,
+		Registry: registry,
+	})
+	if len(got) != 1 {
+		t.Fatalf("mcpV2Dependencies(stack) returned %d dependencies, want one", len(got))
+	}
+	deps := got[0]
+	if deps == nil {
+		t.Fatal("mcpV2Dependencies(stack) returned a nil dependency")
+	}
+	if !deps.Enabled {
+		t.Fatal("mcpV2Dependencies(stack) returned disabled dependencies")
+	}
+	if deps.Service != service {
+		t.Fatal("mcpV2Dependencies(stack) did not preserve the message service pointer")
+	}
+	if deps.V2Store != store {
+		t.Fatal("mcpV2Dependencies(stack) did not preserve the v2 store pointer")
+	}
+	if deps.Registry != registry {
+		t.Fatal("mcpV2Dependencies(stack) did not preserve the registry pointer")
+	}
+}

--- a/internal/tools/download_media.go
+++ b/internal/tools/download_media.go
@@ -2,31 +2,19 @@ package tools
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
-	"os"
-	"path/filepath"
+	"net/url"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/maxghenis/openmessage/internal/app"
-	"github.com/maxghenis/openmessage/internal/db"
-)
-
-var (
-	downloadWhatsAppMedia = func(a *app.App, msg *db.Message) ([]byte, string, error) {
-		return a.DownloadWhatsAppMedia(msg)
-	}
-	downloadSignalMedia = func(a *app.App, msg *db.Message) ([]byte, string, error) {
-		return a.DownloadSignalMedia(msg)
-	}
 )
 
 func downloadMediaTool() mcp.Tool {
 	return mcp.NewTool("download_media",
-		mcp.WithDescription("Download media (voice messages, images, videos) from a message and save to a local file. Supports Google Messages, WhatsApp, and Signal."),
+		mcp.WithDescription("Return the read-only /api/media/<message-id> URL and available metadata for a media attachment. Supports Google Messages, WhatsApp, and Signal."),
 		mcp.WithString("message_id", mcp.Required(), mcp.Description("The message ID containing the media")),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
@@ -52,55 +40,25 @@ func downloadMediaHandler(a *app.App) server.ToolHandlerFunc {
 			return errorResult("this message has no media attachment"), nil
 		}
 
-		mimeType := msg.MimeType
-		var data []byte
-		switch {
-		case msg.SourcePlatform == "whatsapp" || strings.HasPrefix(msg.MessageID, "whatsapp:") || strings.HasPrefix(msg.MediaID, "wa:"):
-			data, mimeType, err = downloadWhatsAppMedia(a, msg)
-			if err != nil {
-				return errorResult(fmt.Sprintf("download media: %v", err)), nil
-			}
-		case msg.SourcePlatform == "signal" || strings.HasPrefix(msg.MessageID, "signal:") || strings.HasPrefix(msg.MediaID, "signalatt:"):
-			data, mimeType, err = downloadSignalMedia(a, msg)
-			if err != nil {
-				return errorResult(fmt.Sprintf("download media: %v", err)), nil
-			}
-		default:
-			cli := a.GetClient()
-			if cli == nil {
-				return errorResult(app.ErrNotConnected), nil
-			}
-
-			key, err := hex.DecodeString(msg.DecryptionKey)
-			if err != nil {
-				return errorResult(fmt.Sprintf("invalid decryption key: %v", err)), nil
-			}
-
-			data, err = cli.GM.DownloadMedia(msg.MediaID, key)
-			if err != nil {
-				return errorResult(fmt.Sprintf("download media: %v", err)), nil
-			}
-		}
+		mimeType := strings.TrimSpace(msg.MimeType)
 		if strings.TrimSpace(mimeType) == "" {
-			mimeType = msg.MimeType
+			mimeType = "application/octet-stream"
 		}
-
-		// Determine file extension from mime type
 		ext := extensionForMime(mimeType)
-
-		// Save to a temp file. Sanitize the message id for use in a filename —
-		// iMessage GUIDs and conversation-scoped ids contain "/" and ":", which
-		// would turn into bogus nested paths and fail the write.
-		tmpDir := os.TempDir()
 		safeID := strings.NewReplacer("/", "_", ":", "_", "\\", "_", " ", "_").Replace(msgID)
 		filename := fmt.Sprintf("openmessage-%s%s", safeID, ext)
-		filePath := filepath.Join(tmpDir, filename)
+		mediaURL := "/api/media/" + url.PathEscape(msgID)
 
-		if err := os.WriteFile(filePath, data, 0644); err != nil {
-			return errorResult(fmt.Sprintf("write file: %v", err)), nil
-		}
-
-		return textResult(fmt.Sprintf("Downloaded %s (%d bytes) to:\n%s", mimeType, len(data), filePath)), nil
+		return structuredResult(map[string]any{
+			"message_id": msgID,
+			"url":        mediaURL,
+			"filename":   filename,
+			"mime_type":  mimeType,
+			// Legacy message rows do not retain attachment size. The serving
+			// endpoint resolves it lazily (including projected v2blob: refs), so
+			// report the value as unknown instead of fetching or inventing bytes.
+			"size_bytes": nil,
+		}, fmt.Sprintf("Media is available at %s (%s, %s; size unknown)", mediaURL, filename, mimeType)), nil
 	}
 }
 

--- a/internal/tools/download_media_url_test.go
+++ b/internal/tools/download_media_url_test.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+func TestDownloadMediaReturnsLegacyMediaURLWithoutDownloadingOrWriting(t *testing.T) {
+	a := testApp(t)
+	const messageID = "whatsapp:thread/with space:message"
+	if err := a.Store.UpsertMessage(&db.Message{
+		MessageID:      messageID,
+		ConversationID: "whatsapp:thread/with space",
+		TimestampMS:    time.Now().UnixMilli(),
+		MediaID:        "v2blob:" + strings.Repeat("a", 64),
+		MimeType:       "image/png",
+		SourcePlatform: "whatsapp",
+	}); err != nil {
+		t.Fatalf("seed projected v2 media message: %v", err)
+	}
+
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"message_id": messageID}
+	result, err := downloadMediaHandler(a)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("downloadMediaHandler(): %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("download_media returned tool error: %#v", result.Content)
+	}
+	payload := structuredMap(t, result)
+	if got, want := payload["url"], "/api/media/"+url.PathEscape(messageID); got != want {
+		t.Fatalf("url = %#v, want %#v", got, want)
+	}
+	if got, want := payload["filename"], "openmessage-whatsapp_thread_with_space_message.png"; got != want {
+		t.Fatalf("filename = %#v, want %#v", got, want)
+	}
+	if got := payload["mime_type"]; got != "image/png" {
+		t.Fatalf("mime_type = %#v, want image/png", got)
+	}
+	if size, ok := payload["size_bytes"]; !ok || size != nil {
+		t.Fatalf("size_bytes = %#v (present=%v), want explicit unknown null", size, ok)
+	}
+
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("ReadDir(temp): %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("download_media wrote temp files: %#v", entries)
+	}
+}
+
+func TestDownloadMediaToolIsReadOnlyServingURL(t *testing.T) {
+	tool := downloadMediaTool()
+	if tool.Annotations.ReadOnlyHint == nil || !*tool.Annotations.ReadOnlyHint {
+		t.Fatalf("readOnlyHint = %#v, want true", tool.Annotations.ReadOnlyHint)
+	}
+	if strings.Contains(strings.ToLower(tool.Description), "save to a local file") {
+		t.Fatalf("description still promises a local-file mutation: %q", tool.Description)
+	}
+	if !strings.Contains(tool.Description, "/api/media/") {
+		t.Fatalf("description does not document the serving URL: %q", tool.Description)
+	}
+}

--- a/internal/tools/legacy_parity_test.go
+++ b/internal/tools/legacy_parity_test.go
@@ -1,0 +1,334 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+// TestLegacySendToolDescriptorParity pins the complete flag-off tools/list
+// surface. In particular, v2-only descriptions or arguments must not leak into
+// the legacy descriptors while OPENMESSAGES_V2_SEND is disabled.
+func TestLegacySendToolDescriptorParity(t *testing.T) {
+	tests := []struct {
+		name string
+		tool mcp.Tool
+		want string
+	}{
+		{
+			name: "send_message",
+			tool: sendMessageTool(),
+			want: `{"annotations":{"readOnlyHint":false,"destructiveHint":false,"idempotentHint":false,"openWorldHint":true},"description":"Send a direct text message across supported platforms. Defaults to SMS/RCS when no platform is specified.","inputSchema":{"type":"object","properties":{"message":{"description":"Message text to send","type":"string"},"phone_number":{"description":"Legacy alias for recipient. For SMS/RCS use a phone number with country code (e.g., +15551234567).","type":"string"},"platform":{"description":"Target platform: sms, rcs, whatsapp, or signal. Defaults to sms.","type":"string"},"recipient":{"description":"Recipient identifier. Use a phone number for SMS/RCS or Signal, and a phone number or WhatsApp JID for WhatsApp.","type":"string"}},"required":["message"]},"name":"send_message"}`,
+		},
+		{
+			name: "send_to_conversation",
+			tool: sendToConversationTool(),
+			want: `{"annotations":{"readOnlyHint":false,"destructiveHint":false,"idempotentHint":false,"openWorldHint":true},"description":"Send a text message to an existing conversation by conversation ID across supported platforms","inputSchema":{"type":"object","properties":{"conversation_id":{"description":"Existing conversation ID from list_conversations or get_conversation","type":"string"},"message":{"description":"Message text to send","type":"string"}},"required":["conversation_id","message"]},"name":"send_to_conversation"}`,
+		},
+		{
+			name: "send_media_to_conversation",
+			tool: sendMediaToConversationTool(),
+			want: `{"annotations":{"readOnlyHint":false,"destructiveHint":false,"idempotentHint":false,"openWorldHint":true},"description":"Send a media attachment to an existing conversation by conversation ID across supported platforms","inputSchema":{"type":"object","properties":{"caption":{"description":"Optional caption for platforms that support media captions","type":"string"},"conversation_id":{"description":"Existing conversation ID from list_conversations or get_conversation","type":"string"},"file_path":{"description":"Absolute or relative path to the local file to send","type":"string"},"mime_type":{"description":"Optional MIME type override, for example image/png","type":"string"},"reply_to_id":{"description":"Optional message ID to reply to when the platform supports media replies","type":"string"}},"required":["conversation_id","file_path"]},"name":"send_media_to_conversation"}`,
+		},
+		{
+			name: "send_group_message",
+			tool: sendGroupMessageTool(),
+			want: `{"annotations":{"readOnlyHint":false,"destructiveHint":false,"idempotentHint":false,"openWorldHint":true},"description":"Send a text message to a group conversation (MMS group). Creates the group if it doesn't exist.","inputSchema":{"type":"object","properties":{"message":{"description":"Message text to send","type":"string"},"phone_numbers":{"description":"JSON array of phone numbers with country code, e.g. [\"+15551234567\", \"+15559876543\"]","type":"string"}},"required":["phone_numbers","message"]},"name":"send_group_message"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertLegacyJSON(t, test.tool, test.want)
+		})
+	}
+}
+
+func TestV2SendToolDescriptorsExplainIdempotencyAndUncertainDelivery(t *testing.T) {
+	tests := []struct {
+		name string
+		tool mcp.Tool
+	}{
+		{name: "send_message", tool: sendMessageTool(true)},
+		{name: "send_to_conversation", tool: sendToConversationTool(true)},
+		{name: "send_media_to_conversation", tool: sendMediaToConversationTool(true)},
+		{name: "send_group_message", tool: sendGroupMessageTool(true)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			idempotency, ok := test.tool.InputSchema.Properties["idempotency_key"].(map[string]any)
+			if !ok {
+				t.Fatalf("idempotency_key schema = %#v, want a property object", test.tool.InputSchema.Properties["idempotency_key"])
+			}
+			if got := idempotency["type"]; got != "string" {
+				t.Fatalf("idempotency_key type = %#v, want string", got)
+			}
+			propertyDescription, _ := idempotency["description"].(string)
+			if !strings.Contains(strings.ToLower(propertyDescription), "same key") {
+				t.Fatalf("idempotency_key description does not explain replay semantics: %q", propertyDescription)
+			}
+			for _, required := range test.tool.InputSchema.Required {
+				if required == "idempotency_key" {
+					t.Fatal("idempotency_key must remain optional")
+				}
+			}
+
+			description := strings.ToLower(test.tool.Description)
+			if !strings.Contains(description, "uncertain") ||
+				!strings.Contains(description, "may have accepted") ||
+				!strings.Contains(description, "do not retry automatically") {
+				t.Fatalf("v2 tool description does not explain uncertain/do-not-retry semantics: %q", test.tool.Description)
+			}
+			if test.tool.Annotations.IdempotentHint == nil || *test.tool.Annotations.IdempotentHint {
+				t.Fatalf("idempotentHint = %#v, want explicit false", test.tool.Annotations.IdempotentHint)
+			}
+		})
+	}
+}
+
+func TestRegisterNilOrDisabledV2UsesLegacySendToolsAndHandler(t *testing.T) {
+	originalSend := sendTextToConversation
+	legacyCalls := 0
+	sendTextToConversation = func(_ *app.App, conversationID, body string) (conversationSummary, messageSummary, error) {
+		legacyCalls++
+		return conversationSummary{
+				ConversationID: conversationID,
+				Name:           "Legacy Selection",
+				SourcePlatform: "sms",
+			}, messageSummary{
+				MessageID:      "legacy-selection-message",
+				ConversationID: conversationID,
+				Body:           body,
+				TimestampMS:    1_700_000_001_000,
+				IsFromMe:       true,
+				SourcePlatform: "sms",
+			}, nil
+	}
+	t.Cleanup(func() { sendTextToConversation = originalSend })
+
+	legacyTools := map[string]mcp.Tool{
+		"send_message":               sendMessageTool(),
+		"send_to_conversation":       sendToConversationTool(),
+		"send_media_to_conversation": sendMediaToConversationTool(),
+		"send_group_message":         sendGroupMessageTool(),
+	}
+	tests := []struct {
+		name string
+		deps *V2Dependencies
+	}{
+		{name: "nil", deps: nil},
+		{name: "disabled", deps: &V2Dependencies{Enabled: false}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := testApp(t)
+			s := mcpserver.NewMCPServer("legacy-selection", "test")
+			Register(s, a, test.deps)
+
+			for name, want := range legacyTools {
+				registered := s.GetTool(name)
+				if registered == nil {
+					t.Fatalf("registered tool %q not found", name)
+				}
+				gotJSON, err := json.Marshal(registered.Tool)
+				if err != nil {
+					t.Fatalf("marshal registered %s: %v", name, err)
+				}
+				wantJSON, err := json.Marshal(want)
+				if err != nil {
+					t.Fatalf("marshal legacy %s: %v", name, err)
+				}
+				if string(gotJSON) != string(wantJSON) {
+					t.Fatalf("registered %s selected a non-legacy descriptor\n got: %s\nwant: %s", name, gotJSON, wantJSON)
+				}
+			}
+
+			sendTool := s.GetTool("send_to_conversation")
+			result, err := sendTool.Handler(context.Background(), legacyCallRequest("send_to_conversation", map[string]any{
+				"conversation_id": "legacy-selection-conversation",
+				"message":         "stay legacy",
+			}))
+			if err != nil {
+				t.Fatalf("registered legacy handler: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("registered legacy handler returned error: %v", result.Content)
+			}
+			payload := structuredMap(t, result)
+			conversation, ok := payload["conversation"].(conversationSummary)
+			if !ok || conversation.Name != "Legacy Selection" {
+				t.Fatalf("registered handler did not select legacy response: %#v", payload)
+			}
+		})
+	}
+	if legacyCalls != len(tests) {
+		t.Fatalf("legacy handler calls = %d, want %d", legacyCalls, len(tests))
+	}
+}
+
+func TestLegacySendMessageExchangeParity(t *testing.T) {
+	a := testApp(t)
+	original := sendSignalText
+	sendSignalText = func(_ *app.App, conversationID, body, replyToID string) (*db.Message, error) {
+		if conversationID != "signal:+15551230000" || body != "legacy hello" || replyToID != "" {
+			t.Fatalf("legacy send args = (%q, %q, %q)", conversationID, body, replyToID)
+		}
+		return &db.Message{
+			MessageID:      "signal:legacy-parity-1",
+			ConversationID: conversationID,
+			Body:           body,
+			TimestampMS:    1_700_000_000_123,
+			Status:         "sent",
+			IsFromMe:       true,
+			SourcePlatform: "signal",
+		}, nil
+	}
+	t.Cleanup(func() { sendSignalText = original })
+
+	req := legacyCallRequest("send_message", map[string]any{
+		"message":   "legacy hello",
+		"platform":  "signal",
+		"recipient": "+15551230000",
+	})
+	assertLegacyJSON(t, req, `{"method":"tools/call","params":{"name":"send_message","arguments":{"message":"legacy hello","platform":"signal","recipient":"+15551230000"}}}`)
+
+	result, err := sendMessageHandler(a)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("sendMessageHandler() error = %v", err)
+	}
+	assertLegacyJSON(t, result, `{"content":[{"type":"text","text":"Message sent to +15551230000: legacy hello"}],"structuredContent":{"conversation":{"conversation_id":"signal:+15551230000","name":"+15551230000","source_platform":"signal","is_group":false},"message":{"message_id":"signal:legacy-parity-1","conversation_id":"signal:+15551230000","body":"legacy hello","timestamp_ms":1700000000123,"status":"sent","is_from_me":true,"source_platform":"signal","display_text":"legacy hello"},"ok":true}}`)
+}
+
+func TestLegacySendToConversationExchangeParity(t *testing.T) {
+	a := testApp(t)
+	original := sendTextToConversation
+	sendTextToConversation = func(_ *app.App, conversationID, body string) (conversationSummary, messageSummary, error) {
+		if conversationID != "signal:legacy-thread" || body != "hello thread" {
+			t.Fatalf("legacy send args = (%q, %q)", conversationID, body)
+		}
+		return conversationSummary{
+				ConversationID: conversationID,
+				Name:           "Legacy Thread",
+				SourcePlatform: "signal",
+				IsGroup:        true,
+			}, messageSummary{
+				MessageID:      "signal:legacy-parity-2",
+				ConversationID: conversationID,
+				Body:           body,
+				TimestampMS:    1_700_000_000_456,
+				Status:         "sent",
+				IsFromMe:       true,
+				SourcePlatform: "signal",
+				DisplayText:    body,
+			}, nil
+	}
+	t.Cleanup(func() { sendTextToConversation = original })
+
+	req := legacyCallRequest("send_to_conversation", map[string]any{
+		"conversation_id": "signal:legacy-thread",
+		"message":         "hello thread",
+	})
+	assertLegacyJSON(t, req, `{"method":"tools/call","params":{"name":"send_to_conversation","arguments":{"conversation_id":"signal:legacy-thread","message":"hello thread"}}}`)
+
+	result, err := sendToConversationHandler(a)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("sendToConversationHandler() error = %v", err)
+	}
+	assertLegacyJSON(t, result, `{"content":[{"type":"text","text":"Message sent to Legacy Thread (signal:legacy-thread): hello thread"}],"structuredContent":{"conversation":{"conversation_id":"signal:legacy-thread","name":"Legacy Thread","source_platform":"signal","is_group":true},"message":{"message_id":"signal:legacy-parity-2","conversation_id":"signal:legacy-thread","body":"hello thread","timestamp_ms":1700000000456,"status":"sent","is_from_me":true,"source_platform":"signal","display_text":"hello thread"},"ok":true}}`)
+}
+
+func TestLegacySendMediaExchangeParity(t *testing.T) {
+	a := testApp(t)
+	if err := a.Store.UpsertConversation(&db.Conversation{
+		ConversationID: "signal:legacy-media",
+		Name:           "Legacy Media",
+		SourcePlatform: "signal",
+	}); err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("legacy-parity.jpg", []byte("legacy jpeg bytes"), 0o600); err != nil {
+		t.Fatalf("write media fixture: %v", err)
+	}
+
+	original := sendSignalMediaMessage
+	sendSignalMediaMessage = func(_ *app.App, conversationID string, data []byte, filename, mimeType, caption, replyToID string) (*db.Message, error) {
+		if conversationID != "signal:legacy-media" || string(data) != "legacy jpeg bytes" ||
+			filename != "legacy-parity.jpg" || mimeType != "image/jpeg" ||
+			caption != "legacy caption" || replyToID != "signal:parent" {
+			t.Fatalf("legacy media args = (%q, %q, %q, %q, %q, %q)", conversationID, data, filename, mimeType, caption, replyToID)
+		}
+		return &db.Message{
+			MessageID:      "signal:legacy-parity-media",
+			ConversationID: conversationID,
+			Body:           caption,
+			TimestampMS:    1_700_000_000_789,
+			Status:         "sent",
+			IsFromMe:       true,
+			MediaID:        "signalatt:legacy-parity-media",
+			MimeType:       mimeType,
+			ReplyToID:      replyToID,
+			SourcePlatform: "signal",
+		}, nil
+	}
+	t.Cleanup(func() { sendSignalMediaMessage = original })
+
+	req := legacyCallRequest("send_media_to_conversation", map[string]any{
+		"caption":         "legacy caption",
+		"conversation_id": "signal:legacy-media",
+		"file_path":       "legacy-parity.jpg",
+		"mime_type":       "image/jpeg",
+		"reply_to_id":     "signal:parent",
+	})
+	assertLegacyJSON(t, req, `{"method":"tools/call","params":{"name":"send_media_to_conversation","arguments":{"caption":"legacy caption","conversation_id":"signal:legacy-media","file_path":"legacy-parity.jpg","mime_type":"image/jpeg","reply_to_id":"signal:parent"}}}`)
+
+	result, err := sendMediaToConversationHandler(a)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("sendMediaToConversationHandler() error = %v", err)
+	}
+	assertLegacyJSON(t, result, `{"content":[{"type":"text","text":"Media sent to Legacy Media (signal:legacy-media): legacy-parity.jpg"}]}`)
+}
+
+func TestLegacySendGroupExchangeParity(t *testing.T) {
+	a := testApp(t)
+	req := legacyCallRequest("send_group_message", map[string]any{
+		"phone_numbers": `["+15551234567"]`,
+		"message":       "legacy group",
+	})
+	assertLegacyJSON(t, req, `{"method":"tools/call","params":{"name":"send_group_message","arguments":{"message":"legacy group","phone_numbers":"[\"+15551234567\"]"}}}`)
+
+	result, err := sendGroupMessageHandler(a)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("sendGroupMessageHandler() error = %v", err)
+	}
+	assertLegacyJSON(t, result, `{"content":[{"type":"text","text":"phone_numbers must contain at least 2 numbers for a group message"}],"isError":true,"structuredContent":{"error":"phone_numbers must contain at least 2 numbers for a group message","ok":false}}`)
+}
+
+func legacyCallRequest(name string, arguments map[string]any) mcp.CallToolRequest {
+	req := mcp.CallToolRequest{}
+	req.Method = string(mcp.MethodToolsCall)
+	req.Params.Name = name
+	req.Params.Arguments = arguments
+	return req
+}
+
+func assertLegacyJSON(t *testing.T, value any, want string) {
+	t.Helper()
+	got, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal(%T): %v", value, err)
+	}
+	if string(got) != want {
+		t.Fatalf("legacy JSON changed\n got: %s\nwant: %s", got, want)
+	}
+}

--- a/internal/tools/send_group_message.go
+++ b/internal/tools/send_group_message.go
@@ -15,17 +15,40 @@ import (
 	"github.com/maxghenis/openmessage/internal/db"
 )
 
-func sendGroupMessageTool() mcp.Tool {
-	return mcp.NewTool("send_group_message",
-		mcp.WithDescription("Send a text message to a group conversation (MMS group). Creates the group if it doesn't exist."),
+var getOrCreateGoogleGroupConversationV2 = func(a *app.App, phones []string) (*gmproto.Conversation, error) {
+	cli := a.GetClient()
+	if cli == nil {
+		return nil, fmt.Errorf(app.ErrNotConnected)
+	}
+	response, err := cli.GM.GetOrCreateConversation(&gmproto.GetOrCreateConversationRequest{
+		Numbers: app.NewContactNumbers(phones),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response.GetConversation(), nil
+}
+
+func sendGroupMessageTool(v2Enabled ...bool) mcp.Tool {
+	description := "Send a text message to a group conversation (MMS group). Creates the group if it doesn't exist."
+	options := []mcp.ToolOption{
+		mcp.WithDescription(description),
 		mcp.WithString("phone_numbers", mcp.Required(), mcp.Description(`JSON array of phone numbers with country code, e.g. ["+15551234567", "+15559876543"]`)),
 		mcp.WithString("message", mcp.Required(), mcp.Description("Message text to send")),
+	}
+	if v2Requested(v2Enabled) {
+		options[0] = mcp.WithDescription(description + v2DeliveryDescription)
+		options = append(options, mcp.WithString("idempotency_key", mcp.Description(v2IdempotencyDescription)))
+	}
+	options = append(options,
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
 	)
+	return mcp.NewTool("send_group_message", options...)
 }
 
-func sendGroupMessageHandler(a *app.App) server.ToolHandlerFunc {
+func sendGroupMessageHandler(a *app.App, v2Options ...*V2Dependencies) server.ToolHandlerFunc {
+	v2 := activeV2(v2Options)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
 		phonesRaw := strArg(args, "phone_numbers")
@@ -44,6 +67,22 @@ func sendGroupMessageHandler(a *app.App) server.ToolHandlerFunc {
 		}
 		if len(phones) < 2 {
 			return errorResult("phone_numbers must contain at least 2 numbers for a group message"), nil
+		}
+		if v2 != nil {
+			conv, err := getOrCreateGoogleGroupConversationV2(a, phones)
+			if err != nil {
+				if !a.HandleGoogleAuthExpiredError(err) {
+					a.RecordGoogleSendError(err)
+				}
+				return errorResult(fmt.Sprintf("failed to get/create group conversation: %v", err)), nil
+			}
+			if conv == nil {
+				return errorResult("no conversation returned"), nil
+			}
+			if err := upsertGoogleConversation(a, conv); err != nil {
+				return errorResult(fmt.Sprintf("failed to persist conversation: %v", err)), nil
+			}
+			return submitV2Text(ctx, a, v2, args, conv.GetConversationID(), message), nil
 		}
 
 		cli := a.GetClient()

--- a/internal/tools/send_media_to_conversation.go
+++ b/internal/tools/send_media_to_conversation.go
@@ -3,7 +3,9 @@ package tools
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
 	"mime"
 	"net/http"
 	"os"
@@ -17,6 +19,8 @@ import (
 
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/v2wire"
 )
 
 var (
@@ -49,17 +53,25 @@ var (
 	}
 )
 
-func sendMediaToConversationTool() mcp.Tool {
-	return mcp.NewTool("send_media_to_conversation",
-		mcp.WithDescription("Send a media attachment to an existing conversation by conversation ID across supported platforms"),
+func sendMediaToConversationTool(v2Enabled ...bool) mcp.Tool {
+	description := "Send a media attachment to an existing conversation by conversation ID across supported platforms"
+	options := []mcp.ToolOption{
+		mcp.WithDescription(description),
 		mcp.WithString("conversation_id", mcp.Required(), mcp.Description("Existing conversation ID from list_conversations or get_conversation")),
 		mcp.WithString("file_path", mcp.Required(), mcp.Description("Absolute or relative path to the local file to send")),
 		mcp.WithString("caption", mcp.Description("Optional caption for platforms that support media captions")),
 		mcp.WithString("mime_type", mcp.Description("Optional MIME type override, for example image/png")),
 		mcp.WithString("reply_to_id", mcp.Description("Optional message ID to reply to when the platform supports media replies")),
+	}
+	if v2Requested(v2Enabled) {
+		options[0] = mcp.WithDescription(description + v2DeliveryDescription)
+		options = append(options, mcp.WithString("idempotency_key", mcp.Description(v2IdempotencyDescription)))
+	}
+	options = append(options,
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
 	)
+	return mcp.NewTool("send_media_to_conversation", options...)
 }
 
 // maxMediaUploadBytes bounds a single MCP media send. It mirrors the HTTP
@@ -67,7 +79,8 @@ func sendMediaToConversationTool() mcp.Tool {
 // into memory and take the backend down.
 const maxMediaUploadBytes = 128 << 20
 
-func sendMediaToConversationHandler(a *app.App) server.ToolHandlerFunc {
+func sendMediaToConversationHandler(a *app.App, v2Options ...*V2Dependencies) server.ToolHandlerFunc {
+	v2 := activeV2(v2Options)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
 		conversationID := strArg(args, "conversation_id")
@@ -97,6 +110,9 @@ func sendMediaToConversationHandler(a *app.App) server.ToolHandlerFunc {
 			return errorResult("file_path must point to a file"), nil
 		} else if info.Size() > maxMediaUploadBytes {
 			return errorResult(fmt.Sprintf("file too large (%d bytes; limit %d MB)", info.Size(), maxMediaUploadBytes>>20)), nil
+		}
+		if v2 != nil {
+			return submitV2MediaFile(ctx, a, v2, args, filePath, mimeType, caption, replyToID), nil
 		}
 		data, err := os.ReadFile(filePath)
 		if err != nil {
@@ -176,6 +192,58 @@ func sendMediaToConversationHandler(a *app.App) server.ToolHandlerFunc {
 			return errorResult(fmt.Sprintf("media sending is not supported for platform %s via OpenMessage MCP yet", conv.SourcePlatform)), nil
 		}
 	}
+}
+
+func submitV2MediaFile(
+	ctx context.Context,
+	a *app.App,
+	v2 *V2Dependencies,
+	args map[string]any,
+	filePath string,
+	mimeType string,
+	caption string,
+	replyToID string,
+) *mcp.CallToolResult {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return errorResult(fmt.Sprintf("read file: %v", err))
+	}
+	defer file.Close()
+
+	filename := filepath.Base(filePath)
+	if filename == "." || filename == string(filepath.Separator) || filename == "" {
+		return errorResult("file_path must point to a file")
+	}
+	sniff := make([]byte, 512)
+	n, err := file.Read(sniff)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return errorResult(fmt.Sprintf("read file: %v", err))
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return errorResult(fmt.Sprintf("read file: %v", err))
+	}
+	mimeType = detectMediaMimeType(filename, sniff[:n], mimeType)
+
+	key, err := v2IdempotencyKey(args)
+	if err != nil {
+		return errorResult(err.Error())
+	}
+	submission, err := v2.submitMedia(ctx, a, v2wire.MediaInput{
+		ConversationID: strArg(args, "conversation_id"),
+		Content:        file,
+		Filename:       filename,
+		MIME:           mimeType,
+		Caption:        caption,
+		ReplyToID:      replyToID,
+		IdempotencyKey: key,
+	})
+	if err != nil {
+		if errors.Is(err, messaging.ErrTooLarge) {
+			return errorResult(fmt.Sprintf("file too large (limit %d MB)", maxMediaUploadBytes>>20))
+		}
+		return errorResult(fmt.Sprintf("failed to submit media: %v", err))
+	}
+	return waitForV2Delivery(ctx, v2, submission, key)
 }
 
 func detectMediaMimeType(filename string, data []byte, explicit string) string {

--- a/internal/tools/send_message.go
+++ b/internal/tools/send_message.go
@@ -44,19 +44,28 @@ var (
 	}
 )
 
-func sendMessageTool() mcp.Tool {
-	return mcp.NewTool("send_message",
-		mcp.WithDescription("Send a direct text message across supported platforms. Defaults to SMS/RCS when no platform is specified."),
+func sendMessageTool(v2Enabled ...bool) mcp.Tool {
+	description := "Send a direct text message across supported platforms. Defaults to SMS/RCS when no platform is specified."
+	options := []mcp.ToolOption{
+		mcp.WithDescription(description),
 		mcp.WithString("phone_number", mcp.Description("Legacy alias for recipient. For SMS/RCS use a phone number with country code (e.g., +15551234567).")),
 		mcp.WithString("recipient", mcp.Description("Recipient identifier. Use a phone number for SMS/RCS or Signal, and a phone number or WhatsApp JID for WhatsApp.")),
 		mcp.WithString("platform", mcp.Description("Target platform: sms, rcs, whatsapp, or signal. Defaults to sms.")),
 		mcp.WithString("message", mcp.Required(), mcp.Description("Message text to send")),
+	}
+	if v2Requested(v2Enabled) {
+		options[0] = mcp.WithDescription(description + v2DeliveryDescription)
+		options = append(options, mcp.WithString("idempotency_key", mcp.Description(v2IdempotencyDescription)))
+	}
+	options = append(options,
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
 	)
+	return mcp.NewTool("send_message", options...)
 }
 
-func sendMessageHandler(a *app.App) server.ToolHandlerFunc {
+func sendMessageHandler(a *app.App, v2Options ...*V2Dependencies) server.ToolHandlerFunc {
+	v2 := activeV2(v2Options)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
 		recipient := firstNonEmpty(strings.TrimSpace(strArg(args, "recipient")), strings.TrimSpace(strArg(args, "phone_number")))
@@ -75,6 +84,12 @@ func sendMessageHandler(a *app.App) server.ToolHandlerFunc {
 			conversationID, name, number, isGroup, err := canonicalWhatsAppDirectConversation(recipient)
 			if err != nil {
 				return errorResult(err.Error()), nil
+			}
+			if v2 != nil {
+				if err := ensureDirectConversationExists(a, conversationID, "whatsapp", name, number, isGroup, time.Now().UnixMilli()); err != nil {
+					return errorResult(fmt.Sprintf("failed to persist conversation: %v", err)), nil
+				}
+				return submitV2Text(ctx, a, v2, args, conversationID, message), nil
 			}
 			msg, err := sendWhatsAppText(a, conversationID, message, "")
 			if err != nil {
@@ -100,6 +115,12 @@ func sendMessageHandler(a *app.App) server.ToolHandlerFunc {
 			conversationID, name, number, isGroup, err := canonicalSignalDirectConversation(recipient)
 			if err != nil {
 				return errorResult(err.Error()), nil
+			}
+			if v2 != nil {
+				if err := ensureDirectConversationExists(a, conversationID, "signal", name, number, isGroup, time.Now().UnixMilli()); err != nil {
+					return errorResult(fmt.Sprintf("failed to persist conversation: %v", err)), nil
+				}
+				return submitV2Text(ctx, a, v2, args, conversationID, message), nil
 			}
 			msg, err := sendSignalText(a, conversationID, message, "")
 			if err != nil {
@@ -141,6 +162,9 @@ func sendMessageHandler(a *app.App) server.ToolHandlerFunc {
 			}
 			if err := upsertGoogleConversation(a, conv); err != nil {
 				return errorResult(fmt.Sprintf("failed to persist conversation: %v", err)), nil
+			}
+			if v2 != nil {
+				return submitV2Text(ctx, a, v2, args, conv.GetConversationID(), message), nil
 			}
 			myParticipantID, simPayload := app.ExtractSIMAndParticipant(conv)
 			payload := app.BuildSendPayload(conv.GetConversationID(), message, "", myParticipantID, simPayload)

--- a/internal/tools/send_to_conversation.go
+++ b/internal/tools/send_to_conversation.go
@@ -20,17 +20,26 @@ var (
 	}
 )
 
-func sendToConversationTool() mcp.Tool {
-	return mcp.NewTool("send_to_conversation",
-		mcp.WithDescription("Send a text message to an existing conversation by conversation ID across supported platforms"),
+func sendToConversationTool(v2Enabled ...bool) mcp.Tool {
+	description := "Send a text message to an existing conversation by conversation ID across supported platforms"
+	options := []mcp.ToolOption{
+		mcp.WithDescription(description),
 		mcp.WithString("conversation_id", mcp.Required(), mcp.Description("Existing conversation ID from list_conversations or get_conversation")),
 		mcp.WithString("message", mcp.Required(), mcp.Description("Message text to send")),
+	}
+	if v2Requested(v2Enabled) {
+		options[0] = mcp.WithDescription(description + v2DeliveryDescription)
+		options = append(options, mcp.WithString("idempotency_key", mcp.Description(v2IdempotencyDescription)))
+	}
+	options = append(options,
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
 	)
+	return mcp.NewTool("send_to_conversation", options...)
 }
 
-func sendToConversationHandler(a *app.App) server.ToolHandlerFunc {
+func sendToConversationHandler(a *app.App, v2Options ...*V2Dependencies) server.ToolHandlerFunc {
+	v2 := activeV2(v2Options)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
 		conversationID := strArg(args, "conversation_id")
@@ -41,6 +50,9 @@ func sendToConversationHandler(a *app.App) server.ToolHandlerFunc {
 		}
 		if message == "" {
 			return errorResult("message is required"), nil
+		}
+		if v2 != nil {
+			return submitV2Text(ctx, a, v2, args, conversationID, message), nil
 		}
 
 		conv, msg, err := sendTextToConversation(a, conversationID, message)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -12,13 +12,20 @@ import (
 	"github.com/maxghenis/openmessage/internal/db"
 )
 
-func Register(s *server.MCPServer, a *app.App) {
+func Register(s *server.MCPServer, a *app.App, v2 ...*V2Dependencies) {
+	configuredV2 := activeV2(v2)
 	s.AddTool(getMessagesTool(), getMessagesHandler(a))
 	s.AddTool(getConversationTool(), getConversationHandler(a))
 	s.AddTool(searchMessagesTool(), searchMessagesHandler(a))
-	s.AddTool(sendMessageTool(), sendMessageHandler(a))
-	s.AddTool(sendToConversationTool(), sendToConversationHandler(a))
-	s.AddTool(sendMediaToConversationTool(), sendMediaToConversationHandler(a))
+	if configuredV2 == nil {
+		s.AddTool(sendMessageTool(), sendMessageHandler(a))
+		s.AddTool(sendToConversationTool(), sendToConversationHandler(a))
+		s.AddTool(sendMediaToConversationTool(), sendMediaToConversationHandler(a))
+	} else {
+		s.AddTool(sendMessageTool(true), sendMessageHandler(a, configuredV2))
+		s.AddTool(sendToConversationTool(true), sendToConversationHandler(a, configuredV2))
+		s.AddTool(sendMediaToConversationTool(true), sendMediaToConversationHandler(a, configuredV2))
+	}
 	s.AddTool(reactToMessageTool(), reactToMessageHandler(a))
 	s.AddTool(setMessageTranscriptTool(), setMessageTranscriptHandler(a))
 	s.AddTool(listConversationsTool(), listConversationsHandler(a))
@@ -36,7 +43,11 @@ func Register(s *server.MCPServer, a *app.App) {
 	s.AddTool(generateVizTool(), generateVizHandler(a))
 	s.AddTool(getPersonMessagesRangeTool(), getPersonMessagesRangeHandler(a))
 	s.AddTool(renderStoryTool(), renderStoryHandler(a))
-	s.AddTool(sendGroupMessageTool(), sendGroupMessageHandler(a))
+	if configuredV2 == nil {
+		s.AddTool(sendGroupMessageTool(), sendGroupMessageHandler(a))
+	} else {
+		s.AddTool(sendGroupMessageTool(true), sendGroupMessageHandler(a, configuredV2))
+	}
 }
 
 func strArg(args map[string]any, key string) string {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1332,7 +1332,7 @@ func TestDownloadMediaNoMediaID(t *testing.T) {
 	}
 }
 
-func TestDownloadMediaNotConnected(t *testing.T) {
+func TestDownloadMediaReturnsURLWithoutConnection(t *testing.T) {
 	a := testApp(t)
 	now := time.Now().UnixMilli()
 
@@ -1354,12 +1354,12 @@ func TestDownloadMediaNotConnected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("handler error: %v", err)
 	}
-	if !result.IsError {
-		t.Error("expected error when not connected")
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
 	}
-	text := result.Content[0].(mcp.TextContent).Text
-	if !strings.Contains(text, "not connected") {
-		t.Errorf("expected 'not connected' error, got: %s", text)
+	payload := structuredMap(t, result)
+	if payload["url"] != "/api/media/media-msg" {
+		t.Fatalf("url = %#v, want /api/media/media-msg", payload["url"])
 	}
 }
 
@@ -1378,17 +1378,6 @@ func TestDownloadMediaWhatsApp(t *testing.T) {
 		t.Fatalf("seed message: %v", err)
 	}
 
-	originalDownloadWhatsAppMedia := downloadWhatsAppMedia
-	downloadWhatsAppMedia = func(_ *app.App, msg *db.Message) ([]byte, string, error) {
-		if msg.MessageID != "whatsapp:media-msg" {
-			t.Fatalf("messageID = %q, want whatsapp:media-msg", msg.MessageID)
-		}
-		return []byte("png"), "image/png", nil
-	}
-	t.Cleanup(func() {
-		downloadWhatsAppMedia = originalDownloadWhatsAppMedia
-	})
-
 	handler := downloadMediaHandler(a)
 	req := mcp.CallToolRequest{}
 	req.Params.Arguments = map[string]any{"message_id": "whatsapp:media-msg"}
@@ -1400,15 +1389,9 @@ func TestDownloadMediaWhatsApp(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected tool error: %v", result.Content)
 	}
-	text := result.Content[0].(mcp.TextContent).Text
-	path := strings.TrimSpace(text[strings.LastIndex(text, "\n")+1:])
-	t.Cleanup(func() { _ = os.Remove(path) })
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile(%s): %v", path, err)
-	}
-	if string(data) != "png" {
-		t.Fatalf("downloaded data = %q, want png", string(data))
+	payload := structuredMap(t, result)
+	if payload["mime_type"] != "image/png" || payload["filename"] != "openmessage-whatsapp_media-msg.png" {
+		t.Fatalf("unexpected media metadata: %#v", payload)
 	}
 }
 
@@ -1427,17 +1410,6 @@ func TestDownloadMediaSignal(t *testing.T) {
 		t.Fatalf("seed message: %v", err)
 	}
 
-	originalDownloadSignalMedia := downloadSignalMedia
-	downloadSignalMedia = func(_ *app.App, msg *db.Message) ([]byte, string, error) {
-		if msg.MessageID != "signal:media-msg" {
-			t.Fatalf("messageID = %q, want signal:media-msg", msg.MessageID)
-		}
-		return []byte("jpg"), "image/jpeg", nil
-	}
-	t.Cleanup(func() {
-		downloadSignalMedia = originalDownloadSignalMedia
-	})
-
 	handler := downloadMediaHandler(a)
 	req := mcp.CallToolRequest{}
 	req.Params.Arguments = map[string]any{"message_id": "signal:media-msg"}
@@ -1449,15 +1421,9 @@ func TestDownloadMediaSignal(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected tool error: %v", result.Content)
 	}
-	text := result.Content[0].(mcp.TextContent).Text
-	path := strings.TrimSpace(text[strings.LastIndex(text, "\n")+1:])
-	t.Cleanup(func() { _ = os.Remove(path) })
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile(%s): %v", path, err)
-	}
-	if string(data) != "jpg" {
-		t.Fatalf("downloaded data = %q, want jpg", string(data))
+	payload := structuredMap(t, result)
+	if payload["mime_type"] != "image/jpeg" || payload["filename"] != "openmessage-signal_media-msg.jpg" {
+		t.Fatalf("unexpected media metadata: %#v", payload)
 	}
 }
 

--- a/internal/tools/v2.go
+++ b/internal/tools/v2.go
@@ -1,0 +1,251 @@
+package tools
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2wire"
+)
+
+// V2Dependencies is the optional durable-send seam used by the four MCP send
+// tools. A nil/disabled value leaves their legacy descriptors and handlers
+// untouched.
+type V2Dependencies struct {
+	Enabled  bool
+	Service  *messaging.MessageService
+	V2Store  *sqlite.Store
+	Registry bridge.Registry
+}
+
+const v2DeliveryDescription = " With v2 sending enabled, this waits for a settled delivery result. Every result includes outbox_id and idempotency_key. If settled is false (the wait was interrupted or the app is retrying automatically), the message is still durably queued and the app finishes sending it in the background: never send it again in response. An uncertain result means the transport may have accepted the message; do not retry automatically. Send again only as a deliberate new intent, reusing the returned idempotency_key when repeating the exact same send after a lost response."
+
+const v2IdempotencyDescription = "Optional retry key for the exact same send. Every result echoes the key in use; reuse the same key only when repeating a send whose response was lost. Omit it to mint a new intent."
+
+func activeV2(options []*V2Dependencies) *V2Dependencies {
+	if len(options) == 0 || options[0] == nil || !options[0].Enabled {
+		return nil
+	}
+	return options[0]
+}
+
+func v2Requested(enabled []bool) bool {
+	return len(enabled) > 0 && enabled[0]
+}
+
+func (v *V2Dependencies) submitDeps(a *app.App) v2wire.Deps {
+	return v2wire.Deps{
+		Legacy:   a.Store,
+		V2:       v.V2Store,
+		Service:  v.Service,
+		Registry: v.Registry,
+	}
+}
+
+func (v *V2Dependencies) submitText(
+	ctx context.Context,
+	a *app.App,
+	input v2wire.TextInput,
+) (messaging.Submission, error) {
+	return v2wire.SubmitText(ctx, v.submitDeps(a), input)
+}
+
+func (v *V2Dependencies) submitMedia(
+	ctx context.Context,
+	a *app.App,
+	input v2wire.MediaInput,
+) (messaging.Submission, error) {
+	return v2wire.SubmitMedia(ctx, v.submitDeps(a), input)
+}
+
+func v2IdempotencyKey(args map[string]any) (string, error) {
+	if raw, present := args["idempotency_key"]; present {
+		key, ok := raw.(string)
+		if !ok {
+			return "", errors.New("idempotency_key must be a string")
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return "", errors.New("idempotency_key must not be blank")
+		}
+		if len(key) > 128 {
+			return "", errors.New("idempotency_key is too long")
+		}
+		for i := 0; i < len(key); i++ {
+			c := key[i]
+			if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+				continue
+			}
+			switch c {
+			case '_', '-', '.', ':':
+				continue
+			default:
+				return "", errors.New("idempotency_key contains unsupported characters")
+			}
+		}
+		return key, nil
+	}
+	return newMCPIdempotencyKey()
+}
+
+func newMCPIdempotencyKey() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate MCP idempotency key: %w", err)
+	}
+	value[6] = (value[6] & 0x0f) | 0x40
+	value[8] = (value[8] & 0x3f) | 0x80
+	return strings.Join([]string{
+		hex.EncodeToString(value[0:4]),
+		hex.EncodeToString(value[4:6]),
+		hex.EncodeToString(value[6:8]),
+		hex.EncodeToString(value[8:10]),
+		hex.EncodeToString(value[10:16]),
+	}, "-"), nil
+}
+
+func submitV2Text(
+	ctx context.Context,
+	a *app.App,
+	v2 *V2Dependencies,
+	args map[string]any,
+	conversationID string,
+	body string,
+) *mcp.CallToolResult {
+	key, err := v2IdempotencyKey(args)
+	if err != nil {
+		return errorResult(err.Error())
+	}
+	submission, err := v2.submitText(ctx, a, v2wire.TextInput{
+		ConversationID: conversationID,
+		Body:           body,
+		IdempotencyKey: key,
+	})
+	if err != nil {
+		return errorResult(fmt.Sprintf("failed to submit message: %v", err))
+	}
+	return waitForV2Delivery(ctx, v2, submission, key)
+}
+
+// waitForV2Delivery reports the durable send's outcome. The intent is already
+// enqueued when this runs, so no path below may return an IsError result: a
+// tool error invites the calling agent to resend, and the outbox will finish
+// the first send regardless. Interrupted waits and auto-retrying states are
+// reported as non-settled statuses with explicit do-not-resend guidance.
+func waitForV2Delivery(
+	ctx context.Context,
+	v2 *V2Dependencies,
+	submission messaging.Submission,
+	idempotencyKey string,
+) *mcp.CallToolResult {
+	if v2.Service == nil {
+		return errorResult("v2 send service is unavailable")
+	}
+	delivery, err := v2.Service.Wait(ctx, submission.OutboxID)
+	if err != nil {
+		return v2InterruptedResult(submission, idempotencyKey, delivery, err)
+	}
+
+	settled := delivery.State != messaging.OutboxNotDispatched
+	payload := map[string]any{
+		"ok":               v2DeliveryOK(delivery.State),
+		"settled":          settled,
+		"outbox_id":        delivery.OutboxID,
+		"state":            delivery.State,
+		"deduplicated":     submission.Deduplicated,
+		"local_message_id": delivery.LocalMessageID,
+		"idempotency_key":  idempotencyKey,
+	}
+	if !settled {
+		payload["auto_retry"] = true
+	}
+	if delivery.RemoteMessageID != "" {
+		payload["remote_message_id"] = delivery.RemoteMessageID
+	}
+	if delivery.ErrorClass != "" {
+		payload["error_class"] = delivery.ErrorClass
+	}
+	if delivery.ErrorCode != "" {
+		payload["error_code"] = delivery.ErrorCode
+	}
+	if delivery.Warning != "" {
+		payload["warning"] = delivery.Warning
+	}
+
+	return structuredResult(payload, v2DeliveryText(delivery))
+}
+
+// v2InterruptedResult handles Wait ending before the delivery settled (request
+// context canceled or timed out, or a transient read failure). The durable row
+// is untouched by the interruption and the dispatcher runs on its own context,
+// so the send still completes in the background.
+func v2InterruptedResult(
+	submission messaging.Submission,
+	idempotencyKey string,
+	lastKnown messaging.Delivery,
+	waitErr error,
+) *mcp.CallToolResult {
+	outboxID := lastKnown.OutboxID
+	if outboxID == "" {
+		outboxID = submission.OutboxID
+	}
+	state := string(lastKnown.State)
+	if state == "" {
+		state = string(messaging.OutboxQueued)
+	}
+	payload := map[string]any{
+		"ok":              false,
+		"settled":         false,
+		"outbox_id":       outboxID,
+		"state":           state,
+		"deduplicated":    submission.Deduplicated,
+		"idempotency_key": idempotencyKey,
+		"wait_error":      waitErr.Error(),
+	}
+	if lastKnown.LocalMessageID != "" {
+		payload["local_message_id"] = lastKnown.LocalMessageID
+	}
+	text := fmt.Sprintf(
+		"The send is durably queued (outbox %s, state %s) and the app will finish sending it in the background; this wait was interrupted (%v) before the outcome settled. Do NOT send this message again. To repeat the exact same send deliberately, reuse idempotency_key %s.",
+		outboxID, state, waitErr, idempotencyKey,
+	)
+	return structuredResult(payload, text)
+}
+
+// v2DeliveryOK reports whether the message reached the transport. store_failed
+// means the transport accepted the send and only the local record needs repair,
+// which the dispatcher performs automatically.
+func v2DeliveryOK(state messaging.OutboxState) bool {
+	return state == messaging.OutboxConfirmed || state == messaging.OutboxStoreFailed
+}
+
+func v2DeliveryText(delivery messaging.Delivery) string {
+	switch delivery.State {
+	case messaging.OutboxConfirmed:
+		if delivery.RemoteMessageID != "" {
+			return fmt.Sprintf("Message delivery confirmed (outbox %s, remote message %s).", delivery.OutboxID, delivery.RemoteMessageID)
+		}
+		return fmt.Sprintf("Message delivery confirmed (outbox %s).", delivery.OutboxID)
+	case messaging.OutboxUncertain:
+		return fmt.Sprintf("Message delivery is uncertain (outbox %s): the transport may have accepted it. Do not retry automatically; send again only as a deliberate new intent.", delivery.OutboxID)
+	case messaging.OutboxNotDispatched:
+		return fmt.Sprintf("Delivery has not succeeded yet (outbox %s, error class %s). The app is retrying it automatically; do NOT send this message again.", delivery.OutboxID, firstNonEmpty(delivery.ErrorClass, "unknown"))
+	case messaging.OutboxStoreFailed:
+		return fmt.Sprintf("The transport accepted the message (outbox %s, remote message %s); the local record is being repaired automatically. Do not resend.", delivery.OutboxID, delivery.RemoteMessageID)
+	case messaging.OutboxRejected:
+		return fmt.Sprintf("Message delivery was rejected (outbox %s, error class %s). The app will not retry it; sending again creates a new message and may fail the same way.", delivery.OutboxID, firstNonEmpty(delivery.ErrorClass, "unknown"))
+	case messaging.OutboxCanceled:
+		return fmt.Sprintf("Message delivery was canceled (outbox %s).", delivery.OutboxID)
+	default:
+		return fmt.Sprintf("Message delivery settled as %s (outbox %s).", delivery.State, delivery.OutboxID)
+	}
+}

--- a/internal/tools/v2_send_test.go
+++ b/internal/tools/v2_send_test.go
@@ -1,0 +1,713 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func TestV2SendToConversationReturnsConfirmedDelivery(t *testing.T) {
+	harness := newV2ToolHarness(t, v2ToolSendStep{result: bridge.SendResult{
+		RemoteMessageID: "remote-confirmed",
+	}})
+	handler := sendToConversationHandler(harness.app, &harness.deps)
+
+	result, err := handler(context.Background(), v2ToolCall(map[string]any{
+		"conversation_id": v2ToolConversationID,
+		"message":         "settle this send",
+		"idempotency_key": "mcp-confirmed-key",
+	}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("confirmed delivery returned tool error: %v", result.Content)
+	}
+
+	payload := v2ToolPayload(t, result)
+	assertV2ToolBool(t, payload, "ok", true)
+	assertV2ToolBool(t, payload, "settled", true)
+	assertV2ToolString(t, payload, "state", string(messaging.OutboxConfirmed))
+	assertV2ToolString(t, payload, "remote_message_id", "remote-confirmed")
+	assertV2ToolString(t, payload, "idempotency_key", "mcp-confirmed-key")
+	assertV2ToolBool(t, payload, "deduplicated", false)
+	if got := v2ToolString(payload, "outbox_id"); got == "" {
+		t.Fatal("outbox_id is empty")
+	}
+	if got := v2ToolString(payload, "local_message_id"); got == "" {
+		t.Fatal("local_message_id is empty")
+	}
+	for _, key := range []string{"error_class", "error_code", "warning"} {
+		if got := v2ToolString(payload, key); got != "" {
+			t.Fatalf("%s = %q, want empty", key, got)
+		}
+	}
+}
+
+func TestV2SendToConversationReturnsHonestUncertainDelivery(t *testing.T) {
+	harness := newV2ToolHarness(t, v2ToolSendStep{err: bridge.OpError{
+		Class:     bridge.FailureTransient,
+		Operation: "send_text",
+		Dispatch:  bridge.DispatchUncertain,
+		Cause:     context.DeadlineExceeded,
+	}})
+	handler := sendToConversationHandler(harness.app, &harness.deps)
+
+	result, err := handler(context.Background(), v2ToolCall(map[string]any{
+		"conversation_id": v2ToolConversationID,
+		"message":         "the outcome may be ambiguous",
+		"idempotency_key": "mcp-uncertain-key",
+	}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("uncertain delivery must be data, not a tool error: %v", result.Content)
+	}
+
+	payload := v2ToolPayload(t, result)
+	assertV2ToolBool(t, payload, "ok", false)
+	assertV2ToolBool(t, payload, "settled", true)
+	assertV2ToolString(t, payload, "state", string(messaging.OutboxUncertain))
+	assertV2ToolString(t, payload, "remote_message_id", "")
+	assertV2ToolString(t, payload, "idempotency_key", "mcp-uncertain-key")
+	assertV2ToolString(t, payload, "error_class", string(bridge.FailureTransient))
+	assertV2ToolString(t, payload, "error_code", "send_text")
+	assertV2ToolString(t, payload, "warning", "delivery outcome is unknown")
+	if got := v2ToolString(payload, "outbox_id"); got == "" {
+		t.Fatal("outbox_id is empty")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(strings.ToLower(text), "uncertain") {
+		t.Fatalf("uncertain result text does not explain its state: %q", text)
+	}
+}
+
+func TestV2SendToConversationDuplicateKeyReturnsSameOutboxAndDispatchesOnce(t *testing.T) {
+	harness := newV2ToolHarness(t, v2ToolSendStep{result: bridge.SendResult{
+		RemoteMessageID: "remote-once",
+	}})
+	handler := sendToConversationHandler(harness.app, &harness.deps)
+	request := v2ToolCall(map[string]any{
+		"conversation_id": v2ToolConversationID,
+		"message":         "send this exactly once",
+		"idempotency_key": "mcp-duplicate-key",
+	})
+
+	first, err := handler(context.Background(), request)
+	if err != nil {
+		t.Fatalf("first handler call: %v", err)
+	}
+	if first.IsError {
+		t.Fatalf("first handler result is error: %v", first.Content)
+	}
+	second, err := handler(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second handler call: %v", err)
+	}
+	if second.IsError {
+		t.Fatalf("second handler result is error: %v", second.Content)
+	}
+
+	firstPayload := v2ToolPayload(t, first)
+	secondPayload := v2ToolPayload(t, second)
+	firstOutboxID := v2ToolString(firstPayload, "outbox_id")
+	if firstOutboxID == "" || v2ToolString(secondPayload, "outbox_id") != firstOutboxID {
+		t.Fatalf("duplicate outbox IDs = %q and %q, want same non-empty ID",
+			firstOutboxID, v2ToolString(secondPayload, "outbox_id"))
+	}
+	assertV2ToolBool(t, firstPayload, "deduplicated", false)
+	assertV2ToolBool(t, secondPayload, "deduplicated", true)
+	assertV2ToolString(t, secondPayload, "state", string(messaging.OutboxConfirmed))
+	assertV2ToolString(t, secondPayload, "remote_message_id", "remote-once")
+	if got := harness.sender.requestCount(); got != 1 {
+		t.Fatalf("transport dispatch count = %d, want 1", got)
+	}
+}
+
+func TestV2SendMediaRejectsMaxPlusOneWithoutOutbox(t *testing.T) {
+	harness := newV2ToolHarness(t)
+	filePath := filepath.Join(t.TempDir(), "too-large.bin")
+	file, err := os.Create(filePath)
+	if err != nil {
+		t.Fatalf("Create(%s): %v", filePath, err)
+	}
+	if err := file.Truncate(int64(maxMediaUploadBytes) + 1); err != nil {
+		_ = file.Close()
+		t.Fatalf("Truncate(%s): %v", filePath, err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close(%s): %v", filePath, err)
+	}
+
+	handler := sendMediaToConversationHandler(harness.app, &harness.deps)
+	result, err := handler(context.Background(), v2ToolCall(map[string]any{
+		"conversation_id": v2ToolConversationID,
+		"file_path":       filePath,
+		"idempotency_key": "mcp-media-too-large",
+	}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("max+1 media result IsError = false; content=%v", result.Content)
+	}
+	payload := v2ToolPayload(t, result)
+	assertV2ToolBool(t, payload, "ok", false)
+	errorText := strings.ToLower(v2ToolString(payload, "error"))
+	if !strings.Contains(errorText, "too large") && !strings.Contains(errorText, "size limit") {
+		t.Fatalf("oversize error = %q, want a clean size-limit message", errorText)
+	}
+	if got := harness.ids.count(); got != 0 {
+		t.Fatalf("message service allocated %d IDs, want 0 before outbox creation", got)
+	}
+	pending, err := harness.deps.Service.ListPending(context.Background(), messaging.ListPendingQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListPending(): %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending deliveries after oversize media = %+v, want none", pending)
+	}
+	outbox, err := sqlite.NewOutboxRepository(harness.deps.V2Store, harness.clock.Now)
+	if err != nil {
+		t.Fatalf("NewOutboxRepository(): %v", err)
+	}
+	confirmed, err := outbox.ListConfirmedSince(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatalf("ListConfirmedSince(): %v", err)
+	}
+	if len(confirmed) != 0 {
+		t.Fatalf("confirmed deliveries after oversize media = %+v, want none", confirmed)
+	}
+	if files := v2ToolBlobFiles(t, harness.blobRoot); len(files) != 0 {
+		t.Fatalf("blob files after oversize media = %v, want none", files)
+	}
+}
+
+func TestV2SendMessageGoogleKeepsLegacyConversationLookupButUsesV2Transport(t *testing.T) {
+	harness := newV2ToolHarness(t, v2ToolSendStep{result: bridge.SendResult{
+		RemoteMessageID: "remote-direct-google",
+	}})
+	lookupCalls := 0
+	legacySendCalls := 0
+	originalLookup := getOrCreateGoogleConversation
+	originalLegacySend := sendGoogleTextPayload
+	getOrCreateGoogleConversation = func(_ *app.App, phone string) (*gmproto.Conversation, error) {
+		lookupCalls++
+		if phone != "+15551230000" {
+			t.Fatalf("legacy GetOrCreate phone = %q, want +15551230000", phone)
+		}
+		return &gmproto.Conversation{
+			ConversationID:       v2ToolDirectConversationID,
+			Name:                 "Taylor",
+			LastMessageTimestamp: 1_700_000_000_000_000,
+		}, nil
+	}
+	sendGoogleTextPayload = func(_ *app.App, _ *gmproto.SendMessageRequest) (*gmproto.SendMessageResponse, error) {
+		legacySendCalls++
+		return nil, errors.New("legacy Google send must not run while v2 is enabled")
+	}
+	t.Cleanup(func() {
+		getOrCreateGoogleConversation = originalLookup
+		sendGoogleTextPayload = originalLegacySend
+	})
+
+	result, err := sendMessageHandler(harness.app, &harness.deps)(
+		context.Background(),
+		v2ToolCall(map[string]any{
+			"phone_number":    "+15551230000",
+			"message":         "direct through v2",
+			"idempotency_key": "mcp-direct-google",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("v2 direct send returned tool error: %v", result.Content)
+	}
+	payload := v2ToolPayload(t, result)
+	assertV2ToolBool(t, payload, "ok", true)
+	assertV2ToolString(t, payload, "state", string(messaging.OutboxConfirmed))
+	assertV2ToolString(t, payload, "remote_message_id", "remote-direct-google")
+	if lookupCalls != 1 {
+		t.Fatalf("legacy GetOrCreate calls = %d, want 1", lookupCalls)
+	}
+	if legacySendCalls != 0 {
+		t.Fatalf("legacy Google send calls = %d, want 0", legacySendCalls)
+	}
+	conversation, err := harness.app.Store.GetConversation(v2ToolDirectConversationID)
+	if err != nil {
+		t.Fatalf("load persisted conversation: %v", err)
+	}
+	if conversation == nil || conversation.Name != "Taylor" || conversation.SourcePlatform != "sms" {
+		t.Fatalf("persisted conversation = %#v, want legacy-upserted Google conversation", conversation)
+	}
+	legacyMessages, err := harness.app.Store.GetMessagesByConversation(v2ToolDirectConversationID, 10)
+	if err != nil {
+		t.Fatalf("load legacy messages: %v", err)
+	}
+	if len(legacyMessages) != 0 {
+		t.Fatalf("legacy send persisted messages = %#v, want none", legacyMessages)
+	}
+	requests := harness.sender.snapshotRequests()
+	if len(requests) != 1 || requests[0].Conversation.RemoteID != v2ToolDirectConversationID ||
+		requests[0].Body != "direct through v2" {
+		t.Fatalf("v2 transport requests = %+v, want direct Google conversation/body", requests)
+	}
+}
+
+func TestV2SendGroupMessageKeepsLegacyConversationLookupButUsesV2Transport(t *testing.T) {
+	harness := newV2ToolHarness(t, v2ToolSendStep{result: bridge.SendResult{
+		RemoteMessageID: "remote-group-google",
+	}})
+	lookupCalls := 0
+	originalLookup := getOrCreateGoogleGroupConversationV2
+	getOrCreateGoogleGroupConversationV2 = func(_ *app.App, phones []string) (*gmproto.Conversation, error) {
+		lookupCalls++
+		want := []string{"+15551230000", "+15551230001"}
+		if len(phones) != len(want) || phones[0] != want[0] || phones[1] != want[1] {
+			t.Fatalf("legacy group GetOrCreate phones = %v, want %v", phones, want)
+		}
+		return &gmproto.Conversation{
+			ConversationID:       v2ToolGroupConversationID,
+			Name:                 "Weekend plans",
+			IsGroupChat:          true,
+			LastMessageTimestamp: 1_700_000_000_000_000,
+		}, nil
+	}
+	t.Cleanup(func() { getOrCreateGoogleGroupConversationV2 = originalLookup })
+
+	result, err := sendGroupMessageHandler(harness.app, &harness.deps)(
+		context.Background(),
+		v2ToolCall(map[string]any{
+			"phone_numbers":   `["+15551230000","+15551230001"]`,
+			"message":         "group through v2",
+			"idempotency_key": "mcp-group-google",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("v2 group send returned tool error: %v", result.Content)
+	}
+	payload := v2ToolPayload(t, result)
+	assertV2ToolBool(t, payload, "ok", true)
+	assertV2ToolString(t, payload, "state", string(messaging.OutboxConfirmed))
+	assertV2ToolString(t, payload, "remote_message_id", "remote-group-google")
+	if lookupCalls != 1 {
+		t.Fatalf("legacy group GetOrCreate calls = %d, want 1", lookupCalls)
+	}
+	conversation, err := harness.app.Store.GetConversation(v2ToolGroupConversationID)
+	if err != nil {
+		t.Fatalf("load persisted group: %v", err)
+	}
+	if conversation == nil || conversation.Name != "Weekend plans" || !conversation.IsGroup ||
+		conversation.SourcePlatform != "sms" {
+		t.Fatalf("persisted group = %#v, want legacy-upserted Google group", conversation)
+	}
+	legacyMessages, err := harness.app.Store.GetMessagesByConversation(v2ToolGroupConversationID, 10)
+	if err != nil {
+		t.Fatalf("load legacy group messages: %v", err)
+	}
+	if len(legacyMessages) != 0 {
+		t.Fatalf("legacy group send persisted messages = %#v, want none", legacyMessages)
+	}
+	requests := harness.sender.snapshotRequests()
+	if len(requests) != 1 || requests[0].Conversation.RemoteID != v2ToolGroupConversationID ||
+		requests[0].Body != "group through v2" {
+		t.Fatalf("v2 transport requests = %+v, want group Google conversation/body", requests)
+	}
+}
+
+func TestV2SendMediaToConversationStreamsAndReturnsConfirmedDelivery(t *testing.T) {
+	harness := newV2ToolHarness(t)
+	content := bytes.Repeat([]byte("stream-through-v2-"), 256)
+	filePath := filepath.Join(t.TempDir(), "streamed-media.bin")
+	if err := os.WriteFile(filePath, content, 0o600); err != nil {
+		t.Fatalf("WriteFile(%s): %v", filePath, err)
+	}
+
+	originalUpload := uploadGoogleMedia
+	originalGetConversation := getGoogleConversation
+	originalLegacySend := sendGoogleMediaMessage
+	uploadGoogleMedia = func(_ *app.App, _ []byte, _, _ string) (*gmproto.MediaContent, error) {
+		return nil, errors.New("legacy Google upload must not run while v2 is enabled")
+	}
+	getGoogleConversation = func(_ *app.App, _ string) (*gmproto.Conversation, error) {
+		return nil, errors.New("legacy Google media lookup must not run while v2 is enabled")
+	}
+	sendGoogleMediaMessage = func(_ *app.App, _ *gmproto.SendMessageRequest) (*gmproto.SendMessageResponse, error) {
+		return nil, errors.New("legacy Google media send must not run while v2 is enabled")
+	}
+	t.Cleanup(func() {
+		uploadGoogleMedia = originalUpload
+		getGoogleConversation = originalGetConversation
+		sendGoogleMediaMessage = originalLegacySend
+	})
+
+	result, err := sendMediaToConversationHandler(harness.app, &harness.deps)(
+		context.Background(),
+		v2ToolCall(map[string]any{
+			"conversation_id": v2ToolConversationID,
+			"file_path":       filePath,
+			"caption":         "streamed caption",
+			"mime_type":       "application/x-openmessage-stream",
+			"idempotency_key": "mcp-streamed-media",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("v2 media send returned tool error: %v", result.Content)
+	}
+	payload := v2ToolPayload(t, result)
+	assertV2ToolBool(t, payload, "ok", true)
+	assertV2ToolString(t, payload, "state", string(messaging.OutboxConfirmed))
+	if got := v2ToolString(payload, "remote_message_id"); got == "" {
+		t.Fatal("remote_message_id is empty")
+	}
+	assertV2ToolBool(t, payload, "deduplicated", false)
+
+	requests := harness.media.snapshotRequests()
+	if len(requests) != 1 {
+		t.Fatalf("media transport request count = %d, want 1", len(requests))
+	}
+	request := requests[0]
+	if request.AccountID != "google-primary" || request.ConversationID != v2ToolConversationID ||
+		request.Filename != "streamed-media.bin" || request.MIME != "application/x-openmessage-stream" ||
+		request.Caption != "streamed caption" || request.Size != int64(len(content)) ||
+		!bytes.Equal(request.Content, content) {
+		t.Fatalf("media transport request = %+v, want full streamed file and metadata", request)
+	}
+	assertV2ToolString(t, payload, "remote_message_id", "remote-"+request.RequestID)
+}
+
+const (
+	v2ToolConversationID       = "v2-tool-conversation"
+	v2ToolDirectConversationID = "v2-tool-direct-google"
+	v2ToolGroupConversationID  = "v2-tool-group-google"
+)
+
+type v2ToolHarness struct {
+	app      *app.App
+	deps     V2Dependencies
+	sender   *v2ToolTextSender
+	media    *v2ToolMediaSender
+	ids      *v2ToolIDs
+	clock    messaging.SystemClock
+	blobRoot string
+}
+
+func newV2ToolHarness(t *testing.T, steps ...v2ToolSendStep) *v2ToolHarness {
+	t.Helper()
+	a := testApp(t)
+	if err := a.Store.UpsertConversation(&db.Conversation{
+		ConversationID: v2ToolConversationID,
+		Name:           "V2 tool conversation",
+		Participants:   `[]`,
+		SourcePlatform: "sms",
+	}); err != nil {
+		t.Fatalf("seed legacy conversation: %v", err)
+	}
+
+	v2Store, err := sqlite.Open(filepath.Join(t.TempDir(), "v2.sqlite3"))
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	blobRoot := filepath.Join(t.TempDir(), "blobs")
+	blobs, err := blob.New(blobRoot)
+	if err != nil {
+		_ = v2Store.Close()
+		t.Fatalf("blob.New(): %v", err)
+	}
+	sender := &v2ToolTextSender{steps: append([]v2ToolSendStep(nil), steps...)}
+	mediaSender := &v2ToolMediaSender{}
+	registry := &v2ToolRegistry{
+		accountID: "google-primary",
+		text:      sender,
+		media:     mediaSender,
+	}
+	clock := messaging.SystemClock{}
+	ids := &v2ToolIDs{}
+	service, err := messaging.NewMessageService(v2Store, registry, blobs, clock, ids)
+	if err != nil {
+		_ = v2Store.Close()
+		t.Fatalf("NewMessageService(): %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- service.Run(runCtx) }()
+	t.Cleanup(func() {
+		cancel()
+		if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("MessageService.Run(): %v", err)
+		}
+		if err := v2Store.Close(); err != nil {
+			t.Errorf("close v2 store: %v", err)
+		}
+	})
+
+	return &v2ToolHarness{
+		app: a,
+		deps: V2Dependencies{
+			Enabled:  true,
+			Service:  service,
+			V2Store:  v2Store,
+			Registry: registry,
+		},
+		sender:   sender,
+		media:    mediaSender,
+		ids:      ids,
+		clock:    clock,
+		blobRoot: blobRoot,
+	}
+}
+
+func v2ToolCall(arguments map[string]any) mcp.CallToolRequest {
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = arguments
+	return request
+}
+
+func v2ToolPayload(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal structured content: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal structured content %s: %v", raw, err)
+	}
+	if payload == nil {
+		t.Fatalf("structured content = %s, want object", raw)
+	}
+	return payload
+}
+
+func assertV2ToolString(t *testing.T, payload map[string]any, key, want string) {
+	t.Helper()
+	if got := v2ToolString(payload, key); got != want {
+		t.Fatalf("%s = %q, want %q; payload=%v", key, got, want, payload)
+	}
+}
+
+func v2ToolString(payload map[string]any, key string) string {
+	value, _ := payload[key].(string)
+	return value
+}
+
+func assertV2ToolBool(t *testing.T, payload map[string]any, key string, want bool) {
+	t.Helper()
+	got, ok := payload[key].(bool)
+	if !ok || got != want {
+		t.Fatalf("%s = %#v, want %t; payload=%v", key, payload[key], want, payload)
+	}
+}
+
+type v2ToolSendStep struct {
+	result bridge.SendResult
+	err    error
+	// block, when non-nil, parks the transport call until the channel closes,
+	// holding the outbox row in dispatching so tests can interrupt Wait.
+	block <-chan struct{}
+}
+
+type v2ToolTextSender struct {
+	mu       sync.Mutex
+	steps    []v2ToolSendStep
+	requests []bridge.TextRequest
+}
+
+func (s *v2ToolTextSender) SendText(
+	_ context.Context,
+	request bridge.TextRequest,
+) (bridge.SendResult, error) {
+	s.mu.Lock()
+	s.requests = append(s.requests, request)
+	if len(s.steps) == 0 {
+		s.mu.Unlock()
+		return bridge.SendResult{RemoteMessageID: "remote-" + request.RequestID}, nil
+	}
+	step := s.steps[0]
+	s.steps = s.steps[1:]
+	s.mu.Unlock()
+	if step.block != nil {
+		<-step.block
+	}
+	return step.result, step.err
+}
+
+func (s *v2ToolTextSender) requestCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.requests)
+}
+
+func (s *v2ToolTextSender) snapshotRequests() []bridge.TextRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]bridge.TextRequest(nil), s.requests...)
+}
+
+type v2ToolMediaRequest struct {
+	AccountID      string
+	ConversationID string
+	Content        []byte
+	Size           int64
+	Filename       string
+	MIME           string
+	Caption        string
+	RequestID      string
+}
+
+type v2ToolMediaSender struct {
+	mu       sync.Mutex
+	requests []v2ToolMediaRequest
+}
+
+func (s *v2ToolMediaSender) SendMedia(
+	_ context.Context,
+	request bridge.MediaRequest,
+) (bridge.SendResult, error) {
+	content, err := io.ReadAll(request.Reader)
+	if err != nil {
+		return bridge.SendResult{}, err
+	}
+	s.mu.Lock()
+	s.requests = append(s.requests, v2ToolMediaRequest{
+		AccountID:      request.AccountID,
+		ConversationID: request.Conversation.RemoteID,
+		Content:        append([]byte(nil), content...),
+		Size:           request.Size,
+		Filename:       request.Filename,
+		MIME:           request.MIME,
+		Caption:        request.Caption,
+		RequestID:      request.RequestID,
+	})
+	s.mu.Unlock()
+	return bridge.SendResult{RemoteMessageID: "remote-" + request.RequestID}, nil
+}
+
+func (s *v2ToolMediaSender) snapshotRequests() []v2ToolMediaRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	requests := make([]v2ToolMediaRequest, len(s.requests))
+	for i, request := range s.requests {
+		requests[i] = request
+		requests[i].Content = append([]byte(nil), request.Content...)
+	}
+	return requests
+}
+
+type v2ToolRegistry struct {
+	accountID string
+	text      bridge.TextSender
+	media     bridge.MediaSender
+}
+
+func (r *v2ToolRegistry) Snapshot(accountID string) (bridge.Snapshot, bool) {
+	if accountID != r.accountID {
+		return bridge.Snapshot{}, false
+	}
+	return bridge.Snapshot{
+		AccountID:  accountID,
+		Platform:   bridge.PlatformGoogle,
+		Generation: 1,
+	}, true
+}
+
+func (r *v2ToolRegistry) Acquire(
+	ctx context.Context,
+	accountID string,
+	capability bridge.Capability,
+) (*bridge.DispatchLease, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if accountID != r.accountID {
+		return nil, fmt.Errorf("%w: %s", bridge.ErrAccountNotRegistered, accountID)
+	}
+	lease := &bridge.DispatchLease{
+		AccountID:  accountID,
+		Platform:   bridge.PlatformGoogle,
+		Generation: 1,
+		Ctx:        ctx,
+	}
+	switch capability {
+	case bridge.CapabilityTextSend:
+		lease.Text = r.text
+	case bridge.CapabilityMediaSend:
+		lease.Media = r.media
+	default:
+		return nil, bridge.ErrCapabilityUnavailable
+	}
+	return lease, nil
+}
+
+func (r *v2ToolRegistry) Capabilities(accountID string) bridge.CapabilitySet {
+	if accountID != r.accountID {
+		return bridge.CapabilitySet{}
+	}
+	return bridge.CapabilitySet{
+		TextSend:  r.text != nil,
+		MediaSend: r.media != nil,
+	}
+}
+
+type v2ToolIDs struct {
+	mu   sync.Mutex
+	next int
+}
+
+func (s *v2ToolIDs) NewID() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.next++
+	return fmt.Sprintf("v2-tool-id-%03d", s.next), nil
+}
+
+func (s *v2ToolIDs) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.next
+}
+
+func v2ToolBlobFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk blob root: %v", err)
+	}
+	return files
+}

--- a/internal/tools/v2_wait_test.go
+++ b/internal/tools/v2_wait_test.go
@@ -1,0 +1,211 @@
+package tools
+
+// Settled-state matrix for the v2 send tools' delivery reporting. The review
+// of this change proved two double-send vectors: an interrupted Wait returned
+// a bare tool error while the durable send completed, and not_dispatched was
+// presented as final while the outbox kept retrying it. These tests pin the
+// corrected contract: once an intent is durably enqueued the tool never
+// returns IsError, every result echoes outbox_id and idempotency_key, and
+// non-settled states carry explicit do-not-resend guidance.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+)
+
+func TestV2SendInterruptedWaitReturnsDurableStatusNotError(t *testing.T) {
+	release := make(chan struct{})
+	harness := newV2ToolHarness(t, v2ToolSendStep{
+		result: bridge.SendResult{RemoteMessageID: "remote-after-interrupt"},
+		block:  release,
+	})
+	handler := sendToConversationHandler(harness.app, &harness.deps)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	results := make(chan *mcp.CallToolResult, 1)
+	go func() {
+		result, err := handler(ctx, v2ToolCall(map[string]any{
+			"conversation_id": v2ToolConversationID,
+			"message":         "interrupt this wait",
+			"idempotency_key": "mcp-interrupt-key",
+		}))
+		if err != nil {
+			t.Errorf("handler error: %v", err)
+		}
+		results <- result
+	}()
+
+	// The transport call parks on the block channel, so once it is observed
+	// the row is in dispatching and the handler is inside Wait.
+	waitForCondition(t, "transport call started", func() bool {
+		return harness.sender.requestCount() == 1
+	})
+	cancel()
+
+	var result *mcp.CallToolResult
+	select {
+	case result = <-results:
+	case <-time.After(10 * time.Second):
+		t.Fatal("handler did not return after ctx cancel")
+	}
+	if result.IsError {
+		t.Fatalf("interrupted wait returned a tool error, inviting a resend: %v", result.Content)
+	}
+
+	payload := v2ToolPayload(t, result)
+	assertV2ToolBool(t, payload, "ok", false)
+	assertV2ToolBool(t, payload, "settled", false)
+	assertV2ToolString(t, payload, "idempotency_key", "mcp-interrupt-key")
+	outboxID := v2ToolString(payload, "outbox_id")
+	if outboxID == "" {
+		t.Fatalf("interrupted result must carry outbox_id; payload=%v", payload)
+	}
+	state := v2ToolString(payload, "state")
+	if state != string(messaging.OutboxQueued) && state != string(messaging.OutboxDispatching) {
+		t.Fatalf("state = %q, want queued or dispatching", state)
+	}
+	if got := v2ToolString(payload, "wait_error"); got == "" {
+		t.Fatal("wait_error is empty")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	for _, fragment := range []string{"durably queued", "Do NOT send this message again", "mcp-interrupt-key"} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("interrupted text missing %q: %q", fragment, text)
+		}
+	}
+
+	// A guidance-following agent does not resend. The durable send finishes in
+	// the background and the transport is called exactly once.
+	close(release)
+	waitForCondition(t, "delivery confirmed in background", func() bool {
+		delivery, err := harness.deps.Service.Get(context.Background(), outboxID)
+		return err == nil && delivery.State == messaging.OutboxConfirmed
+	})
+	if got := harness.sender.requestCount(); got != 1 {
+		t.Fatalf("transport called %d times, want exactly 1", got)
+	}
+}
+
+func TestV2SendNotDispatchedReturnsAutoRetryStatusNotError(t *testing.T) {
+	harness := newV2ToolHarness(t, v2ToolSendStep{err: bridge.OpError{
+		Class:     bridge.FailureTransient,
+		Operation: "send_text",
+		Dispatch:  bridge.DispatchNotCalled,
+		Cause:     context.DeadlineExceeded,
+	}})
+	handler := sendToConversationHandler(harness.app, &harness.deps)
+
+	result, err := handler(context.Background(), v2ToolCall(map[string]any{
+		"conversation_id": v2ToolConversationID,
+		"message":         "the transport is briefly down",
+		"idempotency_key": "mcp-retrying-key",
+	}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("not_dispatched returned a tool error, inviting a resend: %v", result.Content)
+	}
+
+	payload := v2ToolPayload(t, result)
+	assertV2ToolBool(t, payload, "ok", false)
+	assertV2ToolBool(t, payload, "settled", false)
+	assertV2ToolBool(t, payload, "auto_retry", true)
+	assertV2ToolString(t, payload, "state", string(messaging.OutboxNotDispatched))
+	assertV2ToolString(t, payload, "idempotency_key", "mcp-retrying-key")
+	text := result.Content[0].(mcp.TextContent).Text
+	for _, fragment := range []string{"retrying it automatically", "do NOT send this message again"} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("not_dispatched text missing %q: %q", fragment, text)
+		}
+	}
+	if strings.Contains(text, "was not dispatched") {
+		t.Fatalf("not_dispatched text still uses the resend-inviting phrasing: %q", text)
+	}
+
+	// The durable row remains pending for the dispatcher's automatic retry.
+	outboxID := v2ToolString(payload, "outbox_id")
+	delivery, err := harness.deps.Service.Get(context.Background(), outboxID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", outboxID, err)
+	}
+	if delivery.State != messaging.OutboxNotDispatched && delivery.State != messaging.OutboxQueued &&
+		delivery.State != messaging.OutboxDispatching && delivery.State != messaging.OutboxConfirmed {
+		t.Fatalf("row left auto-retry path: state=%s", delivery.State)
+	}
+}
+
+func TestV2SendRejectedIsSettledWithNoRetryGuidance(t *testing.T) {
+	harness := newV2ToolHarness(t, v2ToolSendStep{err: bridge.OpError{
+		Class:     bridge.FailureUnsupported,
+		Operation: "send_text",
+		Cause:     context.DeadlineExceeded,
+	}})
+	handler := sendToConversationHandler(harness.app, &harness.deps)
+
+	result, err := handler(context.Background(), v2ToolCall(map[string]any{
+		"conversation_id": v2ToolConversationID,
+		"message":         "the platform refuses this",
+		"idempotency_key": "mcp-rejected-key",
+	}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("rejected delivery must be data, not a tool error: %v", result.Content)
+	}
+
+	payload := v2ToolPayload(t, result)
+	assertV2ToolBool(t, payload, "ok", false)
+	assertV2ToolBool(t, payload, "settled", true)
+	assertV2ToolString(t, payload, "state", string(messaging.OutboxRejected))
+	assertV2ToolString(t, payload, "idempotency_key", "mcp-rejected-key")
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "will not retry") {
+		t.Fatalf("rejected text missing no-retry statement: %q", text)
+	}
+}
+
+func TestV2DeliveryTextAndOKForRepairAndCancelStates(t *testing.T) {
+	storeFailed := messaging.Delivery{
+		OutboxID:        "outbox-repair",
+		State:           messaging.OutboxStoreFailed,
+		RemoteMessageID: "remote-repair",
+	}
+	if !v2DeliveryOK(storeFailed.State) {
+		t.Fatal("store_failed means the transport delivered; ok must be true")
+	}
+	text := v2DeliveryText(storeFailed)
+	for _, fragment := range []string{"transport accepted", "repaired automatically", "Do not resend"} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("store_failed text missing %q: %q", fragment, text)
+		}
+	}
+
+	canceled := messaging.Delivery{OutboxID: "outbox-canceled", State: messaging.OutboxCanceled}
+	if v2DeliveryOK(canceled.State) {
+		t.Fatal("canceled must not report ok")
+	}
+	if got := v2DeliveryText(canceled); !strings.Contains(got, "canceled") {
+		t.Fatalf("canceled text = %q", got)
+	}
+}
+
+func waitForCondition(t *testing.T, what string, check func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if check() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -27,6 +27,7 @@ import (
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/client"
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/media"
 	"github.com/maxghenis/openmessage/internal/messaging"
 	"github.com/maxghenis/openmessage/internal/story"
 	"github.com/maxghenis/openmessage/internal/whatsapplive"
@@ -3303,38 +3304,6 @@ func normalizeMIME(mimeType string) string {
 	return m
 }
 
-// isPassiveInlineMIME reports whether a media type can be rendered inline in a
-// browser with no risk of executing script. SVG and the HTML/XML family are
-// excluded because they can carry <script>; anything not positively recognized
-// is treated as unsafe and downloaded instead.
-func isPassiveInlineMIME(mimeType string) bool {
-	m := normalizeMIME(mimeType)
-	switch {
-	case m == "image/svg+xml":
-		return false
-	case strings.HasPrefix(m, "image/"),
-		strings.HasPrefix(m, "audio/"),
-		strings.HasPrefix(m, "video/"):
-		return true
-	case m == "application/pdf", m == "text/plain":
-		return true
-	default:
-		return false
-	}
-}
-
-// isActiveMIME reports whether a sniffed type could be interpreted as
-// script-bearing markup. It rejects a payload declared as a passive type whose
-// bytes actually sniff as active content (a spoofed image/png that is really
-// HTML).
-func isActiveMIME(mimeType string) bool {
-	switch normalizeMIME(mimeType) {
-	case "text/html", "application/xhtml+xml", "image/svg+xml", "text/xml", "application/xml":
-		return true
-	}
-	return false
-}
-
 // sanitizeMediaFilename strips path components, control characters, and
 // header-breaking characters so a filename can be placed in a quoted
 // Content-Disposition value. Non-ASCII bytes are replaced to keep the header
@@ -3373,7 +3342,7 @@ func writeMediaResponse(w http.ResponseWriter, data []byte, filename, declaredMI
 	if resolved == "" {
 		resolved = "application/octet-stream"
 	}
-	inline := isPassiveInlineMIME(resolved) && !isActiveMIME(http.DetectContentType(data))
+	inline := media.ServingDisposition(resolved, data) == media.DispositionInline
 
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Content-Security-Policy", "sandbox; default-src 'none'")


### PR DESCRIPTION
## What

With `OPENMESSAGES_V2_SEND` set, the four MCP send tools (`send_message`, `send_to_conversation`, `send_group_message`, `send_media_to_conversation`) submit through `v2wire` into the durable outbox and wait for a delivery outcome. Flag-off behavior is pinned byte-identical by descriptor and exchange parity goldens (mutation-proven to discriminate).

`download_media` now returns the read-only `/api/media/<id>` URL plus metadata instead of writing a world-readable 0644 temp file (the A5a fix). This contract change is deliberate and unconditional (both flag states); any client that read bytes from the returned path must switch to fetching the URL. The serving endpoint's MIME disposition policy moved to `internal/media.ServingDisposition`, behavior-identical (SVG/HTML still forced-download).

## Delivery-reporting contract (post-review hardening)

Adversarial review proved two double-send vectors in the initial build; both are fixed and pinned by tests:

1. **Interrupted wait** (MCP request ctx canceled or timed out while the dispatcher, on its own context, completes the send): previously a bare tool error — an agent's natural retry then created a second intent under a fresh idempotency key. Now a non-error status: `settled:false`, last-known state, `outbox_id`, the idempotency key in use, and explicit do-not-resend guidance.
2. **`not_dispatched`** ("Message was not dispatched…") presented as final while the outbox auto-retries it every 5s. Now reported `settled:false, auto_retry:true` with "the app is retrying it automatically; do NOT send this message again."

Plus: every result echoes `idempotency_key` (previously the server-minted key was unrecoverable, making the documented replay path unusable), and `store_failed` reports `ok:true` (the transport delivered; the local record self-heals).

## Notes

- `size_bytes` stays `null` in `download_media`: legacy rows don't retain attachment size and the endpoint resolves it lazily; reporting unknown beats fetching or inventing bytes.
- The returned media URL is relative; MCP clients need the app origin out-of-band (same framing as the rest of the local API).

## Verification

- Full `go test -race ./...`: all 26 packages green (the two `cmd` listener tests fail only inside sandboxes that forbid loopback binds).
- Review repro scenarios re-run against the fix: one user intent → exactly one transport send with the wait interrupted mid-flight (`TestV2SendInterruptedWaitReturnsDurableStatusNotError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
