### PR TITLE
Ingest foundations: shared v2keys derivation + durable sink, worker, quarantine (ingest I0+I1)

### DIFF
--- a/internal/ingest/counters.go
+++ b/internal/ingest/counters.go
@@ -1,0 +1,128 @@
+package ingest
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// CounterSnapshot is the externally consumable, point-in-time view of one
+// account's ingest activity. Echo outcomes mirror messaging.EchoOutcome;
+// EchoErrors counts reconcile faults that were absorbed without blocking
+// projection of the inbound message.
+type CounterSnapshot struct {
+	Appended         uint64 `json:"appended"`
+	Deduped          uint64 `json:"deduped"`
+	DecodedEvents    uint64 `json:"decoded_events"`
+	Projected        uint64 `json:"projected"`
+	Imported         uint64 `json:"imported"`
+	Mutations        uint64 `json:"mutations"`
+	ReactionsDropped uint64 `json:"reactions_dropped"`
+	ReceiptsSelf     uint64 `json:"receipts_self"`
+	ReceiptsDropped  uint64 `json:"receipts_dropped"`
+	Quarantined      uint64 `json:"quarantined"`
+	StaleReplays     uint64 `json:"stale_replays"`
+	EchoReconciled   uint64 `json:"echo_reconciled"`
+	EchoEnriched     uint64 `json:"echo_enriched"`
+	EchoNoop         uint64 `json:"echo_noop"`
+	EchoNotFound     uint64 `json:"echo_notfound"`
+	EchoErrors       uint64 `json:"echo_errors"`
+	Ephemeral        uint64 `json:"ephemeral"`
+}
+
+type accountCounters struct {
+	appended         atomic.Uint64
+	deduped          atomic.Uint64
+	decodedEvents    atomic.Uint64
+	projected        atomic.Uint64
+	imported         atomic.Uint64
+	mutations        atomic.Uint64
+	reactionsDropped atomic.Uint64
+	receiptsSelf     atomic.Uint64
+	receiptsDropped  atomic.Uint64
+	quarantined      atomic.Uint64
+	staleReplays     atomic.Uint64
+	echoReconciled   atomic.Uint64
+	echoEnriched     atomic.Uint64
+	echoNoop         atomic.Uint64
+	echoNotFound     atomic.Uint64
+	echoErrors       atomic.Uint64
+	ephemeral        atomic.Uint64
+}
+
+// Counters owns atomic ingest counters partitioned by account. Its zero value
+// is ready for use.
+type Counters struct {
+	mu       sync.RWMutex
+	accounts map[string]*accountCounters
+}
+
+func (c *Counters) account(accountID string) *accountCounters {
+	c.mu.RLock()
+	counters := c.accounts[accountID]
+	c.mu.RUnlock()
+	if counters != nil {
+		return counters
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.accounts == nil {
+		c.accounts = make(map[string]*accountCounters)
+	}
+	if counters = c.accounts[accountID]; counters == nil {
+		counters = &accountCounters{}
+		c.accounts[accountID] = counters
+	}
+	return counters
+}
+
+// Snapshot returns one account's counters without creating an entry for an
+// account that has not observed ingest activity.
+func (c *Counters) Snapshot(accountID string) CounterSnapshot {
+	if c == nil {
+		return CounterSnapshot{}
+	}
+	c.mu.RLock()
+	counters := c.accounts[accountID]
+	c.mu.RUnlock()
+	return snapshotCounters(counters)
+}
+
+// PerAccount returns independent snapshots for every observed account.
+func (c *Counters) PerAccount() map[string]CounterSnapshot {
+	result := make(map[string]CounterSnapshot)
+	if c == nil {
+		return result
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for accountID, counters := range c.accounts {
+		result[accountID] = snapshotCounters(counters)
+	}
+	return result
+}
+
+func snapshotCounters(c *accountCounters) CounterSnapshot {
+	if c == nil {
+		return CounterSnapshot{}
+	}
+	return CounterSnapshot{
+		Appended:         c.appended.Load(),
+		Deduped:          c.deduped.Load(),
+		DecodedEvents:    c.decodedEvents.Load(),
+		Projected:        c.projected.Load(),
+		Imported:         c.imported.Load(),
+		Mutations:        c.mutations.Load(),
+		ReactionsDropped: c.reactionsDropped.Load(),
+		ReceiptsSelf:     c.receiptsSelf.Load(),
+		ReceiptsDropped:  c.receiptsDropped.Load(),
+		Quarantined:      c.quarantined.Load(),
+		StaleReplays:     c.staleReplays.Load(),
+		EchoReconciled:   c.echoReconciled.Load(),
+		EchoEnriched:     c.echoEnriched.Load(),
+		EchoNoop:         c.echoNoop.Load(),
+		EchoNotFound:     c.echoNotFound.Load(),
+		EchoErrors:       c.echoErrors.Load(),
+		Ephemeral:        c.ephemeral.Load(),
+	}
+}

--- a/internal/ingest/counters_test.go
+++ b/internal/ingest/counters_test.go
@@ -1,0 +1,47 @@
+package ingest
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestCountersAreAtomicAndAccountScoped(t *testing.T) {
+	t.Parallel()
+
+	var counters Counters
+	const (
+		workers    = 8
+		increments = 250
+	)
+	var wait sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			for index := 0; index < increments; index++ {
+				account := counters.account("account-a")
+				account.appended.Add(1)
+				account.decodedEvents.Add(2)
+			}
+		}()
+	}
+	wait.Wait()
+	counters.account("account-b").ephemeral.Add(1)
+
+	want := uint64(workers * increments)
+	accountA := counters.Snapshot("account-a")
+	if accountA.Appended != want || accountA.DecodedEvents != 2*want {
+		t.Fatalf("account-a snapshot = %+v, want appended=%d decoded_events=%d", accountA, want, 2*want)
+	}
+	accountB := counters.Snapshot("account-b")
+	if accountB.Ephemeral != 1 || accountB.Appended != 0 {
+		t.Fatalf("account-b snapshot = %+v, want only one ephemeral event", accountB)
+	}
+	if missing := counters.Snapshot("missing"); missing != (CounterSnapshot{}) {
+		t.Fatalf("missing account snapshot = %+v, want zero value", missing)
+	}
+	perAccount := counters.PerAccount()
+	if len(perAccount) != 2 || perAccount["account-a"] != accountA || perAccount["account-b"] != accountB {
+		t.Fatalf("PerAccount() = %+v, want independent account snapshots", perAccount)
+	}
+}

--- a/internal/ingest/quarantine.go
+++ b/internal/ingest/quarantine.go
@@ -1,0 +1,104 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	moderncsqlite "modernc.org/sqlite"
+)
+
+const maxTransientRetries = 3
+
+var transientBackoffs = [...]time.Duration{
+	5 * time.Millisecond,
+	10 * time.Millisecond,
+	20 * time.Millisecond,
+}
+
+type quarantineError struct{ cause error }
+
+func (e quarantineError) Error() string { return e.cause.Error() }
+func (e quarantineError) Unwrap() error { return e.cause }
+
+type staleReplayError struct{ cause error }
+
+func (e staleReplayError) Error() string { return e.cause.Error() }
+func (e staleReplayError) Unwrap() error { return e.cause }
+
+type transientExhaustedError struct{ cause error }
+
+func (e transientExhaustedError) Error() string { return e.cause.Error() }
+func (e transientExhaustedError) Unwrap() error { return e.cause }
+
+func quarantine(cause error) error {
+	return quarantineError{cause: cause}
+}
+
+func classifyApplyError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, sqlite.ErrInboxProjectionConflict) {
+		return staleReplayError{cause: err}
+	}
+	if isTransientDBError(err) {
+		return err
+	}
+	return quarantine(err)
+}
+
+func isTransientDBError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var sqliteErr *moderncsqlite.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+	switch sqliteErr.Code() & 0xff {
+	case 5, 6: // SQLITE_BUSY, SQLITE_LOCKED (including extended result codes).
+		return true
+	default:
+		return false
+	}
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func retryTransient(ctx context.Context, operation func() error) error {
+	var err error
+	for attempt := 0; attempt <= maxTransientRetries; attempt++ {
+		err = operation()
+		var deterministic quarantineError
+		var stale staleReplayError
+		if errors.As(err, &deterministic) || errors.As(err, &stale) {
+			return err
+		}
+		if err == nil || !isTransientDBError(err) {
+			return err
+		}
+		if attempt == maxTransientRetries {
+			break
+		}
+		if waitErr := waitForRetry(ctx, transientBackoffs[attempt]); waitErr != nil {
+			return waitErr
+		}
+	}
+	return transientExhaustedError{cause: fmt.Errorf(
+		"transient database failure after %d retries: %w",
+		maxTransientRetries,
+		err,
+	)}
+}

--- a/internal/ingest/quarantine_test.go
+++ b/internal/ingest/quarantine_test.go
@@ -1,0 +1,61 @@
+package ingest
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestRetryTransientBoundsSQLiteLockRetriesAndNeverRetriesQuarantine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "locked.sqlite3")
+	dsn := "file:" + path + "?_pragma=busy_timeout(0)"
+	locker, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open(locker): %v", err)
+	}
+	t.Cleanup(func() { _ = locker.Close() })
+	contender, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open(contender): %v", err)
+	}
+	t.Cleanup(func() { _ = contender.Close() })
+	if _, err := locker.Exec(`CREATE TABLE retry_probe (value INTEGER)`); err != nil {
+		t.Fatalf("create retry probe: %v", err)
+	}
+	connection, err := locker.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("locker.Conn(): %v", err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	if _, err := connection.ExecContext(context.Background(), `BEGIN IMMEDIATE`); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE: %v", err)
+	}
+	t.Cleanup(func() { _, _ = connection.ExecContext(context.Background(), `ROLLBACK`) })
+
+	_, lockedErr := contender.Exec(`INSERT INTO retry_probe (value) VALUES (1)`)
+	if lockedErr == nil || !isTransientDBError(lockedErr) {
+		t.Fatalf("contending insert error = %v, want transient SQLite busy/locked", lockedErr)
+	}
+
+	attempts := 0
+	err = retryTransient(context.Background(), func() error {
+		attempts++
+		return lockedErr
+	})
+	var exhausted transientExhaustedError
+	if !errors.As(err, &exhausted) || attempts != maxTransientRetries+1 {
+		t.Fatalf("retryTransient(locked) = (%d attempts, %v), want %d attempts and exhaustion", attempts, err, maxTransientRetries+1)
+	}
+
+	attempts = 0
+	err = retryTransient(context.Background(), func() error {
+		attempts++
+		return quarantine(lockedErr)
+	})
+	var deterministic quarantineError
+	if !errors.As(err, &deterministic) || attempts != 1 {
+		t.Fatalf("retryTransient(quarantined lock error) = (%d attempts, %v), want one deterministic attempt", attempts, err)
+	}
+}

--- a/internal/ingest/review_fixes_test.go
+++ b/internal/ingest/review_fixes_test.go
@@ -1,0 +1,193 @@
+package ingest
+
+// Pins for the adversarial-review fixes: echo reconciliation is best-effort
+// (a reconcile fault never blocks projecting the inbound message), echo
+// counters mirror the outcomes the real MessageService now surfaces, message
+// frames advance conversation recency monotonically without re-upserting the
+// row, and a self receipt that outruns its conversation or device drops
+// benignly instead of quarantining.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+)
+
+func TestWorkerEchoErrorStillProjectsInbound(t *testing.T) {
+	const (
+		clientRequestID = "client-request-echo-error"
+		remoteMessageID = "remote-echo-error"
+	)
+	recorder := &i01EchoRecorder{
+		err: errors.New("observe transport echo: reconcile confirm affected 0 rows, want 1"),
+	}
+	decoder := i01DecoderFunc(func(
+		_ context.Context,
+		_ bridge.RawIngressRecord,
+	) ([]bridge.Event, error) {
+		return i01OutgoingMessageEvents(remoteMessageID, "still delivered", clientRequestID), nil
+	})
+	harness := i01NewHarness(t, decoder, recorder)
+	i01StartWorker(t, harness.worker)
+
+	i01MustAppend(t, harness.sink, i01IngressRecord(
+		"echo-error:remote-echo-error",
+		[]byte("fake-decoder-echo-error-frame"),
+	))
+	i01WaitFor(t, "projection despite echo error", func() bool {
+		snapshot := harness.counters.Snapshot(i01AccountID)
+		return snapshot.Projected == 1 && snapshot.EchoErrors == 1
+	})
+
+	snapshot := harness.counters.Snapshot(i01AccountID)
+	if snapshot.Quarantined != 0 || snapshot.EchoReconciled != 0 || snapshot.EchoNotFound != 0 {
+		t.Fatalf("echo-error counters = %+v", snapshot)
+	}
+	if calls := recorder.snapshot(); len(calls) != 1 {
+		t.Fatalf("ObserveTransportEcho calls = %d, want 1", len(calls))
+	}
+	message, err := i01GetMessage(harness.messages, remoteMessageID)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote() after echo error: %v", err)
+	}
+	if message.Body != "still delivered" {
+		t.Fatalf("projected body = %q, want still delivered", message.Body)
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
+func TestWorkerEchoOutcomeCountersMirrorService(t *testing.T) {
+	tests := []struct {
+		name    string
+		outcome messaging.EchoOutcome
+		read    func(CounterSnapshot) uint64
+	}{
+		{name: "reconciled", outcome: messaging.EchoReconciled, read: func(s CounterSnapshot) uint64 { return s.EchoReconciled }},
+		{name: "enriched", outcome: messaging.EchoEnriched, read: func(s CounterSnapshot) uint64 { return s.EchoEnriched }},
+		{name: "noop", outcome: messaging.EchoNoop, read: func(s CounterSnapshot) uint64 { return s.EchoNoop }},
+		{name: "notfound", outcome: messaging.EchoNotFound, read: func(s CounterSnapshot) uint64 { return s.EchoNotFound }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := &i01EchoRecorder{outcome: test.outcome}
+			decoder := i01DecoderFunc(func(
+				_ context.Context,
+				_ bridge.RawIngressRecord,
+			) ([]bridge.Event, error) {
+				return i01OutgoingMessageEvents(
+					"remote-outcome-"+test.name,
+					"outcome body",
+					"client-request-"+test.name,
+				), nil
+			})
+			harness := i01NewHarness(t, decoder, recorder)
+			i01StartWorker(t, harness.worker)
+
+			i01MustAppend(t, harness.sink, i01IngressRecord(
+				"echo-outcome:"+test.name,
+				[]byte("fake-decoder-outcome-"+test.name),
+			))
+			i01WaitFor(t, "projection with outcome "+test.name, func() bool {
+				return harness.counters.Snapshot(i01AccountID).Projected == 1
+			})
+
+			snapshot := harness.counters.Snapshot(i01AccountID)
+			if got := test.read(snapshot); got != 1 {
+				t.Fatalf("%s counter = %d, want 1; snapshot=%+v", test.name, got, snapshot)
+			}
+			total := snapshot.EchoReconciled + snapshot.EchoEnriched +
+				snapshot.EchoNoop + snapshot.EchoNotFound + snapshot.EchoErrors
+			if total != 1 {
+				t.Fatalf("echo counters sum = %d, want exactly 1; snapshot=%+v", total, snapshot)
+			}
+		})
+	}
+}
+
+func TestWorkerMessageFrameAdvancesRecencyMonotonically(t *testing.T) {
+	const (
+		remoteConversationID   = "google-recency-thread"
+		existingConversationID = "recency-conversation-pk"
+		existingTitle          = "Recency title survives"
+	)
+	newerAtMS := workerPathNowMS - 500
+	olderAtMS := workerPathNowMS - 8_000
+	harness := newWorkerPathHarness(t, bridge.PlatformGoogle, map[string][]bridge.Event{
+		"newer": {{
+			Kind: bridge.EventMessage,
+			Message: &bridge.MessageEvent{
+				RemoteConversationID: remoteConversationID,
+				RemoteMessageID:      "recency-message-newer",
+				Sender:               bridge.IdentityRef{IsSelf: true},
+				Direction:            "outgoing",
+				Body:                 "newer message",
+				OccurredAt:           time.UnixMilli(newerAtMS),
+			},
+		}},
+		"older": {{
+			Kind: bridge.EventMessage,
+			Message: &bridge.MessageEvent{
+				RemoteConversationID: remoteConversationID,
+				RemoteMessageID:      "recency-message-older",
+				Sender:               bridge.IdentityRef{IsSelf: true},
+				Direction:            "outgoing",
+				Body:                 "older message",
+				OccurredAt:           time.UnixMilli(olderAtMS),
+			},
+		}},
+	})
+	seeded := workerPathSeedConversation(
+		t,
+		harness.store,
+		existingConversationID,
+		remoteConversationID,
+		existingTitle,
+	)
+
+	harness.process(t, "newer")
+	afterNewer, err := harness.store.GetConversationByRemote(workerPathAccountID, remoteConversationID)
+	if err != nil {
+		t.Fatalf("GetConversationByRemote() after newer: %v", err)
+	}
+	if afterNewer.LastMessageAtMS != newerAtMS {
+		t.Fatalf("last_message_at_ms after newer = %d, want %d", afterNewer.LastMessageAtMS, newerAtMS)
+	}
+
+	harness.process(t, "older")
+	afterOlder, err := harness.store.GetConversationByRemote(workerPathAccountID, remoteConversationID)
+	if err != nil {
+		t.Fatalf("GetConversationByRemote() after older: %v", err)
+	}
+	if afterOlder.LastMessageAtMS != newerAtMS {
+		t.Fatalf("last_message_at_ms after older = %d, want it to stay %d", afterOlder.LastMessageAtMS, newerAtMS)
+	}
+	if afterOlder.ConversationID != seeded.ConversationID ||
+		afterOlder.Title != seeded.Title ||
+		afterOlder.Kind != seeded.Kind ||
+		afterOlder.CreatedAtMS != seeded.CreatedAtMS {
+		t.Fatalf("recency bump disturbed the conversation row: %+v, want fields of %+v", afterOlder, seeded)
+	}
+	workerPathAssertAllProcessed(t, harness.messages)
+}
+
+func TestWorkerSelfReceiptBeforeConversationIsBenign(t *testing.T) {
+	harness := newWorkerPathHarness(t, bridge.PlatformGoogle, map[string][]bridge.Event{
+		"orphan-receipt": {workerPathReceiptEvent(
+			"google-unknown-thread",
+			"unknown-message",
+			workerPathNowMS-100,
+		)},
+	})
+
+	harness.process(t, "orphan-receipt")
+
+	snapshot := harness.worker.Counters().Snapshot(workerPathAccountID)
+	if snapshot.ReceiptsDropped != 1 || snapshot.ReceiptsSelf != 0 || snapshot.Quarantined != 0 {
+		t.Fatalf("orphan self-receipt counters = %+v, want dropped=1 self=0 quarantined=0", snapshot)
+	}
+	workerPathAssertAllProcessed(t, harness.messages)
+}

--- a/internal/ingest/sink.go
+++ b/internal/ingest/sink.go
@@ -1,0 +1,145 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+const defaultWorkerQueueCapacity = 64
+
+// SinkConfig contains the durable repository and asynchronous worker used by
+// a ConnectionSink. IDs defaults to messaging.CryptoIDSource.
+type SinkConfig struct {
+	Messages *sqlite.MessageRepository
+	Worker   *Worker
+	Counters *Counters
+	IDs      messaging.IDSource
+}
+
+// Sink durably appends raw ingress and only then notifies the projection
+// worker. It deliberately performs no decoding or projection inline.
+type Sink struct {
+	messages *sqlite.MessageRepository
+	worker   *Worker
+	counters *Counters
+	ids      messaging.IDSource
+}
+
+var _ bridge.ConnectionSink = (*Sink)(nil)
+
+// NewSink constructs a storage-backed ConnectionSink.
+func NewSink(config SinkConfig) (*Sink, error) {
+	if config.Messages == nil {
+		return nil, fmt.Errorf("create ingest sink: message repository is nil")
+	}
+	if config.Worker == nil {
+		return nil, fmt.Errorf("create ingest sink: worker is nil")
+	}
+	if config.Messages != config.Worker.messages {
+		return nil, fmt.Errorf("create ingest sink: message repository does not match worker repository")
+	}
+	if config.Counters == nil {
+		config.Counters = config.Worker.counters
+	}
+	if config.Counters != config.Worker.counters {
+		return nil, fmt.Errorf("create ingest sink: counters do not match worker counters")
+	}
+	if config.IDs == nil {
+		config.IDs = messaging.CryptoIDSource{}
+	}
+	return &Sink{
+		messages: config.Messages,
+		worker:   config.Worker,
+		counters: config.Counters,
+		ids:      config.IDs,
+	}, nil
+}
+
+// AppendIngress validates and durably inserts exactly one raw frame before a
+// best-effort, non-blocking worker notification.
+func (s *Sink) AppendIngress(ctx context.Context, record bridge.RawIngressRecord) error {
+	if err := validateIngress(ctx, record); err != nil {
+		return err
+	}
+
+	inboxID, err := s.ids.NewID()
+	if err != nil {
+		return fmt.Errorf("append ingress: generate inbox ID: %w", err)
+	}
+	if strings.TrimSpace(inboxID) == "" {
+		return fmt.Errorf("append ingress: generated inbox ID is empty")
+	}
+
+	payload := bytes.Clone(record.Payload)
+	if payload == nil {
+		payload = []byte{}
+	}
+	record.Payload = payload
+	effectiveID, err := s.messages.AppendInbox(ctx, sqlite.InboxRecord{
+		InboxID:      inboxID,
+		AccountID:    record.AccountID,
+		Generation:   int64(record.Generation),
+		DedupeKey:    record.DedupeKey,
+		Codec:        record.Codec,
+		CodecVersion: int64(record.CodecVersion),
+		Payload:      payload,
+	})
+	if err != nil {
+		return fmt.Errorf("append ingress for account %q: %w", record.AccountID, err)
+	}
+
+	counters := s.counters.account(record.AccountID)
+	replay := effectiveID != inboxID
+	if replay {
+		counters.deduped.Add(1)
+	} else {
+		counters.appended.Add(1)
+	}
+	s.worker.enqueue(workItem{
+		inboxID: effectiveID,
+		record:  record,
+		replay:  replay,
+	})
+	return nil
+}
+
+// EmitEphemeral counts ephemeral activity. Legacy remains the sole typing UI
+// publisher for this slice.
+func (s *Sink) EmitEphemeral(_ context.Context, event bridge.EphemeralEvent) error {
+	s.counters.account(event.AccountID).ephemeral.Add(1)
+	return nil
+}
+
+// Beat is intentionally a no-op: generationSink consumes liveness beats
+// before forwarding to a configured ConnectionSink.
+func (*Sink) Beat(bridge.Generation, time.Time, string) {}
+
+func validateIngress(ctx context.Context, record bridge.RawIngressRecord) error {
+	if ctx == nil {
+		return fmt.Errorf("append ingress: context is nil")
+	}
+	if strings.TrimSpace(record.AccountID) == "" {
+		return fmt.Errorf("append ingress: account ID is empty")
+	}
+	if strings.TrimSpace(record.Codec) == "" {
+		return fmt.Errorf("append ingress: codec is empty")
+	}
+	if record.DedupeKey != "" && strings.TrimSpace(record.DedupeKey) == "" {
+		return fmt.Errorf("append ingress: dedupe key is whitespace")
+	}
+	if uint64(record.Generation) > math.MaxInt64 {
+		return fmt.Errorf("append ingress: generation %d exceeds SQLite integer range", record.Generation)
+	}
+	if record.ReceivedAt.IsZero() || record.ReceivedAt.UnixMilli() <= 0 {
+		return fmt.Errorf("append ingress: received time is not positive")
+	}
+	return nil
+}

