### PR TITLE
Google receive ingest: adapter tee + decoder + serve wiring + echo reconciliation (ingest I2)

### DIFF
--- a/cmd/binary_test.go
+++ b/cmd/binary_test.go
@@ -203,6 +203,7 @@ func TestBuiltBinaryV2FlagOffDoesNotCreateV2Directory(t *testing.T) {
 		os.Environ(),
 		"OPENMESSAGES_DATA_DIR="+dataDir,
 		"OPENMESSAGES_V2_SEND=0",
+		"OPENMESSAGES_V2_INGEST=0",
 		"OPENMESSAGES_DEMO=0",
 		"OPENMESSAGES_APP_SANDBOX=1",
 		"OPENMESSAGES_MACOS_NOTIFICATIONS=0",
@@ -223,6 +224,35 @@ func TestBuiltBinaryV2FlagOffDoesNotCreateV2Directory(t *testing.T) {
 	}
 }
 
+func TestBuiltBinaryV2IngestFlagCreatesV2Directory(t *testing.T) {
+	binary, dataDir := buildTestBinary(t)
+
+	cmd := exec.Command(binary, "serve", "--mcp-stdio")
+	cmd.Env = append(
+		os.Environ(),
+		"OPENMESSAGES_DATA_DIR="+dataDir,
+		"OPENMESSAGES_V2_SEND=0",
+		"OPENMESSAGES_V2_INGEST=1",
+		"OPENMESSAGES_DEMO=0",
+		"OPENMESSAGES_APP_SANDBOX=1",
+		"OPENMESSAGES_MACOS_NOTIFICATIONS=0",
+		"OPENMESSAGES_LOG_LEVEL=info",
+		"OPENMESSAGE_TELEMETRY=0",
+	)
+	cmd.Stdin = strings.NewReader("")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("serve --mcp-stdio: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "Starting MCP stdio transport") {
+		t.Fatalf("serve did not reach MCP stdio startup:\n%s", output)
+	}
+
+	if _, err := os.Stat(filepath.Join(dataDir, "v2", "store.sqlite3")); err != nil {
+		t.Fatalf("ingest flag did not create the v2 store: %v", err)
+	}
+}
+
 func TestBuiltBinaryDemoSkipsV2StackWhenFlagOn(t *testing.T) {
 	binary, dataDir := buildTestBinary(t)
 
@@ -231,6 +261,7 @@ func TestBuiltBinaryDemoSkipsV2StackWhenFlagOn(t *testing.T) {
 		os.Environ(),
 		"OPENMESSAGES_DATA_DIR="+dataDir,
 		"OPENMESSAGES_V2_SEND=1",
+		"OPENMESSAGES_V2_INGEST=1",
 		"OPENMESSAGES_APP_SANDBOX=1",
 		"OPENMESSAGES_MACOS_NOTIFICATIONS=0",
 		"OPENMESSAGES_LOG_LEVEL=info",

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -54,6 +54,19 @@ func mcpV2Dependencies(stack *v2Stack) []*tools.V2Dependencies {
 	}}
 }
 
+func v2SendWebOptions(stack *v2Stack, enabled bool) *web.V2Options {
+	if stack == nil || !enabled {
+		return nil
+	}
+	return &web.V2Options{
+		Service:  stack.Service,
+		Media:    stack.Media,
+		V2Store:  stack.Store,
+		Blobs:    stack.Blobs,
+		Registry: stack.Registry,
+	}
+}
+
 // buildVersion is the version string baked in at build time. SetVersion is
 // called from main() with the value of main.version (set via -ldflags).
 var buildVersion = "dev"
@@ -100,6 +113,8 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	listenAddr := net.JoinHostPort(host, port)
 	baseURL := "http://" + net.JoinHostPort(publicHost(host), port)
 	isDemo := app.DemoMode()