--- a/internal/ingest/sink_worker_test.go
+++ b/internal/ingest/sink_worker_test.go
@@ -1,0 +1,596 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2keys"
+	"github.com/rs/zerolog"
+)
+
+const (
+	i01AccountID            = "account-i01-ingest"
+	i01Codec                = "test.i01.scripted"
+	i01RemoteConversationID = "conversation-i01-remote"
+)
+
+var i01TestTime = time.Date(2026, 7, 17, 15, 0, 0, 0, time.UTC)
+
+type i01DecoderFunc func(context.Context, bridge.RawIngressRecord) ([]bridge.Event, error)
+
+func (decode i01DecoderFunc) Decode(
+	ctx context.Context,
+	record bridge.RawIngressRecord,
+) ([]bridge.Event, error) {
+	return decode(ctx, record)
+}
+
+type i01EchoRecorder struct {
+	mu      sync.Mutex
+	calls   []messaging.TransportEcho
+	outcome messaging.EchoOutcome
+	err     error
+}
+
+func (recorder *i01EchoRecorder) ObserveTransportEcho(
+	_ context.Context,
+	echo messaging.TransportEcho,
+) (messaging.EchoOutcome, error) {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	recorder.calls = append(recorder.calls, echo)
+	if recorder.err != nil {
+		return "", recorder.err
+	}
+	if recorder.outcome != "" {
+		return recorder.outcome, nil
+	}
+	return messaging.EchoReconciled, nil
+}
+
+func (recorder *i01EchoRecorder) snapshot() []messaging.TransportEcho {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	return append([]messaging.TransportEcho(nil), recorder.calls...)
+}
+
+type i01Harness struct {
+	path     string
+	store    *sqlite.Store
+	messages *sqlite.MessageRepository
+	counters *Counters
+	worker   *Worker
+	sink     *Sink
+}
+
+func TestI01SinkDedupeReplayAndStaleProcessedFrame(t *testing.T) {
+	decoder := i01DecoderFunc(func(
+		_ context.Context,
+		record bridge.RawIngressRecord,
+	) ([]bridge.Event, error) {
+		return i01OutgoingMessageEvents("remote-i01-dedupe", string(record.Payload), ""), nil
+	})
+	harness := i01NewHarness(t, decoder, nil)
+	i01StartWorker(t, harness.worker)
+
+	frameA := i01IngressRecord("msg:remote-i01-dedupe:hash-a", []byte("body-a"))
+	i01MustAppend(t, harness.sink, frameA)
+	i01WaitFor(t, "first frame projection", func() bool {
+		message, err := i01GetMessage(harness.messages, "remote-i01-dedupe")
+		return err == nil && message.Body == "body-a" &&
+			harness.counters.Snapshot(i01AccountID).Projected == 1
+	})
+
+	// An exact replay resolves to the original inbox row and is a successful
+	// idempotent projection.
+	i01MustAppend(t, harness.sink, frameA)
+	i01WaitFor(t, "exact replay", func() bool {
+		snapshot := harness.counters.Snapshot(i01AccountID)
+		return snapshot.Deduped == 1 && snapshot.Projected == 2
+	})
+
+	// A content hash change gets its own durable inbox row and updates the one
+	// message selected by its remote natural key.
+	frameB := i01IngressRecord("msg:remote-i01-dedupe:hash-b", []byte("body-b"))
+	i01MustAppend(t, harness.sink, frameB)
+	i01WaitFor(t, "changed-content projection", func() bool {
+		message, err := i01GetMessage(harness.messages, "remote-i01-dedupe")
+		return err == nil && message.Body == "body-b" &&
+			harness.counters.Snapshot(i01AccountID).Projected == 3
+	})
+
+	// Replaying the now-superseded original content is classified as stale. It
+	// must not restore the old body or surface as a worker failure.
+	i01MustAppend(t, harness.sink, frameA)
+	i01WaitFor(t, "stale processed replay classification", func() bool {
+		return harness.counters.Snapshot(i01AccountID).StaleReplays == 1
+	})
+
+	message, err := i01GetMessage(harness.messages, "remote-i01-dedupe")
+	if err != nil {
+		t.Fatalf("GetMessageByRemote() after stale replay: %v", err)
+	}
+	if message.Body != "body-b" {
+		t.Fatalf("message body after stale replay = %q, want body-b", message.Body)
+	}
+	snapshot := harness.counters.Snapshot(i01AccountID)
+	if snapshot.Appended != 2 || snapshot.Deduped != 2 ||
+		snapshot.DecodedEvents != 4 || snapshot.Projected != 3 ||
+		snapshot.StaleReplays != 1 || snapshot.Quarantined != 0 {
+		t.Fatalf("dedupe/replay counters = %+v", snapshot)
+	}
+	if got := i01QueryInt64(t, harness.path, `SELECT COUNT(*) FROM inbox`); got != 2 {
+		t.Fatalf("inbox rows = %d, want 2 content-distinct rows", got)
+	}
+	if got := i01QueryInt64(t, harness.path, `SELECT COUNT(*) FROM messages`); got != 1 {
+		t.Fatalf("message rows = %d, want 1 natural-key row", got)
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
+func TestI01WorkerQuarantinesDecoderFailuresAndContinues(t *testing.T) {
+	decoder := i01DecoderFunc(func(
+		_ context.Context,
+		record bridge.RawIngressRecord,
+	) ([]bridge.Event, error) {
+		switch string(record.Payload) {
+		case "decoder-error-payload":
+			return nil, errors.New("scripted decoder failure")
+		case "decoder-panic-payload":
+			panic("scripted decoder panic")
+		case "continuation-payload":
+			return i01OutgoingMessageEvents(
+				"remote-i01-after-quarantine",
+				"worker-continued",
+				"",
+			), nil
+		default:
+			return nil, fmt.Errorf("unexpected scripted payload %q", record.Payload)
+		}
+	})
+	harness := i01NewHarness(t, decoder, nil)
+	i01StartWorker(t, harness.worker)
+
+	i01MustAppend(t, harness.sink, i01IngressRecord(
+		"quarantine:error",
+		[]byte("decoder-error-payload"),
+	))
+	i01MustAppend(t, harness.sink, i01IngressRecord(
+		"quarantine:panic",
+		[]byte("decoder-panic-payload"),
+	))
+	i01MustAppend(t, harness.sink, i01IngressRecord(
+		"quarantine:continuation",
+		[]byte("continuation-payload"),
+	))
+
+	i01WaitFor(t, "quarantine and continuation", func() bool {
+		snapshot := harness.counters.Snapshot(i01AccountID)
+		message, err := i01GetMessage(harness.messages, "remote-i01-after-quarantine")
+		return snapshot.Quarantined == 2 && snapshot.Projected == 1 &&
+			err == nil && message.Body == "worker-continued"
+	})
+
+	snapshot := harness.counters.Snapshot(i01AccountID)
+	if snapshot.Appended != 3 || snapshot.DecodedEvents != 1 ||
+		snapshot.Quarantined != 2 || snapshot.Projected != 1 {
+		t.Fatalf("quarantine counters = %+v", snapshot)
+	}
+	for _, test := range []struct {
+		dedupeKey string
+		payload   []byte
+	}{
+		{dedupeKey: "quarantine:error", payload: []byte("decoder-error-payload")},
+		{dedupeKey: "quarantine:panic", payload: []byte("decoder-panic-payload")},
+	} {
+		gotPayload, processedAt := i01InboxPayload(t, harness.path, test.dedupeKey)
+		if !bytes.Equal(gotPayload, test.payload) {
+			t.Errorf("retained payload for %q = %q, want %q", test.dedupeKey, gotPayload, test.payload)
+		}
+		if !processedAt.Valid || processedAt.Int64 <= 0 {
+			t.Errorf("processed_at_ms for quarantined %q = %+v, want positive", test.dedupeKey, processedAt)
+		}
+	}
+	if got := i01QueryInt64(t, harness.path, `SELECT COUNT(*) FROM inbox`); got != 3 {
+		t.Fatalf("inbox rows after quarantine = %d, want all 3 retained", got)
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
+func TestI01WorkerRoutesGenericEchoNotFoundAndProjects(t *testing.T) {
+	const (
+		clientRequestID = "client-request-i01"
+		remoteMessageID = "remote-i01-echo"
+	)
+	recorder := &i01EchoRecorder{outcome: messaging.EchoNotFound}
+	decoder := i01DecoderFunc(func(
+		_ context.Context,
+		_ bridge.RawIngressRecord,
+	) ([]bridge.Event, error) {
+		return i01OutgoingMessageEvents(remoteMessageID, "echo body", clientRequestID), nil
+	})
+	harness := i01NewHarness(t, decoder, recorder)
+	i01StartWorker(t, harness.worker)
+
+	i01MustAppend(t, harness.sink, i01IngressRecord(
+		"echo:remote-i01-echo",
+		[]byte("fake-decoder-echo-frame"),
+	))
+	i01WaitFor(t, "echo route and projection", func() bool {
+		return len(recorder.snapshot()) == 1 &&
+			harness.counters.Snapshot(i01AccountID).Projected == 1
+	})
+
+	calls := recorder.snapshot()
+	want := messaging.TransportEcho{
+		AccountID:          i01AccountID,
+		TransportRequestID: clientRequestID,
+		RemoteMessageID:    remoteMessageID,
+	}
+	if len(calls) != 1 || calls[0] != want {
+		t.Fatalf("ObserveTransportEcho calls = %+v, want exactly %+v", calls, want)
+	}
+	snapshot := harness.counters.Snapshot(i01AccountID)
+	if snapshot.EchoNotFound != 1 || snapshot.EchoReconciled != 0 ||
+		snapshot.Projected != 1 || snapshot.Quarantined != 0 {
+		t.Fatalf("echo-not-found counters = %+v", snapshot)
+	}
+	message, err := i01GetMessage(harness.messages, remoteMessageID)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote() after echo not-found: %v", err)
+	}
+	if message.Body != "echo body" {
+		t.Fatalf("projected echo body = %q, want echo body", message.Body)
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
+func TestI01WorkerStartupDrainsDurableFramesAfterCrash(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "store.sqlite3")
+	firstStore, err := sqlite.Open(path)
+	if err != nil {
+		t.Fatalf("first sqlite.Open(): %v", err)
+	}
+	firstClosed := false
+	t.Cleanup(func() {
+		if !firstClosed {
+			if err := firstStore.Close(); err != nil {
+				t.Errorf("close first store: %v", err)
+			}
+		}
+	})
+	i01SeedAccount(t, firstStore)
+	firstMessages := i01NewMessageRepository(t, firstStore)
+	decoder := i01DecoderFunc(func(
+		_ context.Context,
+		record bridge.RawIngressRecord,
+	) ([]bridge.Event, error) {
+		remoteMessageID := string(record.Payload)
+		return i01OutgoingMessageEvents(
+			remoteMessageID,
+			"recovered "+remoteMessageID,
+			"",
+		), nil
+	})
+
+	// The sink requires a worker for notification, but this first worker never
+	// runs. Its in-memory notifications disappear with the simulated process.
+	firstCounters := &Counters{}
+	firstWorker := i01NewWorker(t, firstStore, firstMessages, firstCounters, decoder, nil)
+	firstSink := i01NewSink(t, firstMessages, firstWorker, firstCounters, "crashed-inbox")
+	i01MustAppend(t, firstSink, i01IngressRecord("crash:one", []byte("remote-i01-crash-one")))
+	i01MustAppend(t, firstSink, i01IngressRecord("crash:two", []byte("remote-i01-crash-two")))
+	pending, err := firstMessages.Unprocessed(ctx)
+	if err != nil {
+		t.Fatalf("Unprocessed() before crash: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("unprocessed frames before crash = %d, want 2", len(pending))
+	}
+	if got := i01QueryInt64(t, path, `SELECT COUNT(*) FROM messages`); got != 0 {
+		t.Fatalf("messages before worker startup = %d, want 0", got)
+	}
+	if err := firstStore.Close(); err != nil {
+		t.Fatalf("close first store after durable appends: %v", err)
+	}
+	firstClosed = true
+
+	secondStore, err := sqlite.Open(path)
+	if err != nil {
+		t.Fatalf("second sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := secondStore.Close(); err != nil {
+			t.Errorf("close second store: %v", err)
+		}
+	})
+	secondMessages := i01NewMessageRepository(t, secondStore)
+	pending, err = secondMessages.Unprocessed(ctx)
+	if err != nil {
+		t.Fatalf("Unprocessed() after reopen: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("durable frames after reopen = %d, want 2", len(pending))
+	}
+
+	secondCounters := &Counters{}
+	secondWorker := i01NewWorker(t, secondStore, secondMessages, secondCounters, decoder, nil)
+	i01StartWorker(t, secondWorker)
+	i01WaitFor(t, "startup recovery drain", func() bool {
+		first, firstErr := i01GetMessage(secondMessages, "remote-i01-crash-one")
+		second, secondErr := i01GetMessage(secondMessages, "remote-i01-crash-two")
+		pending, pendingErr := secondMessages.Unprocessed(ctx)
+		return firstErr == nil && first.Body == "recovered remote-i01-crash-one" &&
+			secondErr == nil && second.Body == "recovered remote-i01-crash-two" &&
+			pendingErr == nil && len(pending) == 0
+	})
+	snapshot := secondCounters.Snapshot(i01AccountID)
+	if snapshot.Appended != 0 || snapshot.DecodedEvents != 2 || snapshot.Projected != 2 {
+		t.Fatalf("startup-drain counters = %+v", snapshot)
+	}
+	if got := i01QueryInt64(t, path, `SELECT COUNT(*) FROM messages`); got != 2 {
+		t.Fatalf("messages after startup drain = %d, want 2", got)
+	}
+}
+
+func i01NewHarness(
+	t *testing.T,
+	decoder bridge.Decoder,
+	echoes EchoObserver,
+) *i01Harness {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "store.sqlite3")
+	store, err := sqlite.Open(path)
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close store: %v", err)
+		}
+	})
+	i01SeedAccount(t, store)
+	messages := i01NewMessageRepository(t, store)
+	counters := &Counters{}
+	worker := i01NewWorker(t, store, messages, counters, decoder, echoes)
+	sink := i01NewSink(t, messages, worker, counters, "inbox-i01")
+	return &i01Harness{
+		path:     path,
+		store:    store,
+		messages: messages,
+		counters: counters,
+		worker:   worker,
+		sink:     sink,
+	}
+}
+
+func i01NewMessageRepository(
+	t *testing.T,
+	store *sqlite.Store,
+) *sqlite.MessageRepository {
+	t.Helper()
+	messages, err := sqlite.NewMessageRepository(store, func() time.Time { return i01TestTime })
+	if err != nil {
+		t.Fatalf("sqlite.NewMessageRepository(): %v", err)
+	}
+	return messages
+}
+
+func i01NewWorker(
+	t *testing.T,
+	store *sqlite.Store,
+	messages *sqlite.MessageRepository,
+	counters *Counters,
+	decoder bridge.Decoder,
+	echoes EchoObserver,
+) *Worker {
+	t.Helper()
+	worker, err := NewWorker(WorkerConfig{
+		Store:        store,
+		Messages:     messages,
+		EchoObserver: echoes,
+		Counters:     counters,
+		Logger:       zerolog.Nop(),
+		Now:          func() time.Time { return i01TestTime },
+		Decoders: []DecoderRegistration{{
+			Codec:    i01Codec,
+			Platform: bridge.PlatformGoogle,
+			Decoder:  decoder,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewWorker(): %v", err)
+	}
+	return worker
+}
+
+func i01NewSink(
+	t *testing.T,
+	messages *sqlite.MessageRepository,
+	worker *Worker,
+	counters *Counters,
+	idPrefix string,
+) *Sink {
+	t.Helper()
+	var next atomic.Uint64
+	sink, err := NewSink(SinkConfig{
+		Messages: messages,
+		Worker:   worker,
+		Counters: counters,
+		IDs: messaging.IDSourceFunc(func() (string, error) {
+			return fmt.Sprintf("%s-%04d", idPrefix, next.Add(1)), nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewSink(): %v", err)
+	}
+	return sink
+}
+
+func i01SeedAccount(t *testing.T, store *sqlite.Store) {
+	t.Helper()
+	err := store.UpsertAccount(sqlite.Account{
+		AccountID:   i01AccountID,
+		BridgeKey:   "google_messages",
+		DisplayName: "I01 ingest test",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: i01TestTime.UnixMilli(),
+		UpdatedAtMS: i01TestTime.UnixMilli(),
+	})
+	if err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+}
+
+func i01StartWorker(t *testing.T, worker *Worker) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- worker.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Worker.Run(): %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("Worker.Run() did not stop after cancellation")
+		}
+	})
+}
+
+func i01IngressRecord(dedupeKey string, payload []byte) bridge.RawIngressRecord {
+	return bridge.RawIngressRecord{
+		AccountID:    i01AccountID,
+		Generation:   17,
+		DedupeKey:    dedupeKey,
+		Codec:        i01Codec,
+		CodecVersion: 1,
+		ReceivedAt:   i01TestTime,
+		Payload:      payload,
+	}
+}
+
+func i01OutgoingMessageEvents(
+	remoteMessageID string,
+	body string,
+	clientRequestID string,
+) []bridge.Event {
+	return []bridge.Event{{
+		Kind: bridge.EventMessage,
+		Message: &bridge.MessageEvent{
+			RemoteConversationID: i01RemoteConversationID,
+			RemoteMessageID:      remoteMessageID,
+			ClientRequestID:      clientRequestID,
+			Direction:            string(sqlite.MessageDirectionOutgoing),
+			Body:                 body,
+			OccurredAt:           i01TestTime.Add(-time.Minute),
+		},
+	}}
+}
+
+func i01MustAppend(t *testing.T, sink *Sink, record bridge.RawIngressRecord) {
+	t.Helper()
+	if err := sink.AppendIngress(context.Background(), record); err != nil {
+		t.Fatalf("AppendIngress(%q): %v", record.DedupeKey, err)
+	}
+}
+
+func i01GetMessage(
+	messages *sqlite.MessageRepository,
+	remoteMessageID string,
+) (sqlite.Message, error) {
+	return messages.GetMessageByRemote(
+		context.Background(),
+		i01AccountID,
+		v2keys.DeriveID("conversation", i01AccountID, i01RemoteConversationID),
+		remoteMessageID,
+	)
+}
+
+func i01WaitFor(t *testing.T, description string, ready func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if ready() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", description)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func i01AssertNoPending(t *testing.T, messages *sqlite.MessageRepository) {
+	t.Helper()
+	pending, err := messages.Unprocessed(context.Background())
+	if err != nil {
+		t.Fatalf("Unprocessed(): %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("unprocessed frames = %d, want 0", len(pending))
+	}
+}
+
+func i01QueryInt64(t *testing.T, path, query string, args ...any) int64 {
+	t.Helper()
+	database := i01OpenInspector(t, path)
+	defer database.Close()
+	var value int64
+	if err := database.QueryRow(query, args...).Scan(&value); err != nil {
+		t.Fatalf("query %q: %v", query, err)
+	}
+	return value
+}
+
+func i01InboxPayload(
+	t *testing.T,
+	path string,
+	dedupeKey string,
+) ([]byte, sql.NullInt64) {
+	t.Helper()
+	database := i01OpenInspector(t, path)
+	defer database.Close()
+	var payload []byte
+	var processedAt sql.NullInt64
+	if err := database.QueryRow(`
+		SELECT payload, processed_at_ms
+		FROM inbox
+		WHERE account_id = ? AND dedupe_key = ?
+	`, i01AccountID, dedupeKey).Scan(&payload, &processedAt); err != nil {
+		t.Fatalf("read inbox payload for %q: %v", dedupeKey, err)
+	}
+	return payload, processedAt
+}
+
+func i01OpenInspector(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	database, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open(inspector): %v", err)
+	}
+	database.SetMaxOpenConns(1)
+	if err := database.Ping(); err != nil {
+		_ = database.Close()
+		t.Fatalf("inspector Ping(): %v", err)
+	}
+	return database
+}

--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -1,0 +1,968 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2keys"
+	"github.com/rs/zerolog"
+)
+
+// EchoObserver is the transport-neutral echo reconciliation seam implemented
+// by messaging.MessageService.
+type EchoObserver interface {
+	ObserveTransportEcho(context.Context, messaging.TransportEcho) (messaging.EchoOutcome, error)
+}
+
+// DecoderRegistration binds a durable codec to both its pure decoder and the
+// platform needed for shared key derivation.
+type DecoderRegistration struct {
+	Codec    string
+	Platform bridge.Platform
+	Decoder  bridge.Decoder
+}
+
+// WorkerConfig configures the single-goroutine projection worker.
+type WorkerConfig struct {
+	Store         *sqlite.Store
+	Messages      *sqlite.MessageRepository
+	EchoObserver  EchoObserver
+	Counters      *Counters
+	Logger        zerolog.Logger
+	Now           func() time.Time
+	QueueCapacity int
+	Decoders      []DecoderRegistration
+}
+
+type registeredDecoder struct {
+	platform bridge.Platform
+	decoder  bridge.Decoder
+}
+
+type workItem struct {
+	inboxID string
+	record  bridge.RawIngressRecord
+	replay  bool
+}
+
+// Worker drains durable inbox records and applies normalized events without
+// touching the legacy store.
+type Worker struct {
+	store    *sqlite.Store
+	messages *sqlite.MessageRepository
+	echoes   EchoObserver
+	counters *Counters
+	logger   zerolog.Logger
+	now      func() time.Time
+	decoders map[string]registeredDecoder
+	work     chan workItem
+	running  atomic.Bool
+}
+
+// NewWorker validates and copies its decoder registry. Run starts no work
+// until explicitly invoked by the owner.
+func NewWorker(config WorkerConfig) (*Worker, error) {
+	if config.Store == nil {
+		return nil, fmt.Errorf("create ingest worker: store is nil")
+	}
+	if config.Messages == nil {
+		return nil, fmt.Errorf("create ingest worker: message repository is nil")
+	}
+	if config.Counters == nil {
+		config.Counters = &Counters{}
+	}
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	if config.QueueCapacity <= 0 {
+		config.QueueCapacity = defaultWorkerQueueCapacity
+	}
+
+	decoders := make(map[string]registeredDecoder, len(config.Decoders))
+	for index, registration := range config.Decoders {
+		codec := strings.TrimSpace(registration.Codec)
+		if codec == "" {
+			return nil, fmt.Errorf("create ingest worker: decoder %d codec is empty", index)
+		}
+		if registration.Decoder == nil {
+			return nil, fmt.Errorf("create ingest worker: decoder for codec %q is nil", codec)
+		}
+		switch registration.Platform {
+		case bridge.PlatformGoogle, bridge.PlatformWhatsApp, bridge.PlatformSignal:
+		default:
+			return nil, fmt.Errorf(
+				"create ingest worker: decoder for codec %q has invalid platform %q",
+				codec,
+				registration.Platform,
+			)
+		}
+		if _, exists := decoders[codec]; exists {
+			return nil, fmt.Errorf("create ingest worker: duplicate decoder codec %q", codec)
+		}
+		decoders[codec] = registeredDecoder{
+			platform: registration.Platform,
+			decoder:  registration.Decoder,
+		}
+	}
+
+	return &Worker{
+		store:    config.Store,
+		messages: config.Messages,
+		echoes:   config.EchoObserver,
+		counters: config.Counters,
+		logger:   config.Logger,
+		now:      config.Now,
+		decoders: decoders,
+		work:     make(chan workItem, config.QueueCapacity),
+	}, nil
+}
+
+// Counters returns the worker's shared per-account counter set.
+func (w *Worker) Counters() *Counters { return w.counters }
+
+// Run performs a startup crash-recovery drain, then consumes non-blocking sink
+// notifications. Only one Run call may be active at a time.
+func (w *Worker) Run(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("run ingest worker: context is nil")
+	}
+	if !w.running.CompareAndSwap(false, true) {
+		return fmt.Errorf("run ingest worker: already running")
+	}
+	defer w.running.Store(false)
+
+	w.drain(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case item := <-w.work:
+			// New records are loaded from durable storage. A deduplicated replay
+			// is absent from Unprocessed once processed, so re-decode the stable
+			// dedupe-equivalent frame to exercise stale-replay classification.
+			if item.replay {
+				w.handleRecord(ctx, item.inboxID, item.record)
+			}
+			w.drain(ctx)
+		}
+	}
+}
+
+func (w *Worker) enqueue(item workItem) {
+	select {
+	case w.work <- item:
+	default:
+	}
+}
+
+func (w *Worker) drain(ctx context.Context) {
+	var records []sqlite.InboxRecord
+	err := retryTransient(ctx, func() error {
+		var err error
+		records, err = w.messages.Unprocessed(ctx)
+		return err
+	})
+	if err != nil {
+		if ctx.Err() == nil {
+			w.logger.Warn().Err(err).Msg("Failed to list unprocessed ingest frames")
+		}
+		return
+	}
+	for _, record := range records {
+		if ctx.Err() != nil {
+			return
+		}
+		w.handleRecord(ctx, record.InboxID, rawIngressRecord(record))
+	}
+}
+
+func rawIngressRecord(record sqlite.InboxRecord) bridge.RawIngressRecord {
+	return bridge.RawIngressRecord{
+		AccountID:    record.AccountID,
+		Generation:   bridge.Generation(record.Generation),
+		DedupeKey:    record.DedupeKey,
+		Codec:        record.Codec,
+		CodecVersion: uint32(record.CodecVersion),
+		ReceivedAt:   time.UnixMilli(record.ReceivedAtMS),
+		Payload:      record.Payload,
+	}
+}
+
+func (w *Worker) handleRecord(
+	ctx context.Context,
+	inboxID string,
+	record bridge.RawIngressRecord,
+) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			w.markQuarantined(ctx, inboxID, record, fmt.Errorf(
+				"ingest frame panic: %v\n%s",
+				recovered,
+				debug.Stack(),
+			))
+		}
+	}()
+
+	err := retryTransient(ctx, func() error {
+		return w.processRecord(ctx, inboxID, record)
+	})
+	if err == nil || ctx.Err() != nil {
+		return
+	}
+
+	var stale staleReplayError
+	if errors.As(err, &stale) {
+		w.counters.account(record.AccountID).staleReplays.Add(1)
+		w.logger.Debug().
+			Err(stale.cause).
+			Str("account_id", record.AccountID).
+			Str("inbox_id", inboxID).
+			Str("codec", record.Codec).
+			Msg("Ignored stale ingest replay")
+		return
+	}
+
+	var deterministic quarantineError
+	if errors.As(err, &deterministic) {
+		w.markQuarantined(ctx, inboxID, record, deterministic.cause)
+		return
+	}
+
+	var exhausted transientExhaustedError
+	if errors.As(err, &exhausted) || isTransientDBError(err) {
+		w.logger.Warn().
+			Err(err).
+			Str("account_id", record.AccountID).
+			Str("inbox_id", inboxID).
+			Str("codec", record.Codec).
+			Msg("Ingest projection exhausted transient retries; leaving frame unprocessed")
+		return
+	}
+
+	w.markQuarantined(ctx, inboxID, record, err)
+}
+
+func (w *Worker) markQuarantined(
+	ctx context.Context,
+	inboxID string,
+	record bridge.RawIngressRecord,
+	cause error,
+) {
+	err := retryTransient(ctx, func() error {
+		return w.messages.MarkInboxProcessed(ctx, inboxID, record.AccountID)
+	})
+	if err != nil {
+		if ctx.Err() == nil {
+			w.logger.Warn().
+				Err(err).
+				Str("account_id", record.AccountID).
+				Str("inbox_id", inboxID).
+				Str("codec", record.Codec).
+				Msg("Failed to mark quarantined ingest frame processed")
+		}
+		return
+	}
+	w.counters.account(record.AccountID).quarantined.Add(1)
+	w.logger.Warn().
+		Err(cause).
+		Str("account_id", record.AccountID).
+		Str("inbox_id", inboxID).
+		Str("codec", record.Codec).
+		Msg("Quarantined ingest frame")
+}
+
+func (w *Worker) processRecord(
+	ctx context.Context,
+	inboxID string,
+	record bridge.RawIngressRecord,
+) error {
+	registration, exists := w.decoders[record.Codec]
+	if !exists {
+		return quarantine(fmt.Errorf("unknown ingress codec %q", record.Codec))
+	}
+	events, err := decodeSafely(ctx, registration.decoder, record)
+	if err != nil {
+		return quarantine(err)
+	}
+	for index := range events {
+		events[index].AccountID = record.AccountID
+		events[index].SourceInboxID = inboxID
+		if err := validateDecodedEvent(events[index]); err != nil {
+			return quarantine(fmt.Errorf("decoded event %d: %w", index, err))
+		}
+	}
+	w.counters.account(record.AccountID).decodedEvents.Add(uint64(len(events)))
+	return classifyApplyError(w.applyEvents(ctx, registration.platform, record, inboxID, events))
+}
+
+func decodeSafely(
+	ctx context.Context,
+	decoder bridge.Decoder,
+	record bridge.RawIngressRecord,
+) (events []bridge.Event, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("decoder panic: %v\n%s", recovered, debug.Stack())
+			events = nil
+		}
+	}()
+	return decoder.Decode(ctx, record)
+}
+
+func validateDecodedEvent(event bridge.Event) error {
+	payloads := 0
+	if event.Conversation != nil {
+		payloads++
+	}
+	if event.Message != nil {
+		payloads++
+	}
+	if event.MessageMutation != nil {
+		payloads++
+	}
+	if event.Reaction != nil {
+		payloads++
+	}
+	if event.Receipt != nil {
+		payloads++
+	}
+	if payloads != 1 {
+		return fmt.Errorf("event has %d payloads, want exactly one", payloads)
+	}
+	switch event.Kind {
+	case bridge.EventConversation:
+		if event.Conversation == nil {
+			return fmt.Errorf("conversation event has wrong payload")
+		}
+	case bridge.EventMessage:
+		if event.Message == nil {
+			return fmt.Errorf("message event has wrong payload")
+		}
+	case bridge.EventMessageMutation:
+		if event.MessageMutation == nil {
+			return fmt.Errorf("message mutation event has wrong payload")
+		}
+	case bridge.EventReaction:
+		if event.Reaction == nil {
+			return fmt.Errorf("reaction event has wrong payload")
+		}
+	case bridge.EventReceipt:
+		if event.Receipt == nil {
+			return fmt.Errorf("receipt event has wrong payload")
+		}
+	default:
+		return fmt.Errorf("unknown event kind %q", event.Kind)
+	}
+	return nil
+}
+
+func (w *Worker) applyEvents(
+	ctx context.Context,
+	platform bridge.Platform,
+	record bridge.RawIngressRecord,
+	inboxID string,
+	events []bridge.Event,
+) error {
+	accountID := record.AccountID
+	for _, event := range events {
+		if event.Kind != bridge.EventConversation {
+			continue
+		}
+		if _, err := w.refreshConversation(accountID, platform, *event.Conversation); err != nil {
+			return err
+		}
+	}
+
+	messageCount := 0
+	projected := false
+	for _, event := range events {
+		if event.Kind != bridge.EventMessage {
+			continue
+		}
+		projection, err := w.messageProjection(
+			ctx,
+			accountID,
+			platform,
+			inboxID,
+			*event.Message,
+			messageCount == 0,
+		)
+		if err != nil {
+			return err
+		}
+		if messageCount == 0 {
+			if err := w.messages.ProjectMessage(ctx, projection); err != nil {
+				return err
+			}
+			projected = true
+			w.counters.account(accountID).projected.Add(1)
+		} else {
+			if err := w.messages.ImportMessage(ctx, projection); err != nil {
+				return err
+			}
+			w.counters.account(accountID).imported.Add(1)
+		}
+		// Conversation rows are never re-upserted from message frames, so
+		// recency advances through this targeted monotone bump instead.
+		if err := w.store.BumpConversationRecency(
+			projection.Message.ConversationID,
+			projection.Message.OccurredAtMS,
+		); err != nil {
+			return err
+		}
+		messageCount++
+	}
+
+	for _, event := range events {
+		if event.Kind != bridge.EventMessageMutation {
+			continue
+		}
+		mutation := *event.MessageMutation
+		if strings.TrimSpace(mutation.RemoteMessageID) == "" {
+			return fmt.Errorf("message mutation remote ID is empty")
+		}
+		conversation, remoteConversationID, err := w.existingConversation(
+			accountID,
+			platform,
+			mutation.RemoteConversationID,
+		)
+		conversationID := conversation.ConversationID
+		if errors.Is(err, sqlite.ErrNotFound) {
+			// A mutation whose conversation/message was never stored is the same
+			// benign missing-target case handled by ApplyMessageMutation. Use the
+			// canonical would-be PK without creating a conversation row.
+			conversationID = v2keys.DeriveID("conversation", accountID, remoteConversationID)
+		} else if err != nil {
+			return err
+		}
+		updated, err := w.messages.ApplyMessageMutation(
+			ctx,
+			accountID,
+			conversationID,
+			strings.TrimSpace(mutation.RemoteMessageID),
+			mutation.Kind,
+			mutation.Body,
+			inboxID,
+		)
+		if err != nil {
+			return err
+		}
+		if updated {
+			w.counters.account(accountID).mutations.Add(1)
+		} else {
+			w.logger.Debug().
+				Str("account_id", accountID).
+				Str("inbox_id", inboxID).
+				Str("remote_message_id", mutation.RemoteMessageID).
+				Msg("Ignored mutation for missing message")
+		}
+	}
+
+	for _, event := range events {
+		if event.Kind == bridge.EventReaction {
+			w.counters.account(accountID).reactionsDropped.Add(1)
+		}
+	}
+
+	for _, event := range events {
+		if event.Kind != bridge.EventReceipt {
+			continue
+		}
+		if !event.Receipt.Actor.IsSelf {
+			w.counters.account(accountID).receiptsDropped.Add(1)
+			continue
+		}
+		applied, err := w.advanceReadCursor(ctx, accountID, platform, *event.Receipt)
+		if err != nil {
+			return err
+		}
+		if applied {
+			w.counters.account(accountID).receiptsSelf.Add(1)
+		} else {
+			// The conversation or local device is not known yet. That is an
+			// ordering gap, not a defect: drop the cursor advance benignly
+			// rather than quarantining a valid frame.
+			w.counters.account(accountID).receiptsDropped.Add(1)
+		}
+	}
+
+	if !projected {
+		if err := w.messages.MarkInboxProcessed(ctx, inboxID, accountID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *Worker) refreshConversation(
+	accountID string,
+	platform bridge.Platform,
+	event bridge.ConversationEvent,
+) (sqlite.Conversation, error) {
+	remoteID := v2keys.NormalizeRemoteConversationID(string(platform), event.RemoteConversationID)
+	if strings.TrimSpace(remoteID) == "" {
+		return sqlite.Conversation{}, fmt.Errorf("conversation remote ID is empty")
+	}
+	type preparedParticipant struct {
+		participant bridge.Participant
+		role        sqlite.ParticipantRole
+	}
+	prepared := make([]preparedParticipant, 0, len(event.Participants))
+	seenIdentities := make(map[string]struct{}, len(event.Participants))
+	for _, participant := range event.Participants {
+		raw := identityRaw(participant.Identity)
+		key, keyErr := v2keys.IdentityKey(accountID, string(platform), raw)
+		if keyErr != nil {
+			return sqlite.Conversation{}, keyErr
+		}
+		naturalKey := key.Kind + "\x1f" + key.Canonical
+		if _, duplicate := seenIdentities[naturalKey]; duplicate {
+			return sqlite.Conversation{}, fmt.Errorf(
+				"conversation participant identity %q is duplicated",
+				key.Canonical,
+			)
+		}
+		seenIdentities[naturalKey] = struct{}{}
+		role, roleErr := participantRole(participant.Role)
+		if roleErr != nil {
+			return sqlite.Conversation{}, roleErr
+		}
+		prepared = append(prepared, preparedParticipant{participant: participant, role: role})
+	}
+	nowMS, err := w.nowMS()
+	if err != nil {
+		return sqlite.Conversation{}, err
+	}
+
+	conversation, err := w.store.GetConversationByRemote(accountID, remoteID)
+	if errors.Is(err, sqlite.ErrNotFound) {
+		kind, kindErr := conversationKind(event.Kind, sqlite.ConversationKindDirect)
+		if kindErr != nil {
+			return sqlite.Conversation{}, kindErr
+		}
+		conversation = sqlite.Conversation{
+			ConversationID:       v2keys.DeriveID("conversation", accountID, remoteID),
+			AccountID:            accountID,
+			RemoteConversationID: remoteID,
+			Kind:                 kind,
+			Title:                event.Title,
+			RemoteRevision:       optionalTrimmed(event.RemoteRevision),
+			NotificationMode:     sqlite.NotificationModeAll,
+			MetadataJSON:         "{}",
+			CreatedAtMS:          nowMS,
+			UpdatedAtMS:          nowMS,
+		}
+	} else if err != nil {
+		return sqlite.Conversation{}, err
+	} else {
+		if strings.TrimSpace(event.Kind) != "" {
+			kind, kindErr := conversationKind(event.Kind, conversation.Kind)
+			if kindErr != nil {
+				return sqlite.Conversation{}, kindErr
+			}
+			conversation.Kind = kind
+		}
+		conversation.Title = event.Title
+		conversation.RemoteRevision = optionalTrimmed(event.RemoteRevision)
+		conversation.UpdatedAtMS = nowMS
+	}
+	if err := w.store.UpsertConversation(conversation); err != nil {
+		return sqlite.Conversation{}, err
+	}
+	conversation, err = w.store.GetConversationByRemote(accountID, remoteID)
+	if err != nil {
+		return sqlite.Conversation{}, err
+	}
+
+	participants := make([]sqlite.ConversationParticipant, 0, len(prepared))
+	for _, item := range prepared {
+		identity, identityErr := w.resolveIdentity(accountID, platform, item.participant.Identity)
+		if identityErr != nil {
+			return sqlite.Conversation{}, identityErr
+		}
+		participants = append(participants, sqlite.ConversationParticipant{
+			AccountID:      accountID,
+			ConversationID: conversation.ConversationID,
+			IdentityID:     identity.IdentityID,
+			Role:           item.role,
+			DisplayName:    item.participant.Identity.Name,
+			IsActive:       item.participant.Active,
+		})
+	}
+	if err := w.store.ReplaceConversationParticipants(conversation.ConversationID, participants); err != nil {
+		return sqlite.Conversation{}, err
+	}
+	return conversation, nil
+}
+
+func (w *Worker) ensureMessageConversation(
+	accountID string,
+	platform bridge.Platform,
+	remoteConversationID string,
+	occurredAtMS int64,
+) (sqlite.Conversation, string, error) {
+	conversation, remoteID, err := w.existingConversation(accountID, platform, remoteConversationID)
+	if err == nil {
+		return conversation, remoteID, nil
+	}
+	if !errors.Is(err, sqlite.ErrNotFound) {
+		return sqlite.Conversation{}, "", err
+	}
+	if occurredAtMS <= 0 {
+		occurredAtMS, err = w.nowMS()
+		if err != nil {
+			return sqlite.Conversation{}, "", err
+		}
+	}
+	conversation = sqlite.Conversation{
+		ConversationID:       v2keys.DeriveID("conversation", accountID, remoteID),
+		AccountID:            accountID,
+		RemoteConversationID: remoteID,
+		Kind:                 sqlite.ConversationKindDirect,
+		NotificationMode:     sqlite.NotificationModeAll,
+		LastMessageAtMS:      occurredAtMS,
+		MetadataJSON:         "{}",
+		CreatedAtMS:          occurredAtMS,
+		UpdatedAtMS:          occurredAtMS,
+	}
+	if err := w.store.UpsertConversation(conversation); err != nil {
+		return sqlite.Conversation{}, "", err
+	}
+	conversation, err = w.store.GetConversationByRemote(accountID, remoteID)
+	return conversation, remoteID, err
+}
+
+func (w *Worker) existingConversation(
+	accountID string,
+	platform bridge.Platform,
+	remoteConversationID string,
+) (sqlite.Conversation, string, error) {
+	remoteID := v2keys.NormalizeRemoteConversationID(string(platform), remoteConversationID)
+	if strings.TrimSpace(remoteID) == "" {
+		return sqlite.Conversation{}, "", fmt.Errorf("conversation remote ID is empty")
+	}
+	conversation, err := w.store.GetConversationByRemote(accountID, remoteID)
+	return conversation, remoteID, err
+}
+
+func (w *Worker) resolveIdentity(
+	accountID string,
+	platform bridge.Platform,
+	reference bridge.IdentityRef,
+) (sqlite.Identity, error) {
+	raw := identityRaw(reference)
+	key, err := v2keys.IdentityKey(accountID, string(platform), raw)
+	if err != nil {
+		return sqlite.Identity{}, err
+	}
+	nowMS, err := w.nowMS()
+	if err != nil {
+		return sqlite.Identity{}, err
+	}
+	kind := sqlite.IdentityKind(key.Kind)
+	identity, err := w.store.GetIdentityByCanonical(accountID, kind, key.Canonical)
+	if errors.Is(err, sqlite.ErrNotFound) {
+		identity = sqlite.Identity{
+			IdentityID:     v2keys.DeriveID("identity", accountID, key.Kind+"\x1f"+key.Canonical),
+			AccountID:      accountID,
+			Kind:           kind,
+			CanonicalValue: key.Canonical,
+			RawValue:       raw,
+			DisplayName:    strings.TrimSpace(reference.Name),
+			IsSelf:         reference.IsSelf,
+			MetadataJSON:   "{}",
+			CreatedAtMS:    nowMS,
+			UpdatedAtMS:    nowMS,
+		}
+	} else if err != nil {
+		return sqlite.Identity{}, err
+	} else {
+		identity.RawValue = raw
+		if name := strings.TrimSpace(reference.Name); name != "" {
+			identity.DisplayName = name
+		}
+		identity.IsSelf = identity.IsSelf || reference.IsSelf
+		identity.UpdatedAtMS = nowMS
+	}
+	if err := w.store.UpsertIdentity(identity); err != nil {
+		return sqlite.Identity{}, err
+	}
+	return w.store.GetIdentityByCanonical(accountID, kind, key.Canonical)
+}
+
+func identityRaw(reference bridge.IdentityRef) string {
+	raw := strings.TrimSpace(reference.Raw)
+	if raw == "" {
+		raw = strings.TrimSpace(reference.Canonical)
+	}
+	return raw
+}
+
+func (w *Worker) messageProjection(
+	ctx context.Context,
+	accountID string,
+	platform bridge.Platform,
+	inboxID string,
+	event bridge.MessageEvent,
+	routeEcho bool,
+) (sqlite.MessageProjection, error) {
+	direction, err := messageDirection(event.Direction)
+	if err != nil {
+		return sqlite.MessageProjection{}, err
+	}
+	remoteMessageID := strings.TrimSpace(event.RemoteMessageID)
+	if remoteMessageID == "" {
+		return sqlite.MessageProjection{}, fmt.Errorf("message remote ID is empty")
+	}
+
+	if routeEcho && strings.TrimSpace(event.ClientRequestID) != "" && direction == sqlite.MessageDirectionOutgoing {
+		if w.echoes == nil {
+			return sqlite.MessageProjection{}, fmt.Errorf("echo observer is unavailable")
+		}
+		outcome, err := w.echoes.ObserveTransportEcho(ctx, messaging.TransportEcho{
+			AccountID:          accountID,
+			TransportRequestID: event.ClientRequestID,
+			RemoteMessageID:    remoteMessageID,
+		})
+		switch {
+		case err != nil:
+			// Echo reconciliation is best-effort enrichment of outbound send
+			// state. A reconcile fault (for example a concurrent confirm by
+			// the dispatcher) must never block durable delivery of the
+			// inbound message itself, so count it and keep projecting.
+			w.counters.account(accountID).echoErrors.Add(1)
+			w.logger.Warn().
+				Str("account_id", accountID).
+				Str("transport_request_id", event.ClientRequestID).
+				Err(err).
+				Msg("ingest: transport echo reconcile failed; projecting anyway")
+		case outcome == messaging.EchoEnriched:
+			w.counters.account(accountID).echoEnriched.Add(1)
+		case outcome == messaging.EchoNotFound:
+			w.counters.account(accountID).echoNotFound.Add(1)
+		case outcome == messaging.EchoNoop:
+			w.counters.account(accountID).echoNoop.Add(1)
+		default:
+			w.counters.account(accountID).echoReconciled.Add(1)
+		}
+	}
+
+	occurredAtMS := event.OccurredAt.UnixMilli()
+	if occurredAtMS <= 0 {
+		return sqlite.MessageProjection{}, fmt.Errorf("message occurrence time is not positive")
+	}
+	conversation, remoteConversationID, err := w.ensureMessageConversation(
+		accountID,
+		platform,
+		event.RemoteConversationID,
+		occurredAtMS,
+	)
+	if err != nil {
+		return sqlite.MessageProjection{}, err
+	}
+
+	if platform == bridge.PlatformSignal && direction == sqlite.MessageDirectionOutgoing {
+		remoteMessageID, err = w.signalOutgoingRemoteID(
+			ctx,
+			accountID,
+			conversation.ConversationID,
+			remoteConversationID,
+			remoteMessageID,
+		)
+		if err != nil {
+			return sqlite.MessageProjection{}, err
+		}
+	}
+
+	var senderIdentityID *string
+	if direction != sqlite.MessageDirectionOutgoing && !event.Sender.IsSelf {
+		identity, identityErr := w.resolveIdentity(accountID, platform, event.Sender)
+		if identityErr != nil {
+			return sqlite.MessageProjection{}, identityErr
+		}
+		senderIdentityID = &identity.IdentityID
+	}
+
+	var replyToRemoteID *string
+	if reply := strings.TrimSpace(event.ReplyToRemoteID); reply != "" {
+		replyToRemoteID = &reply
+	}
+	attachments := make([]sqlite.MessageAttachment, 0, len(event.Attachments))
+	for index, attachment := range event.Attachments {
+		size := attachment.Size
+		attachments = append(attachments, sqlite.MessageAttachment{
+			RemoteID:  attachment.RemoteID,
+			Ordinal:   int64(index),
+			RemoteRef: attachment.RemoteRef,
+			Filename:  attachment.Filename,
+			MIME:      attachment.MIME,
+			SizeBytes: &size,
+			State:     "pending",
+		})
+	}
+
+	return sqlite.MessageProjection{
+		InboxID: inboxID,
+		Message: sqlite.Message{
+			MessageID:        v2keys.DeriveID("message", accountID, remoteConversationID+"\x1f"+remoteMessageID),
+			ConversationID:   conversation.ConversationID,
+			AccountID:        accountID,
+			RemoteMessageID:  remoteMessageID,
+			SenderIdentityID: senderIdentityID,
+			Direction:        direction,
+			Body:             event.Body,
+			ReplyToRemoteID:  replyToRemoteID,
+			State:            sqlite.MessageStateActive,
+			OccurredAtMS:     occurredAtMS,
+		},
+		Attachments: attachments,
+	}, nil
+}
+
+func (w *Worker) signalOutgoingRemoteID(
+	ctx context.Context,
+	accountID string,
+	conversationID string,
+	remoteConversationID string,
+	remoteMessageID string,
+) (string, error) {
+	if _, err := w.messages.GetMessageByRemote(ctx, accountID, conversationID, remoteMessageID); err == nil {
+		return remoteMessageID, nil
+	} else if !errors.Is(err, sqlite.ErrNotFound) {
+		return "", err
+	}
+	timestamp, err := strconv.ParseInt(remoteMessageID, 10, 64)
+	if err != nil {
+		return remoteMessageID, nil
+	}
+	alias := v2keys.SignalLocalAlias(remoteConversationID, timestamp)
+	if _, err := w.messages.GetMessageByRemote(ctx, accountID, conversationID, alias); err == nil {
+		return alias, nil
+	} else if errors.Is(err, sqlite.ErrNotFound) {
+		return remoteMessageID, nil
+	} else {
+		return "", err
+	}
+}
+
+func (w *Worker) advanceReadCursor(
+	ctx context.Context,
+	accountID string,
+	platform bridge.Platform,
+	event bridge.ReceiptEvent,
+) (bool, error) {
+	conversation, _, err := w.existingConversation(accountID, platform, event.RemoteConversationID)
+	if errors.Is(err, sqlite.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	device, err := w.store.GetLocalInstallationDevice(ctx, accountID)
+	if errors.Is(err, sqlite.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	var lastReadMessageID *string
+	for index := len(event.RemoteMessageIDs) - 1; index >= 0; index-- {
+		remoteID := strings.TrimSpace(event.RemoteMessageIDs[index])
+		if remoteID == "" {
+			continue
+		}
+		message, getErr := w.messages.GetMessageByRemote(
+			ctx,
+			accountID,
+			conversation.ConversationID,
+			remoteID,
+		)
+		if errors.Is(getErr, sqlite.ErrNotFound) {
+			break
+		}
+		if getErr != nil {
+			return false, getErr
+		}
+		lastReadMessageID = &message.MessageID
+		break
+	}
+	readAtMS := event.OccurredAt.UnixMilli()
+	if readAtMS <= 0 {
+		return false, fmt.Errorf("receipt occurrence time is not positive")
+	}
+	updatedAtMS, err := w.nowMS()
+	if err != nil {
+		return false, err
+	}
+	if err := w.store.UpsertReadCursor(sqlite.ReadCursor{
+		AccountID:         accountID,
+		DeviceID:          device.DeviceID,
+		ConversationID:    conversation.ConversationID,
+		LastReadMessageID: lastReadMessageID,
+		LastReadAtMS:      readAtMS,
+		UpdatedAtMS:       updatedAtMS,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (w *Worker) nowMS() (int64, error) {
+	nowMS := w.now().UnixMilli()
+	if nowMS <= 0 {
+		return 0, fmt.Errorf("ingest worker clock is not positive")
+	}
+	return nowMS, nil
+}
+
+func conversationKind(value string, fallback sqlite.ConversationKind) (sqlite.ConversationKind, error) {
+	switch kind := sqlite.ConversationKind(strings.TrimSpace(value)); kind {
+	case "":
+		return fallback, nil
+	case sqlite.ConversationKindDirect,
+		sqlite.ConversationKindGroup,
+		sqlite.ConversationKindBroadcast,
+		sqlite.ConversationKindSystem:
+		return kind, nil
+	default:
+		return "", fmt.Errorf("invalid conversation kind %q", value)
+	}
+}
+
+func participantRole(value string) (sqlite.ParticipantRole, error) {
+	switch role := sqlite.ParticipantRole(strings.TrimSpace(value)); role {
+	case "", sqlite.ParticipantRoleMember:
+		return sqlite.ParticipantRoleMember, nil
+	case sqlite.ParticipantRoleAdmin, sqlite.ParticipantRoleOwner, sqlite.ParticipantRoleUnknown:
+		return role, nil
+	default:
+		return "", fmt.Errorf("invalid participant role %q", value)
+	}
+}
+
+func messageDirection(value string) (sqlite.MessageDirection, error) {
+	switch direction := sqlite.MessageDirection(strings.TrimSpace(value)); direction {
+	case sqlite.MessageDirectionIncoming, sqlite.MessageDirectionOutgoing:
+		return direction, nil
+	default:
+		return "", fmt.Errorf("invalid message direction %q", value)
+	}
+}
+
+func optionalTrimmed(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}

--- a/internal/ingest/worker_contract_test.go
+++ b/internal/ingest/worker_contract_test.go
@@ -1,0 +1,231 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func TestWorkerOnlyFirstMessageRoutesEchoAndAdditionalMessagesImport(t *testing.T) {
+	recorder := &i01EchoRecorder{}
+	decoder := i01DecoderFunc(func(
+		_ context.Context,
+		_ bridge.RawIngressRecord,
+	) ([]bridge.Event, error) {
+		first := i01OutgoingMessageEvents("multi-first", "first body", "request-first")[0]
+		second := i01OutgoingMessageEvents("multi-second", "second body", "request-second")[0]
+		return []bridge.Event{first, second}, nil
+	})
+	harness := i01NewHarness(t, decoder, recorder)
+	i01StartWorker(t, harness.worker)
+
+	i01MustAppend(t, harness.sink, i01IngressRecord("multi:frame", []byte("multi")))
+	i01WaitFor(t, "multi-message projection", func() bool {
+		snapshot := harness.counters.Snapshot(i01AccountID)
+		return snapshot.Projected == 1 && snapshot.Imported == 1
+	})
+
+	calls := recorder.snapshot()
+	want := messaging.TransportEcho{
+		AccountID:          i01AccountID,
+		TransportRequestID: "request-first",
+		RemoteMessageID:    "multi-first",
+	}
+	if len(calls) != 1 || calls[0] != want {
+		t.Fatalf("ObserveTransportEcho calls = %+v, want only first message %+v", calls, want)
+	}
+	for _, remoteID := range []string{"multi-first", "multi-second"} {
+		if _, err := i01GetMessage(harness.messages, remoteID); err != nil {
+			t.Errorf("GetMessageByRemote(%q): %v", remoteID, err)
+		}
+	}
+	snapshot := harness.counters.Snapshot(i01AccountID)
+	if snapshot.EchoReconciled != 1 || snapshot.DecodedEvents != 2 {
+		t.Fatalf("multi-message counters = %+v, want one echo and two decoded events", snapshot)
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
+func TestWorkerQuarantinesUnknownCodecAndProcessesNoEventFrame(t *testing.T) {
+	decoder := i01DecoderFunc(func(
+		_ context.Context,
+		_ bridge.RawIngressRecord,
+	) ([]bridge.Event, error) {
+		return nil, nil
+	})
+	harness := i01NewHarness(t, decoder, nil)
+	i01StartWorker(t, harness.worker)
+
+	unknown := i01IngressRecord("unknown:codec", []byte("retained unknown payload"))
+	unknown.Codec = "unknown.codec"
+	i01MustAppend(t, harness.sink, unknown)
+	i01MustAppend(t, harness.sink, i01IngressRecord("no:events", []byte("no events")))
+	i01WaitFor(t, "unknown quarantine and no-event processing", func() bool {
+		snapshot := harness.counters.Snapshot(i01AccountID)
+		pending, err := harness.messages.Unprocessed(context.Background())
+		return err == nil && len(pending) == 0 && snapshot.Quarantined == 1
+	})
+
+	snapshot := harness.counters.Snapshot(i01AccountID)
+	if snapshot.Appended != 2 || snapshot.Quarantined != 1 || snapshot.DecodedEvents != 0 {
+		t.Fatalf("unknown/no-event counters = %+v", snapshot)
+	}
+	payload, processedAt := i01InboxPayload(t, harness.path, "unknown:codec")
+	if string(payload) != "retained unknown payload" || !processedAt.Valid {
+		t.Fatalf("unknown-codec durable row = (%q, %+v), want retained and processed", payload, processedAt)
+	}
+}
+
+type panickingEchoObserver struct{}
+
+func (panickingEchoObserver) ObserveTransportEcho(context.Context, messaging.TransportEcho) (messaging.EchoOutcome, error) {
+	panic("scripted echo observer panic")
+}
+
+func TestWorkerContainsApplyPanicAndContinues(t *testing.T) {
+	decoder := i01DecoderFunc(func(
+		_ context.Context,
+		record bridge.RawIngressRecord,
+	) ([]bridge.Event, error) {
+		if string(record.Payload) == "panic" {
+			return i01OutgoingMessageEvents("panic-message", "panic", "panic-request"), nil
+		}
+		return i01OutgoingMessageEvents("after-panic", "continued", ""), nil
+	})
+	harness := i01NewHarness(t, decoder, panickingEchoObserver{})
+	i01StartWorker(t, harness.worker)
+
+	i01MustAppend(t, harness.sink, i01IngressRecord("apply:panic", []byte("panic")))
+	i01MustAppend(t, harness.sink, i01IngressRecord("apply:continue", []byte("continue")))
+	i01WaitFor(t, "apply panic quarantine and continuation", func() bool {
+		snapshot := harness.counters.Snapshot(i01AccountID)
+		message, err := i01GetMessage(harness.messages, "after-panic")
+		return snapshot.Quarantined == 1 && err == nil && message.Body == "continued"
+	})
+	if _, err := i01GetMessage(harness.messages, "panic-message"); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("panicking message lookup error = %v, want ErrNotFound", err)
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
+func TestWorkerConversationSnapshotAndIdentityNaturalKeysPreserveLocalRows(t *testing.T) {
+	const (
+		remoteConversationID = "whatsapp:15551234567@s.whatsapp.net"
+		conversationID       = "mirror-conversation-pk"
+		identityID           = "mirror-identity-pk"
+	)
+	harness := newWorkerPathHarness(t, bridge.PlatformWhatsApp, map[string][]bridge.Event{
+		"snapshot": {{
+			Kind: bridge.EventConversation,
+			Conversation: &bridge.ConversationEvent{
+				RemoteConversationID: remoteConversationID,
+				Kind:                 "direct",
+				Title:                "Transport title",
+				RemoteRevision:       "revision-2",
+				Participants: []bridge.Participant{{
+					Identity: bridge.IdentityRef{
+						Raw:  "+1 (555) 123-4567",
+						Name: "Updated display",
+					},
+					Role:   "member",
+					Active: true,
+				}},
+			},
+		}},
+		"message": {{
+			Kind: bridge.EventMessage,
+			Message: &bridge.MessageEvent{
+				RemoteConversationID: remoteConversationID,
+				RemoteMessageID:      "incoming-natural-key",
+				Sender: bridge.IdentityRef{
+					Raw:  "+1 (555) 123-4567",
+					Name: "Newest display",
+				},
+				Direction:  "incoming",
+				Body:       "incoming",
+				OccurredAt: time.UnixMilli(workerPathNowMS - 500),
+			},
+		}},
+	})
+	conversation := workerPathSeedConversation(
+		t,
+		harness.store,
+		conversationID,
+		remoteConversationID,
+		"Local title",
+	)
+	conversation.NotificationMode = sqlite.NotificationModeMuted
+	if err := harness.store.UpsertConversation(conversation); err != nil {
+		t.Fatalf("UpsertConversation(local preferences): %v", err)
+	}
+	if err := harness.store.UpsertIdentity(sqlite.Identity{
+		IdentityID:     identityID,
+		AccountID:      workerPathAccountID,
+		Kind:           sqlite.IdentityKind("e164"),
+		CanonicalValue: "+15551234567",
+		RawValue:       "+15551234567",
+		DisplayName:    "Mirror display",
+		MetadataJSON:   `{"source":"mirror"}`,
+		CreatedAtMS:    workerPathNowMS - 10_000,
+		UpdatedAtMS:    workerPathNowMS - 5_000,
+	}); err != nil {
+		t.Fatalf("UpsertIdentity(mirror): %v", err)
+	}
+
+	harness.process(t, "snapshot")
+	gotConversation, err := harness.store.GetConversationByRemote(
+		workerPathAccountID,
+		remoteConversationID,
+	)
+	if err != nil {
+		t.Fatalf("GetConversationByRemote(): %v", err)
+	}
+	if gotConversation.ConversationID != conversationID ||
+		gotConversation.Title != "Transport title" ||
+		gotConversation.Kind != sqlite.ConversationKindDirect ||
+		gotConversation.NotificationMode != sqlite.NotificationModeMuted ||
+		!gotConversation.IsFavorite || gotConversation.MetadataJSON != conversation.MetadataJSON ||
+		gotConversation.CreatedAtMS != conversation.CreatedAtMS {
+		t.Fatalf("refreshed conversation = %+v, want transport fields plus preserved local fields", gotConversation)
+	}
+	participants, err := harness.store.ListParticipants(conversationID)
+	if err != nil {
+		t.Fatalf("ListParticipants(): %v", err)
+	}
+	if len(participants) != 1 || participants[0].IdentityID != identityID {
+		t.Fatalf("participants = %+v, want existing natural-key identity %q", participants, identityID)
+	}
+
+	harness.process(t, "message")
+	message, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		workerPathAccountID,
+		conversationID,
+		"incoming-natural-key",
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(): %v", err)
+	}
+	if message.SenderIdentityID == nil || *message.SenderIdentityID != identityID {
+		t.Fatalf("sender identity = %v, want existing PK %q", message.SenderIdentityID, identityID)
+	}
+	identity, err := harness.store.GetIdentity(identityID)
+	if err != nil {
+		t.Fatalf("GetIdentity(): %v", err)
+	}
+	if identity.DisplayName != "Newest display" || identity.MetadataJSON != `{"source":"mirror"}` {
+		t.Fatalf("refreshed identity = %+v, want new display and preserved metadata", identity)
+	}
+	identities, err := harness.store.ListIdentities(workerPathAccountID)
+	if err != nil {
+		t.Fatalf("ListIdentities(): %v", err)
+	}
+	if len(identities) != 1 {
+		t.Fatalf("identity rows = %d, want one natural-key row", len(identities))
+	}
+}

--- a/internal/ingest/worker_paths_test.go
+++ b/internal/ingest/worker_paths_test.go
@@ -1,0 +1,561 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2keys"
+)
+
+const (
+	workerPathAccountID = "worker-path-account"
+	workerPathCodec     = "worker.path.fake"
+	workerPathNowMS     = int64(2_000_000_000_000)
+)
+
+type workerPathDecoder struct {
+	eventsByPayload map[string][]bridge.Event
+}
+
+func (d *workerPathDecoder) Decode(
+	_ context.Context,
+	record bridge.RawIngressRecord,
+) ([]bridge.Event, error) {
+	events, ok := d.eventsByPayload[string(record.Payload)]
+	if !ok {
+		return nil, fmt.Errorf("worker-path decoder has no script for payload %q", record.Payload)
+	}
+	return append([]bridge.Event(nil), events...), nil
+}
+
+type workerPathHarness struct {
+	store    *sqlite.Store
+	messages *sqlite.MessageRepository
+	worker   *Worker
+	nextID   int
+}
+
+func newWorkerPathHarness(
+	t *testing.T,
+	platform bridge.Platform,
+	eventsByPayload map[string][]bridge.Event,
+) *workerPathHarness {
+	t.Helper()
+	store, err := sqlite.Open(filepath.Join(t.TempDir(), "worker-path.sqlite3"))
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Store.Close(): %v", err)
+		}
+	})
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   workerPathAccountID,
+		BridgeKey:   string(platform),
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: workerPathNowMS,
+		UpdatedAtMS: workerPathNowMS,
+	}); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	now := func() time.Time { return time.UnixMilli(workerPathNowMS) }
+	messages, err := sqlite.NewMessageRepository(store, now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	worker, err := NewWorker(WorkerConfig{
+		Store:    store,
+		Messages: messages,
+		Counters: &Counters{},
+		Now:      now,
+		Decoders: []DecoderRegistration{{
+			Codec:    workerPathCodec,
+			Platform: platform,
+			Decoder: &workerPathDecoder{
+				eventsByPayload: eventsByPayload,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewWorker(): %v", err)
+	}
+	return &workerPathHarness{
+		store:    store,
+		messages: messages,
+		worker:   worker,
+	}
+}
+
+func (h *workerPathHarness) process(t *testing.T, payload string) string {
+	t.Helper()
+	h.nextID++
+	inboxID := fmt.Sprintf("worker-path-inbox-%d", h.nextID)
+	record := bridge.RawIngressRecord{
+		AccountID:    workerPathAccountID,
+		Generation:   1,
+		DedupeKey:    "worker-path-dedupe-" + payload,
+		Codec:        workerPathCodec,
+		CodecVersion: 1,
+		ReceivedAt:   time.UnixMilli(workerPathNowMS),
+		Payload:      []byte(payload),
+	}
+	effectiveID, err := h.messages.AppendInbox(context.Background(), sqlite.InboxRecord{
+		InboxID:      inboxID,
+		AccountID:    record.AccountID,
+		Generation:   int64(record.Generation),
+		DedupeKey:    record.DedupeKey,
+		Codec:        record.Codec,
+		CodecVersion: int64(record.CodecVersion),
+		Payload:      record.Payload,
+	})
+	if err != nil {
+		t.Fatalf("AppendInbox(%q): %v", payload, err)
+	}
+	if effectiveID != inboxID {
+		t.Fatalf("AppendInbox(%q) ID = %q, want %q", payload, effectiveID, inboxID)
+	}
+	if err := h.worker.processRecord(context.Background(), inboxID, record); err != nil {
+		t.Fatalf("processRecord(%q): %v", payload, err)
+	}
+	return inboxID
+}
+
+func TestWorkerPathsMutationEditDeleteAndMissingTarget(t *testing.T) {
+	const (
+		remoteConversationID = "whatsapp:15551234567@s.whatsapp.net"
+		conversationID       = "worker-path-mutation-conversation"
+		remoteMessageID      = "worker-path-target-message"
+	)
+	harness := newWorkerPathHarness(t, bridge.PlatformWhatsApp, map[string][]bridge.Event{
+		"edit": {{
+			Kind: bridge.EventMessageMutation,
+			MessageMutation: &bridge.MessageMutationEvent{
+				RemoteConversationID: remoteConversationID,
+				RemoteMessageID:      remoteMessageID,
+				Kind:                 "edit",
+				Body:                 "edited body",
+			},
+		}},
+		"delete": {{
+			Kind: bridge.EventMessageMutation,
+			MessageMutation: &bridge.MessageMutationEvent{
+				RemoteConversationID: remoteConversationID,
+				RemoteMessageID:      remoteMessageID,
+				Kind:                 "delete",
+				Body:                 "must not replace the edited body",
+			},
+		}},
+		"missing": {{
+			Kind: bridge.EventMessageMutation,
+			MessageMutation: &bridge.MessageMutationEvent{
+				RemoteConversationID: remoteConversationID,
+				RemoteMessageID:      "missing-target",
+				Kind:                 "edit",
+				Body:                 "ignored",
+			},
+		}},
+	})
+	workerPathSeedConversation(
+		t,
+		harness.store,
+		conversationID,
+		remoteConversationID,
+		"Mutation thread",
+	)
+	workerPathSeedMessage(
+		t,
+		harness.messages,
+		"worker-path-message",
+		conversationID,
+		remoteMessageID,
+		sqlite.MessageDirectionIncoming,
+		"original body",
+		workerPathNowMS-1_000,
+	)
+
+	harness.process(t, "edit")
+	got, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		workerPathAccountID,
+		conversationID,
+		remoteMessageID,
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(after edit): %v", err)
+	}
+	if got.State != sqlite.MessageStateEdited || got.Body != "edited body" {
+		t.Fatalf("message after edit = %+v, want edited state/body", got)
+	}
+
+	harness.process(t, "delete")
+	got, err = harness.messages.GetMessageByRemote(
+		context.Background(),
+		workerPathAccountID,
+		conversationID,
+		remoteMessageID,
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(after delete): %v", err)
+	}
+	if got.State != sqlite.MessageStateDeleted || got.Body != "edited body" {
+		t.Fatalf("message after delete = %+v, want deleted state and preserved body", got)
+	}
+
+	missingInboxID := harness.process(t, "missing")
+	if _, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		workerPathAccountID,
+		conversationID,
+		"missing-target",
+	); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("missing mutation target lookup error = %v, want ErrNotFound", err)
+	}
+	workerPathAssertProcessed(t, harness.messages, missingInboxID)
+	snapshot := harness.worker.Counters().Snapshot(workerPathAccountID)
+	if snapshot.Mutations != 2 || snapshot.Quarantined != 0 {
+		t.Fatalf("mutation counters = %+v, want mutations=2 and quarantined=0", snapshot)
+	}
+	workerPathAssertAllProcessed(t, harness.messages)
+}
+
+func TestWorkerPathsSelfReceiptMonotoneAndMissingPosition(t *testing.T) {
+	const (
+		remoteConversationID = "whatsapp:15557654321@s.whatsapp.net"
+		conversationID       = "worker-path-receipt-conversation"
+		deviceID             = "worker-path-local-device"
+		remoteMessageID      = "worker-path-read-message"
+		messageID            = "worker-path-read-message-local"
+	)
+	harness := newWorkerPathHarness(t, bridge.PlatformWhatsApp, map[string][]bridge.Event{
+		"known-newer":   {workerPathReceiptEvent(remoteConversationID, remoteMessageID, workerPathNowMS+200)},
+		"missing-older": {workerPathReceiptEvent(remoteConversationID, "missing-remote", workerPathNowMS+100)},
+		"missing-newer": {workerPathReceiptEvent(remoteConversationID, "missing-remote", workerPathNowMS+300)},
+		"known-older":   {workerPathReceiptEvent(remoteConversationID, remoteMessageID, workerPathNowMS+250)},
+	})
+	workerPathSeedConversation(
+		t,
+		harness.store,
+		conversationID,
+		remoteConversationID,
+		"Receipt thread",
+	)
+	workerPathSeedLocalDevice(t, harness.store, deviceID)
+	workerPathSeedMessage(
+		t,
+		harness.messages,
+		messageID,
+		conversationID,
+		remoteMessageID,
+		sqlite.MessageDirectionIncoming,
+		"read me",
+		workerPathNowMS-1_000,
+	)
+
+	harness.process(t, "known-newer")
+	workerPathAssertCursor(t, harness.store, deviceID, conversationID, workerPathNowMS+200, messageID)
+
+	harness.process(t, "missing-older")
+	workerPathAssertCursor(t, harness.store, deviceID, conversationID, workerPathNowMS+200, messageID)
+
+	harness.process(t, "missing-newer")
+	workerPathAssertCursor(t, harness.store, deviceID, conversationID, workerPathNowMS+300, "")
+
+	harness.process(t, "known-older")
+	workerPathAssertCursor(t, harness.store, deviceID, conversationID, workerPathNowMS+300, "")
+
+	snapshot := harness.worker.Counters().Snapshot(workerPathAccountID)
+	if snapshot.ReceiptsSelf != 4 || snapshot.Quarantined != 0 {
+		t.Fatalf("receipt counters = %+v, want receipts_self=4 and quarantined=0", snapshot)
+	}
+	workerPathAssertAllProcessed(t, harness.messages)
+}
+
+func TestWorkerPathsSignalOutgoingAliasConverges(t *testing.T) {
+	const (
+		remoteConversationID = "signal:+16505550100"
+		conversationID       = "worker-path-signal-conversation"
+		timestamp            = int64(1_700_000_006_000)
+		migratedMessageID    = "worker-path-migrated-signal-message"
+	)
+	timestampID := strconv.FormatInt(timestamp, 10)
+	alias := v2keys.SignalLocalAlias(remoteConversationID, timestamp)
+	harness := newWorkerPathHarness(t, bridge.PlatformSignal, map[string][]bridge.Event{
+		"signal-outgoing": {{
+			Kind: bridge.EventMessage,
+			Message: &bridge.MessageEvent{
+				RemoteConversationID: remoteConversationID,
+				RemoteMessageID:      timestampID,
+				Sender:               bridge.IdentityRef{IsSelf: true},
+				Direction:            "outgoing",
+				Body:                 "outgoing sync replay",
+				OccurredAt:           time.UnixMilli(timestamp),
+			},
+		}},
+	})
+	workerPathSeedConversation(
+		t,
+		harness.store,
+		conversationID,
+		remoteConversationID,
+		"Signal thread",
+	)
+	workerPathSeedMessage(
+		t,
+		harness.messages,
+		migratedMessageID,
+		conversationID,
+		alias,
+		sqlite.MessageDirectionOutgoing,
+		"migrated body",
+		timestamp,
+	)
+
+	harness.process(t, "signal-outgoing")
+	got, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		workerPathAccountID,
+		conversationID,
+		alias,
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(alias): %v", err)
+	}
+	if got.MessageID != migratedMessageID || got.RemoteMessageID != alias ||
+		got.Body != "outgoing sync replay" {
+		t.Fatalf("converged Signal message = %+v, want migrated PK/alias with replay body", got)
+	}
+	if _, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		workerPathAccountID,
+		conversationID,
+		timestampID,
+	); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("timestamp-form Signal lookup error = %v, want ErrNotFound", err)
+	}
+	if snapshot := harness.worker.Counters().Snapshot(workerPathAccountID); snapshot.Projected != 1 {
+		t.Fatalf("Signal counters = %+v, want projected=1", snapshot)
+	}
+	workerPathAssertAllProcessed(t, harness.messages)
+}
+
+func TestWorkerPathsMessageFramePreservesExistingConversation(t *testing.T) {
+	const (
+		remoteConversationID   = "google-remote-thread"
+		existingConversationID = "mirror-verbatim-conversation-pk"
+		existingTitle          = "Mirror title must survive"
+		remoteMessageID        = "google-message-1"
+	)
+	harness := newWorkerPathHarness(t, bridge.PlatformGoogle, map[string][]bridge.Event{
+		"message-only": {{
+			Kind: bridge.EventMessage,
+			Message: &bridge.MessageEvent{
+				RemoteConversationID: remoteConversationID,
+				RemoteMessageID:      remoteMessageID,
+				Sender:               bridge.IdentityRef{IsSelf: true},
+				Direction:            "outgoing",
+				Body:                 "message frame",
+				OccurredAt:           time.UnixMilli(workerPathNowMS - 500),
+			},
+		}},
+	})
+	existing := workerPathSeedConversation(
+		t,
+		harness.store,
+		existingConversationID,
+		remoteConversationID,
+		existingTitle,
+	)
+
+	harness.process(t, "message-only")
+	gotConversation, err := harness.store.GetConversationByRemote(
+		workerPathAccountID,
+		remoteConversationID,
+	)
+	if err != nil {
+		t.Fatalf("GetConversationByRemote(): %v", err)
+	}
+	if gotConversation.ConversationID != existing.ConversationID ||
+		gotConversation.Title != existing.Title ||
+		gotConversation.Kind != existing.Kind ||
+		gotConversation.CreatedAtMS != existing.CreatedAtMS {
+		t.Fatalf("conversation after message-only frame = %+v, want existing %+v", gotConversation, existing)
+	}
+	if gotConversation.LastMessageAtMS != workerPathNowMS-500 {
+		t.Fatalf(
+			"last_message_at_ms = %d, want the ingested message's %d: recency must advance even though the row is never re-upserted",
+			gotConversation.LastMessageAtMS,
+			workerPathNowMS-500,
+		)
+	}
+	message, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		workerPathAccountID,
+		existingConversationID,
+		remoteMessageID,
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(): %v", err)
+	}
+	if message.ConversationID != existingConversationID {
+		t.Fatalf("projected message conversation ID = %q, want existing PK %q", message.ConversationID, existingConversationID)
+	}
+	conversations, err := harness.store.ListConversationsByRecency(workerPathAccountID)
+	if err != nil {
+		t.Fatalf("ListConversationsByRecency(): %v", err)
+	}
+	if len(conversations) != 1 {
+		t.Fatalf("conversation rows = %d, want 1", len(conversations))
+	}
+	workerPathAssertAllProcessed(t, harness.messages)
+}
+
+func workerPathReceiptEvent(
+	remoteConversationID string,
+	remoteMessageID string,
+	readAtMS int64,
+) bridge.Event {
+	return bridge.Event{
+		Kind: bridge.EventReceipt,
+		Receipt: &bridge.ReceiptEvent{
+			RemoteConversationID: remoteConversationID,
+			RemoteMessageIDs:     []string{remoteMessageID},
+			Actor:                bridge.IdentityRef{IsSelf: true},
+			Status:               "read",
+			OccurredAt:           time.UnixMilli(readAtMS),
+		},
+	}
+}
+
+func workerPathSeedConversation(
+	t *testing.T,
+	store *sqlite.Store,
+	conversationID string,
+	remoteConversationID string,
+	title string,
+) sqlite.Conversation {
+	t.Helper()
+	conversation := sqlite.Conversation{
+		ConversationID:       conversationID,
+		AccountID:            workerPathAccountID,
+		RemoteConversationID: remoteConversationID,
+		Kind:                 sqlite.ConversationKindGroup,
+		Title:                title,
+		NotificationMode:     sqlite.NotificationModeAll,
+		IsFavorite:           true,
+		LastMessageAtMS:      workerPathNowMS - 2_000,
+		MetadataJSON:         `{"origin":"worker-path"}`,
+		CreatedAtMS:          workerPathNowMS - 10_000,
+		UpdatedAtMS:          workerPathNowMS - 5_000,
+	}
+	if err := store.UpsertConversation(conversation); err != nil {
+		t.Fatalf("UpsertConversation(%q): %v", conversationID, err)
+	}
+	return conversation
+}
+
+func workerPathSeedMessage(
+	t *testing.T,
+	messages *sqlite.MessageRepository,
+	messageID string,
+	conversationID string,
+	remoteMessageID string,
+	direction sqlite.MessageDirection,
+	body string,
+	occurredAtMS int64,
+) {
+	t.Helper()
+	if err := messages.ImportMessage(context.Background(), sqlite.MessageProjection{
+		Message: sqlite.Message{
+			MessageID:       messageID,
+			ConversationID:  conversationID,
+			AccountID:       workerPathAccountID,
+			RemoteMessageID: remoteMessageID,
+			Direction:       direction,
+			Body:            body,
+			State:           sqlite.MessageStateActive,
+			OccurredAtMS:    occurredAtMS,
+		},
+	}); err != nil {
+		t.Fatalf("ImportMessage(%q): %v", messageID, err)
+	}
+}
+
+func workerPathSeedLocalDevice(t *testing.T, store *sqlite.Store, deviceID string) {
+	t.Helper()
+	if err := store.UpsertDevice(sqlite.Device{
+		DeviceID:    deviceID,
+		AccountID:   workerPathAccountID,
+		Kind:        sqlite.DeviceKindLocalInstallation,
+		State:       sqlite.DeviceStateActive,
+		IsCurrent:   true,
+		CreatedAtMS: workerPathNowMS - 10_000,
+		UpdatedAtMS: workerPathNowMS - 5_000,
+	}); err != nil {
+		t.Fatalf("UpsertDevice(%q): %v", deviceID, err)
+	}
+}
+
+func workerPathAssertCursor(
+	t *testing.T,
+	store *sqlite.Store,
+	deviceID string,
+	conversationID string,
+	wantReadAtMS int64,
+	wantMessageID string,
+) {
+	t.Helper()
+	cursor, err := store.GetReadCursor(deviceID, conversationID)
+	if err != nil {
+		t.Fatalf("GetReadCursor(): %v", err)
+	}
+	if cursor.LastReadAtMS != wantReadAtMS {
+		t.Fatalf("cursor read time = %d, want %d", cursor.LastReadAtMS, wantReadAtMS)
+	}
+	if wantMessageID == "" {
+		if cursor.LastReadMessageID != nil {
+			t.Fatalf("cursor message position = %q, want NULL", *cursor.LastReadMessageID)
+		}
+		return
+	}
+	if cursor.LastReadMessageID == nil || *cursor.LastReadMessageID != wantMessageID {
+		t.Fatalf("cursor message position = %v, want %q", cursor.LastReadMessageID, wantMessageID)
+	}
+}
+
+func workerPathAssertProcessed(
+	t *testing.T,
+	messages *sqlite.MessageRepository,
+	inboxID string,
+) {
+	t.Helper()
+	records, err := messages.Unprocessed(context.Background())
+	if err != nil {
+		t.Fatalf("Unprocessed(): %v", err)
+	}
+	for _, record := range records {
+		if record.InboxID == inboxID {
+			t.Fatalf("inbox %q remains unprocessed", inboxID)
+		}
+	}
+}
+
+func workerPathAssertAllProcessed(t *testing.T, messages *sqlite.MessageRepository) {
+	t.Helper()
+	records, err := messages.Unprocessed(context.Background())
+	if err != nil {
+		t.Fatalf("Unprocessed(): %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("unprocessed inbox records = %+v, want none", records)
+	}
+}

--- a/internal/messaging/dispatch.go
+++ b/internal/messaging/dispatch.go
@@ -67,6 +67,13 @@ func (s *MessageService) DispatchDue(ctx context.Context, limit int) (int, error
 		Limit:    limit,
 	})
 	if err != nil {
+		// Shutdown can race the lease transaction: database/sql auto-rolls-back
+		// a transaction whose context is canceled, so the subsequent commit
+		// fails. No lease was handed out, so this is a clean stop rather than a
+		// dispatch fault. Surface the cancellation itself.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return 0, ctxErr
+		}
 		return 0, fmt.Errorf("lease due messages: %w", err)
 	}
 

--- a/internal/messaging/dispatch_reconcile_test.go
+++ b/internal/messaging/dispatch_reconcile_test.go
@@ -37,7 +37,7 @@ func TestObserveTransportEchoConfirmsUncertainAndRepointsMessage(t *testing.T) {
 	}
 
 	const realID = "remote-reconciled"
-	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+	if _, err := service.ObserveTransportEcho(context.Background(), TransportEcho{
 		AccountID:          item.AccountID,
 		TransportRequestID: item.TransportRequestID,
 		RemoteMessageID:    realID,
@@ -89,7 +89,7 @@ func TestObserveTransportEchoCollisionKeepsOptimisticFKAnchor(t *testing.T) {
 	if got := mustDelivery(t, service, submission.OutboxID).State; got != OutboxUncertain {
 		t.Fatalf("delivery before echo = %q, want uncertain", got)
 	}
-	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+	if _, err := service.ObserveTransportEcho(context.Background(), TransportEcho{
 		AccountID:          item.AccountID,
 		TransportRequestID: item.TransportRequestID,
 		RemoteMessageID:    realID,
@@ -138,7 +138,7 @@ func TestObserveTransportEchoEnrichesPlaceholderConfirmation(t *testing.T) {
 	}
 
 	const permanentID = "remote-permanent"
-	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+	if _, err := service.ObserveTransportEcho(context.Background(), TransportEcho{
 		AccountID:          item.AccountID,
 		TransportRequestID: item.TransportRequestID,
 		RemoteMessageID:    permanentID,
@@ -177,7 +177,7 @@ func TestObserveTransportEchoNoOpsNeverCreateOrCorrupt(t *testing.T) {
 			{AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: "remote-foreign"},
 			{AccountID: item.AccountID, TransportRequestID: "missing-request", RemoteMessageID: "remote-orphan"},
 		} {
-			if err := service.ObserveTransportEcho(context.Background(), echo); err != nil {
+			if _, err := service.ObserveTransportEcho(context.Background(), echo); err != nil {
 				t.Fatalf("ObserveTransportEcho(%+v): %v", echo, err)
 			}
 		}
@@ -215,7 +215,7 @@ func TestObserveTransportEchoNoOpsNeverCreateOrCorrupt(t *testing.T) {
 		if got := mustDelivery(t, service, submission.OutboxID).State; got != OutboxRejected {
 			t.Fatalf("delivery before echo = %q, want rejected", got)
 		}
-		if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+		if _, err := service.ObserveTransportEcho(context.Background(), TransportEcho{
 			AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: "remote-rejected",
 		}); err != nil {
 			t.Fatalf("ObserveTransportEcho(rejected): %v", err)
@@ -243,7 +243,7 @@ func TestObserveTransportEchoNoOpsNeverCreateOrCorrupt(t *testing.T) {
 		if _, err := service.Cancel(context.Background(), submission.OutboxID); err != nil {
 			t.Fatalf("Cancel(): %v", err)
 		}
-		if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+		if _, err := service.ObserveTransportEcho(context.Background(), TransportEcho{
 			AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: "remote-canceled",
 		}); err != nil {
 			t.Fatalf("ObserveTransportEcho(canceled): %v", err)
@@ -279,7 +279,7 @@ func TestObserveTransportEchoDuringDispatchingDefersToLeaseOwner(t *testing.T) {
 		messageErr    error
 	)
 	sender.onSend = func() {
-		echoErr = service.ObserveTransportEcho(context.Background(), TransportEcho{
+		_, echoErr = service.ObserveTransportEcho(context.Background(), TransportEcho{
 			AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: realID,
 		})
 		during, duringErr = service.Get(context.Background(), submission.OutboxID)
@@ -303,7 +303,7 @@ func TestObserveTransportEchoDuringDispatchingDefersToLeaseOwner(t *testing.T) {
 	if got := mustReconcileMessage(t, service, submission.LocalMessageID).RemoteMessageID; got != realID {
 		t.Fatalf("message after lease confirmation = %q, want %q", got, realID)
 	}
-	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+	if _, err := service.ObserveTransportEcho(context.Background(), TransportEcho{
 		AccountID: item.AccountID, TransportRequestID: item.TransportRequestID, RemoteMessageID: realID,
 	}); err != nil {
 		t.Fatalf("ObserveTransportEcho(replay): %v", err)
@@ -452,7 +452,7 @@ func TestSendTextReplayAfterEchoRepointReturnsOriginalSubmission(t *testing.T) {
 	}
 
 	const permanentID = "remote-permanent-echo"
-	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{
+	if _, err := service.ObserveTransportEcho(context.Background(), TransportEcho{
 		AccountID:          item.AccountID,
 		TransportRequestID: item.TransportRequestID,
 		RemoteMessageID:    permanentID,

--- a/internal/messaging/dispatch_test.go
+++ b/internal/messaging/dispatch_test.go
@@ -1,0 +1,59 @@
+package messaging
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A canceled context must not turn a raced lease transaction into a hard
+// dispatch fault. database/sql auto-rolls-back a transaction whose context is
+// canceled, so LeaseDue's commit fails; because no lease was handed out, the
+// dispatcher must report the cancellation itself and Run must treat it as a
+// clean stop. Regression for the shutdown flake in DispatchDue's lease path.
+func TestDispatchDueCanceledContextIsCleanStopNotLeaseFault(t *testing.T) {
+	clock := newManualClock(messagingTestTime)
+	store := openMessagingTestStore(t, clock.Now())
+	service := newMessagingTestService(
+		t,
+		store,
+		newScriptedRegistry("lease-cancel", &scriptedTextSender{}),
+		clock,
+	)
+
+	// A due, queued intent exists, so LeaseDue would otherwise open its
+	// transaction and claim it.
+	mustSendText(t, service, SendTextCommand{
+		CommonCommand: testCommonCommand("lease-cancel-key"),
+		Body:          "durably queued before shutdown",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	processed, err := service.DispatchDue(ctx, service.batchLimit)
+	if processed != 0 {
+		t.Fatalf("DispatchDue processed = %d, want 0 under a canceled context", processed)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("DispatchDue error = %v, want context.Canceled", err)
+	}
+	// The cancellation must surface as itself, not be reframed as a lease-path
+	// storage fault. This is what the guard changes: without it, the error is
+	// "lease due messages: ...: context canceled" (a raced commit reads as a
+	// dispatch failure); with it, the bare cancellation.
+	if strings.Contains(err.Error(), "lease due") {
+		t.Fatalf("DispatchDue error = %q, want the bare cancellation, not a lease-path fault", err)
+	}
+
+	// Run wraps the same path; it too must exit cleanly, and Run's own wrapper
+	// ("run message service:") is the only framing permitted.
+	runErr := service.Run(ctx)
+	if !errors.Is(runErr, context.Canceled) {
+		t.Fatalf("Run error = %v, want context.Canceled", runErr)
+	}
+	if strings.Contains(runErr.Error(), "lease due") {
+		t.Fatalf("Run error = %q, want a clean stop, not a lease-path fault", runErr)
+	}
+}

--- a/internal/messaging/service.go
+++ b/internal/messaging/service.go
@@ -885,9 +885,12 @@ func (s *MessageService) SendAgain(
 // detached mutation context): echoes are at-least-once and reconciliation is
 // idempotent, so a canceled write is simply replayed by the next delivery —
 // unlike dispatch finalization, where losing the write loses real state.
-func (s *MessageService) ObserveTransportEcho(ctx context.Context, echo TransportEcho) error {
+func (s *MessageService) ObserveTransportEcho(
+	ctx context.Context,
+	echo TransportEcho,
+) (EchoOutcome, error) {
 	if ctx == nil {
-		return fmt.Errorf("observe transport echo: context is nil")
+		return "", fmt.Errorf("observe transport echo: context is nil")
 	}
 	checks := []struct {
 		name  string
@@ -899,7 +902,7 @@ func (s *MessageService) ObserveTransportEcho(ctx context.Context, echo Transpor
 	}
 	for _, check := range checks {
 		if strings.TrimSpace(check.value) == "" {
-			return fmt.Errorf("%w: %s is empty", ErrInvalidCommand, check.name)
+			return "", fmt.Errorf("%w: %s is empty", ErrInvalidCommand, check.name)
 		}
 	}
 
@@ -909,16 +912,16 @@ func (s *MessageService) ObserveTransportEcho(ctx context.Context, echo Transpor
 		ResultRemoteID:     echo.RemoteMessageID,
 	})
 	if err != nil {
-		return fmt.Errorf("observe transport echo: %w", err)
+		return "", fmt.Errorf("observe transport echo: %w", err)
 	}
 	switch outcome {
 	case sqlite.ReconcileOutcomeNotFound, sqlite.ReconcileOutcomeNoop:
-		return nil
+		return outcome, nil
 	case sqlite.ReconcileOutcomeReconciled, sqlite.ReconcileOutcomeEnriched:
 		s.signalChange()
-		return nil
+		return outcome, nil
 	default:
-		return fmt.Errorf("observe transport echo: unexpected reconcile outcome %q", outcome)
+		return "", fmt.Errorf("observe transport echo: unexpected reconcile outcome %q", outcome)
 	}
 }
 

--- a/internal/messaging/service_test.go
+++ b/internal/messaging/service_test.go
@@ -1484,7 +1484,7 @@ func TestCancelAndDeferredAPIs(t *testing.T) {
 	if _, err := service.SendAgain(context.Background(), submission.OutboxID, "new-key"); !errors.Is(err, ErrInvalidState) {
 		t.Fatalf("SendAgain(canceled) error = %v, want ErrInvalidState", err)
 	}
-	if err := service.ObserveTransportEcho(context.Background(), TransportEcho{}); !errors.Is(err, ErrInvalidCommand) {
+	if _, err := service.ObserveTransportEcho(context.Background(), TransportEcho{}); !errors.Is(err, ErrInvalidCommand) {
 		t.Fatalf("ObserveTransportEcho() error = %v, want ErrInvalidCommand", err)
 	}
 }

--- a/internal/messaging/types.go
+++ b/internal/messaging/types.go
@@ -28,6 +28,16 @@ const (
 	OutboxCanceled      = sqlite.OutboxCanceled
 )
 
+// EchoOutcome is what observing a transport echo did to durable send state.
+type EchoOutcome = sqlite.ReconcileOutcome
+
+const (
+	EchoReconciled = sqlite.ReconcileOutcomeReconciled
+	EchoEnriched   = sqlite.ReconcileOutcomeEnriched
+	EchoNoop       = sqlite.ReconcileOutcomeNoop
+	EchoNotFound   = sqlite.ReconcileOutcomeNotFound
+)
+
 var (
 	// ErrIdempotencyConflict means the account-scoped key already names a
 	// different outbound intent.

--- a/internal/migration/transform.go
+++ b/internal/migration/transform.go
@@ -10,13 +10,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/maxghenis/openmessage/internal/storage/blob"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2keys"
 	"github.com/maxghenis/openmessage/internal/whatsappmedia"
 )
 
@@ -66,11 +66,7 @@ var platformAccounts = map[string]accountSpec{
 	},
 }
 
-type identityKey struct {
-	AccountID string
-	Kind      string
-	Canonical string
-}
+type identityKey = v2keys.Identity
 
 type identityCandidate struct {
 	Key         identityKey
@@ -304,7 +300,7 @@ func buildTransformState(dataset legacyDataset, report *Report) (*transformState
 		state.accounts[account.Platform] = account
 		plan := &conversationPlan{
 			Legacy: legacy, Account: account,
-			V2ID: deriveID("conversation", account.AccountID, legacy.ID),
+			V2ID: v2keys.DeriveID("conversation", account.AccountID, legacy.ID),
 		}
 		var participants []legacyParticipant
 		if err := json.Unmarshal([]byte(legacy.ParticipantsJSON), &participants); err != nil {
@@ -378,7 +374,7 @@ func buildTransformState(dataset legacyDataset, report *Report) (*transformState
 		}
 		plan := unifiedContactPlan{
 			Legacy:   legacy,
-			PersonID: deriveID("person", "", legacy.ID),
+			PersonID: v2keys.DeriveID("person", "", legacy.ID),
 		}
 		var identifiers []unifiedIdentifier
 		if err := json.Unmarshal([]byte(legacy.IdentifiersJSON), &identifiers); err != nil {
@@ -428,7 +424,7 @@ func writeAccounts(target *sqlite.Store, state *transformState) error {
 		}); err != nil {
 			return fmt.Errorf("upsert %s account: %w", platform, err)
 		}
-		deviceID := deriveID("device", account.AccountID, account.AccountID+"\x1flocal")
+		deviceID := v2keys.DeriveID("device", account.AccountID, account.AccountID+"\x1flocal")
 		if err := target.UpsertDevice(sqlite.Device{
 			DeviceID: deviceID, AccountID: account.AccountID,
 			Kind: sqlite.DeviceKindLocalInstallation, DisplayName: "OpenMessage",
@@ -513,7 +509,7 @@ func writeConversations(target *sqlite.Store, state *transformState) error {
 		}
 		if err := target.UpsertConversation(sqlite.Conversation{
 			ConversationID: plan.V2ID, AccountID: plan.Account.AccountID,
-			RemoteConversationID: normalizeRemoteConversationID(plan.Account.Platform, plan.Legacy.ID),
+			RemoteConversationID: v2keys.NormalizeRemoteConversationID(plan.Account.Platform, plan.Legacy.ID),
 			Kind:                 kind, Title: plan.Legacy.Name, NotificationMode: notification,
 			IsFavorite: plan.Legacy.IsFavorite, ArchivedAtMS: archivedAt,
 			LastMessageAtMS: lastMessageAt, MetadataJSON: "{}",
@@ -552,7 +548,7 @@ func writeHistory(
 	for _, legacy := range dataset.messages {
 		conversation := state.conversations[legacy.ConversationID]
 		remoteID := deriveRemoteMessageID(legacy)
-		messageID := deriveID(
+		messageID := v2keys.DeriveID(
 			"message", conversation.Account.AccountID,
 			legacy.ConversationID+"\x1f"+remoteID,
 		)
@@ -569,7 +565,11 @@ func writeHistory(
 
 		var senderID *string
 		if !legacy.IsFromMe && strings.TrimSpace(legacy.SenderNumber) != "" {
-			key, err := identityKeyFor(conversation.Account, legacy.SenderNumber)
+			key, err := v2keys.IdentityKey(
+				conversation.Account.AccountID,
+				conversation.Account.Platform,
+				legacy.SenderNumber,
+			)
 			if err != nil {
 				return fmt.Errorf("message %q sender identity: %w", legacy.ID, err)
 			}
@@ -656,8 +656,8 @@ func writeScheduled(
 		if createdAt <= 0 {
 			createdAt = state.baseTimestampMS
 		}
-		requestID := deriveID("transport_request", conversation.Account.AccountID, scheduled.ID)
-		localMessageID := deriveID(
+		requestID := v2keys.DeriveID("transport_request", conversation.Account.AccountID, scheduled.ID)
+		localMessageID := v2keys.DeriveID(
 			"message", conversation.Account.AccountID,
 			scheduled.ConversationID+"\x1f"+requestID,
 		)
@@ -688,7 +688,7 @@ func writeScheduled(
 		}
 
 		item := sqlite.NewOutboxItem{
-			OutboxID:  deriveID("outbox", conversation.Account.AccountID, scheduled.ID),
+			OutboxID:  v2keys.DeriveID("outbox", conversation.Account.AccountID, scheduled.ID),
 			AccountID: conversation.Account.AccountID, ConversationID: conversation.V2ID,
 			IdempotencyKey: scheduled.ID, LocalMessageID: localMessageID,
 			TransportRequestID: requestID, ScheduledForMS: scheduled.SendAtMS,
@@ -793,7 +793,7 @@ func writeReadCursors(
 			lastReadID = &value
 			lastReadAt = positions[index].At
 		}
-		deviceID := deriveID(
+		deviceID := v2keys.DeriveID(
 			"device", conversation.Account.AccountID,
 			conversation.Account.AccountID+"\x1flocal",
 		)
@@ -906,7 +906,7 @@ func addIdentity(
 	isSelf bool,
 	priority int,
 ) (identityKey, error) {
-	key, err := identityKeyFor(account, raw)
+	key, err := v2keys.IdentityKey(account.AccountID, account.Platform, raw)
 	if err != nil {
 		return identityKey{}, err
 	}
@@ -926,50 +926,8 @@ func addIdentity(
 	return key, nil
 }
 
-var signalACI = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
-
-func identityKeyFor(account accountSpec, raw string) (identityKey, error) {
-	value := strings.TrimSpace(raw)
-	if value == "" {
-		return identityKey{}, fmt.Errorf("identity value is empty")
-	}
-	kind := "username"
-	canonical := value
-	switch {
-	case strings.HasPrefix(value, "+"):
-		var digits strings.Builder
-		for _, character := range value[1:] {
-			if character >= '0' && character <= '9' {
-				digits.WriteRune(character)
-			}
-		}
-		if digits.Len() == 0 {
-			return identityKey{}, fmt.Errorf("invalid E.164 identity %q", value)
-		}
-		kind = "e164"
-		canonical = "+" + digits.String()
-	case account.Platform == "signal" && signalACI.MatchString(value):
-		kind = "signal_aci"
-		canonical = strings.ToLower(value)
-	case strings.Contains(value, "@") && account.Platform == "whatsapp":
-		kind = "jid"
-		canonical = strings.ToLower(value)
-	case strings.Contains(value, "@"):
-		kind = "email"
-		canonical = strings.ToLower(value)
-	case strings.HasPrefix(value, "legacy-participant:"):
-		kind = "legacy_participant"
-	}
-	return identityKey{AccountID: account.AccountID, Kind: kind, Canonical: canonical}, nil
-}
-
 func identityID(key identityKey) string {
-	return deriveID("identity", key.AccountID, key.Kind+"\x1f"+key.Canonical)
-}
-
-func deriveID(entity, accountID, naturalKey string) string {
-	sum := sha256.Sum256([]byte(entity + "\x1f" + accountID + "\x1f" + naturalKey))
-	return hex.EncodeToString(sum[:])[:32]
+	return v2keys.DeriveID("identity", key.AccountID, key.Kind+"\x1f"+key.Canonical)
 }
 
 func deriveRemoteMessageID(message legacyMessage) string {
@@ -1011,20 +969,6 @@ func accountForPlatform(platform string) (accountSpec, error) {
 		return accountSpec{}, fmt.Errorf("unsupported legacy source_platform %q", platform)
 	}
 	return account, nil
-}
-
-func normalizeRemoteConversationID(platform, legacyID string) string {
-	value := strings.TrimSpace(legacyID)
-	if platform != "signal" {
-		return value
-	}
-	if strings.HasPrefix(value, "signal-group:") {
-		return "signal-group:" + strings.TrimSpace(strings.TrimPrefix(value, "signal-group:"))
-	}
-	if strings.HasPrefix(value, "signal:") {
-		return "signal:" + strings.TrimSpace(strings.TrimPrefix(value, "signal:"))
-	}
-	return value
 }
 
 func minLegacyTimestamp(dataset legacyDataset) int64 {

--- a/internal/migration/transform_test.go
+++ b/internal/migration/transform_test.go
@@ -19,6 +19,7 @@ import (
 	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
 	legacydb "github.com/maxghenis/openmessage/internal/db"
 	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/v2keys"
 	"github.com/maxghenis/openmessage/internal/whatsappmedia"
 )
 
@@ -142,7 +143,7 @@ func TestDeterministicID(t *testing.T) {
 	t.Parallel()
 
 	const want = "5b66e34164c6cc052fd1dd40eb5975be"
-	got := deriveID(
+	got := v2keys.DeriveID(
 		"message",
 		"google-primary",
 		"sms-conversation\x1fgoogle-server-1",
@@ -150,7 +151,7 @@ func TestDeterministicID(t *testing.T) {
 	if got != want {
 		t.Fatalf("deriveID() = %q, want %q", got, want)
 	}
-	if again := deriveID("message", "google-primary", "sms-conversation\x1fgoogle-server-1"); again != got {
+	if again := v2keys.DeriveID("message", "google-primary", "sms-conversation\x1fgoogle-server-1"); again != got {
 		t.Fatalf("deriveID() was not repeatable: first %q, second %q", got, again)
 	}
 	if len(got) != 32 || strings.ToLower(got) != got {
@@ -159,10 +160,10 @@ func TestDeterministicID(t *testing.T) {
 	if _, err := hex.DecodeString(got); err != nil {
 		t.Fatalf("deriveID() = %q, want lowercase hex: %v", got, err)
 	}
-	if got == deriveID("message", "signal-primary", "sms-conversation\x1fgoogle-server-1") {
+	if got == v2keys.DeriveID("message", "signal-primary", "sms-conversation\x1fgoogle-server-1") {
 		t.Fatal("deriveID() did not include account_id")
 	}
-	if got == deriveID("conversation", "google-primary", "sms-conversation\x1fgoogle-server-1") {
+	if got == v2keys.DeriveID("conversation", "google-primary", "sms-conversation\x1fgoogle-server-1") {
 		t.Fatal("deriveID() did not include entity")
 	}
 }
@@ -605,7 +606,7 @@ func assertFixtureMessages(t *testing.T, database *sql.DB) {
 			legacyConversation: "sms-conversation", accountID: "google-primary",
 			remoteID: "google-server-1", body: "google incoming media", direction: "incoming",
 			occurredAt:       fixtureBaseMS + 1_000,
-			senderIdentityID: deriveID("identity", "google-primary", "e164\x1f+15550100001"),
+			senderIdentityID: v2keys.DeriveID("identity", "google-primary", "e164\x1f+15550100001"),
 		},
 		{
 			legacyConversation: "sms-conversation", accountID: "google-primary",
@@ -616,7 +617,7 @@ func assertFixtureMessages(t *testing.T, database *sql.DB) {
 			legacyConversation: "whatsapp:fixture-group@g.us", accountID: "whatsapp-primary",
 			remoteID: "wa-source-1", body: "whatsapp incoming media", direction: "incoming",
 			occurredAt:       fixtureBaseMS + 3_000,
-			senderIdentityID: deriveID("identity", "whatsapp-primary", "jid\x1f15550100002@s.whatsapp.net"),
+			senderIdentityID: v2keys.DeriveID("identity", "whatsapp-primary", "jid\x1f15550100002@s.whatsapp.net"),
 		},
 		{
 			legacyConversation: "whatsapp:fixture-group@g.us", accountID: "whatsapp-primary",
@@ -627,7 +628,7 @@ func assertFixtureMessages(t *testing.T, database *sql.DB) {
 			legacyConversation: "signal:+16505550100", accountID: "signal-primary",
 			remoteID: "1700000001000", body: "signal incoming media", direction: "incoming",
 			occurredAt:       fixtureBaseMS + 5_000,
-			senderIdentityID: deriveID("identity", "signal-primary", "e164\x1f+16505550100"),
+			senderIdentityID: v2keys.DeriveID("identity", "signal-primary", "e164\x1f+16505550100"),
 		},
 		{
 			legacyConversation: "signal:+16505550100", accountID: "signal-primary",
@@ -636,10 +637,10 @@ func assertFixtureMessages(t *testing.T, database *sql.DB) {
 		},
 	}
 	for _, want := range wants {
-		messageID := deriveID(
+		messageID := v2keys.DeriveID(
 			"message", want.accountID, want.legacyConversation+"\x1f"+want.remoteID,
 		)
-		conversationID := deriveID("conversation", want.accountID, want.legacyConversation)
+		conversationID := v2keys.DeriveID("conversation", want.accountID, want.legacyConversation)
 		var gotConversationID, gotAccountID, remoteID, body, direction, state string
 		var replyTo, sender sql.NullString
 		var occurredAt, createdAt, updatedAt int64
@@ -705,7 +706,7 @@ func assertFixtureAttachments(t *testing.T, database *sql.DB, whatsAppRef string
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			messageID := deriveID(
+			messageID := v2keys.DeriveID(
 				"message", test.accountID,
 				test.legacyConversation+"\x1f"+test.remoteMessageID,
 			)
@@ -784,12 +785,12 @@ func assertFixtureSchedules(t *testing.T, database *sql.DB, blobRoot string, sch
 		{"scheduled-pending-media", "whatsapp-primary", "whatsapp:fixture-group@g.us", "media", fixtureBaseMS + 200_000},
 	}
 	for _, want := range wants {
-		outboxID := deriveID("outbox", want.accountID, want.id)
-		requestID := deriveID("transport_request", want.accountID, want.id)
-		messageID := deriveID(
+		outboxID := v2keys.DeriveID("outbox", want.accountID, want.id)
+		requestID := v2keys.DeriveID("transport_request", want.accountID, want.id)
+		messageID := v2keys.DeriveID(
 			"message", want.accountID, want.legacyConversation+"\x1f"+requestID,
 		)
-		conversationID := deriveID("conversation", want.accountID, want.legacyConversation)
+		conversationID := v2keys.DeriveID("conversation", want.accountID, want.legacyConversation)
 		var gotOutboxID, accountID, gotConversationID, kind, idempotencyKey, state string
 		var localMessageID, transportRequestID string
 		var scheduledFor, attempts int64
@@ -821,8 +822,8 @@ func assertFixtureSchedules(t *testing.T, database *sql.DB, blobRoot string, sch
 			t.Errorf("outbox contains %d rows for skipped schedule %q", got, skipped)
 		}
 	}
-	sendingRequestID := deriveID("transport_request", "signal-primary", "scheduled-sending")
-	sendingMessageID := deriveID(
+	sendingRequestID := v2keys.DeriveID("transport_request", "signal-primary", "scheduled-sending")
+	sendingMessageID := v2keys.DeriveID(
 		"message", "signal-primary", "signal:+16505550100\x1f"+sendingRequestID,
 	)
 	var sendingBody, sendingDirection string
@@ -831,7 +832,7 @@ func assertFixtureSchedules(t *testing.T, database *sql.DB, blobRoot string, sch
 		t.Errorf("ambiguous sending optimistic row = %q/%q", sendingBody, sendingDirection)
 	}
 
-	mediaOutboxID := deriveID("outbox", "whatsapp-primary", "scheduled-pending-media")
+	mediaOutboxID := v2keys.DeriveID("outbox", "whatsapp-primary", "scheduled-pending-media")
 	var hash, mime, filename string
 	var size int64
 	mustNoError(t, database.QueryRow(`
@@ -860,11 +861,11 @@ func assertFixtureSchedules(t *testing.T, database *sql.DB, blobRoot string, sch
 func assertFixtureReadCursors(t *testing.T, database *sql.DB) {
 	t.Helper()
 
-	smsConversationID := deriveID("conversation", "google-primary", "sms-conversation")
-	smsDeviceID := deriveID(
+	smsConversationID := v2keys.DeriveID("conversation", "google-primary", "sms-conversation")
+	smsDeviceID := v2keys.DeriveID(
 		"device", "google-primary", "google-primary\x1flocal",
 	)
-	smsLastReadMessageID := deriveID(
+	smsLastReadMessageID := v2keys.DeriveID(
 		"message", "google-primary", "sms-conversation\x1fgoogle-server-1",
 	)
 	var lastRead sql.NullString
@@ -878,8 +879,8 @@ func assertFixtureReadCursors(t *testing.T, database *sql.DB) {
 	}
 
 	aciConversation := "signal:" + fixtureSignalACI
-	aciConversationID := deriveID("conversation", "signal-primary", aciConversation)
-	signalDeviceID := deriveID("device", "signal-primary", "signal-primary\x1flocal")
+	aciConversationID := v2keys.DeriveID("conversation", "signal-primary", aciConversation)
+	signalDeviceID := v2keys.DeriveID("device", "signal-primary", "signal-primary\x1flocal")
 	mustNoError(t, database.QueryRow(`
 		SELECT last_read_message_id, last_read_at_ms
 		FROM read_cursors WHERE device_id = ? AND conversation_id = ?

--- a/internal/storage/sqlite/ingest_support.go
+++ b/internal/storage/sqlite/ingest_support.go
@@ -1,0 +1,223 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ApplyMessageMutation updates an existing normalized message and marks the
+// mutation's durable source frame processed in the same transaction. updated
+// reports whether the target message existed. A missing target is a benign
+// no-op, but the source frame is still marked processed.
+func (r *MessageRepository) ApplyMessageMutation(
+	ctx context.Context,
+	accountID string,
+	conversationID string,
+	remoteMessageID string,
+	kind string,
+	body string,
+	inboxID string,
+) (updated bool, err error) {
+	if kind != "edit" && kind != "delete" {
+		return false, fmt.Errorf("apply message mutation: unsupported kind %q", kind)
+	}
+
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf(
+			"apply %s mutation to message (%q, %q, %q): begin transaction: %w",
+			kind,
+			accountID,
+			conversationID,
+			remoteMessageID,
+			err,
+		)
+	}
+	defer tx.Rollback()
+
+	var inboxAccountID string
+	if err := tx.QueryRowContext(ctx, `
+		SELECT account_id
+		FROM inbox
+		WHERE inbox_id = ?
+	`, inboxID).Scan(&inboxAccountID); errors.Is(err, sql.ErrNoRows) {
+		return false, invalidMessageError(
+			orphanMessageError(ErrOrphanMessageInbox),
+			"mutation source inbox %q does not exist",
+			inboxID,
+		)
+	} else if err != nil {
+		return false, fmt.Errorf(
+			"apply %s mutation to message (%q, %q, %q): read inbox %q: %w",
+			kind,
+			accountID,
+			conversationID,
+			remoteMessageID,
+			inboxID,
+			err,
+		)
+	}
+	if inboxAccountID != accountID {
+		return false, invalidMessageError(
+			ErrCrossAccountMessage,
+			"mutation source inbox %q account %q does not match message account %q",
+			inboxID,
+			inboxAccountID,
+			accountID,
+		)
+	}
+
+	nowMS, err := r.nowMS("apply message mutation")
+	if err != nil {
+		return false, err
+	}
+
+	var result sql.Result
+	switch kind {
+	case "edit":
+		result, err = tx.ExecContext(ctx, `
+			UPDATE messages
+			SET body = ?, state = 'edited', updated_at_ms = ?
+			WHERE account_id = ?
+			  AND conversation_id = ?
+			  AND remote_message_id = ?
+		`, body, nowMS, accountID, conversationID, remoteMessageID)
+	case "delete":
+		result, err = tx.ExecContext(ctx, `
+			UPDATE messages
+			SET state = 'deleted', updated_at_ms = ?
+			WHERE account_id = ?
+			  AND conversation_id = ?
+			  AND remote_message_id = ?
+		`, nowMS, accountID, conversationID, remoteMessageID)
+	}
+	if err != nil {
+		if isSQLiteConstraint(err) {
+			return false, invalidMessageConstraintError(
+				nil,
+				err,
+				"apply %s mutation to message (%q, %q, %q)",
+				kind,
+				accountID,
+				conversationID,
+				remoteMessageID,
+			)
+		}
+		return false, fmt.Errorf(
+			"apply %s mutation to message (%q, %q, %q): %w",
+			kind,
+			accountID,
+			conversationID,
+			remoteMessageID,
+			err,
+		)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf(
+			"apply %s mutation to message (%q, %q, %q): read rows affected: %w",
+			kind,
+			accountID,
+			conversationID,
+			remoteMessageID,
+			err,
+		)
+	}
+	if affected != 0 && affected != 1 {
+		return false, fmt.Errorf(
+			"apply %s mutation to message (%q, %q, %q): affected %d rows, want at most 1",
+			kind,
+			accountID,
+			conversationID,
+			remoteMessageID,
+			affected,
+		)
+	}
+
+	if err := markInboxProcessed(ctx, tx, inboxID, accountID, nowMS); err != nil {
+		return false, fmt.Errorf(
+			"apply %s mutation to message (%q, %q, %q): %w",
+			kind,
+			accountID,
+			conversationID,
+			remoteMessageID,
+			err,
+		)
+	}
+	if err := tx.Commit(); err != nil {
+		if isSQLiteConstraint(err) {
+			return false, invalidMessageConstraintError(
+				nil,
+				err,
+				"commit %s mutation to message (%q, %q, %q)",
+				kind,
+				accountID,
+				conversationID,
+				remoteMessageID,
+			)
+		}
+		return false, fmt.Errorf(
+			"apply %s mutation to message (%q, %q, %q): commit: %w",
+			kind,
+			accountID,
+			conversationID,
+			remoteMessageID,
+			err,
+		)
+	}
+	return affected == 1, nil
+}
+
+// GetLocalInstallationDevice resolves the account's persisted local device by
+// its natural role instead of assuming a particular derived device ID.
+func (s *Store) GetLocalInstallationDevice(
+	ctx context.Context,
+	accountID string,
+) (Device, error) {
+	device, err := scanDevice(s.db.QueryRowContext(ctx, `
+		SELECT `+deviceColumns+`
+		FROM devices
+		WHERE account_id = ? AND kind = 'local_installation'
+		ORDER BY is_current DESC, device_id
+		LIMIT 1
+	`, accountID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Device{}, fmt.Errorf(
+			"local installation device for account %q: %w",
+			accountID,
+			ErrNotFound,
+		)
+	}
+	if err != nil {
+		return Device{}, fmt.Errorf(
+			"get local installation device for account %q: %w",
+			accountID,
+			err,
+		)
+	}
+	return device, nil
+}
+
+// BumpConversationRecency advances a conversation's last_message_at_ms to at
+// least atMS. Message frames never re-upsert existing conversation rows (their
+// titles and kinds are transport-refresh territory), so ingest recency flows
+// through this targeted monotone update instead. A missing conversation is a
+// no-op.
+func (s *Store) BumpConversationRecency(conversationID string, atMS int64) error {
+	if atMS <= 0 {
+		return fmt.Errorf("bump conversation recency %q: time %d is not positive", conversationID, atMS)
+	}
+	_, err := s.db.Exec(
+		`UPDATE conversations
+		 SET last_message_at_ms = MAX(COALESCE(last_message_at_ms, 0), ?)
+		 WHERE conversation_id = ?`,
+		atMS,
+		conversationID,
+	)
+	if err != nil {
+		return fmt.Errorf("bump conversation recency %q: %w", conversationID, err)
+	}
+	return nil
+}

--- a/internal/storage/sqlite/ingest_support_test.go
+++ b/internal/storage/sqlite/ingest_support_test.go
@@ -1,0 +1,437 @@
+package sqlite
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMarkInboxProcessedIsIdempotentAndRetainsPayload(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageAccount(t, store, "account-a", "signal")
+
+	record := messageTestInbox(
+		"inbox-mark",
+		"account-a",
+		"frame-mark",
+		[]byte("raw transport payload"),
+	)
+	if _, err := repository.AppendInbox(context.Background(), record); err != nil {
+		t.Fatalf("AppendInbox(): %v", err)
+	}
+
+	clock.Set(messageTestTimeMS + 100)
+	for _, test := range []struct {
+		name      string
+		inboxID   string
+		accountID string
+	}{
+		{name: "missing row", inboxID: "missing", accountID: "account-a"},
+		{name: "wrong account", inboxID: record.InboxID, accountID: "account-b"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := repository.MarkInboxProcessed(
+				context.Background(),
+				test.inboxID,
+				test.accountID,
+			); err != nil {
+				t.Fatalf("MarkInboxProcessed(): %v", err)
+			}
+		})
+	}
+	assertInboxUnprocessed(t, store, record.InboxID)
+
+	if err := repository.MarkInboxProcessed(
+		context.Background(),
+		record.InboxID,
+		record.AccountID,
+	); err != nil {
+		t.Fatalf("MarkInboxProcessed(first): %v", err)
+	}
+	assertInboxProcessedAt(t, store, record.InboxID, messageTestTimeMS+100)
+
+	clock.Set(messageTestTimeMS + 200)
+	if err := repository.MarkInboxProcessed(
+		context.Background(),
+		record.InboxID,
+		record.AccountID,
+	); err != nil {
+		t.Fatalf("MarkInboxProcessed(replay): %v", err)
+	}
+	assertInboxProcessedAt(t, store, record.InboxID, messageTestTimeMS+100)
+
+	var payload []byte
+	if err := store.db.QueryRow(`
+		SELECT payload
+		FROM inbox
+		WHERE inbox_id = ?
+	`, record.InboxID).Scan(&payload); err != nil {
+		t.Fatalf("read retained inbox payload: %v", err)
+	}
+	if !bytes.Equal(payload, record.Payload) {
+		t.Fatalf("retained payload = %q, want %q", payload, record.Payload)
+	}
+}
+
+func TestApplyMessageMutationEditThenDelete(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageProjectionGraph(t, store)
+
+	replyToRemoteID := "remote-parent"
+	message := messageTestMessage(
+		"message-a",
+		"conversation-a",
+		"account-a",
+		"remote-message-a",
+		pointer("identity-a"),
+	)
+	message.ReplyToRemoteID = &replyToRemoteID
+	message.Body = "original body"
+	source := messageTestInbox("inbox-message", "account-a", "message", []byte("message"))
+	if _, err := repository.AppendInbox(context.Background(), source); err != nil {
+		t.Fatalf("AppendInbox(message): %v", err)
+	}
+	if err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: source.InboxID,
+		Message: message,
+	}); err != nil {
+		t.Fatalf("ProjectMessage(): %v", err)
+	}
+
+	clock.Set(messageTestTimeMS + 100)
+	edit := messageTestInbox("inbox-edit", "account-a", "edit", []byte("edit"))
+	if _, err := repository.AppendInbox(context.Background(), edit); err != nil {
+		t.Fatalf("AppendInbox(edit): %v", err)
+	}
+	clock.Set(messageTestTimeMS + 200)
+	updated, err := repository.ApplyMessageMutation(
+		context.Background(),
+		message.AccountID,
+		message.ConversationID,
+		message.RemoteMessageID,
+		"edit",
+		"edited body",
+		edit.InboxID,
+	)
+	if err != nil {
+		t.Fatalf("ApplyMessageMutation(edit): %v", err)
+	}
+	if !updated {
+		t.Fatal("ApplyMessageMutation(edit) updated = false, want true")
+	}
+	got, err := repository.GetMessage(context.Background(), message.MessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(after edit): %v", err)
+	}
+	assertMutationPreservedMessageShape(t, got, message)
+	if got.Body != "edited body" || got.State != MessageStateEdited {
+		t.Fatalf("edited message = %+v, want edited body/state", got)
+	}
+	if got.UpdatedAtMS != messageTestTimeMS+200 {
+		t.Fatalf("edited updated_at_ms = %d, want %d", got.UpdatedAtMS, messageTestTimeMS+200)
+	}
+	assertInboxProcessedAt(t, store, edit.InboxID, messageTestTimeMS+200)
+
+	clock.Set(messageTestTimeMS + 300)
+	deleteFrame := messageTestInbox("inbox-delete", "account-a", "delete", []byte("delete"))
+	if _, err := repository.AppendInbox(context.Background(), deleteFrame); err != nil {
+		t.Fatalf("AppendInbox(delete): %v", err)
+	}
+	clock.Set(messageTestTimeMS + 400)
+	updated, err = repository.ApplyMessageMutation(
+		context.Background(),
+		message.AccountID,
+		message.ConversationID,
+		message.RemoteMessageID,
+		"delete",
+		"must be ignored",
+		deleteFrame.InboxID,
+	)
+	if err != nil {
+		t.Fatalf("ApplyMessageMutation(delete): %v", err)
+	}
+	if !updated {
+		t.Fatal("ApplyMessageMutation(delete) updated = false, want true")
+	}
+	got, err = repository.GetMessage(context.Background(), message.MessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(after delete): %v", err)
+	}
+	assertMutationPreservedMessageShape(t, got, message)
+	if got.Body != "edited body" {
+		t.Fatalf("deleted body = %q, want edited body preserved", got.Body)
+	}
+	if got.State != MessageStateDeleted {
+		t.Fatalf("deleted state = %q, want %q", got.State, MessageStateDeleted)
+	}
+	if got.UpdatedAtMS != messageTestTimeMS+400 {
+		t.Fatalf("deleted updated_at_ms = %d, want %d", got.UpdatedAtMS, messageTestTimeMS+400)
+	}
+	assertInboxProcessedAt(t, store, deleteFrame.InboxID, messageTestTimeMS+400)
+}
+
+func TestApplyMessageMutationMissingTargetIsBenignAndObservable(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageProjectionGraph(t, store)
+
+	record := messageTestInbox("inbox-missing-edit", "account-a", "missing-edit", []byte("edit"))
+	if _, err := repository.AppendInbox(context.Background(), record); err != nil {
+		t.Fatalf("AppendInbox(): %v", err)
+	}
+	clock.Set(messageTestTimeMS + 100)
+	updated, err := repository.ApplyMessageMutation(
+		context.Background(),
+		"account-a",
+		"conversation-a",
+		"missing-remote-message",
+		"edit",
+		"new body",
+		record.InboxID,
+	)
+	if err != nil {
+		t.Fatalf("ApplyMessageMutation(missing): %v", err)
+	}
+	if updated {
+		t.Fatal("ApplyMessageMutation(missing) updated = true, want false")
+	}
+	assertInboxProcessedAt(t, store, record.InboxID, messageTestTimeMS+100)
+	assertRowCount(t, store.db, "messages", 0)
+}
+
+func TestApplyMessageMutationRollsBackWhenInboxMarkFails(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageProjectionGraph(t, store)
+
+	message := messageTestMessage(
+		"message-a",
+		"conversation-a",
+		"account-a",
+		"remote-message-a",
+		pointer("identity-a"),
+	)
+	source := messageTestInbox("inbox-message", "account-a", "message", []byte("message"))
+	if _, err := repository.AppendInbox(context.Background(), source); err != nil {
+		t.Fatalf("AppendInbox(message): %v", err)
+	}
+	if err := repository.ProjectMessage(context.Background(), MessageProjection{
+		InboxID: source.InboxID,
+		Message: message,
+	}); err != nil {
+		t.Fatalf("ProjectMessage(): %v", err)
+	}
+
+	clock.Set(messageTestTimeMS + 300)
+	edit := messageTestInbox("inbox-edit", "account-a", "edit", []byte("edit"))
+	if _, err := repository.AppendInbox(context.Background(), edit); err != nil {
+		t.Fatalf("AppendInbox(edit): %v", err)
+	}
+	clock.Set(messageTestTimeMS + 299)
+	updated, err := repository.ApplyMessageMutation(
+		context.Background(),
+		message.AccountID,
+		message.ConversationID,
+		message.RemoteMessageID,
+		"edit",
+		"must roll back",
+		edit.InboxID,
+	)
+	if updated {
+		t.Fatal("ApplyMessageMutation() updated = true after rollback")
+	}
+	for _, want := range []error{ErrInvalidInboxRecord, ErrConstraintViolation} {
+		if !errors.Is(err, want) {
+			t.Fatalf("ApplyMessageMutation() error = %v, want %v", err, want)
+		}
+	}
+	got, getErr := repository.GetMessage(context.Background(), message.MessageID)
+	if getErr != nil {
+		t.Fatalf("GetMessage(): %v", getErr)
+	}
+	if got.Body != message.Body || got.State != message.State || got.UpdatedAtMS != messageTestTimeMS {
+		t.Fatalf("message after rollback = %+v, want original body/state/timestamp", got)
+	}
+	assertInboxUnprocessed(t, store, edit.InboxID)
+}
+
+func TestApplyMessageMutationRejectsUnknownKindWithoutProcessingInbox(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageAccount(t, store, "account-a", "signal")
+	record := messageTestInbox("inbox-unknown", "account-a", "unknown", []byte("unknown"))
+	if _, err := repository.AppendInbox(context.Background(), record); err != nil {
+		t.Fatalf("AppendInbox(): %v", err)
+	}
+	updated, err := repository.ApplyMessageMutation(
+		context.Background(),
+		"account-a",
+		"conversation-a",
+		"remote-message-a",
+		"replace",
+		"body",
+		record.InboxID,
+	)
+	if updated || err == nil || !strings.Contains(err.Error(), "unsupported kind") {
+		t.Fatalf("ApplyMessageMutation(unknown) = (%t, %v), want false and unsupported-kind error", updated, err)
+	}
+	assertInboxUnprocessed(t, store, record.InboxID)
+}
+
+func TestApplyMessageMutationRejectsMissingAndCrossAccountInbox(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, repository := openMessageTestRepository(t, clock.Now)
+	seedMessageProjectionGraph(t, store)
+	seedMessageAccount(t, store, "account-b", "signal")
+	foreign := messageTestInbox("inbox-account-b", "account-b", "foreign", []byte("foreign"))
+	if _, err := repository.AppendInbox(context.Background(), foreign); err != nil {
+		t.Fatalf("AppendInbox(foreign): %v", err)
+	}
+
+	for _, test := range []struct {
+		name    string
+		inboxID string
+		want    error
+	}{
+		{name: "missing", inboxID: "missing-inbox", want: ErrOrphanMessageInbox},
+		{name: "cross account", inboxID: foreign.InboxID, want: ErrCrossAccountMessage},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			updated, err := repository.ApplyMessageMutation(
+				context.Background(),
+				"account-a",
+				"conversation-a",
+				"missing-target",
+				"edit",
+				"body",
+				test.inboxID,
+			)
+			if updated || !errors.Is(err, ErrInvalidMessage) || !errors.Is(err, test.want) {
+				t.Fatalf("ApplyMessageMutation() = (%t, %v), want invalid message wrapping %v", updated, err, test.want)
+			}
+		})
+	}
+	assertInboxUnprocessed(t, store, foreign.InboxID)
+}
+
+func TestGetLocalInstallationDeviceUsesAccountScopedRole(t *testing.T) {
+	store, _ := openMessageTestRepository(t, func() time.Time {
+		return time.UnixMilli(messageTestTimeMS)
+	})
+	seedMessageAccount(t, store, "account-a", "signal")
+	seedMessageAccount(t, store, "account-b", "whatsapp")
+
+	devices := []Device{
+		{
+			DeviceID:    "remote-endpoint",
+			AccountID:   "account-a",
+			Kind:        DeviceKindRemoteEndpoint,
+			State:       DeviceStateActive,
+			CreatedAtMS: repositoryTestTimeMS,
+			UpdatedAtMS: repositoryTestTimeMS,
+		},
+		{
+			DeviceID:    "derived-local-id",
+			AccountID:   "account-a",
+			Kind:        DeviceKindLocalInstallation,
+			State:       DeviceStateRevoked,
+			CreatedAtMS: repositoryTestTimeMS,
+			UpdatedAtMS: repositoryTestTimeMS,
+		},
+		{
+			DeviceID:    "local-primary:account-a",
+			AccountID:   "account-a",
+			Kind:        DeviceKindLocalInstallation,
+			State:       DeviceStateActive,
+			IsCurrent:   true,
+			CreatedAtMS: repositoryTestTimeMS,
+			UpdatedAtMS: repositoryTestTimeMS,
+		},
+		{
+			DeviceID:    "local-primary:account-b",
+			AccountID:   "account-b",
+			Kind:        DeviceKindLocalInstallation,
+			State:       DeviceStateActive,
+			IsCurrent:   true,
+			CreatedAtMS: repositoryTestTimeMS,
+			UpdatedAtMS: repositoryTestTimeMS,
+		},
+	}
+	for _, device := range devices {
+		if err := store.UpsertDevice(device); err != nil {
+			t.Fatalf("UpsertDevice(%q): %v", device.DeviceID, err)
+		}
+	}
+
+	got, err := store.GetLocalInstallationDevice(context.Background(), "account-a")
+	if err != nil {
+		t.Fatalf("GetLocalInstallationDevice(): %v", err)
+	}
+	if got.DeviceID != "local-primary:account-a" || got.AccountID != "account-a" ||
+		got.Kind != DeviceKindLocalInstallation {
+		t.Fatalf("GetLocalInstallationDevice() = %+v, want account-a current local device", got)
+	}
+
+	if _, err := store.GetLocalInstallationDevice(context.Background(), "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetLocalInstallationDevice(missing) error = %v, want ErrNotFound", err)
+	}
+}
+
+func assertMutationPreservedMessageShape(t *testing.T, got, original Message) {
+	t.Helper()
+	if got.MessageID != original.MessageID ||
+		got.ConversationID != original.ConversationID ||
+		got.AccountID != original.AccountID ||
+		got.RemoteMessageID != original.RemoteMessageID ||
+		got.Direction != original.Direction ||
+		got.OccurredAtMS != original.OccurredAtMS ||
+		got.CreatedAtMS != messageTestTimeMS ||
+		(got.SenderIdentityID == nil) != (original.SenderIdentityID == nil) ||
+		(got.SenderIdentityID != nil && *got.SenderIdentityID != *original.SenderIdentityID) ||
+		(got.ReplyToRemoteID == nil) != (original.ReplyToRemoteID == nil) ||
+		(got.ReplyToRemoteID != nil && *got.ReplyToRemoteID != *original.ReplyToRemoteID) {
+		t.Fatalf("mutated message shape = %+v, want immutable fields from %+v", got, original)
+	}
+}
+
+func TestBumpConversationRecencyIsMonotoneAndMissingRowIsNoOp(t *testing.T) {
+	clock := newMessageTestClock(messageTestTimeMS)
+	store, _ := openMessageTestRepository(t, clock.Now)
+	seedMessageAccount(t, store, "account-a", "google")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+
+	read := func() int64 {
+		t.Helper()
+		conversation, err := store.GetConversationByRemote("account-a", "remote-conversation-a")
+		if err != nil {
+			t.Fatalf("GetConversationByRemote(): %v", err)
+		}
+		return conversation.LastMessageAtMS
+	}
+
+	if err := store.BumpConversationRecency("conversation-a", messageTestTimeMS+5_000); err != nil {
+		t.Fatalf("BumpConversationRecency(newer): %v", err)
+	}
+	if got := read(); got != messageTestTimeMS+5_000 {
+		t.Fatalf("last_message_at_ms after newer bump = %d, want %d", got, messageTestTimeMS+5_000)
+	}
+
+	if err := store.BumpConversationRecency("conversation-a", messageTestTimeMS+1_000); err != nil {
+		t.Fatalf("BumpConversationRecency(older): %v", err)
+	}
+	if got := read(); got != messageTestTimeMS+5_000 {
+		t.Fatalf("last_message_at_ms after older bump = %d, want unchanged %d", got, messageTestTimeMS+5_000)
+	}
+
+	if err := store.BumpConversationRecency("conversation-missing", messageTestTimeMS+9_000); err != nil {
+		t.Fatalf("BumpConversationRecency(missing) = %v, want no-op nil", err)
+	}
+	if err := store.BumpConversationRecency("conversation-a", 0); err == nil {
+		t.Fatal("BumpConversationRecency(0) = nil, want error for non-positive time")
+	}
+}

--- a/internal/storage/sqlite/messages.go
+++ b/internal/storage/sqlite/messages.go
@@ -174,6 +174,57 @@ func (r *MessageRepository) Unprocessed(ctx context.Context) ([]InboxRecord, err
 	return records, nil
 }
 
+// MarkInboxProcessed removes a durable frame from the worker's unprocessed
+// queue without deleting its payload. Repeated calls, including calls for a
+// row that is already processed or does not exist for the account, succeed.
+func (r *MessageRepository) MarkInboxProcessed(
+	ctx context.Context,
+	inboxID string,
+	accountID string,
+) error {
+	nowMS, err := r.nowMS("mark inbox processed")
+	if err != nil {
+		return err
+	}
+	return markInboxProcessed(ctx, r.store.db, inboxID, accountID, nowMS)
+}
+
+type inboxProcessExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func markInboxProcessed(
+	ctx context.Context,
+	execer inboxProcessExecer,
+	inboxID string,
+	accountID string,
+	processedAtMS int64,
+) error {
+	_, err := execer.ExecContext(ctx, `
+		UPDATE inbox
+		SET processed_at_ms = ?
+		WHERE inbox_id = ? AND account_id = ? AND processed_at_ms IS NULL
+	`, processedAtMS, inboxID, accountID)
+	if err == nil {
+		return nil
+	}
+	if isSQLiteConstraint(err) {
+		return fmt.Errorf(
+			"mark inbox %q for account %q processed: %w: %w",
+			inboxID,
+			accountID,
+			ErrInvalidInboxRecord,
+			mapConstraintError(err),
+		)
+	}
+	return fmt.Errorf(
+		"mark inbox %q for account %q processed: %w",
+		inboxID,
+		accountID,
+		err,
+	)
+}
+
 // GetMessage returns the normalized message with messageID.
 func (r *MessageRepository) GetMessage(
 	ctx context.Context,

--- a/internal/v2keys/derive.go
+++ b/internal/v2keys/derive.go
@@ -1,0 +1,98 @@
+// Package v2keys owns deterministic keys shared by v2 migration and live
+// ingestion.
+package v2keys
+
+import (
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Identity is the natural key for an account-scoped identity.
+type Identity struct {
+	AccountID string
+	Kind      string
+	Canonical string
+}
+
+// DeriveID deterministically mints a v2 primary key from an entity, account,
+// and natural key.
+func DeriveID(entity, accountID, naturalKey string) string {
+	sum := sha256.Sum256([]byte(entity + "\x1f" + accountID + "\x1f" + naturalKey))
+	return hex.EncodeToString(sum[:])[:32]
+}
+
+var signalACI = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// IdentityKey classifies and canonicalizes a platform identity.
+func IdentityKey(accountID, platform, raw string) (Identity, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return Identity{}, fmt.Errorf("identity value is empty")
+	}
+	kind := "username"
+	canonical := value
+	switch {
+	case strings.HasPrefix(value, "+"):
+		var digits strings.Builder
+		for _, character := range value[1:] {
+			if character >= '0' && character <= '9' {
+				digits.WriteRune(character)
+			}
+		}
+		if digits.Len() == 0 {
+			return Identity{}, fmt.Errorf("invalid E.164 identity %q", value)
+		}
+		kind = "e164"
+		canonical = "+" + digits.String()
+	case platform == "signal" && signalACI.MatchString(value):
+		kind = "signal_aci"
+		canonical = strings.ToLower(value)
+	case strings.Contains(value, "@") && platform == "whatsapp":
+		kind = "jid"
+		canonical = strings.ToLower(value)
+	case strings.Contains(value, "@"):
+		kind = "email"
+		canonical = strings.ToLower(value)
+	case strings.HasPrefix(value, "legacy-participant:"):
+		kind = "legacy_participant"
+	}
+	return Identity{AccountID: accountID, Kind: kind, Canonical: canonical}, nil
+}
+
+// NormalizeRemoteConversationID preserves the legacy remote conversation form
+// while removing whitespace around Signal address payloads.
+func NormalizeRemoteConversationID(platform, legacyID string) string {
+	value := strings.TrimSpace(legacyID)
+	if platform != "signal" {
+		return value
+	}
+	if strings.HasPrefix(value, "signal-group:") {
+		return "signal-group:" + strings.TrimSpace(strings.TrimPrefix(value, "signal-group:"))
+	}
+	if strings.HasPrefix(value, "signal:") {
+		return "signal:" + strings.TrimSpace(strings.TrimPrefix(value, "signal:"))
+	}
+	return value
+}
+
+// SignalIncomingSourceID computes the body-independent SHA-1 message id used
+// by the Signal live bridge for incoming envelopes.
+func SignalIncomingSourceID(conversationID, source string, timestamp int64) string {
+	sum := sha1.Sum([]byte(strings.Join([]string{
+		strings.TrimSpace(conversationID),
+		strings.TrimSpace(source),
+		strconv.FormatInt(timestamp, 10),
+	}, "\x1f")))
+	return hex.EncodeToString(sum[:])
+}
+
+// SignalLocalAlias returns the migration remote-message key for a fabricated
+// local Signal message.
+func SignalLocalAlias(conversationID string, timestamp int64) string {
+	return "local:" + SignalIncomingSourceID(conversationID, "me", timestamp)
+}

--- a/internal/v2keys/derive_test.go
+++ b/internal/v2keys/derive_test.go
@@ -1,0 +1,145 @@
+package v2keys
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDeriveIDMigrationFixtureGoldens(t *testing.T) {
+	t.Parallel()
+
+	// These values were produced by migration's pre-extraction deriveID. The
+	// corpus spans every account and derived entity used by the live fixtures.
+	tests := []struct {
+		name       string
+		entity     string
+		accountID  string
+		naturalKey string
+		want       string
+	}{
+		{name: "google account", entity: "account", naturalKey: "google-primary", want: "1ead391d67780be44786c24a64c24c24"},
+		{name: "google conversation", entity: "conversation", accountID: "google-primary", naturalKey: "sms-conversation", want: "e5abadc3f4832c388c253f721477bd69"},
+		{name: "google identity", entity: "identity", accountID: "google-primary", naturalKey: "e164\x1f+15550100001", want: "04d918d802930bf35edc293767526613"},
+		{name: "google message", entity: "message", accountID: "google-primary", naturalKey: "sms-conversation\x1fgoogle-server-1", want: "5b66e34164c6cc052fd1dd40eb5975be"},
+		{name: "google device", entity: "device", accountID: "google-primary", naturalKey: "google-primary\x1flocal", want: "9bcc134365b6f21de496ec1693b68421"},
+		{name: "whatsapp account", entity: "account", naturalKey: "whatsapp-primary", want: "6b76048039141e9bd397ca32918b093b"},
+		{name: "whatsapp conversation", entity: "conversation", accountID: "whatsapp-primary", naturalKey: "whatsapp:fixture-group@g.us", want: "21126fe0e64728af81ec3524454e59bc"},
+		{name: "whatsapp identity", entity: "identity", accountID: "whatsapp-primary", naturalKey: "jid\x1f15550100002@s.whatsapp.net", want: "3e6c1c89010c1ddb057ce4a17ac39d7c"},
+		{name: "whatsapp message", entity: "message", accountID: "whatsapp-primary", naturalKey: "whatsapp:fixture-group@g.us\x1fwa-source-1", want: "9c657e0bffa05e3baa7299982adb5742"},
+		{name: "whatsapp device", entity: "device", accountID: "whatsapp-primary", naturalKey: "whatsapp-primary\x1flocal", want: "1aa97228aad2f8a40a7eea579625d579"},
+		{name: "signal account", entity: "account", naturalKey: "signal-primary", want: "8eaaaab3cf32c276b14075f8d9531788"},
+		{name: "signal conversation", entity: "conversation", accountID: "signal-primary", naturalKey: "signal:+16505550100", want: "e7167f0610029446f589ea5373ead528"},
+		{name: "signal e164 identity", entity: "identity", accountID: "signal-primary", naturalKey: "e164\x1f+16505550100", want: "0e611895ca81bcc570dfe8754f0c55da"},
+		{name: "signal aci identity", entity: "identity", accountID: "signal-primary", naturalKey: "signal_aci\x1f11111111-2222-3333-4444-555555555555", want: "3e1fff6f5b7bd9c20293dde8f8c8a60d"},
+		{name: "signal incoming message", entity: "message", accountID: "signal-primary", naturalKey: "signal:+16505550100\x1f1700000001000", want: "ad474018087651496559b5faa428554a"},
+		{name: "signal local message", entity: "message", accountID: "signal-primary", naturalKey: "signal:+16505550100\x1flocal:abc123", want: "eff6af5e8d89176e528cfb0adf9f25a8"},
+		{name: "signal device", entity: "device", accountID: "signal-primary", naturalKey: "signal-primary\x1flocal", want: "f5725a0b516450efeab65b0ccdc9d041"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := DeriveID(test.entity, test.accountID, test.naturalKey); got != test.want {
+				t.Fatalf("DeriveID(%q, %q, %q) = %q, want pre-extraction golden %q", test.entity, test.accountID, test.naturalKey, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIdentityKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		accountID string
+		platform  string
+		raw       string
+		want      Identity
+		wantErr   string
+	}{
+		{name: "empty", accountID: "google-primary", platform: "sms", raw: " \t", wantErr: "identity value is empty"},
+		{name: "formatted e164", accountID: "google-primary", platform: "sms", raw: " +1 (555) 010-0001 ", want: Identity{AccountID: "google-primary", Kind: "e164", Canonical: "+15550100001"}},
+		{name: "invalid e164", accountID: "signal-primary", platform: "signal", raw: "+---", wantErr: `invalid E.164 identity "+---"`},
+		{name: "signal aci", accountID: "signal-primary", platform: "signal", raw: " ABCDEF12-3456-7890-ABCD-EF1234567890 ", want: Identity{AccountID: "signal-primary", Kind: "signal_aci", Canonical: "abcdef12-3456-7890-abcd-ef1234567890"}},
+		{name: "signal platform comparison remains exact", accountID: "signal-primary", platform: "Signal", raw: "ABCDEF12-3456-7890-ABCD-EF1234567890", want: Identity{AccountID: "signal-primary", Kind: "username", Canonical: "ABCDEF12-3456-7890-ABCD-EF1234567890"}},
+		{name: "whatsapp jid", accountID: "whatsapp-primary", platform: "whatsapp", raw: " USER@S.WHATSAPP.NET ", want: Identity{AccountID: "whatsapp-primary", Kind: "jid", Canonical: "user@s.whatsapp.net"}},
+		{name: "email", accountID: "gchat-archive", platform: "gchat", raw: " Friend@Example.COM ", want: Identity{AccountID: "gchat-archive", Kind: "email", Canonical: "friend@example.com"}},
+		{name: "legacy participant", accountID: "imessage-archive", platform: "imessage", raw: "legacy-participant:42", want: Identity{AccountID: "imessage-archive", Kind: "legacy_participant", Canonical: "legacy-participant:42"}},
+		{name: "username preserves case", accountID: "signal-primary", platform: "signal", raw: " MixedCaseHandle ", want: Identity{AccountID: "signal-primary", Kind: "username", Canonical: "MixedCaseHandle"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := IdentityKey(test.accountID, test.platform, test.raw)
+			if test.wantErr != "" {
+				if err == nil || err.Error() != test.wantErr {
+					t.Fatalf("IdentityKey() error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("IdentityKey() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("IdentityKey() = %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeRemoteConversationID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name, platform, legacyID, want string
+	}{
+		{name: "google trims outer whitespace", platform: "sms", legacyID: "  sms-conversation  ", want: "sms-conversation"},
+		{name: "whatsapp preserves canonical form", platform: "whatsapp", legacyID: "  whatsapp:15550100002@s.whatsapp.net  ", want: "whatsapp:15550100002@s.whatsapp.net"},
+		{name: "signal address", platform: "signal", legacyID: " signal:  +16505550100  ", want: "signal:+16505550100"},
+		{name: "signal group", platform: "signal", legacyID: " signal-group:  group-id  ", want: "signal-group:group-id"},
+		{name: "signal unprefixed", platform: "signal", legacyID: "  unprefixed  ", want: "unprefixed"},
+		{name: "platform comparison remains exact", platform: "Signal", legacyID: " signal:  +16505550100  ", want: "signal:  +16505550100"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := NormalizeRemoteConversationID(test.platform, test.legacyID); got != test.want {
+				t.Fatalf("NormalizeRemoteConversationID(%q, %q) = %q, want %q", test.platform, test.legacyID, got, test.want)
+			}
+		})
+	}
+}
+
+func TestSignalIncomingSourceIDSignallivePin(t *testing.T) {
+	t.Parallel()
+
+	// The expected SHA-1 strings were captured from signallive's original
+	// signalIncomingSourceID implementation. Keep that package untouched: this
+	// table is the cross-package pin for its (conversation, source, timestamp)
+	// algorithm.
+	tests := []struct {
+		name           string
+		conversationID string
+		source         string
+		timestamp      int64
+		want           string
+	}{
+		{name: "direct e164", conversationID: "signal:+16505550100", source: "+16505550100", timestamp: 1_700_000_001_000, want: "47b5e94ed638811b34db7cb7c6a8c946e60c8af9"},
+		{name: "group aci", conversationID: "signal-group:group-fixture", source: "11111111-2222-3333-4444-555555555555", timestamp: 1_700_000_002_000, want: "f5c371a6b529e426f63e6c9fea72447837705c1e"},
+		{name: "trims fields", conversationID: "  signal:+16505550100  ", source: "  +16505550100  ", timestamp: 1_700_000_001_000, want: "47b5e94ed638811b34db7cb7c6a8c946e60c8af9"},
+		{name: "zero timestamp", conversationID: "signal:+15550000000", source: "source-aci", timestamp: 0, want: "24a8f375364d0fb84e43e655d091de8c0c40d4c5"},
+		{name: "signed timestamp", conversationID: "signal-group: spaced group ", source: " sender ", timestamp: -42, want: "31c28133a5d453dc70fbc87fd577ed7540ef4a31"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := SignalIncomingSourceID(test.conversationID, test.source, test.timestamp); got != test.want {
+				t.Fatalf("SignalIncomingSourceID(%q, %q, %d) = %q, want signallive pin %q", test.conversationID, test.source, test.timestamp, got, test.want)
+			}
+		})
+	}
+}
+
+func TestSignalLocalAlias(t *testing.T) {
+	t.Parallel()
+
+	const want = "local:053fa0da59a9c2dee79cc0a2b18e4599ad080bf8"
+	if got := SignalLocalAlias("signal:+16505550100", 1_700_000_006_000); got != want {
+		t.Fatalf("SignalLocalAlias() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

The receive-side foundation for the v2 ingest slice, per `ingest-echo-spec-2026-07-17.md` §I0/§I1. Hermetic: no serve wiring, no adapter changes (those are I2–I4).

**I0 — `internal/v2keys`**: the deterministic identity recipe (`hex(sha256(entity\x1f acct\x1f key))[:32]`), identity-key classification (e164/jid/email/username/Signal-ACI), remote-conversation normalization, and the Signal incoming source-id + local-alias derivations, extracted verbatim from the migration transformer. Byte-identity goldens pin the recipe with hardcoded literals (independently recomputed during review — not derived by calling the function under test), plus a cross-pin against signallive's sha1 form. The migration's full suite passes unchanged as the second witness.

**I1 — `internal/ingest`**: the storage-backed `ConnectionSink` (validate → one durable `AppendInbox` INSERT → non-blocking worker handoff; runs under the supervisor's generation fence without ever blocking it), the single projection worker (decoder registry with per-frame panic containment, conversations-before-messages ordering, a never-clobber rule for existing conversation rows, generic transport-echo routing, Signal outgoing-alias convergence, mutation and self-receipt application), the quarantine classification table (decoder faults retained-and-processed, stale replays counted, transient DB errors retried 3x then left durable, orphans quarantined), and per-account atomic counters. Storage gains `MarkInboxProcessed` (idempotent), `ApplyMessageMutation` (one tx, missing target benign), `GetLocalInstallationDevice`, and `BumpConversationRecency`.

## Adversarial-review fixes (folded in)

- **`ObserveTransportEcho` now returns its reconcile outcome** (`messaging.EchoOutcome`, aliasing the existing sqlite enum). The worker's echo counters previously had a dead NotFound branch and a test asserting the inverse of production behavior; counters now mirror what the service actually did (reconciled/enriched/noop/notfound), which the I5 ingest smoke reads.
- **Echo reconcile faults never block inbound delivery**: a hard error (e.g. a concurrent-confirm race) is counted (`echo_errors`), logged, and projection proceeds. Previously the frame quarantined and the inbound message was lost.
- **Ingested messages advance `conversations.last_message_at_ms`** via a targeted monotone `MAX()` bump — the never-clobber rule stays intact, but the conversation list no longer freezes at migration-time recency.
- **A self receipt arriving before its conversation or local device** drops benignly (counted) instead of quarantining a valid frame.

## Verification

Full `go test -race ./...`: 28 packages green (26 baseline + `v2keys` + `ingest`), independently run outside the codex sandbox. Review repro scenarios re-run against the fixes (echo-error-still-projects, recency monotonicity, orphan-receipt benignity, per-outcome counter mirror).

Known deferral: an end-to-end migrate-then-ingest Signal-alias fixture test lands with I4 (where the real Signal decoder makes it natural); the byte chain is currently pinned by the v2keys goldens + signallive cross-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