+	v2Send := v2SendEnabled()
+	v2Ingest := v2IngestEnabled()
 
 	events := web.NewEventBroker()
 	isConnected := func() bool {
@@ -136,6 +151,8 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	var whatsappControl *whatsappSupervisorControl
 	var signalLifecycle *signaladapter.Adapter
 	var signalControl *signalSupervisorControl
+	var stack *v2Stack
+	var stopV2Stack func()
 
 	// Google has one lifecycle owner. Transient retry, liveness probes,
 	// credential repair, and terminal parking all flow through this supervisor;
@@ -143,6 +160,24 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	if !isDemo {
 		googleLifecycle = googleadapter.New(googleAccountID, a, canRefreshGoogleCookies)
 		a.SetGoogleLifecycleNotifier(googleLifecycle)
+		if v2Send || v2Ingest {
+			stack, err = newV2Stack(v2StackDeps{
+				Logger:  logger,
+				DataDir: app.DefaultDataDir(),
+				Google:  googleLifecycle,
+			})
+			if err != nil {
+				return fmt.Errorf("init v2 stack: %w", err)
+			}
+			stopV2Stack = func() {
+				if err := stack.Store.Close(); err != nil {
+					logger.Warn().Err(err).Msg("Failed to close unstarted v2 message store")
+				}
+			}
+			defer func() { stopV2Stack() }()
+		} else {
+			logger.Info().Msg("V2 stack disabled (flags off)")
+		}
 		repairer := newGoogleCredentialRepairer(
 			a.SessionPath,
 			canRefreshGoogleCookies,
@@ -151,6 +186,12 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 			a.ClearGoogleRepairFlag,
 		)
 		newGoogleSupervisor := func() (*bridge.Supervisor, error) {
+			supervisorOptions := []bridge.SupervisorOption{
+				bridge.WithCredentialRepairer(repairer),
+			}
+			if stack != nil {
+				supervisorOptions = append(supervisorOptions, bridge.WithConnectionSink(stack.Sink))
+			}
 			return bridge.NewSupervisor(
 				googleAccountID,
 				bridge.PlatformGoogle,
@@ -158,7 +199,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				googleSupervisorPolicy(),
 				googleWallClock{},
 				googleRandom{},
-				bridge.WithCredentialRepairer(repairer),
+				supervisorOptions...,
 			)
 		}
 		googleSupervisor, err = newGoogleSupervisor()
@@ -207,7 +248,19 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		if initialized {
 			whatsappLifecycle = whatsappadapter.New(whatsappAccountID, whatsappBridge)
 			a.SetWhatsAppLifecycleNotifier(whatsappLifecycle)
+			if stack != nil {
+				if err := stack.RegisterAdapter(whatsappLifecycle); err != nil {
+					return fmt.Errorf("register WhatsApp adapter with v2 stack: %w", err)
+				}
+			}
 			newWhatsAppSupervisor := func(initial bridge.State) (*bridge.Supervisor, error) {
+				supervisorOptions := []bridge.SupervisorOption{
+					bridge.WithPairer(whatsappLifecycle),
+					bridge.WithInitialState(initial),
+				}
+				if stack != nil {
+					supervisorOptions = append(supervisorOptions, bridge.WithConnectionSink(stack.Sink))
+				}
 				return bridge.NewSupervisor(
 					whatsappAccountID,
 					bridge.PlatformWhatsApp,
@@ -215,8 +268,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 					whatsappSupervisorPolicy(),
 					whatsappWallClock{},
 					whatsappRandom{},
-					bridge.WithPairer(whatsappLifecycle),
-					bridge.WithInitialState(initial),
+					supervisorOptions...,
 				)
 			}
 			initialState := bridge.StateUnpaired
@@ -270,7 +322,16 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		} else {
 			signalLifecycle = signaladapter.New(signalAccountID, signalBridge)
 			a.SetSignalLifecycleNotifier(signalLifecycle)
+			if stack != nil {
+				if err := stack.RegisterAdapter(signalLifecycle); err != nil {
+					return fmt.Errorf("register Signal adapter with v2 stack: %w", err)
+				}
+			}
 			newSignalSupervisor := func() (*bridge.Supervisor, error) {
+				var supervisorOptions []bridge.SupervisorOption
+				if stack != nil {
+					supervisorOptions = append(supervisorOptions, bridge.WithConnectionSink(stack.Sink))
+				}
 				return bridge.NewSupervisor(
 					signalAccountID,
 					bridge.PlatformSignal,
@@ -278,6 +339,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 					signalSupervisorPolicy(),
 					signalWallClock{},
 					signalRandom{},
+					supervisorOptions...,
 				)
 			}
 			signalSupervisor, err := newSignalSupervisor()
@@ -317,23 +379,12 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		logger.Info().Msg("Demo mode — skipping Signal live bridge")
 	}
 
-	var stack *v2Stack
-	if v2SendEnabled() && !isDemo {
-		stack, err = newV2Stack(v2StackDeps{
-			Logger:   logger,
-			DataDir:  app.DefaultDataDir(),
-			Google:   googleLifecycle,
-			WhatsApp: whatsappLifecycle,
-			Signal:   signalLifecycle,
-		})
-		if err != nil {
-			return fmt.Errorf("init v2 send stack: %w", err)
-		}
-		stopV2Stack := stack.Start(context.Background(), a.Store, events)
-		defer stopV2Stack()
-		logger.Info().Msg("V2 send stack enabled")
-	} else {
-		logger.Info().Msg("V2 send stack disabled (flag off or demo mode)")
+	if stack != nil {
+		stopV2Stack = stack.Start(context.Background(), a.Store, events)
+		logger.Info().
+			Bool("send", v2Send).
+			Bool("ingest", v2Ingest).
+			Msg("V2 stack enabled")
 	}
 
 	// Sync WhatsApp and iMessage periodically (every 30s, incremental)
@@ -465,7 +516,11 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		buildVersion,
 		mcpserver.WithToolCapabilities(true),
 	)
-	tools.Register(mcpSrv, a, mcpV2Dependencies(stack)...)
+	v2SendStack := stack
+	if !v2Send {
+		v2SendStack = nil
+	}
+	tools.Register(mcpSrv, a, mcpV2Dependencies(v2SendStack)...)
 
 	var mcpHTTPHandler http.Handler
 	if opts.mcpSSE {
@@ -511,16 +566,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	// Background loop that sends due scheduled ("send later") messages.
 	a.StartScheduler()
 
-	var v2Options *web.V2Options
-	if stack != nil {
-		v2Options = &web.V2Options{
-			Service:  stack.Service,
-			Media:    stack.Media,
-			V2Store:  stack.Store,
-			Blobs:    stack.Blobs,
-			Registry: stack.Registry,
-		}
-	}
+	v2Options := v2SendWebOptions(stack, v2Send)
 
 	httpEnabled := opts.web || opts.mcpSSE
 	if httpEnabled {

--- a/cmd/serve_tools_test.go
+++ b/cmd/serve_tools_test.go
@@ -41,3 +41,29 @@ func TestMCPV2Dependencies(t *testing.T) {
 		t.Fatal("mcpV2Dependencies(stack) did not preserve the registry pointer")
 	}
 }
+
+func TestV2SendWebOptionsRequiresSendFlag(t *testing.T) {
+	if got := v2SendWebOptions(nil, true); got != nil {
+		t.Fatal("v2SendWebOptions(nil, true) returned enabled options")
+	}
+
+	service := &messaging.MessageService{}
+	store := &sqlite.Store{}
+	registry := bridge.NewRegistry()
+	stack := &v2Stack{
+		Service:  service,
+		Store:    store,
+		Registry: registry,
+	}
+	if got := v2SendWebOptions(stack, false); got != nil {
+		t.Fatal("v2SendWebOptions(stack, false) enabled v2 send routes")
+	}
+
+	got := v2SendWebOptions(stack, true)
+	if got == nil {
+		t.Fatal("v2SendWebOptions(stack, true) returned nil")
+	}
+	if got.Service != service || got.V2Store != store || got.Registry != registry {
+		t.Fatal("v2SendWebOptions(stack, true) did not preserve stack dependencies")
+	}
+}

--- a/cmd/v2stack.go
+++ b/cmd/v2stack.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -16,6 +17,7 @@ import (
 	signaladapter "github.com/maxghenis/openmessage/internal/bridgeadapters/signal"
 	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/ingest"
 	"github.com/maxghenis/openmessage/internal/media"
 	"github.com/maxghenis/openmessage/internal/messaging"
 	"github.com/maxghenis/openmessage/internal/storage/blob"
@@ -40,13 +42,26 @@ type v2Stack struct {
 	Registry *bridge.AccountRegistry
 	Service  *messaging.MessageService
 	Media    *media.Service
+	Sink     *ingest.Sink
+	Counters *ingest.Counters
 
 	outbox *sqlite.OutboxRepository
+	worker *ingest.Worker
 	logger zerolog.Logger
+
+	registerMu sync.Mutex
 }
 
 func v2SendEnabled() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("OPENMESSAGES_V2_SEND"))) {
+	return v2FlagEnabled("OPENMESSAGES_V2_SEND")
+}
+
+func v2IngestEnabled() bool {
+	return v2FlagEnabled("OPENMESSAGES_V2_INGEST")
+}
+
+func v2FlagEnabled(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
 	case "1", "true", "yes", "on":
 		return true
 	default:
@@ -54,16 +69,84 @@ func v2SendEnabled() bool {
 	}
 }
 
+type v2LiveAccountSpec struct {
+	bridgeKey   string
+	displayName string
+}
+
+func liveAccountSpec(platform bridge.Platform) (v2LiveAccountSpec, error) {
+	switch platform {
+	case bridge.PlatformGoogle:
+		return v2LiveAccountSpec{bridgeKey: "google_messages", displayName: "Google Messages"}, nil
+	case bridge.PlatformWhatsApp:
+		return v2LiveAccountSpec{bridgeKey: "whatsmeow", displayName: "WhatsApp"}, nil
+	case bridge.PlatformSignal:
+		return v2LiveAccountSpec{bridgeKey: "signal_cli", displayName: "Signal"}, nil
+	default:
+		return v2LiveAccountSpec{}, fmt.Errorf("unsupported live account platform %q", platform)
+	}
+}
+
+// RegisterAdapter query-first bootstraps the adapter's account row, then adds
+// the adapter to the dispatch registry. Existing account metadata is preserved
+// verbatim. Registration is serialized so the validity/duplicate preflight
+// makes the final Register deterministic for concrete adapters.
+func (s *v2Stack) RegisterAdapter(adapter bridge.Adapter) error {
+	if s == nil || s.Store == nil || s.Registry == nil {
+		return fmt.Errorf("register v2 adapter: stack is incomplete")
+	}
+
+	s.registerMu.Lock()
+	defer s.registerMu.Unlock()
+
+	probe := bridge.NewRegistry()
+	if err := probe.Register(adapter); err != nil {
+		return fmt.Errorf("register v2 adapter: %w", err)
+	}
+	accountID := adapter.AccountID()
+	platform := adapter.Platform()
+	if _, exists := s.Registry.Snapshot(accountID); exists {
+		return fmt.Errorf("register v2 adapter: %w: %q", bridge.ErrAccountAlreadyExists, accountID)
+	}
+	spec, err := liveAccountSpec(platform)
+	if err != nil {
+		return fmt.Errorf("register v2 adapter %q: %w", accountID, err)
+	}
+
+	if _, err := s.Store.GetAccount(accountID); err != nil {
+		if !errors.Is(err, sqlite.ErrNotFound) {
+			return fmt.Errorf("register v2 adapter %q: load account: %w", accountID, err)
+		}
+		nowMS := time.Now().UnixMilli()
+		if err := s.Store.UpsertAccount(sqlite.Account{
+			AccountID:   accountID,
+			BridgeKey:   spec.bridgeKey,
+			DisplayName: spec.displayName,
+			Mode:        sqlite.AccountModeLive,
+			Enabled:     true,
+			ConfigJSON:  "{}",
+			CreatedAtMS: nowMS,
+			UpdatedAtMS: nowMS,
+		}); err != nil {
+			return fmt.Errorf("register v2 adapter %q: bootstrap account: %w", accountID, err)
+		}
+	}
+	if err := s.Registry.Register(adapter); err != nil {
+		return fmt.Errorf("register v2 adapter %q after preflight: %w", accountID, err)
+	}
+	return nil
+}
+
 func newV2Stack(deps v2StackDeps) (_ *v2Stack, resultErr error) {
 	v2Dir := filepath.Join(deps.DataDir, "v2")
 	if err := os.MkdirAll(v2Dir, 0o700); err != nil {
-		return nil, fmt.Errorf("configure v2 send stack: create data directory %q: %w", v2Dir, err)
+		return nil, fmt.Errorf("configure v2 stack: create data directory %q: %w", v2Dir, err)
 	}
 
 	storePath := filepath.Join(v2Dir, "store.sqlite3")
 	store, err := sqlite.Open(storePath)
 	if err != nil {
-		return nil, fmt.Errorf("configure v2 send stack: open store %q: %w", storePath, err)
+		return nil, fmt.Errorf("configure v2 stack: open store %q: %w", storePath, err)
 	}
 	closeStore := true
 	defer func() {
@@ -78,56 +161,87 @@ func newV2Stack(deps v2StackDeps) (_ *v2Stack, resultErr error) {
 	blobPath := filepath.Join(v2Dir, "blobs")
 	blobs, err := blob.New(blobPath)
 	if err != nil {
-		return nil, fmt.Errorf("configure v2 send stack: create blob store %q: %w", blobPath, err)
+		return nil, fmt.Errorf("configure v2 stack: create blob store %q: %w", blobPath, err)
 	}
 
-	registry := bridge.NewRegistry()
+	stack := &v2Stack{
+		Store:    store,
+		Blobs:    blobs,
+		Registry: bridge.NewRegistry(),
+		logger:   deps.Logger,
+	}
 	if deps.Google != nil {
-		if err := registry.Register(deps.Google); err != nil {
-			return nil, fmt.Errorf("configure v2 send stack: register Google adapter: %w", err)
+		if err := stack.RegisterAdapter(deps.Google); err != nil {
+			return nil, fmt.Errorf("configure v2 stack: register Google adapter: %w", err)
 		}
 	}
 	if deps.WhatsApp != nil {
-		if err := registry.Register(deps.WhatsApp); err != nil {
-			return nil, fmt.Errorf("configure v2 send stack: register WhatsApp adapter: %w", err)
+		if err := stack.RegisterAdapter(deps.WhatsApp); err != nil {
+			return nil, fmt.Errorf("configure v2 stack: register WhatsApp adapter: %w", err)
 		}
 	}
 	if deps.Signal != nil {
-		if err := registry.Register(deps.Signal); err != nil {
-			return nil, fmt.Errorf("configure v2 send stack: register Signal adapter: %w", err)
+		if err := stack.RegisterAdapter(deps.Signal); err != nil {
+			return nil, fmt.Errorf("configure v2 stack: register Signal adapter: %w", err)
 		}
 	}
 
 	clock := messaging.SystemClock{}
 	service, err := messaging.NewMessageService(
 		store,
-		registry,
+		stack.Registry,
 		blobs,
 		clock,
 		messaging.CryptoIDSource{},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("configure v2 send stack: create message service: %w", err)
+		return nil, fmt.Errorf("configure v2 stack: create message service: %w", err)
+	}
+	messages, err := sqlite.NewMessageRepository(store, clock.Now)
+	if err != nil {
+		return nil, fmt.Errorf("configure v2 stack: create ingest message repository: %w", err)
+	}
+	counters := &ingest.Counters{}
+	worker, err := ingest.NewWorker(ingest.WorkerConfig{
+		Store:        store,
+		Messages:     messages,
+		EchoObserver: service,
+		Counters:     counters,
+		Logger:       deps.Logger,
+		Decoders: []ingest.DecoderRegistration{{
+			Codec:    ingest.GoogleCodec,
+			Platform: bridge.PlatformGoogle,
+			Decoder:  ingest.NewGoogleDecoder(counters),
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("configure v2 stack: create ingest worker: %w", err)
+	}
+	sink, err := ingest.NewSink(ingest.SinkConfig{
+		Messages: messages,
+		Worker:   worker,
+		Counters: counters,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("configure v2 stack: create ingest sink: %w", err)
 	}
 	outbox, err := sqlite.NewOutboxRepository(store, clock.Now)
 	if err != nil {
-		return nil, fmt.Errorf("configure v2 send stack: create projector outbox: %w", err)
+		return nil, fmt.Errorf("configure v2 stack: create projector outbox: %w", err)
 	}
-	mediaService, err := media.NewService(store, registry, blobs, clock)
+	mediaService, err := media.NewService(store, stack.Registry, blobs, clock)
 	if err != nil {
-		return nil, fmt.Errorf("configure v2 send stack: create media service: %w", err)
+		return nil, fmt.Errorf("configure v2 stack: create media service: %w", err)
 	}
 
 	closeStore = false
-	return &v2Stack{
-		Store:    store,
-		Blobs:    blobs,
-		Registry: registry,
-		Service:  service,
-		Media:    mediaService,
-		outbox:   outbox,
-		logger:   deps.Logger,
-	}, nil
+	stack.Service = service
+	stack.Media = mediaService
+	stack.Sink = sink
+	stack.Counters = counters
+	stack.outbox = outbox
+	stack.worker = worker
+	return stack, nil
 }
 
 func (s *v2Stack) Start(ctx context.Context, legacy *db.Store, events v2wire.EventPublisher) (stop func()) {
@@ -143,7 +257,13 @@ func (s *v2Stack) Start(ctx context.Context, legacy *db.Store, events v2wire.Eve
 	}
 
 	var runWG sync.WaitGroup
-	runWG.Add(2)
+	runWG.Add(3)
+	go func() {
+		defer runWG.Done()
+		if err := s.worker.Run(runCtx); err != nil && !errors.Is(err, context.Canceled) {
+			s.logger.Error().Err(err).Msg("V2 ingest worker stopped")
+		}
+	}()
 	go func() {
 		defer runWG.Done()
 		if err := s.Service.Run(runCtx); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/v2stack_test.go
+++ b/cmd/v2stack_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,8 @@ import (
 	signaladapter "github.com/maxghenis/openmessage/internal/bridgeadapters/signal"
 	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/ingest"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 	"github.com/maxghenis/openmessage/internal/web"
 )
 
@@ -48,6 +51,41 @@ func TestV2SendEnabled(t *testing.T) {
 			}
 			if got := v2SendEnabled(); got != tt.want {
 				t.Fatalf("v2SendEnabled() = %t, want %t for %q", got, tt.want, tt.value)
+			}
+		})
+	}
+}
+
+func TestV2IngestEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		unset bool
+		want  bool
+	}{
+		{name: "unset", unset: true, want: false},
+		{name: "zero", value: "0", want: false},
+		{name: "false", value: "false", want: false},
+		{name: "no", value: "no", want: false},
+		{name: "off", value: "off", want: false},
+		{name: "unknown", value: "enabled", want: false},
+		{name: "one", value: "1", want: true},
+		{name: "true", value: "true", want: true},
+		{name: "yes", value: "yes", want: true},
+		{name: "on", value: "on", want: true},
+		{name: "case and whitespace insensitive", value: "  TrUe\t", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OPENMESSAGES_V2_INGEST", tt.value)
+			if tt.unset {
+				if err := os.Unsetenv("OPENMESSAGES_V2_INGEST"); err != nil {
+					t.Fatalf("unset OPENMESSAGES_V2_INGEST: %v", err)
+				}
+			}
+			if got := v2IngestEnabled(); got != tt.want {
+				t.Fatalf("v2IngestEnabled() = %t, want %t for %q", got, tt.want, tt.value)
 			}
 		})
 	}
@@ -138,8 +176,12 @@ func TestNewV2StackAllowsEmptyAdapterRegistry(t *testing.T) {
 	}
 	defer stack.Store.Close()
 
-	if stack.Store == nil || stack.Blobs == nil || stack.Registry == nil || stack.Service == nil || stack.Media == nil {
+	if stack.Store == nil || stack.Blobs == nil || stack.Registry == nil || stack.Service == nil ||
+		stack.Media == nil || stack.Sink == nil || stack.Counters == nil || stack.worker == nil {
 		t.Fatalf("newV2Stack() returned incomplete stack: %+v", stack)
+	}
+	if stack.worker.Counters() != stack.Counters {
+		t.Fatal("newV2Stack() did not expose the worker's shared ingest counters")
 	}
 	for _, accountID := range []string{googleAccountID, whatsappAccountID, signalAccountID} {
 		if _, ok := stack.Registry.Snapshot(accountID); ok {
@@ -179,12 +221,14 @@ func TestNewV2StackRegistersConcreteLifecycleAdapters(t *testing.T) {
 	defer stack.Store.Close()
 
 	for _, want := range []struct {
-		accountID string
-		platform  bridge.Platform
+		accountID   string
+		platform    bridge.Platform
+		bridgeKey   string
+		displayName string
 	}{
-		{accountID: googleAccountID, platform: bridge.PlatformGoogle},
-		{accountID: whatsappAccountID, platform: bridge.PlatformWhatsApp},
-		{accountID: signalAccountID, platform: bridge.PlatformSignal},
+		{accountID: googleAccountID, platform: bridge.PlatformGoogle, bridgeKey: "google_messages", displayName: "Google Messages"},
+		{accountID: whatsappAccountID, platform: bridge.PlatformWhatsApp, bridgeKey: "whatsmeow", displayName: "WhatsApp"},
+		{accountID: signalAccountID, platform: bridge.PlatformSignal, bridgeKey: "signal_cli", displayName: "Signal"},
 	} {
 		snapshot, ok := stack.Registry.Snapshot(want.accountID)
 		if !ok {
@@ -194,7 +238,97 @@ func TestNewV2StackRegistersConcreteLifecycleAdapters(t *testing.T) {
 		if snapshot.Platform != want.platform {
 			t.Errorf("registry platform for %q = %q, want %q", want.accountID, snapshot.Platform, want.platform)
 		}
+		account, err := stack.Store.GetAccount(want.accountID)
+		if err != nil {
+			t.Errorf("GetAccount(%q): %v", want.accountID, err)
+			continue
+		}
+		if account.BridgeKey != want.bridgeKey || account.DisplayName != want.displayName ||
+			account.Mode != sqlite.AccountModeLive || !account.Enabled || account.ConfigJSON != "{}" {
+			t.Errorf("bootstrapped account %q = %+v", want.accountID, account)
+		}
 	}
+}
+
+func TestV2StackRegisterAdapterPreservesExistingAccount(t *testing.T) {
+	stack, err := newV2Stack(v2StackDeps{
+		Logger:  zerolog.Nop(),
+		DataDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("newV2Stack(): %v", err)
+	}
+	defer stack.Store.Close()
+
+	remoteID := "remote-google-account"
+	existing := sqlite.Account{
+		AccountID:       googleAccountID,
+		BridgeKey:       "preserve-this-bridge",
+		RemoteAccountID: &remoteID,
+		DisplayName:     "Preserve this name",
+		Mode:            sqlite.AccountModeArchive,
+		Enabled:         false,
+		ConfigJSON:      `{"preserve":true}`,
+		CreatedAtMS:     111,
+		UpdatedAtMS:     222,
+	}
+	if err := stack.Store.UpsertAccount(existing); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	if err := stack.RegisterAdapter(googleadapter.New(googleAccountID, nil, func() bool { return false })); err != nil {
+		t.Fatalf("RegisterAdapter(): %v", err)
+	}
+	got, err := stack.Store.GetAccount(googleAccountID)
+	if err != nil {
+		t.Fatalf("GetAccount(): %v", err)
+	}
+	if !reflect.DeepEqual(got, existing) {
+		t.Fatalf("RegisterAdapter() changed existing account\n got: %+v\nwant: %+v", got, existing)
+	}
+}
+
+func TestV2StackFreshGoogleIngressReachesWorker(t *testing.T) {
+	stack, err := newV2Stack(v2StackDeps{
+		Logger:  zerolog.Nop(),
+		DataDir: t.TempDir(),
+		Google:  googleadapter.New(googleAccountID, nil, func() bool { return false }),
+	})
+	if err != nil {
+		t.Fatalf("newV2Stack(): %v", err)
+	}
+
+	legacy, err := db.New(filepath.Join(t.TempDir(), "legacy.sqlite3"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer legacy.Close()
+	stop := stack.Start(context.Background(), legacy, web.NewEventBroker())
+	defer stop()
+
+	if err := stack.Sink.AppendIngress(context.Background(), bridge.RawIngressRecord{
+		AccountID:    googleAccountID,
+		Generation:   1,
+		DedupeKey:    "fresh-google-malformed",
+		Codec:        ingest.GoogleCodec,
+		CodecVersion: ingest.GoogleCodecVersion,
+		ReceivedAt:   time.Now(),
+		Payload:      []byte("{"),
+	}); err != nil {
+		t.Fatalf("AppendIngress() on fresh stack: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := stack.Counters.Snapshot(googleAccountID)
+		if snapshot.Quarantined == 1 {
+			if snapshot.Appended != 1 {
+				t.Fatalf("ingest counters after quarantine = %+v", snapshot)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("malformed fresh-stack frame was not quarantined: %+v", stack.Counters.Snapshot(googleAccountID))
 }
 
 func TestV2StackStopJoinsRunAndClosesStore(t *testing.T) {

--- a/internal/bridgeadapters/google/google.go
+++ b/internal/bridgeadapters/google/google.go
@@ -6,12 +6,14 @@ package google
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
 	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.mau.fi/mautrix-gmessages/pkg/libgm"
@@ -21,6 +23,7 @@ import (
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/bridge"
 	"github.com/maxghenis/openmessage/internal/client"
+	"github.com/maxghenis/openmessage/internal/ingest"
 )
 
 type transportClient interface {
@@ -43,6 +46,8 @@ type Adapter struct {
 	mu       sync.Mutex
 	current  *run
 	starting bool
+
+	ingressErrors atomic.Uint64
 }
 
 func New(accountID string, host *app.App, canRepair func() bool) *Adapter {
@@ -65,6 +70,15 @@ func (a *Adapter) DeclaredCapabilities() bridge.CapabilitySet {
 		PairQR:            true,
 		MediaDownload:     true,
 	}
+}
+
+// IngressErrorCount returns the number of Google tee failures absorbed by
+// this one-account adapter while preserving legacy event delivery.
+func (a *Adapter) IngressErrorCount() uint64 {
+	if a == nil {
+		return 0
+	}
+	return a.ingressErrors.Load()
 }
 
 func (a *Adapter) loadClient() (*client.Client, transportClient, error) {
@@ -485,6 +499,7 @@ func (r *run) handleEvent(evt any) {
 		})
 	}
 
+	r.teeIngress(evt, eventAt)
 	r.generation.Handler.Handle(evt)
 	if failure, terminal := r.classifyEvent(evt); terminal {
 		if failure.Class == bridge.FailureCredentialsExpired ||
@@ -493,6 +508,88 @@ func (r *run) handleEvent(evt any) {
 		}
 		r.requestFinish(failure)
 	}
+}
+
+func (r *run) teeIngress(evt any, receivedAt time.Time) {
+	if r.sink == nil {
+		return
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			r.recordIngressError(evt, fmt.Errorf(
+				"panic in Google ingest tee: %v\n%s",
+				recovered,
+				debug.Stack(),
+			))
+		}
+	}()
+
+	var err error
+	switch event := evt.(type) {
+	case *libgm.WrappedMessage:
+		var payload, protoBytes []byte
+		payload, protoBytes, err = ingest.MarshalGoogleMessageFrame(event)
+		if err == nil {
+			err = r.sink.AppendIngress(context.Background(), bridge.RawIngressRecord{
+				AccountID:    r.request.AccountID,
+				Generation:   r.request.Generation,
+				DedupeKey:    googleIngressDedupeKey("msg", event.GetMessageID(), protoBytes),
+				Codec:        ingest.GoogleCodec,
+				CodecVersion: ingest.GoogleCodecVersion,
+				ReceivedAt:   receivedAt,
+				Payload:      payload,
+			})
+		}
+	case *gmproto.Conversation:
+		var payload, protoBytes []byte
+		payload, protoBytes, err = ingest.MarshalGoogleConversationFrame(event)
+		if err == nil {
+			err = r.sink.AppendIngress(context.Background(), bridge.RawIngressRecord{
+				AccountID:    r.request.AccountID,
+				Generation:   r.request.Generation,
+				DedupeKey:    googleIngressDedupeKey("conv", event.GetConversationID(), protoBytes),
+				Codec:        ingest.GoogleCodec,
+				CodecVersion: ingest.GoogleCodecVersion,
+				ReceivedAt:   receivedAt,
+				Payload:      payload,
+			})
+		}
+	case *gmproto.TypingData:
+		number := event.GetUser().GetNumber()
+		err = r.sink.EmitEphemeral(context.Background(), bridge.EphemeralEvent{
+			AccountID:  r.request.AccountID,
+			Generation: r.request.Generation,
+			Typing: &bridge.TypingEvent{
+				RemoteConversationID: event.GetConversationID(),
+				Actor: bridge.IdentityRef{
+					Raw:       number,
+					Canonical: number,
+				},
+				Typing: event.GetType() == gmproto.TypingTypes_STARTED_TYPING,
+			},
+		})
+	default:
+		return
+	}
+	if err == nil {
+		return
+	}
+	r.recordIngressError(evt, err)
+}
+
+func (r *run) recordIngressError(evt any, err error) {
+	r.adapter.ingressErrors.Add(1)
+	r.adapter.host.Logger.Warn().
+		Err(err).
+		Str("account_id", r.request.AccountID).
+		Uint64("generation", uint64(r.request.Generation)).
+		Type("event_type", evt).
+		Msg("Google ingest tee failed; continuing legacy event handling")
+}
+
+func googleIngressDedupeKey(kind, remoteID string, protoBytes []byte) string {
+	digest := sha256.Sum256(protoBytes)
+	return fmt.Sprintf("%s:%s:%x", kind, remoteID, digest[:4])
 }
 
 func (r *run) classifyEvent(evt any) (bridge.OpError, bool) {

--- a/internal/bridgeadapters/google/google_test.go
+++ b/internal/bridgeadapters/google/google_test.go
@@ -1,8 +1,14 @@
 package google
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -11,10 +17,13 @@ import (
 	"go.mau.fi/mautrix-gmessages/pkg/libgm"
 	"go.mau.fi/mautrix-gmessages/pkg/libgm/events"
 	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/bridge"
 	"github.com/maxghenis/openmessage/internal/client"
+	"github.com/maxghenis/openmessage/internal/ingest"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 )
 
 func TestEventFailureClassification(t *testing.T) {
@@ -395,6 +404,361 @@ func TestPhoneUnreachableSurvivesRepeatedLivenessWindowsAndRecovers(t *testing.T
 	}
 }
 
+func TestIngressTeeMessageFramesUseContentHash(t *testing.T) {
+	host := newTestApp(t)
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	sink := &recordingSink{}
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 7,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+
+	message := &gmproto.Message{
+		MessageID:      "message-1",
+		ConversationID: "conversation-1",
+		Timestamp:      1_234_000,
+	}
+	frame := &libgm.WrappedMessage{Message: message, IsOld: false}
+	fake.emit(frame)
+	fake.emit(frame)
+
+	changed := proto.Clone(message).(*gmproto.Message)
+	changed.MessageStatus = &gmproto.MessageStatus{SubCode: 1}
+	fake.emit(&libgm.WrappedMessage{Message: changed, IsOld: false})
+
+	records := sink.ingressRecords()
+	if len(records) != 3 {
+		t.Fatalf("AppendIngress calls = %d, want 3", len(records))
+	}
+	first := records[0]
+	if first.AccountID != "google-primary" || first.Generation != 7 {
+		t.Fatalf("frame ownership = (%q, %d), want (google-primary, 7)", first.AccountID, first.Generation)
+	}
+	if first.Codec != "google.protobuf" || first.CodecVersion != 1 {
+		t.Fatalf("codec = %q v%d, want google.protobuf v1", first.Codec, first.CodecVersion)
+	}
+	if first.ReceivedAt.IsZero() {
+		t.Fatal("ReceivedAt was not stamped at the tee")
+	}
+
+	var envelope struct {
+		Kind  string `json:"kind"`
+		Proto []byte `json:"proto_b64"`
+		IsOld *bool  `json:"is_old"`
+	}
+	if err := json.Unmarshal(first.Payload, &envelope); err != nil {
+		t.Fatalf("decode message envelope: %v", err)
+	}
+	if envelope.Kind != "message" || envelope.IsOld == nil || *envelope.IsOld {
+		t.Fatalf("message envelope metadata = kind %q is_old %v", envelope.Kind, envelope.IsOld)
+	}
+	var roundTrip gmproto.Message
+	if err := proto.Unmarshal(envelope.Proto, &roundTrip); err != nil {
+		t.Fatalf("unmarshal teed message proto: %v", err)
+	}
+	if !proto.Equal(&roundTrip, message) {
+		t.Fatalf("teed proto = %v, want %v", &roundTrip, message)
+	}
+	digest := sha256.Sum256(envelope.Proto)
+	wantKey := "msg:message-1:" + hex.EncodeToString(digest[:4])
+	if first.DedupeKey != wantKey {
+		t.Fatalf("dedupe key = %q, want %q", first.DedupeKey, wantKey)
+	}
+	if records[1].DedupeKey != first.DedupeKey || !bytes.Equal(records[1].Payload, first.Payload) {
+		t.Fatal("an exact frame replay did not produce the same dedupe key and payload")
+	}
+	if records[2].DedupeKey == first.DedupeKey {
+		t.Fatal("same MessageID with changed status content reused the replay dedupe key")
+	}
+}
+
+func TestIngressTeeThroughRealSinkDedupesExactFrames(t *testing.T) {
+	host := newTestApp(t)
+	storePath := filepath.Join(t.TempDir(), "v2.sqlite3")
+	store, err := sqlite.Open(storePath)
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Now
+	nowMS := now().UnixMilli()
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   "google-primary",
+		BridgeKey:   "google_messages",
+		DisplayName: "Google Messages",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  "{}",
+		CreatedAtMS: nowMS,
+		UpdatedAtMS: nowMS,
+	}); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	messages, err := sqlite.NewMessageRepository(store, now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	counters := &ingest.Counters{}
+	worker, err := ingest.NewWorker(ingest.WorkerConfig{
+		Store:    store,
+		Messages: messages,
+		Counters: counters,
+		Logger:   zerolog.Nop(),
+		Decoders: []ingest.DecoderRegistration{{
+			Codec:    ingest.GoogleCodec,
+			Platform: bridge.PlatformGoogle,
+			Decoder:  ingest.NewGoogleDecoder(counters),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewWorker(): %v", err)
+	}
+	sink, err := ingest.NewSink(ingest.SinkConfig{
+		Messages: messages,
+		Worker:   worker,
+		Counters: counters,
+	})
+	if err != nil {
+		t.Fatalf("NewSink(): %v", err)
+	}
+	workerCtx, cancelWorker := context.WithCancel(context.Background())
+	workerDone := make(chan error, 1)
+	go func() { workerDone <- worker.Run(workerCtx) }()
+	t.Cleanup(func() {
+		cancelWorker()
+		select {
+		case runErr := <-workerDone:
+			if runErr != nil {
+				t.Errorf("Worker.Run(): %v", runErr)
+			}
+		case <-time.After(time.Second):
+			t.Error("Worker.Run() did not stop")
+		}
+	})
+
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 21,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+
+	message := &gmproto.Message{
+		MessageID:      "real-sink-message",
+		ConversationID: "real-sink-conversation",
+		Timestamp:      1_750_000_000_000_000,
+		MessageStatus:  &gmproto.MessageStatus{Status: gmproto.MessageStatusType_INCOMING_COMPLETE},
+		SenderParticipant: &gmproto.Participant{
+			FullName: "Ada",
+			ID:       &gmproto.SmallInfo{Number: "+15551234567"},
+		},
+		MessageInfo: []*gmproto.MessageInfo{{
+			Data: &gmproto.MessageInfo_MessageContent{
+				MessageContent: &gmproto.MessageContent{Content: "same body"},
+			},
+		}},
+	}
+	frame := &libgm.WrappedMessage{Message: message}
+	fake.emit(frame)
+	fake.emit(frame)
+	changed := proto.Clone(message).(*gmproto.Message)
+	changed.MessageStatus.SubCode = 1
+	fake.emit(&libgm.WrappedMessage{Message: changed})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := counters.Snapshot("google-primary")
+		if snapshot.Appended == 2 && snapshot.Deduped == 1 && snapshot.Projected >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	snapshot := counters.Snapshot("google-primary")
+	if snapshot.Appended != 2 || snapshot.Deduped != 1 || snapshot.Projected < 2 {
+		t.Fatalf("real sink counters = %+v", snapshot)
+	}
+
+	inspection, err := sql.Open("sqlite", storePath)
+	if err != nil {
+		t.Fatalf("sql.Open(): %v", err)
+	}
+	defer inspection.Close()
+	for table, want := range map[string]int{"inbox": 2, "messages": 1} {
+		var got int
+		if err := inspection.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&got); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if got != want {
+			t.Fatalf("%s rows = %d, want %d", table, got, want)
+		}
+	}
+}
+
+func TestIngressTeeConversationEnvelope(t *testing.T) {
+	host := newTestApp(t)
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	sink := &recordingSink{}
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 4,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+
+	conversation := &gmproto.Conversation{
+		ConversationID: "conversation-1",
+		Name:           "Family",
+		IsGroupChat:    true,
+	}
+	fake.emit(conversation)
+
+	records := sink.ingressRecords()
+	if len(records) != 1 {
+		t.Fatalf("AppendIngress calls = %d, want 1", len(records))
+	}
+	var envelope struct {
+		Kind  string          `json:"kind"`
+		Proto []byte          `json:"proto_b64"`
+		IsOld json.RawMessage `json:"is_old"`
+	}
+	if err := json.Unmarshal(records[0].Payload, &envelope); err != nil {
+		t.Fatalf("decode conversation envelope: %v", err)
+	}
+	if envelope.Kind != "conversation" {
+		t.Fatalf("envelope kind = %q, want conversation", envelope.Kind)
+	}
+	if envelope.IsOld != nil {
+		t.Fatalf("conversation envelope unexpectedly included is_old: %s", envelope.IsOld)
+	}
+	var roundTrip gmproto.Conversation
+	if err := proto.Unmarshal(envelope.Proto, &roundTrip); err != nil {
+		t.Fatalf("unmarshal teed conversation proto: %v", err)
+	}
+	if !proto.Equal(&roundTrip, conversation) {
+		t.Fatalf("teed proto = %v, want %v", &roundTrip, conversation)
+	}
+	digest := sha256.Sum256(envelope.Proto)
+	wantKey := "conv:conversation-1:" + hex.EncodeToString(digest[:4])
+	if records[0].DedupeKey != wantKey {
+		t.Fatalf("dedupe key = %q, want %q", records[0].DedupeKey, wantKey)
+	}
+}
+
+func TestIngressTeeRoutesTypingButNotLifecycleEvents(t *testing.T) {
+	host := newTestApp(t)
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	sink := &recordingSink{}
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 9,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+
+	fake.emit(&gmproto.TypingData{
+		ConversationID: "conversation-typing",
+		User:           &gmproto.User{Number: "+15551234567"},
+		Type:           gmproto.TypingTypes_STARTED_TYPING,
+	})
+	fake.emit(&events.PhoneRespondingAgain{})
+
+	if records := sink.ingressRecords(); len(records) != 0 {
+		t.Fatalf("durable ingress records = %d, want 0 for typing/lifecycle events", len(records))
+	}
+	ephemeral := sink.ephemeralEvents()
+	if len(ephemeral) != 1 {
+		t.Fatalf("EmitEphemeral calls = %d, want 1", len(ephemeral))
+	}
+	got := ephemeral[0]
+	if got.AccountID != "google-primary" || got.Generation != 9 || got.Typing == nil {
+		t.Fatalf("ephemeral ownership/payload = %#v", got)
+	}
+	if got.Typing.RemoteConversationID != "conversation-typing" ||
+		got.Typing.Actor.Raw != "+15551234567" || !got.Typing.Typing {
+		t.Fatalf("typing payload = %#v", got.Typing)
+	}
+}
+
+func TestIngressTeeAppendErrorDoesNotInterruptLegacyHandler(t *testing.T) {
+	host := newTestApp(t)
+	legacyHandled := 0
+	host.OnConversationsChange = func() { legacyHandled++ }
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	sink := &recordingSink{appendErr: errors.New("inbox unavailable")}
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 12,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+
+	fake.emit(&gmproto.Conversation{ConversationID: "legacy-still-runs", Name: "Legacy"})
+
+	if legacyHandled != 1 {
+		t.Fatalf("legacy conversation callbacks = %d, want 1", legacyHandled)
+	}
+	if got := a.IngressErrorCount(); got != 1 {
+		t.Fatalf("recorded ingress errors = %d, want 1", got)
+	}
+	if records := sink.ingressRecords(); len(records) != 1 {
+		t.Fatalf("AppendIngress calls = %d, want 1", len(records))
+	}
+	select {
+	case terminal := <-run.Done():
+		t.Fatalf("tee error ended the generation: %v", terminal)
+	default:
+	}
+}
+
+func TestIngressTeeAppendPanicDoesNotInterruptLegacyHandler(t *testing.T) {
+	host := newTestApp(t)
+	legacyHandled := 0
+	host.OnConversationsChange = func() { legacyHandled++ }
+	fake := &fakeTransport{}
+	a := newTestAdapter(t, host, fake)
+	sink := &recordingSink{appendPanic: "inbox panic"}
+	run, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "google-primary",
+		Generation: 13,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, run) })
+
+	fake.emit(&gmproto.Conversation{ConversationID: "legacy-survives-panic", Name: "Legacy"})
+
+	if legacyHandled != 1 {
+		t.Fatalf("legacy conversation callbacks = %d, want 1", legacyHandled)
+	}
+	if got := a.IngressErrorCount(); got != 1 {
+		t.Fatalf("recorded ingress errors = %d, want 1", got)
+	}
+	select {
+	case terminal := <-run.Done():
+		t.Fatalf("tee panic ended the generation: %v", terminal)
+	default:
+	}
+}
+
 func newTestApp(t *testing.T) *app.App {
 	t.Helper()
 	t.Setenv("OPENMESSAGES_DATA_DIR", t.TempDir())
@@ -523,13 +887,32 @@ func (f *fakeTransport) probeCount() int {
 }
 
 type recordingSink struct {
-	mu    sync.Mutex
-	beats int
+	mu           sync.Mutex
+	beats        int
+	records      []bridge.RawIngressRecord
+	ephemeral    []bridge.EphemeralEvent
+	appendErr    error
+	appendPanic  any
+	ephemeralErr error
 }
 
-func (*recordingSink) AppendIngress(context.Context, bridge.RawIngressRecord) error { return nil }
+func (s *recordingSink) AppendIngress(_ context.Context, record bridge.RawIngressRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record.Payload = bytes.Clone(record.Payload)
+	s.records = append(s.records, record)
+	if s.appendPanic != nil {
+		panic(s.appendPanic)
+	}
+	return s.appendErr
+}
 
-func (*recordingSink) EmitEphemeral(context.Context, bridge.EphemeralEvent) error { return nil }
+func (s *recordingSink) EmitEphemeral(_ context.Context, event bridge.EphemeralEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ephemeral = append(s.ephemeral, event)
+	return s.ephemeralErr
+}
 
 func (s *recordingSink) Beat(bridge.Generation, time.Time, string) {
 	s.mu.Lock()
@@ -542,4 +925,21 @@ func (s *recordingSink) beatCount() int {
 	count := s.beats
 	s.mu.Unlock()
 	return count
+}
+
+func (s *recordingSink) ingressRecords() []bridge.RawIngressRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records := make([]bridge.RawIngressRecord, len(s.records))
+	for i, record := range s.records {
+		record.Payload = bytes.Clone(record.Payload)
+		records[i] = record
+	}
+	return records
+}
+
+func (s *recordingSink) ephemeralEvents() []bridge.EphemeralEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]bridge.EphemeralEvent(nil), s.ephemeral...)
 }

--- a/internal/ingest/counters.go
+++ b/internal/ingest/counters.go
@@ -10,43 +10,47 @@ import (
 // EchoErrors counts reconcile faults that were absorbed without blocking
 // projection of the inbound message.
 type CounterSnapshot struct {
-	Appended         uint64 `json:"appended"`
-	Deduped          uint64 `json:"deduped"`
-	DecodedEvents    uint64 `json:"decoded_events"`
-	Projected        uint64 `json:"projected"`
-	Imported         uint64 `json:"imported"`
-	Mutations        uint64 `json:"mutations"`
-	ReactionsDropped uint64 `json:"reactions_dropped"`
-	ReceiptsSelf     uint64 `json:"receipts_self"`
-	ReceiptsDropped  uint64 `json:"receipts_dropped"`
-	Quarantined      uint64 `json:"quarantined"`
-	StaleReplays     uint64 `json:"stale_replays"`
-	EchoReconciled   uint64 `json:"echo_reconciled"`
-	EchoEnriched     uint64 `json:"echo_enriched"`
-	EchoNoop         uint64 `json:"echo_noop"`
-	EchoNotFound     uint64 `json:"echo_notfound"`
-	EchoErrors       uint64 `json:"echo_errors"`
-	Ephemeral        uint64 `json:"ephemeral"`
+	Appended          uint64 `json:"appended"`
+	Deduped           uint64 `json:"deduped"`
+	DecodedEvents     uint64 `json:"decoded_events"`
+	Projected         uint64 `json:"projected"`
+	Imported          uint64 `json:"imported"`
+	Mutations         uint64 `json:"mutations"`
+	ReactionsDropped  uint64 `json:"reactions_dropped"`
+	TapbackMessages   uint64 `json:"tapback_messages"`
+	EmptyStubsSkipped uint64 `json:"empty_stubs_skipped"`
+	ReceiptsSelf      uint64 `json:"receipts_self"`
+	ReceiptsDropped   uint64 `json:"receipts_dropped"`
+	Quarantined       uint64 `json:"quarantined"`
+	StaleReplays      uint64 `json:"stale_replays"`
+	EchoReconciled    uint64 `json:"echo_reconciled"`
+	EchoEnriched      uint64 `json:"echo_enriched"`
+	EchoNoop          uint64 `json:"echo_noop"`
+	EchoNotFound      uint64 `json:"echo_notfound"`
+	EchoErrors        uint64 `json:"echo_errors"`
+	Ephemeral         uint64 `json:"ephemeral"`
 }
 
 type accountCounters struct {
-	appended         atomic.Uint64
-	deduped          atomic.Uint64
-	decodedEvents    atomic.Uint64
-	projected        atomic.Uint64
-	imported         atomic.Uint64
-	mutations        atomic.Uint64
-	reactionsDropped atomic.Uint64
-	receiptsSelf     atomic.Uint64
-	receiptsDropped  atomic.Uint64
-	quarantined      atomic.Uint64
-	staleReplays     atomic.Uint64
-	echoReconciled   atomic.Uint64
-	echoEnriched     atomic.Uint64
-	echoNoop         atomic.Uint64
-	echoNotFound     atomic.Uint64
-	echoErrors       atomic.Uint64
-	ephemeral        atomic.Uint64
+	appended          atomic.Uint64
+	deduped           atomic.Uint64
+	decodedEvents     atomic.Uint64
+	projected         atomic.Uint64
+	imported          atomic.Uint64
+	mutations         atomic.Uint64
+	reactionsDropped  atomic.Uint64
+	tapbackMessages   atomic.Uint64
+	emptyStubsSkipped atomic.Uint64
+	receiptsSelf      atomic.Uint64
+	receiptsDropped   atomic.Uint64
+	quarantined       atomic.Uint64
+	staleReplays      atomic.Uint64
+	echoReconciled    atomic.Uint64
+	echoEnriched      atomic.Uint64
+	echoNoop          atomic.Uint64
+	echoNotFound      atomic.Uint64
+	echoErrors        atomic.Uint64
+	ephemeral         atomic.Uint64
 }
 
 // Counters owns atomic ingest counters partitioned by account. Its zero value
@@ -107,22 +111,24 @@ func snapshotCounters(c *accountCounters) CounterSnapshot {
 		return CounterSnapshot{}
 	}
 	return CounterSnapshot{
-		Appended:         c.appended.Load(),
-		Deduped:          c.deduped.Load(),
-		DecodedEvents:    c.decodedEvents.Load(),
-		Projected:        c.projected.Load(),
-		Imported:         c.imported.Load(),
-		Mutations:        c.mutations.Load(),
-		ReactionsDropped: c.reactionsDropped.Load(),
-		ReceiptsSelf:     c.receiptsSelf.Load(),
-		ReceiptsDropped:  c.receiptsDropped.Load(),
-		Quarantined:      c.quarantined.Load(),
-		StaleReplays:     c.staleReplays.Load(),
-		EchoReconciled:   c.echoReconciled.Load(),
-		EchoEnriched:     c.echoEnriched.Load(),
-		EchoNoop:         c.echoNoop.Load(),
-		EchoNotFound:     c.echoNotFound.Load(),
-		EchoErrors:       c.echoErrors.Load(),
-		Ephemeral:        c.ephemeral.Load(),
+		Appended:          c.appended.Load(),
+		Deduped:           c.deduped.Load(),
+		DecodedEvents:     c.decodedEvents.Load(),
+		Projected:         c.projected.Load(),
+		Imported:          c.imported.Load(),
+		Mutations:         c.mutations.Load(),
+		ReactionsDropped:  c.reactionsDropped.Load(),
+		TapbackMessages:   c.tapbackMessages.Load(),
+		EmptyStubsSkipped: c.emptyStubsSkipped.Load(),
+		ReceiptsSelf:      c.receiptsSelf.Load(),
+		ReceiptsDropped:   c.receiptsDropped.Load(),
+		Quarantined:       c.quarantined.Load(),
+		StaleReplays:      c.staleReplays.Load(),
+		EchoReconciled:    c.echoReconciled.Load(),
+		EchoEnriched:      c.echoEnriched.Load(),
+		EchoNoop:          c.echoNoop.Load(),
+		EchoNotFound:      c.echoNotFound.Load(),
+		EchoErrors:        c.echoErrors.Load(),
+		Ephemeral:         c.ephemeral.Load(),
 	}
 }

--- a/internal/ingest/counters_test.go
+++ b/internal/ingest/counters_test.go
@@ -27,6 +27,8 @@ func TestCountersAreAtomicAndAccountScoped(t *testing.T) {
 	}
 	wait.Wait()
 	counters.account("account-b").ephemeral.Add(1)
+	counters.account("account-b").tapbackMessages.Add(2)
+	counters.account("account-b").emptyStubsSkipped.Add(3)
 
 	want := uint64(workers * increments)
 	accountA := counters.Snapshot("account-a")
@@ -34,8 +36,9 @@ func TestCountersAreAtomicAndAccountScoped(t *testing.T) {
 		t.Fatalf("account-a snapshot = %+v, want appended=%d decoded_events=%d", accountA, want, 2*want)
 	}
 	accountB := counters.Snapshot("account-b")
-	if accountB.Ephemeral != 1 || accountB.Appended != 0 {
-		t.Fatalf("account-b snapshot = %+v, want only one ephemeral event", accountB)
+	if accountB.Ephemeral != 1 || accountB.TapbackMessages != 2 || accountB.EmptyStubsSkipped != 3 ||
+		accountB.Appended != 0 {
+		t.Fatalf("account-b snapshot = %+v, want additive ingest counters", accountB)
 	}
 	if missing := counters.Snapshot("missing"); missing != (CounterSnapshot{}) {
 		t.Fatalf("missing account snapshot = %+v, want zero value", missing)

--- a/internal/ingest/google_echo_e2e_test.go
+++ b/internal/ingest/google_echo_e2e_test.go
@@ -1,0 +1,804 @@
+package ingest
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2wire"
+)
+
+const (
+	googleEchoAccountID            = "google-primary"
+	googleEchoConversationID       = "google-echo-conversation"
+	googleEchoRemoteConversationID = "google-remote-conversation"
+)
+
+var googleEchoNow = time.Date(2026, time.July, 17, 16, 0, 0, 0, time.UTC)
+
+func TestGoogleEchoEndToEndOrderAEnrichesPlaceholder(t *testing.T) {
+	harness := newGoogleEchoHarness(t, nil)
+	submission, requestID := harness.enqueueAndConfirm(t, "order-a", "hello from v2")
+
+	const permanentID = "google-permanent-order-a"
+	harness.appendMessage(t, googleEchoMessage(
+		permanentID,
+		requestID,
+		"hello from v2",
+		true,
+		googleEchoNow.Add(time.Minute),
+	))
+	harness.waitFor(t, "Order-A echo enrichment and projection", func(snapshot CounterSnapshot) bool {
+		return snapshot.EchoEnriched == 1 && snapshot.Projected == 1
+	})
+
+	harness.assertSinglePermanentMessage(t, submission.LocalMessageID, requestID, permanentID)
+	delivery, err := harness.service.Get(context.Background(), submission.OutboxID)
+	if err != nil {
+		t.Fatalf("MessageService.Get(): %v", err)
+	}
+	if delivery.State != messaging.OutboxConfirmed || delivery.RemoteMessageID != permanentID {
+		t.Fatalf("delivery after echo = %+v, want confirmed at %q", delivery, permanentID)
+	}
+}
+
+func TestGoogleEchoEndToEndOrderBEchoFirstReplayConverges(t *testing.T) {
+	harness := newGoogleEchoHarness(t, nil)
+	submission, requestID := harness.enqueue(t, "order-b", "echo wins the first race")
+
+	const permanentID = "google-permanent-order-b"
+	record := harness.messageRecord(t, googleEchoMessage(
+		permanentID,
+		requestID,
+		"echo wins the first race",
+		true,
+		googleEchoNow.Add(2*time.Minute),
+	))
+	harness.appendRecord(t, record)
+	harness.waitFor(t, "Order-B initial echo projection", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 1 && snapshot.EchoNoop == 1
+	})
+	if got := harness.countV2Messages(t); got != 2 {
+		t.Fatalf("messages after echo outran confirm = %d, want optimistic plus echoed rows", got)
+	}
+
+	// A Google send confirms provisionally with result_remote_id equal to its
+	// transport request ID, so Confirm alone does not converge the two rows: the
+	// repoint early-returns because the "real" id is still the request id.
+	// Convergence is driven by re-delivery of the echo, which production
+	// guarantees — Google re-delivers the same MessageID on every status
+	// transition (sent -> delivered -> read), and the content hash in the dedupe
+	// key lets those changed frames through. Re-delivery then takes the enrich
+	// path: it deletes the projected collision, preserves the optimistic local
+	// row, and the ensuing processed-inbox projection is a benign stale conflict.
+	harness.confirm(t, submission.OutboxID)
+	harness.appendRecord(t, record)
+	harness.waitFor(t, "Order-B collision cleanup and stale replay", func(snapshot CounterSnapshot) bool {
+		return snapshot.EchoEnriched == 1 && snapshot.StaleReplays == 1
+	})
+
+	harness.assertSinglePermanentMessage(t, submission.LocalMessageID, requestID, permanentID)
+	if snapshot := harness.counters.Snapshot(googleEchoAccountID); snapshot.Deduped != 1 {
+		t.Fatalf("Order-B counters = %+v, want one deduplicated frame replay", snapshot)
+	}
+}
+
+func TestGoogleEchoUnknownTmpIDsAreSuccessfulNoops(t *testing.T) {
+	tests := []struct {
+		name  string
+		tmpID string
+		body  string
+	}{
+		{name: "phone-originated", tmpID: "phone-originated-request", body: "sent from the phone"},
+		{name: "media-caption-second-payload", tmpID: "reqid:caption", body: "photo caption"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			harness := newGoogleEchoHarness(t, nil)
+			remoteID := "google-" + test.name
+			harness.appendMessage(t, googleEchoMessage(
+				remoteID,
+				test.tmpID,
+				test.body,
+				true,
+				googleEchoNow.Add(3*time.Minute),
+			))
+			harness.waitFor(t, "unknown TmpID projection", func(snapshot CounterSnapshot) bool {
+				return snapshot.EchoNotFound == 1 && snapshot.Projected == 1
+			})
+
+			message, err := harness.messages.GetMessageByRemote(
+				context.Background(),
+				googleEchoAccountID,
+				googleEchoConversationID,
+				remoteID,
+			)
+			if err != nil {
+				t.Fatalf("GetMessageByRemote(): %v", err)
+			}
+			if message.Body != test.body || message.Direction != sqlite.MessageDirectionOutgoing {
+				t.Fatalf("projected message = %+v", message)
+			}
+			if got := harness.countV2Messages(t); got != 1 {
+				t.Fatalf("messages = %d, want one normally projected message", got)
+			}
+		})
+	}
+}
+
+func TestGoogleIngestDoesNotFeedLegacyProjector(t *testing.T) {
+	harness := newGoogleEchoHarness(t, nil)
+	legacy, err := db.New(filepath.Join(t.TempDir(), "legacy.sqlite3"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+
+	harness.appendMessage(t, googleEchoMessage(
+		"google-inbound-no-feedback",
+		"",
+		"inbound must stay v2-only",
+		false,
+		googleEchoNow.Add(4*time.Minute),
+	))
+	harness.waitFor(t, "inbound projection", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 1
+	})
+	if got := harness.countOutboxRows(t); got != 0 {
+		t.Fatalf("outbox rows after inbound ingest = %d, want zero", got)
+	}
+
+	outbox, err := sqlite.NewOutboxRepository(harness.store, harness.clock.Now)
+	if err != nil {
+		t.Fatalf("NewOutboxRepository(): %v", err)
+	}
+	projector := &v2wire.Projector{
+		V2Store: harness.store,
+		Outbox:  outbox,
+		Legacy:  legacy,
+		Blobs:   harness.blobs,
+		Service: harness.service,
+		Logger:  zerolog.Nop(),
+		Now:     harness.clock.Now,
+	}
+	projectorCtx, cancelProjector := context.WithCancel(context.Background())
+	projectorDone := make(chan error, 1)
+	go func() { projectorDone <- projector.Run(projectorCtx) }()
+	// Run scans immediately. Once it remains alive, it has reached its wait
+	// loop with an empty confirmed-outbox selection.
+	time.Sleep(25 * time.Millisecond)
+	select {
+	case err := <-projectorDone:
+		t.Fatalf("Projector.Run() returned before cancellation: %v", err)
+	default:
+	}
+	cancelProjector()
+	if err := <-projectorDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Projector.Run() error = %v, want context.Canceled", err)
+	}
+	if got, err := legacy.MessageCount(""); err != nil {
+		t.Fatalf("legacy MessageCount(): %v", err)
+	} else if got != 0 {
+		t.Fatalf("legacy messages after v2 inbound projection = %d, want zero", got)
+	}
+}
+
+func TestGoogleFrameDedupeAndContentHash(t *testing.T) {
+	harness := newGoogleEchoHarness(t, nil)
+	first := harness.messageRecord(t, googleEchoMessage(
+		"google-content-hash",
+		"",
+		"first content",
+		false,
+		googleEchoNow.Add(5*time.Minute),
+	))
+	harness.appendRecord(t, first)
+	harness.waitFor(t, "first frame", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 1
+	})
+	harness.appendRecord(t, first)
+	harness.waitFor(t, "exact replay dedupe", func(snapshot CounterSnapshot) bool {
+		return snapshot.Deduped == 1
+	})
+	if got := harness.countInboxRows(t); got != 1 {
+		t.Fatalf("inbox rows after exact replay = %d, want one", got)
+	}
+
+	changed := harness.messageRecord(t, googleEchoMessage(
+		"google-content-hash",
+		"",
+		"changed content",
+		false,
+		googleEchoNow.Add(5*time.Minute),
+	))
+	if changed.DedupeKey == first.DedupeKey {
+		t.Fatalf("changed same-ID frames share dedupe key %q", changed.DedupeKey)
+	}
+	harness.appendRecord(t, changed)
+	harness.waitFor(t, "changed frame append", func(snapshot CounterSnapshot) bool {
+		return snapshot.Appended == 2 && snapshot.Projected >= 3
+	})
+	if got := harness.countInboxRows(t); got != 2 {
+		t.Fatalf("inbox rows after changed same-ID frame = %d, want two", got)
+	}
+	if got := harness.countV2Messages(t); got != 1 {
+		t.Fatalf("messages after changed same-ID frame = %d, want one natural-key row", got)
+	}
+	message, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		googleEchoAccountID,
+		googleEchoConversationID,
+		"google-content-hash",
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(): %v", err)
+	}
+	if message.Body != "changed content" {
+		t.Fatalf("message body = %q, want changed content", message.Body)
+	}
+}
+
+func TestGoogleDecoderPanicIsQuarantinedAndWorkerContinues(t *testing.T) {
+	counters := &Counters{}
+	decoder := &panicOnMalformedGoogleDecoder{delegate: NewGoogleDecoder(counters)}
+	harness := newGoogleEchoHarness(t, decoder)
+	harness.appendRecord(t, bridge.RawIngressRecord{
+		AccountID:    googleEchoAccountID,
+		Generation:   1,
+		DedupeKey:    "malformed-google-envelope",
+		Codec:        GoogleCodec,
+		CodecVersion: GoogleCodecVersion,
+		ReceivedAt:   googleEchoNow,
+		Payload:      []byte(`{"kind":"message","proto_b64":`),
+	})
+	harness.waitFor(t, "decoder panic quarantine", func(snapshot CounterSnapshot) bool {
+		return snapshot.Quarantined == 1
+	})
+
+	harness.appendMessage(t, googleEchoMessage(
+		"google-after-decoder-panic",
+		"",
+		"worker stayed alive",
+		false,
+		googleEchoNow.Add(6*time.Minute),
+	))
+	harness.waitFor(t, "projection after decoder panic", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 1
+	})
+	if pending, err := harness.messages.Unprocessed(context.Background()); err != nil {
+		t.Fatalf("Unprocessed(): %v", err)
+	} else if len(pending) != 0 {
+		t.Fatalf("unprocessed frames = %+v, want panic quarantined and valid frame processed", pending)
+	}
+}
+
+type googleEchoHarness struct {
+	store     *sqlite.Store
+	storePath string
+	messages  *sqlite.MessageRepository
+	service   *messaging.MessageService
+	sink      *Sink
+	worker    *Worker
+	counters  *Counters
+	clock     *googleEchoClock
+	blobs     *blob.BlobStore
+	done      chan error
+	cancel    context.CancelFunc
+}
+
+func newGoogleEchoHarness(t *testing.T, decoder bridge.Decoder) *googleEchoHarness {
+	t.Helper()
+	storePath := filepath.Join(t.TempDir(), "v2.sqlite3")
+	store, err := sqlite.Open(storePath)
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	clock := &googleEchoClock{now: googleEchoNow}
+	seedGoogleEchoStore(t, store, clock.Now())
+	blobs, err := blob.New(filepath.Join(t.TempDir(), "blobs"))
+	if err != nil {
+		t.Fatalf("blob.New(): %v", err)
+	}
+	sender := &googleEchoTextSender{clock: clock}
+	service, err := messaging.NewMessageService(
+		store,
+		&googleEchoRegistry{sender: sender},
+		blobs,
+		clock,
+		&googleEchoIDs{},
+	)
+	if err != nil {
+		t.Fatalf("NewMessageService(): %v", err)
+	}
+	messages, err := sqlite.NewMessageRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	counters := &Counters{}
+	if decoder == nil {
+		decoder = NewGoogleDecoder(counters)
+	}
+	worker, err := NewWorker(WorkerConfig{
+		Store:        store,
+		Messages:     messages,
+		EchoObserver: service,
+		Counters:     counters,
+		Logger:       zerolog.Nop(),
+		Now:          clock.Now,
+		Decoders: []DecoderRegistration{{
+			Codec:    GoogleCodec,
+			Platform: bridge.PlatformGoogle,
+			Decoder:  decoder,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewWorker(): %v", err)
+	}
+	sink, err := NewSink(SinkConfig{
+		Messages: messages,
+		Worker:   worker,
+		Counters: counters,
+		IDs:      &googleEchoIDs{prefix: "inbox"},
+	})
+	if err != nil {
+		t.Fatalf("NewSink(): %v", err)
+	}
+	workerCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- worker.Run(workerCtx) }()
+
+	harness := &googleEchoHarness{
+		store:     store,
+		storePath: storePath,
+		messages:  messages,
+		service:   service,
+		sink:      sink,
+		worker:    worker,
+		counters:  counters,
+		clock:     clock,
+		blobs:     blobs,
+		done:      done,
+		cancel:    cancel,
+	}
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Worker.Run() cleanup error: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("Worker.Run() did not stop")
+		}
+		if err := store.Close(); err != nil {
+			t.Errorf("Store.Close(): %v", err)
+		}
+	})
+	return harness
+}
+
+func seedGoogleEchoStore(t *testing.T, store *sqlite.Store, now time.Time) {
+	t.Helper()
+	nowMS := now.UnixMilli()
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   googleEchoAccountID,
+		BridgeKey:   "google_messages",
+		DisplayName: "Google Messages",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: nowMS,
+		UpdatedAtMS: nowMS,
+	}); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	if err := store.UpsertConversation(sqlite.Conversation{
+		ConversationID:       googleEchoConversationID,
+		AccountID:            googleEchoAccountID,
+		RemoteConversationID: googleEchoRemoteConversationID,
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Echo test",
+		NotificationMode:     sqlite.NotificationModeAll,
+		MetadataJSON:         `{}`,
+		CreatedAtMS:          nowMS,
+		UpdatedAtMS:          nowMS,
+	}); err != nil {
+		t.Fatalf("UpsertConversation(): %v", err)
+	}
+}
+
+func (h *googleEchoHarness) enqueue(t *testing.T, key, body string) (messaging.Submission, string) {
+	t.Helper()
+	submission, err := h.service.SendText(context.Background(), messaging.SendTextCommand{
+		CommonCommand: messaging.CommonCommand{
+			AccountID:      googleEchoAccountID,
+			ConversationID: googleEchoConversationID,
+			IdempotencyKey: "google-echo-" + key,
+		},
+		Body: body,
+	})
+	if err != nil {
+		t.Fatalf("MessageService.SendText(): %v", err)
+	}
+	outbox, err := sqlite.NewOutboxRepository(h.store, h.clock.Now)
+	if err != nil {
+		t.Fatalf("NewOutboxRepository(): %v", err)
+	}
+	item, err := outbox.FindByID(context.Background(), submission.OutboxID)
+	if err != nil {
+		t.Fatalf("FindByID(): %v", err)
+	}
+	return submission, item.TransportRequestID
+}
+
+func (h *googleEchoHarness) enqueueAndConfirm(
+	t *testing.T,
+	key string,
+	body string,
+) (messaging.Submission, string) {
+	t.Helper()
+	submission, requestID := h.enqueue(t, key, body)
+	h.confirm(t, submission.OutboxID)
+	return submission, requestID
+}
+
+func (h *googleEchoHarness) confirm(t *testing.T, outboxID string) {
+	t.Helper()
+	processed, err := h.service.DispatchDue(context.Background(), 1)
+	if err != nil || processed != 1 {
+		t.Fatalf("DispatchDue() = %d, %v; want 1, nil", processed, err)
+	}
+	delivery, err := h.service.Get(context.Background(), outboxID)
+	if err != nil {
+		t.Fatalf("MessageService.Get(): %v", err)
+	}
+	if delivery.State != messaging.OutboxConfirmed || delivery.RemoteMessageID == "" {
+		t.Fatalf("provisional delivery = %+v, want confirmed with request ID", delivery)
+	}
+}
+
+func (h *googleEchoHarness) appendMessage(t *testing.T, message *gmproto.Message) {
+	t.Helper()
+	h.appendRecord(t, h.messageRecord(t, message))
+}
+
+func (h *googleEchoHarness) appendRecord(t *testing.T, record bridge.RawIngressRecord) {
+	t.Helper()
+	if err := h.sink.AppendIngress(context.Background(), record); err != nil {
+		t.Fatalf("AppendIngress(): %v", err)
+	}
+}
+
+func (h *googleEchoHarness) messageRecord(
+	t *testing.T,
+	message *gmproto.Message,
+) bridge.RawIngressRecord {
+	t.Helper()
+	protoBytes, err := proto.Marshal(message)
+	if err != nil {
+		t.Fatalf("proto.Marshal(): %v", err)
+	}
+	payload, err := json.Marshal(struct {
+		Kind     string `json:"kind"`
+		ProtoB64 []byte `json:"proto_b64"`
+		IsOld    bool   `json:"is_old"`
+	}{
+		Kind:     "message",
+		ProtoB64: protoBytes,
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(): %v", err)
+	}
+	hash := sha256.Sum256(protoBytes)
+	return bridge.RawIngressRecord{
+		AccountID:    googleEchoAccountID,
+		Generation:   1,
+		DedupeKey:    "msg:" + message.GetMessageID() + ":" + hex.EncodeToString(hash[:])[:8],
+		Codec:        GoogleCodec,
+		CodecVersion: GoogleCodecVersion,
+		ReceivedAt:   googleEchoNow,
+		Payload:      payload,
+	}
+}
+
+func googleEchoMessage(
+	remoteID string,
+	tmpID string,
+	body string,
+	fromMe bool,
+	occurredAt time.Time,
+) *gmproto.Message {
+	participant := &gmproto.Participant{
+		IsMe:     fromMe,
+		FullName: "Echo Sender",
+		ID:       &gmproto.SmallInfo{Number: "+15551234567"},
+	}
+	status := gmproto.MessageStatusType_INCOMING_COMPLETE
+	if fromMe {
+		status = gmproto.MessageStatusType_OUTGOING_COMPLETE
+	}
+	return &gmproto.Message{
+		MessageID:         remoteID,
+		ConversationID:    googleEchoRemoteConversationID,
+		TmpID:             tmpID,
+		Timestamp:         occurredAt.UnixMilli() * 1000,
+		SenderParticipant: participant,
+		MessageStatus:     &gmproto.MessageStatus{Status: status},
+		MessageInfo: []*gmproto.MessageInfo{{
+			Data: &gmproto.MessageInfo_MessageContent{
+				MessageContent: &gmproto.MessageContent{Content: body},
+			},
+		}},
+	}
+}
+
+func (h *googleEchoHarness) waitFor(
+	t *testing.T,
+	description string,
+	condition func(CounterSnapshot) bool,
+) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := h.counters.Snapshot(googleEchoAccountID)
+		if condition(snapshot) {
+			return
+		}
+		select {
+		case err := <-h.done:
+			t.Fatalf("Worker.Run() stopped while waiting for %s: %v", description, err)
+		default:
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s; counters=%+v", description, h.counters.Snapshot(googleEchoAccountID))
+}
+
+func (h *googleEchoHarness) assertSinglePermanentMessage(
+	t *testing.T,
+	wantLocalID string,
+	placeholderID string,
+	permanentID string,
+) {
+	t.Helper()
+	message, err := h.messages.GetMessageByRemote(
+		context.Background(),
+		googleEchoAccountID,
+		googleEchoConversationID,
+		permanentID,
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(permanent): %v", err)
+	}
+	if message.MessageID != wantLocalID || message.RemoteMessageID != permanentID {
+		t.Fatalf("permanent message = %+v, want local %q remote %q", message, wantLocalID, permanentID)
+	}
+	if _, err := h.messages.GetMessageByRemote(
+		context.Background(),
+		googleEchoAccountID,
+		googleEchoConversationID,
+		placeholderID,
+	); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("GetMessageByRemote(placeholder) error = %v, want ErrNotFound", err)
+	}
+	if got := h.countV2Messages(t); got != 1 {
+		t.Fatalf("messages after convergence = %d, want exactly one", got)
+	}
+}
+
+func (h *googleEchoHarness) countV2Messages(t *testing.T) int {
+	t.Helper()
+	return countSQLiteRows(t, h.storePath,
+		"SELECT COUNT(*) FROM messages WHERE account_id = ? AND conversation_id = ?",
+		googleEchoAccountID,
+		googleEchoConversationID,
+	)
+}
+
+func (h *googleEchoHarness) countInboxRows(t *testing.T) int {
+	t.Helper()
+	return countSQLiteRows(t, h.storePath,
+		"SELECT COUNT(*) FROM inbox WHERE account_id = ?",
+		googleEchoAccountID,
+	)
+}
+
+func (h *googleEchoHarness) countOutboxRows(t *testing.T) int {
+	t.Helper()
+	return countSQLiteRows(t, h.storePath,
+		"SELECT COUNT(*) FROM outbox WHERE account_id = ?",
+		googleEchoAccountID,
+	)
+}
+
+func countSQLiteRows(t *testing.T, path, query string, args ...any) int {
+	t.Helper()
+	inspection, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open(inspect): %v", err)
+	}
+	defer inspection.Close()
+	var count int
+	if err := inspection.QueryRow(query, args...).Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	return count
+}
+
+type googleEchoTextSender struct {
+	clock *googleEchoClock
+}
+
+func (s *googleEchoTextSender) SendText(
+	_ context.Context,
+	request bridge.TextRequest,
+) (bridge.SendResult, error) {
+	return bridge.SendResult{
+		RemoteMessageID: request.RequestID,
+		AcceptedAt:      s.clock.Now(),
+		EchoExpected:    true,
+	}, nil
+}
+
+type googleEchoRegistry struct {
+	sender bridge.TextSender
+}
+
+func (r *googleEchoRegistry) Snapshot(accountID string) (bridge.Snapshot, bool) {
+	if accountID != googleEchoAccountID {
+		return bridge.Snapshot{}, false
+	}
+	return bridge.Snapshot{
+		AccountID: googleEchoAccountID,
+		Platform:  bridge.PlatformGoogle,
+		State:     bridge.StateOnline,
+	}, true
+}
+
+func (r *googleEchoRegistry) Acquire(
+	ctx context.Context,
+	accountID string,
+	capability bridge.Capability,
+) (*bridge.DispatchLease, error) {
+	if ctx == nil {
+		return nil, errors.New("nil acquire context")
+	}
+	if accountID != googleEchoAccountID {
+		return nil, bridge.ErrAccountNotRegistered
+	}
+	if capability != bridge.CapabilityTextSend || r.sender == nil {
+		return nil, bridge.ErrCapabilityUnavailable
+	}
+	return &bridge.DispatchLease{
+		AccountID: googleEchoAccountID,
+		Platform:  bridge.PlatformGoogle,
+		Ctx:       ctx,
+		Text:      r.sender,
+	}, nil
+}
+
+func (r *googleEchoRegistry) Capabilities(accountID string) bridge.CapabilitySet {
+	return bridge.CapabilitySet{TextSend: accountID == googleEchoAccountID && r.sender != nil}
+}
+
+type googleEchoClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *googleEchoClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *googleEchoClock) NewTimer(delay time.Duration) messaging.Timer {
+	return googleEchoTimer{Timer: time.NewTimer(delay)}
+}
+
+type googleEchoTimer struct{ *time.Timer }
+
+func (t googleEchoTimer) C() <-chan time.Time { return t.Timer.C }
+
+type googleEchoIDs struct {
+	mu     sync.Mutex
+	prefix string
+	next   int
+}
+
+func (s *googleEchoIDs) NewID() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.next++
+	prefix := s.prefix
+	if prefix == "" {
+		prefix = "echo"
+	}
+	return fmt.Sprintf("%s-%03d", prefix, s.next), nil
+}
+
+type panicOnMalformedGoogleDecoder struct {
+	delegate bridge.Decoder
+}
+
+func (d *panicOnMalformedGoogleDecoder) Decode(
+	ctx context.Context,
+	record bridge.RawIngressRecord,
+) ([]bridge.Event, error) {
+	if !json.Valid(record.Payload) {
+		panic("malformed Google envelope")
+	}
+	return d.delegate.Decode(ctx, record)
+}
+
+// A group RCS message can arrive with a sender that has only a display name —
+// the number lives in the conversation roster, not the message. The v2 ingest
+// path must project it with a null sender rather than quarantining real content
+// on an unresolvable identity (the legacy store tolerates an empty sender).
+func TestGoogleIngestNumberlessSenderProjectsWithNullSender(t *testing.T) {
+	harness := newGoogleEchoHarness(t, nil)
+
+	const remoteID = "google-numberless-sender"
+	message := &gmproto.Message{
+		MessageID:      remoteID,
+		ConversationID: googleEchoRemoteConversationID,
+		Timestamp:      googleEchoNow.Add(time.Minute).UnixMilli() * 1000,
+		SenderParticipant: &gmproto.Participant{
+			IsMe:     false,
+			FullName: "Roster Only",
+			// No ID/Number: the identifying number is not on the message.
+		},
+		MessageStatus: &gmproto.MessageStatus{Status: gmproto.MessageStatusType_INCOMING_COMPLETE},
+		MessageInfo: []*gmproto.MessageInfo{{
+			Data: &gmproto.MessageInfo_MessageContent{
+				MessageContent: &gmproto.MessageContent{Content: "group message from a roster-only sender"},
+			},
+		}},
+	}
+	harness.appendRecord(t, harness.messageRecord(t, message))
+	harness.waitFor(t, "numberless sender projection", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 1
+	})
+
+	if snapshot := harness.counters.Snapshot(googleEchoAccountID); snapshot.Quarantined != 0 {
+		t.Fatalf("numberless sender quarantined the message: counters=%+v", snapshot)
+	}
+	stored, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		googleEchoAccountID,
+		googleEchoConversationID,
+		remoteID,
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(numberless): %v", err)
+	}
+	if stored.Body != "group message from a roster-only sender" {
+		t.Fatalf("projected body = %q, want the roster-only message", stored.Body)
+	}
+	if stored.SenderIdentityID != nil {
+		t.Fatalf("sender_identity_id = %v, want NULL for an unresolvable sender", *stored.SenderIdentityID)
+	}
+	nullSenderRows := countSQLiteRows(t, harness.storePath,
+		"SELECT COUNT(*) FROM messages WHERE account_id = ? AND remote_message_id = ? AND sender_identity_id IS NULL",
+		googleEchoAccountID, remoteID)
+	if nullSenderRows != 1 {
+		t.Fatalf("null-sender rows = %d, want 1", nullSenderRows)
+	}
+}

--- a/internal/ingest/googledecoder.go
+++ b/internal/ingest/googledecoder.go
@@ -1,0 +1,352 @@
+package ingest
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.mau.fi/mautrix-gmessages/pkg/libgm"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/client"
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+const (
+	// GoogleCodec is the durable Google Messages protobuf envelope codec.
+	GoogleCodec = "google.protobuf"
+	// GoogleCodecVersion is the only envelope version understood by this decoder.
+	GoogleCodecVersion uint32 = 1
+)
+
+const (
+	googleFrameMessage      = "message"
+	googleFrameConversation = "conversation"
+)
+
+// googleFrameEnvelope keeps the protobuf byte-preserving while making its
+// concrete message type explicit. A non-nil IsOld makes the field appear for
+// message frames even when false; conversation frames omit it.
+type googleFrameEnvelope struct {
+	Kind     string `json:"kind"`
+	ProtoB64 []byte `json:"proto_b64"`
+	IsOld    *bool  `json:"is_old,omitempty"`
+}
+
+// MarshalGoogleMessageFrame serializes the exact v1 frame used by the Google
+// adapter tee. protoBytes is returned separately for content-hash dedupe.
+func MarshalGoogleMessageFrame(
+	event *libgm.WrappedMessage,
+) (payload, protoBytes []byte, err error) {
+	if event == nil {
+		return nil, nil, fmt.Errorf("marshal Google message frame: wrapped message is nil")
+	}
+	if event.Message == nil {
+		return nil, nil, fmt.Errorf("marshal Google message frame: protobuf message is nil")
+	}
+	protoBytes, err = proto.Marshal(event.Message)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal Google message protobuf: %w", err)
+	}
+	isOld := event.IsOld
+	payload, err = json.Marshal(googleFrameEnvelope{
+		Kind:     googleFrameMessage,
+		ProtoB64: protoBytes,
+		IsOld:    &isOld,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal Google message envelope: %w", err)
+	}
+	return payload, protoBytes, nil
+}
+
+// MarshalGoogleConversationFrame serializes the exact v1 frame used by the
+// Google adapter tee. protoBytes is returned separately for content-hash dedupe.
+func MarshalGoogleConversationFrame(
+	conversation *gmproto.Conversation,
+) (payload, protoBytes []byte, err error) {
+	if conversation == nil {
+		return nil, nil, fmt.Errorf("marshal Google conversation frame: conversation is nil")
+	}
+	protoBytes, err = proto.Marshal(conversation)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal Google conversation protobuf: %w", err)
+	}
+	payload, err = json.Marshal(googleFrameEnvelope{
+		Kind:     googleFrameConversation,
+		ProtoB64: protoBytes,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal Google conversation envelope: %w", err)
+	}
+	return payload, protoBytes, nil
+}
+
+// GoogleDecoder maps durable Google protobuf envelopes to transport-neutral
+// events. The zero value is usable; a configured Counters records Google-only
+// skip/divergence classifications per account.
+type GoogleDecoder struct {
+	counters *Counters
+}
+
+var _ bridge.Decoder = (*GoogleDecoder)(nil)
+
+// NewGoogleDecoder constructs the v1 Google protobuf decoder.
+func NewGoogleDecoder(counters *Counters) *GoogleDecoder {
+	return &GoogleDecoder{counters: counters}
+}
+
+// Decode parses one v1 envelope and applies only store-free mappings.
+func (d *GoogleDecoder) Decode(
+	ctx context.Context,
+	record bridge.RawIngressRecord,
+) ([]bridge.Event, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("decode Google ingress: context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if record.Codec != GoogleCodec {
+		return nil, fmt.Errorf("decode Google ingress: codec %q is not %q", record.Codec, GoogleCodec)
+	}
+	if record.CodecVersion != GoogleCodecVersion {
+		return nil, fmt.Errorf(
+			"decode Google ingress: codec version %d is unsupported",
+			record.CodecVersion,
+		)
+	}
+
+	var envelope googleFrameEnvelope
+	if err := json.Unmarshal(record.Payload, &envelope); err != nil {
+		return nil, fmt.Errorf("decode Google ingress envelope: %w", err)
+	}
+	if len(envelope.ProtoB64) == 0 {
+		return nil, fmt.Errorf("decode Google ingress envelope: proto_b64 is empty")
+	}
+
+	switch envelope.Kind {
+	case googleFrameMessage:
+		if envelope.IsOld == nil {
+			return nil, fmt.Errorf("decode Google ingress envelope: message is_old is missing")
+		}
+		var message gmproto.Message
+		if err := proto.Unmarshal(envelope.ProtoB64, &message); err != nil {
+			return nil, fmt.Errorf("decode Google message protobuf: %w", err)
+		}
+		return d.decodeMessage(record.AccountID, &message)
+	case googleFrameConversation:
+		var conversation gmproto.Conversation
+		if err := proto.Unmarshal(envelope.ProtoB64, &conversation); err != nil {
+			return nil, fmt.Errorf("decode Google conversation protobuf: %w", err)
+		}
+		return []bridge.Event{googleConversationEvent(&conversation)}, nil
+	default:
+		return nil, fmt.Errorf("decode Google ingress envelope: kind %q is unsupported", envelope.Kind)
+	}
+}
+
+func (d *GoogleDecoder) decodeMessage(
+	accountID string,
+	message *gmproto.Message,
+) ([]bridge.Event, error) {
+	body := client.ExtractMessageBody(message)
+	media := client.ExtractMediaInfo(message)
+	reactions := client.ExtractReactions(message)
+	replyToRemoteID := client.ExtractReplyToID(message)
+	senderName, senderNumber := client.ExtractSenderInfo(message)
+	fromMe := client.MessageIsFromMe(message)
+
+	if googleMessageIsEmptyStub(message, body, media, reactions) {
+		if d != nil && d.counters != nil {
+			d.counters.account(accountID).emptyStubsSkipped.Add(1)
+		}
+		return nil, nil
+	}
+
+	sender := bridge.IdentityRef{
+		Raw:    senderNumber,
+		Name:   senderName,
+		IsSelf: fromMe,
+	}
+	direction := "incoming"
+	if fromMe {
+		direction = "outgoing"
+	}
+	clientRequestID := ""
+	if tmpID := message.GetTmpID(); fromMe && tmpID != "" && tmpID != message.GetMessageID() {
+		clientRequestID = tmpID
+	}
+	occurredAt := time.UnixMilli(message.GetTimestamp() / 1000)
+	attachments, err := googleAttachments(media)
+	if err != nil {
+		return nil, err
+	}
+
+	events := []bridge.Event{{
+		Kind: bridge.EventMessage,
+		Message: &bridge.MessageEvent{
+			RemoteConversationID: message.GetConversationID(),
+			RemoteMessageID:      message.GetMessageID(),
+			ClientRequestID:      clientRequestID,
+			Sender:               sender,
+			Direction:            direction,
+			Body:                 body,
+			Attachments:          attachments,
+			ReplyToRemoteID:      replyToRemoteID,
+			OccurredAt:           occurredAt,
+		},
+	}}
+
+	for _, reaction := range reactions {
+		if len(reaction.Actors) == 0 {
+			events = append(events, googleReactionEvent(
+				message,
+				reaction.Emoji,
+				bridge.IdentityRef{},
+				bridge.ReactionAdd,
+			))
+			continue
+		}
+		for _, actor := range reaction.Actors {
+			events = append(events, googleReactionEvent(
+				message,
+				reaction.Emoji,
+				bridge.IdentityRef{Raw: actor},
+				bridge.ReactionAdd,
+			))
+		}
+	}
+
+	// Tapbacks arrive as standalone SMS/RCS bodies. Keep the MessageEvent and
+	// also surface the reaction. Resolving the quoted text to a target ID is
+	// store-dependent, so its target remains empty until the deferred reaction
+	// read model can perform that lookup.
+	if tapback, ok := db.ParseTapback(body); ok {
+		action := bridge.ReactionAdd
+		if tapback.Remove {
+			action = bridge.ReactionRemove
+		}
+		tapbackEvent := googleReactionEvent(message, tapback.Emoji, sender, action)
+		tapbackEvent.Reaction.TargetRemoteMessageID = ""
+		events = append(events, tapbackEvent)
+		if d != nil && d.counters != nil {
+			d.counters.account(accountID).tapbackMessages.Add(1)
+		}
+	}
+
+	return events, nil
+}
+
+func googleConversationEvent(conversation *gmproto.Conversation) bridge.Event {
+	kind := "direct"
+	if conversation.GetIsGroupChat() {
+		kind = "group"
+	}
+	participants := make([]bridge.Participant, 0, len(conversation.GetParticipants()))
+	for _, participant := range conversation.GetParticipants() {
+		if participant == nil {
+			continue
+		}
+		number := ""
+		if id := participant.GetID(); id != nil {
+			number = id.GetNumber()
+		}
+		if number == "" {
+			number = participant.GetFormattedNumber()
+		}
+		participants = append(participants, bridge.Participant{
+			Identity: bridge.IdentityRef{
+				Raw:    number,
+				Name:   participant.GetFullName(),
+				IsSelf: participant.GetIsMe(),
+			},
+			Role:   "member",
+			Active: true,
+		})
+	}
+
+	return bridge.Event{
+		Kind: bridge.EventConversation,
+		Conversation: &bridge.ConversationEvent{
+			RemoteConversationID: conversation.GetConversationID(),
+			Kind:                 kind,
+			Title:                conversation.GetName(),
+			Participants:         participants,
+		},
+	}
+}
+
+func googleReactionEvent(
+	message *gmproto.Message,
+	emoji string,
+	actor bridge.IdentityRef,
+	action bridge.ReactionAction,
+) bridge.Event {
+	return bridge.Event{
+		Kind: bridge.EventReaction,
+		Reaction: &bridge.ReactionEvent{
+			RemoteConversationID:  message.GetConversationID(),
+			TargetRemoteMessageID: message.GetMessageID(),
+			Actor:                 actor,
+			Emoji:                 emoji,
+			Action:                action,
+			OccurredAt:            time.UnixMilli(message.GetTimestamp() / 1000),
+		},
+	}
+}
+
+func googleMessageIsEmptyStub(
+	message *gmproto.Message,
+	body string,
+	media *client.MediaInfo,
+	reactions []client.Reaction,
+) bool {
+	status := ""
+	if messageStatus := message.GetMessageStatus(); messageStatus != nil {
+		status = messageStatus.GetStatus().String()
+	}
+	mediaID := ""
+	if media != nil {
+		mediaID = media.MediaID
+	}
+	reactionMarker := ""
+	if len(reactions) > 0 {
+		reactionMarker = "present"
+	}
+	return db.IsEmptyStubMessage(&db.Message{
+		Body:      body,
+		MediaID:   mediaID,
+		Reactions: reactionMarker,
+		Status:    status,
+	})
+}
+
+func googleAttachments(media *client.MediaInfo) ([]bridge.Attachment, error) {
+	if media == nil {
+		return nil, nil
+	}
+	remoteRef, err := json.Marshal(struct {
+		Version       int    `json:"v"`
+		MediaID       string `json:"media_id"`
+		DecryptionKey string `json:"decryption_key"`
+	}{
+		Version:       1,
+		MediaID:       media.MediaID,
+		DecryptionKey: hex.EncodeToString(media.DecryptionKey),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pack Google attachment %q: %w", media.MediaID, err)
+	}
+	return []bridge.Attachment{{
+		RemoteID:  media.MediaID,
+		RemoteRef: remoteRef,
+		Filename:  media.MediaName,
+		MIME:      media.MimeType,
+		Size:      media.Size,
+	}}, nil
+}

--- a/internal/ingest/googledecoder_test.go
+++ b/internal/ingest/googledecoder_test.go
@@ -1,0 +1,551 @@
+package ingest_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.mau.fi/mautrix-gmessages/pkg/libgm"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	googleadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/google"
+	"github.com/maxghenis/openmessage/internal/ingest"
+)
+
+func TestGoogleFrameMarshalEnvelopeShapes(t *testing.T) {
+	t.Parallel()
+
+	message := &gmproto.Message{MessageID: "message-1", ConversationID: "conversation-1"}
+	payload, protoBytes, err := ingest.MarshalGoogleMessageFrame(&libgm.WrappedMessage{
+		Message: message,
+		IsOld:   false,
+	})
+	if err != nil {
+		t.Fatalf("MarshalGoogleMessageFrame: %v", err)
+	}
+	wantProto, err := proto.Marshal(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(protoBytes, wantProto) {
+		t.Fatalf("message proto bytes = %x, want %x", protoBytes, wantProto)
+	}
+	var messageEnvelope map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &messageEnvelope); err != nil {
+		t.Fatalf("decode message envelope: %v", err)
+	}
+	assertJSONString(t, messageEnvelope["kind"], "message")
+	assertEnvelopeProto(t, messageEnvelope["proto_b64"], wantProto)
+	var isOld bool
+	if raw, ok := messageEnvelope["is_old"]; !ok {
+		t.Fatal("message envelope omitted is_old=false")
+	} else if err := json.Unmarshal(raw, &isOld); err != nil {
+		t.Fatalf("decode message is_old: %v", err)
+	} else if isOld {
+		t.Fatal("message envelope is_old = true, want false")
+	}
+
+	conversation := &gmproto.Conversation{ConversationID: "conversation-2", Name: "Thread"}
+	payload, protoBytes, err = ingest.MarshalGoogleConversationFrame(conversation)
+	if err != nil {
+		t.Fatalf("MarshalGoogleConversationFrame: %v", err)
+	}
+	wantProto, err = proto.Marshal(conversation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(protoBytes, wantProto) {
+		t.Fatalf("conversation proto bytes = %x, want %x", protoBytes, wantProto)
+	}
+	var conversationEnvelope map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &conversationEnvelope); err != nil {
+		t.Fatalf("decode conversation envelope: %v", err)
+	}
+	assertJSONString(t, conversationEnvelope["kind"], "conversation")
+	assertEnvelopeProto(t, conversationEnvelope["proto_b64"], wantProto)
+	if _, ok := conversationEnvelope["is_old"]; ok {
+		t.Fatal("conversation envelope unexpectedly contains is_old")
+	}
+}
+
+func TestGoogleDecoderMapsMessageAndReactions(t *testing.T) {
+	t.Parallel()
+
+	const timestampUS = int64(1_701_234_567_890_123)
+	message := &gmproto.Message{
+		MessageID:      "message-1",
+		ConversationID: "conversation-1",
+		Timestamp:      timestampUS,
+		MessageStatus: &gmproto.MessageStatus{
+			Status: gmproto.MessageStatusType_INCOMING_COMPLETE,
+		},
+		SenderParticipant: &gmproto.Participant{
+			FullName: "Ada Lovelace",
+			ID:       &gmproto.SmallInfo{Number: "+15551234567"},
+		},
+		MessageInfo: []*gmproto.MessageInfo{
+			{
+				Data: &gmproto.MessageInfo_MessageContent{
+					MessageContent: &gmproto.MessageContent{Content: "photo caption"},
+				},
+			},
+			{
+				Data: &gmproto.MessageInfo_MediaContent{
+					MediaContent: &gmproto.MediaContent{
+						MediaID:       "media-1",
+						MediaName:     "photo.jpg",
+						MimeType:      "image/jpeg",
+						Size:          321,
+						DecryptionKey: []byte{0xde, 0xad, 0xbe, 0xef},
+					},
+				},
+			},
+		},
+		ReplyMessage: &gmproto.ReplyMessage{MessageID: "message-0"},
+		Reactions: []*gmproto.ReactionEntry{
+			{
+				Data:           &gmproto.ReactionData{Unicode: "😂"},
+				ParticipantIDs: []string{"participant-a", "participant-b"},
+			},
+			{
+				Data: &gmproto.ReactionData{Unicode: "❤️"},
+			},
+		},
+	}
+
+	events := decodeGoogleMessage(t, ingest.NewGoogleDecoder(nil), "account-1", message, false)
+	if len(events) != 4 {
+		t.Fatalf("event count = %d, want message + three per-actor reactions", len(events))
+	}
+	if events[0].Kind != bridge.EventMessage || events[0].Message == nil {
+		t.Fatalf("first event = %+v, want MessageEvent", events[0])
+	}
+	got := events[0].Message
+	wantOccurredAt := time.UnixMilli(timestampUS / 1000)
+	if got.RemoteConversationID != "conversation-1" || got.RemoteMessageID != "message-1" ||
+		got.ClientRequestID != "" || got.Direction != "incoming" || got.Body != "photo caption" ||
+		got.ReplyToRemoteID != "message-0" || !got.OccurredAt.Equal(wantOccurredAt) {
+		t.Fatalf("message event = %+v", got)
+	}
+	if got.Sender.Raw != "+15551234567" || got.Sender.Name != "Ada Lovelace" || got.Sender.IsSelf {
+		t.Fatalf("sender = %+v", got.Sender)
+	}
+	if len(got.Attachments) != 1 {
+		t.Fatalf("attachments = %+v, want one", got.Attachments)
+	}
+	attachment := got.Attachments[0]
+	if attachment.RemoteID != "media-1" || attachment.Filename != "photo.jpg" ||
+		attachment.MIME != "image/jpeg" || attachment.Size != 321 {
+		t.Fatalf("attachment = %+v", attachment)
+	}
+	if err := googleadapter.ValidateDownloadOpaque(attachment.RemoteRef); err != nil {
+		t.Fatalf("ValidateDownloadOpaque: %v; opaque=%s", err, attachment.RemoteRef)
+	}
+	var opaque struct {
+		Version       int    `json:"v"`
+		MediaID       string `json:"media_id"`
+		DecryptionKey string `json:"decryption_key"`
+	}
+	if err := json.Unmarshal(attachment.RemoteRef, &opaque); err != nil {
+		t.Fatalf("decode attachment opaque: %v", err)
+	}
+	if opaque.Version != 1 || opaque.MediaID != "media-1" ||
+		opaque.DecryptionKey != hex.EncodeToString([]byte{0xde, 0xad, 0xbe, 0xef}) {
+		t.Fatalf("attachment opaque = %+v", opaque)
+	}
+
+	wantReactions := []struct {
+		emoji string
+		actor string
+	}{
+		{emoji: "😂", actor: "participant-a"},
+		{emoji: "😂", actor: "participant-b"},
+		{emoji: "❤️", actor: ""},
+	}
+	for index, want := range wantReactions {
+		event := events[index+1]
+		if event.Kind != bridge.EventReaction || event.Reaction == nil {
+			t.Fatalf("event %d = %+v, want ReactionEvent", index+1, event)
+		}
+		reaction := event.Reaction
+		if reaction.RemoteConversationID != "conversation-1" ||
+			reaction.TargetRemoteMessageID != "message-1" ||
+			reaction.Emoji != want.emoji || reaction.Actor.Raw != want.actor ||
+			reaction.Action != bridge.ReactionAdd || !reaction.OccurredAt.Equal(wantOccurredAt) {
+			t.Fatalf("reaction %d = %+v", index, reaction)
+		}
+	}
+	for _, event := range events {
+		if event.Kind == bridge.EventReceipt || event.Receipt != nil {
+			t.Fatalf("Google decoder emitted forbidden receipt event: %+v", event)
+		}
+	}
+}
+
+func TestGoogleDecoderOutgoingClientRequestMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		status        gmproto.MessageStatusType
+		senderIsSelf  bool
+		tmpID         string
+		messageID     string
+		wantDirection string
+		wantRequestID string
+	}{
+		{
+			name:          "outgoing status fallback correlates distinct tmp id",
+			status:        gmproto.MessageStatusType_OUTGOING_COMPLETE,
+			tmpID:         "request-1",
+			messageID:     "permanent-1",
+			wantDirection: "outgoing",
+			wantRequestID: "request-1",
+		},
+		{
+			name:          "self participant correlates distinct tmp id",
+			status:        gmproto.MessageStatusType_INCOMING_COMPLETE,
+			senderIsSelf:  true,
+			tmpID:         "request-2",
+			messageID:     "permanent-2",
+			wantDirection: "outgoing",
+			wantRequestID: "request-2",
+		},
+		{
+			name:          "tmp id equal to message id does not correlate",
+			status:        gmproto.MessageStatusType_OUTGOING_COMPLETE,
+			tmpID:         "same-id",
+			messageID:     "same-id",
+			wantDirection: "outgoing",
+		},
+		{
+			name:          "incoming tmp id does not correlate",
+			status:        gmproto.MessageStatusType_INCOMING_COMPLETE,
+			tmpID:         "phone-tmp",
+			messageID:     "incoming-1",
+			wantDirection: "incoming",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			message := &gmproto.Message{
+				MessageID:      test.messageID,
+				ConversationID: "conversation-1",
+				Timestamp:      1_700_000_000_000_000,
+				TmpID:          test.tmpID,
+				MessageStatus:  &gmproto.MessageStatus{Status: test.status},
+				SenderParticipant: &gmproto.Participant{
+					IsMe:     test.senderIsSelf,
+					FullName: "Me",
+					ID:       &gmproto.SmallInfo{Number: "+15550001111"},
+				},
+				MessageInfo: textInfo("hello"),
+			}
+			events := decodeGoogleMessage(t, ingest.NewGoogleDecoder(nil), "account-1", message, false)
+			if len(events) != 1 || events[0].Message == nil {
+				t.Fatalf("events = %+v, want one MessageEvent", events)
+			}
+			got := events[0].Message
+			if got.Direction != test.wantDirection || got.ClientRequestID != test.wantRequestID {
+				t.Fatalf("direction/request = %q/%q, want %q/%q", got.Direction, got.ClientRequestID, test.wantDirection, test.wantRequestID)
+			}
+			if got.Sender.IsSelf != (test.wantDirection == "outgoing") {
+				t.Fatalf("sender IsSelf = %v, direction = %q", got.Sender.IsSelf, got.Direction)
+			}
+		})
+	}
+}
+
+func TestGoogleDecoderTapbackPreservesMessageAndCountsDivergence(t *testing.T) {
+	t.Parallel()
+
+	var counters ingest.Counters
+	decoder := ingest.NewGoogleDecoder(&counters)
+	message := &gmproto.Message{
+		MessageID:      "tapback-message",
+		ConversationID: "conversation-1",
+		Timestamp:      1_700_000_000_000_000,
+		MessageStatus:  &gmproto.MessageStatus{Status: gmproto.MessageStatusType_INCOMING_COMPLETE},
+		SenderParticipant: &gmproto.Participant{
+			FullName: "Ada",
+			ID:       &gmproto.SmallInfo{Number: "+15551234567"},
+		},
+		MessageInfo: textInfo(`Removed a like from "hello"`),
+	}
+
+	events := decodeGoogleMessage(t, decoder, "account-1", message, false)
+	if len(events) != 2 || events[0].Message == nil || events[1].Reaction == nil {
+		t.Fatalf("events = %+v, want preserved message plus tapback reaction", events)
+	}
+	if events[0].Message.Body != `Removed a like from "hello"` {
+		t.Fatalf("preserved message body = %q", events[0].Message.Body)
+	}
+	reaction := events[1].Reaction
+	if reaction.TargetRemoteMessageID != "" || reaction.Emoji != "👍" ||
+		reaction.Action != bridge.ReactionRemove || reaction.Actor.Raw != "+15551234567" ||
+		reaction.Actor.Name != "Ada" || reaction.Actor.IsSelf {
+		t.Fatalf("tapback reaction = %+v", reaction)
+	}
+	if got := counters.Snapshot("account-1").TapbackMessages; got != 1 {
+		t.Fatalf("tapback_messages = %d, want 1", got)
+	}
+}
+
+func TestGoogleDecoderEmptyStubPolicy(t *testing.T) {
+	t.Parallel()
+
+	var counters ingest.Counters
+	decoder := ingest.NewGoogleDecoder(&counters)
+	terminalStub := &gmproto.Message{
+		MessageID:      "empty-terminal",
+		ConversationID: "conversation-1",
+		Timestamp:      1_700_000_000_000_000,
+		MessageStatus:  &gmproto.MessageStatus{Status: gmproto.MessageStatusType_INCOMING_COMPLETE},
+	}
+	if events := decodeGoogleMessage(t, decoder, "account-1", terminalStub, false); len(events) != 0 {
+		t.Fatalf("terminal stub events = %+v, want none", events)
+	}
+
+	pendingPlaceholder := proto.Clone(terminalStub).(*gmproto.Message)
+	pendingPlaceholder.MessageID = "empty-pending"
+	pendingPlaceholder.MessageStatus.Status = gmproto.MessageStatusType_INCOMING_AUTO_DOWNLOADING
+	events := decodeGoogleMessage(t, decoder, "account-1", pendingPlaceholder, false)
+	if len(events) != 1 || events[0].Message == nil {
+		t.Fatalf("pending placeholder events = %+v, want one MessageEvent", events)
+	}
+	if got := counters.Snapshot("account-1").EmptyStubsSkipped; got != 1 {
+		t.Fatalf("empty_stubs_skipped = %d, want 1", got)
+	}
+}
+
+func TestGoogleDecoderMapsConversationSnapshot(t *testing.T) {
+	t.Parallel()
+
+	conversation := &gmproto.Conversation{
+		ConversationID: "conversation-1",
+		Name:           "Study group",
+		IsGroupChat:    true,
+		Participants: []*gmproto.Participant{
+			{
+				FullName: "Ada Lovelace",
+				ID:       &gmproto.SmallInfo{Number: "+15551234567"},
+			},
+			{
+				FullName:        "Me",
+				IsMe:            true,
+				ID:              &gmproto.SmallInfo{},
+				FormattedNumber: "+15550001111",
+			},
+		},
+	}
+	payload, _, err := ingest.MarshalGoogleConversationFrame(conversation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := ingest.NewGoogleDecoder(nil).Decode(context.Background(), bridge.RawIngressRecord{
+		AccountID:    "account-1",
+		Codec:        ingest.GoogleCodec,
+		CodecVersion: ingest.GoogleCodecVersion,
+		Payload:      payload,
+	})
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != bridge.EventConversation || events[0].Conversation == nil {
+		t.Fatalf("events = %+v, want one ConversationEvent", events)
+	}
+	got := events[0].Conversation
+	if got.RemoteConversationID != "conversation-1" || got.Kind != "group" || got.Title != "Study group" {
+		t.Fatalf("conversation = %+v", got)
+	}
+	wantParticipants := []bridge.Participant{
+		{
+			Identity: bridge.IdentityRef{Raw: "+15551234567", Name: "Ada Lovelace"},
+			Role:     "member",
+			Active:   true,
+		},
+		{
+			Identity: bridge.IdentityRef{Raw: "+15550001111", Name: "Me", IsSelf: true},
+			Role:     "member",
+			Active:   true,
+		},
+	}
+	if !reflect.DeepEqual(got.Participants, wantParticipants) {
+		t.Fatalf("participants = %+v, want %+v", got.Participants, wantParticipants)
+	}
+}
+
+func TestGoogleDecoderRejectsMalformedOrUnsupportedFrames(t *testing.T) {
+	t.Parallel()
+
+	decoder := ingest.NewGoogleDecoder(nil)
+	tests := []struct {
+		name   string
+		record bridge.RawIngressRecord
+		ctx    context.Context
+	}{
+		{
+			name: "wrong codec",
+			record: bridge.RawIngressRecord{
+				Codec: "other", CodecVersion: ingest.GoogleCodecVersion, Payload: []byte(`{}`),
+			},
+			ctx: context.Background(),
+		},
+		{
+			name: "wrong version",
+			record: bridge.RawIngressRecord{
+				Codec: ingest.GoogleCodec, CodecVersion: 2, Payload: []byte(`{}`),
+			},
+			ctx: context.Background(),
+		},
+		{
+			name: "malformed json",
+			record: bridge.RawIngressRecord{
+				Codec: ingest.GoogleCodec, CodecVersion: ingest.GoogleCodecVersion, Payload: []byte(`{`),
+			},
+			ctx: context.Background(),
+		},
+		{
+			name: "empty proto",
+			record: bridge.RawIngressRecord{
+				Codec: ingest.GoogleCodec, CodecVersion: ingest.GoogleCodecVersion,
+				Payload: []byte(`{"kind":"message","proto_b64":""}`),
+			},
+			ctx: context.Background(),
+		},
+		{
+			name: "message missing is_old",
+			record: bridge.RawIngressRecord{
+				Codec: ingest.GoogleCodec, CodecVersion: ingest.GoogleCodecVersion,
+				Payload: []byte(`{"kind":"message","proto_b64":"AQ=="}`),
+			},
+			ctx: context.Background(),
+		},
+		{
+			name: "unknown kind",
+			record: bridge.RawIngressRecord{
+				Codec: ingest.GoogleCodec, CodecVersion: ingest.GoogleCodecVersion,
+				Payload: []byte(`{"kind":"other","proto_b64":"AQ=="}`),
+			},
+			ctx: context.Background(),
+		},
+		{
+			// is_old present so decode reaches proto.Unmarshal and fails there,
+			// rather than short-circuiting on the missing-field guard.
+			name: "invalid protobuf",
+			record: bridge.RawIngressRecord{
+				Codec: ingest.GoogleCodec, CodecVersion: ingest.GoogleCodecVersion,
+				Payload: []byte(`{"kind":"message","is_old":false,"proto_b64":"/w=="}`),
+			},
+			ctx: context.Background(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if events, err := decoder.Decode(test.ctx, test.record); err == nil {
+				t.Fatalf("Decode() = %+v, nil error", events)
+			}
+		})
+	}
+	if _, err := decoder.Decode(nil, bridge.RawIngressRecord{}); err == nil {
+		t.Fatal("Decode(nil context) returned nil error")
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := decoder.Decode(canceled, bridge.RawIngressRecord{}); err == nil {
+		t.Fatal("Decode(canceled context) returned nil error")
+	}
+}
+
+func TestGoogleAttachmentRemoteRefRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	message := &gmproto.Message{
+		MessageID:      "media-message",
+		ConversationID: "conversation-1",
+		Timestamp:      1_700_000_000_000_000,
+		MessageStatus:  &gmproto.MessageStatus{Status: gmproto.MessageStatusType_INCOMING_COMPLETE},
+		MessageInfo: []*gmproto.MessageInfo{{
+			Data: &gmproto.MessageInfo_MediaContent{MediaContent: &gmproto.MediaContent{
+				MediaID: "media-id", DecryptionKey: []byte{0x01, 0x02}, MimeType: "image/jpeg",
+			}},
+		}},
+	}
+	events := decodeGoogleMessage(t, ingest.NewGoogleDecoder(nil), "account-1", message, false)
+	if len(events) != 1 || events[0].Message == nil || len(events[0].Message.Attachments) != 1 {
+		t.Fatalf("events = %+v", events)
+	}
+	if err := googleadapter.ValidateDownloadOpaque(events[0].Message.Attachments[0].RemoteRef); err != nil {
+		t.Fatalf("packed RemoteRef failed Google adapter validation: %v", err)
+	}
+}
+
+func decodeGoogleMessage(
+	t *testing.T,
+	decoder *ingest.GoogleDecoder,
+	accountID string,
+	message *gmproto.Message,
+	isOld bool,
+) []bridge.Event {
+	t.Helper()
+	payload, _, err := ingest.MarshalGoogleMessageFrame(&libgm.WrappedMessage{
+		Message: message,
+		IsOld:   isOld,
+	})
+	if err != nil {
+		t.Fatalf("MarshalGoogleMessageFrame: %v", err)
+	}
+	events, err := decoder.Decode(context.Background(), bridge.RawIngressRecord{
+		AccountID:    accountID,
+		Codec:        ingest.GoogleCodec,
+		CodecVersion: ingest.GoogleCodecVersion,
+		Payload:      payload,
+	})
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	return events
+}
+
+func textInfo(body string) []*gmproto.MessageInfo {
+	return []*gmproto.MessageInfo{{
+		Data: &gmproto.MessageInfo_MessageContent{
+			MessageContent: &gmproto.MessageContent{Content: body},
+		},
+	}}
+}
+
+func assertJSONString(t *testing.T, raw json.RawMessage, want string) {
+	t.Helper()
+	var got string
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode JSON string: %v", err)
+	}
+	if got != want {
+		t.Fatalf("JSON string = %q, want %q", got, want)
+	}
+}
+
+func assertEnvelopeProto(t *testing.T, raw json.RawMessage, want []byte) {
+	t.Helper()
+	var encoded string
+	if err := json.Unmarshal(raw, &encoded); err != nil {
+		t.Fatalf("decode proto_b64 string: %v", err)
+	}
+	got, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode proto_b64: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("decoded proto_b64 = %x, want %x", got, want)
+	}
+}

--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -784,7 +784,12 @@ func (w *Worker) messageProjection(
 	}
 
 	var senderIdentityID *string
-	if direction != sqlite.MessageDirectionOutgoing && !event.Sender.IsSelf {
+	// A transport may deliver a message whose sender carries only a display
+	// name (group RCS puts the number in the conversation roster, not the
+	// message). Legacy stores that as an empty sender rather than dropping the
+	// message; the v2 path degrades the same way — project with a null sender
+	// instead of quarantining real content on an unresolvable identity.
+	if direction != sqlite.MessageDirectionOutgoing && !event.Sender.IsSelf && identityRaw(event.Sender) != "" {
 		identity, identityErr := w.resolveIdentity(accountID, platform, event.Sender)
 		if identityErr != nil {
 			return sqlite.MessageProjection{}, identityErr


### PR DESCRIPTION
## What

Makes v2 receive-side ingest live for Google, per `ingest-echo-spec-2026-07-17.md` §2.1/§5/§6/§7.

- **Tee** (`internal/bridgeadapters/google/google.go`): each `*libgm.WrappedMessage` and `*gmproto.Conversation` is teed into the durable inbox via `Sink.AppendIngress` (codec `google.protobuf` v1, dedupe key `msg:<id>:<hash8(proto)>` — content-hashed because Google re-delivers the same MessageID on status/reaction/backfill) **before** the legacy handler runs. The tee is wrapped in its own recover; a sink error or panic is counted and isolated — the legacy handler runs unconditionally and the receive loop survives.
- **Decoder** (`internal/ingest/googledecoder.go`): pure, reuses the `internal/client` extractors (never reimplements them); maps per the §2.1 table (ClientRequestID only for the app's own echoes, µs→ms, tapback emits message + counted reaction, empty-stub skip, conversation kind/participants); packs media RemoteRefs round-tripped against `google.ValidateDownloadOpaque`.
- **Wiring** (`cmd/serve.go`, `cmd/v2stack.go`): sink + worker constructed under `v2SendEnabled() || v2IngestEnabled()` (new `OPENMESSAGES_V2_INGEST`), `WithConnectionSink` added to all three supervisors, LIFO shutdown; `OPENMESSAGES_V2_SEND` alone still gates `/api/v1`.
- **Echo reconciliation**: the app's own sent-message echo confirms the uncertain send and repoints the optimistic row to its permanent id. Both orders (confirm-first enrich, echo-first collision-delete) are proven to converge to **exactly one row** by tests that `SELECT COUNT(*)`.

## Adversarial-review fixes (verdict was SHIP)

1. **Number-less sender no longer quarantines content.** A group RCS message whose sender carries only a display name (number in the roster, not the message) previously hard-failed identity resolution and dropped the message; it now projects with a null sender, matching legacy tolerance. Regression test asserts projection + null `sender_identity_id`.
2. **Order-B convergence documented.** `Confirm` alone leaves two rows in the rare echo-before-confirm race; convergence is driven by the guaranteed status re-delivery (Google re-delivers on sent→delivered→read). Comment added at the test.
3. **Invalid-protobuf decoder test** now includes `is_old` so it reaches `proto.Unmarshal` instead of short-circuiting on the missing-field guard.

## Merge sequencing

First of the three platform-decoder PRs (I2/I3/I4 built in parallel). This establishes the serve-level sink/worker construction and the `WorkerConfig.Decoders` slice; I3 (WhatsApp) and I4 (Signal) fold their decoders into that slice on top of this.

## Verification

Full `go test -race ./...`: 28 packages green, independently verified outside the sandbox (the two `cmd` listener tests fail only in sandboxes that forbid loopback binds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
