### PR TITLE
WhatsApp receive ingest: capture hook + pure decoder + worker wiring (ingest I3)

### DIFF
--- a/cmd/v2stack.go
+++ b/cmd/v2stack.go
@@ -208,11 +208,14 @@ func newV2Stack(deps v2StackDeps) (_ *v2Stack, resultErr error) {
 		EchoObserver: service,
 		Counters:     counters,
 		Logger:       deps.Logger,
-		Decoders: []ingest.DecoderRegistration{{
-			Codec:    ingest.GoogleCodec,
-			Platform: bridge.PlatformGoogle,
-			Decoder:  ingest.NewGoogleDecoder(counters),
-		}},
+		Decoders: []ingest.DecoderRegistration{
+			{
+				Codec:    ingest.GoogleCodec,
+				Platform: bridge.PlatformGoogle,
+				Decoder:  ingest.NewGoogleDecoder(counters),
+			},
+			ingest.NewWhatsAppDecoderRegistration(),
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("configure v2 stack: create ingest worker: %w", err)

--- a/internal/bridgeadapters/google/google.go
+++ b/internal/bridgeadapters/google/google.go
@@ -579,6 +579,9 @@ func (r *run) teeIngress(evt any, receivedAt time.Time) {
 
 func (r *run) recordIngressError(evt any, err error) {
 	r.adapter.ingressErrors.Add(1)
+	if recorder, ok := r.sink.(interface{ RecordIngressError(string) }); ok && recorder != nil {
+		recorder.RecordIngressError(r.request.AccountID)
+	}
 	r.adapter.host.Logger.Warn().
 		Err(err).
 		Str("account_id", r.request.AccountID).

--- a/internal/bridgeadapters/whatsapp/ingress_test.go
+++ b/internal/bridgeadapters/whatsapp/ingress_test.go
@@ -1,0 +1,425 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	waevents "go.mau.fi/whatsmeow/types/events"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/whatsapplive"
+)
+
+func TestIngressObserverStampsFrameAndRegistersBeforeConnect(t *testing.T) {
+	client := newFakeLifecycleClient()
+	observer := newIngressObserverHarness()
+	a := newTestAdapter(t, client, func() time.Time { return whatsappAdapterTestEpoch })
+	a.observeIngress = observer.Observe
+	connectSawObserver := make(chan bool, 1)
+	a.connect = func(context.Context) error {
+		connectSawObserver <- observer.Registered()
+		return nil
+	}
+	sink := &ingressRecordingSink{}
+
+	lifecycleRun, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "whatsapp-primary",
+		Generation: 17,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, lifecycleRun) })
+
+	if registered := receiveValue(t, connectSawObserver, "Connect observer state"); !registered {
+		t.Fatal("Connect began before the ingress observer was registered")
+	}
+	frame := whatsapplive.IngressFrame{
+		DedupeKey: "msg:stanza-1:0123abcd",
+		ReceivedAt: whatsappAdapterTestEpoch.Add(
+			3 * time.Second,
+		),
+		Payload: []byte(`{"kind":"message","message_id":"stanza-1"}`),
+	}
+	if !observer.Emit(frame) {
+		t.Fatal("ingress observer was not installed")
+	}
+
+	records, contexts, ingressErrors := sink.Snapshot()
+	want := bridge.RawIngressRecord{
+		AccountID:    "whatsapp-primary",
+		Generation:   17,
+		DedupeKey:    frame.DedupeKey,
+		Codec:        whatsapplive.IngressCodec,
+		CodecVersion: whatsapplive.IngressCodecVersion,
+		ReceivedAt:   frame.ReceivedAt,
+		Payload:      frame.Payload,
+	}
+	if len(records) != 1 || !reflect.DeepEqual(records[0], want) {
+		t.Fatalf("AppendIngress records = %#v, want [%#v]", records, want)
+	}
+	if len(contexts) != 1 || contexts[0] != context.Background() {
+		t.Fatalf("AppendIngress context = %#v, want context.Background()", contexts)
+	}
+	if len(ingressErrors) != 0 {
+		t.Fatalf("RecordIngressError calls = %v, want none", ingressErrors)
+	}
+	registrations, removals := observer.Counts()
+	if registrations != 1 || removals != 0 {
+		t.Fatalf("observer counts before Stop = (%d registrations, %d removals), want (1, 0)", registrations, removals)
+	}
+}
+
+func TestIngressObserverUnregisteredOnStop(t *testing.T) {
+	client := newFakeLifecycleClient()
+	observer := newIngressObserverHarness()
+	a := newTestAdapter(t, client, func() time.Time { return whatsappAdapterTestEpoch })
+	a.observeIngress = observer.Observe
+	sink := &ingressRecordingSink{}
+
+	lifecycleRun, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "whatsapp-primary",
+		Generation: 2,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	retained := observer.Callback()
+	if retained == nil {
+		t.Fatal("Start() did not register an ingress observer")
+	}
+	stopRun(t, lifecycleRun)
+	stopRun(t, lifecycleRun)
+
+	registrations, removals := observer.Counts()
+	if registrations != 1 || removals != 1 {
+		t.Fatalf("observer counts after repeated Stop = (%d registrations, %d removals), want (1, 1)", registrations, removals)
+	}
+	if observer.Registered() {
+		t.Fatal("ingress observer remains registered after Stop")
+	}
+	retained(whatsapplive.IngressFrame{
+		DedupeKey:  "late",
+		ReceivedAt: whatsappAdapterTestEpoch,
+		Payload:    []byte(`{"kind":"receipt"}`),
+	})
+	records, _, _ := sink.Snapshot()
+	if len(records) != 0 {
+		t.Fatalf("late retained observer appended %d records after Stop, want zero", len(records))
+	}
+}
+
+func TestIngressObserverUnregisteredOnTerminalEvent(t *testing.T) {
+	client := newFakeLifecycleClient()
+	observer := newIngressObserverHarness()
+	a := newTestAdapter(t, client, func() time.Time { return whatsappAdapterTestEpoch })
+	a.observeIngress = observer.Observe
+
+	lifecycleRun, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "whatsapp-primary",
+		Generation: 3,
+	}, &ingressRecordingSink{})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { stopRun(t, lifecycleRun) })
+
+	a.handleLifecycleEvent(whatsapplive.LifecycleEvent{
+		Raw: &waevents.Disconnected{},
+		At:  whatsappAdapterTestEpoch,
+	})
+	select {
+	case terminal := <-lifecycleRun.Done():
+		if terminal == nil {
+			t.Fatal("Done terminal error = nil after Disconnected event")
+		}
+	case <-time.After(whatsappAdapterTestTimeout):
+		t.Fatal("timed out waiting for terminal generation completion")
+	}
+
+	registrations, removals := observer.Counts()
+	if registrations != 1 || removals != 1 {
+		t.Fatalf("observer counts after terminal event = (%d registrations, %d removals), want (1, 1)", registrations, removals)
+	}
+	if observer.Registered() {
+		t.Fatal("ingress observer remains registered after terminal completion")
+	}
+}
+
+func TestIngressAppendErrorsDoNotRetireGeneration(t *testing.T) {
+	nonStale := errors.New("durable ingress unavailable")
+	tests := []struct {
+		name             string
+		appendErr        error
+		wantErrorRecords int
+		wantLogs         int
+	}{
+		{
+			name:      "stale generation is benign",
+			appendErr: bridge.ErrStaleGeneration,
+		},
+		{
+			name:             "other append error is counted and logged",
+			appendErr:        nonStale,
+			wantErrorRecords: 1,
+			wantLogs:         1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newFakeLifecycleClient()
+			observer := newIngressObserverHarness()
+			a := newTestAdapter(t, client, func() time.Time { return whatsappAdapterTestEpoch })
+			a.observeIngress = observer.Observe
+			logs := &ingressLogCapture{}
+			a.logIngressError = logs.Record
+			sink := &ingressRecordingSink{appendErr: test.appendErr}
+
+			lifecycleRun, err := a.Start(context.Background(), bridge.StartRequest{
+				AccountID:  "whatsapp-primary",
+				Generation: 23,
+			}, sink)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			t.Cleanup(func() { stopRun(t, lifecycleRun) })
+			if !observer.Emit(whatsapplive.IngressFrame{
+				DedupeKey:  "frame",
+				ReceivedAt: whatsappAdapterTestEpoch,
+				Payload:    []byte(`{"kind":"message"}`),
+			}) {
+				t.Fatal("ingress observer was not installed")
+			}
+
+			select {
+			case terminal := <-lifecycleRun.Done():
+				t.Fatalf("generation completed after AppendIngress error: %v", terminal)
+			default:
+			}
+			records, _, errorRecords := sink.Snapshot()
+			if len(records) != 1 {
+				t.Fatalf("AppendIngress call count = %d, want 1", len(records))
+			}
+			if len(errorRecords) != test.wantErrorRecords {
+				t.Fatalf("RecordIngressError calls = %v, want %d", errorRecords, test.wantErrorRecords)
+			}
+			gotLogs := logs.Snapshot()
+			if len(gotLogs) != test.wantLogs {
+				t.Fatalf("LogIngressError calls = %+v, want %d", gotLogs, test.wantLogs)
+			}
+			if test.wantLogs == 1 {
+				got := gotLogs[0]
+				if !errors.Is(got.err, nonStale) || got.accountID != "whatsapp-primary" || got.generation != 23 {
+					t.Fatalf("LogIngressError call = %+v, want error/account/generation %v/%q/%d", got, nonStale, "whatsapp-primary", 23)
+				}
+			}
+		})
+	}
+}
+
+func TestStopJoinsInFlightIngressAppend(t *testing.T) {
+	client := newFakeLifecycleClient()
+	observer := newIngressObserverHarness()
+	a := newTestAdapter(t, client, func() time.Time { return whatsappAdapterTestEpoch })
+	a.observeIngress = observer.Observe
+	appendEntered := make(chan struct{})
+	releaseAppend := make(chan struct{})
+	sink := &ingressRecordingSink{
+		append: func(context.Context, bridge.RawIngressRecord) error {
+			close(appendEntered)
+			<-releaseAppend
+			return nil
+		},
+	}
+
+	lifecycleRun, err := a.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "whatsapp-primary",
+		Generation: 29,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	callback := observer.Callback()
+	if callback == nil {
+		t.Fatal("Start() did not register an ingress observer")
+	}
+	appendDone := make(chan struct{})
+	go func() {
+		defer close(appendDone)
+		callback(whatsapplive.IngressFrame{
+			DedupeKey:  "blocking-frame",
+			ReceivedAt: whatsappAdapterTestEpoch,
+			Payload:    []byte(`{"kind":"history_sync"}`),
+		})
+	}()
+	receiveValue(t, appendEntered, "in-flight AppendIngress")
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), whatsappAdapterTestTimeout)
+	defer cancel()
+	stopResult := make(chan error, 1)
+	go func() { stopResult <- lifecycleRun.Stop(stopCtx) }()
+	observer.AwaitRemoval(t)
+	select {
+	case err := <-stopResult:
+		t.Fatalf("Stop() returned before in-flight AppendIngress completed: %v", err)
+	default:
+	}
+
+	close(releaseAppend)
+	receiveValue(t, appendDone, "AppendIngress completion")
+	if err := receiveValue(t, stopResult, "Run.Stop completion"); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+}
+
+type ingressObserverHarness struct {
+	mu            sync.Mutex
+	nextID        uint64
+	currentID     uint64
+	callback      func(whatsapplive.IngressFrame)
+	registrations int
+	removals      int
+	removed       chan struct{}
+}
+
+func newIngressObserverHarness() *ingressObserverHarness {
+	return &ingressObserverHarness{removed: make(chan struct{})}
+}
+
+func (h *ingressObserverHarness) Observe(callback func(whatsapplive.IngressFrame)) func() {
+	h.mu.Lock()
+	h.nextID++
+	id := h.nextID
+	h.currentID = id
+	h.callback = callback
+	h.registrations++
+	h.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			h.mu.Lock()
+			if h.currentID == id {
+				h.currentID = 0
+				h.callback = nil
+				h.removals++
+				close(h.removed)
+			}
+			h.mu.Unlock()
+		})
+	}
+}
+
+func (h *ingressObserverHarness) Callback() func(whatsapplive.IngressFrame) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.callback
+}
+
+func (h *ingressObserverHarness) Emit(frame whatsapplive.IngressFrame) bool {
+	callback := h.Callback()
+	if callback == nil {
+		return false
+	}
+	callback(frame)
+	return true
+}
+
+func (h *ingressObserverHarness) Registered() bool {
+	return h.Callback() != nil
+}
+
+func (h *ingressObserverHarness) Counts() (int, int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.registrations, h.removals
+}
+
+func (h *ingressObserverHarness) AwaitRemoval(t *testing.T) {
+	t.Helper()
+	select {
+	case <-h.removed:
+	case <-time.After(whatsappAdapterTestTimeout):
+		t.Fatal("timed out waiting for ingress observer removal")
+	}
+}
+
+type ingressRecordingSink struct {
+	mu            sync.Mutex
+	records       []bridge.RawIngressRecord
+	contexts      []context.Context
+	ingressErrors []string
+	appendErr     error
+	append        func(context.Context, bridge.RawIngressRecord) error
+}
+
+func (s *ingressRecordingSink) AppendIngress(ctx context.Context, record bridge.RawIngressRecord) error {
+	s.mu.Lock()
+	s.records = append(s.records, record)
+	s.contexts = append(s.contexts, ctx)
+	appendFn := s.append
+	appendErr := s.appendErr
+	s.mu.Unlock()
+	if appendFn != nil {
+		return appendFn(ctx, record)
+	}
+	return appendErr
+}
+
+func (*ingressRecordingSink) EmitEphemeral(context.Context, bridge.EphemeralEvent) error {
+	return nil
+}
+
+func (*ingressRecordingSink) Beat(bridge.Generation, time.Time, string) {}
+
+func (s *ingressRecordingSink) RecordIngressError(accountID string) {
+	s.mu.Lock()
+	s.ingressErrors = append(s.ingressErrors, accountID)
+	s.mu.Unlock()
+}
+
+func (s *ingressRecordingSink) Snapshot() (
+	[]bridge.RawIngressRecord,
+	[]context.Context,
+	[]string,
+) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]bridge.RawIngressRecord(nil), s.records...),
+		append([]context.Context(nil), s.contexts...),
+		append([]string(nil), s.ingressErrors...)
+}
+
+type ingressLogCall struct {
+	err        error
+	accountID  string
+	generation uint64
+}
+
+type ingressLogCapture struct {
+	mu    sync.Mutex
+	calls []ingressLogCall
+}
+
+func (l *ingressLogCapture) Record(err error, accountID string, generation uint64) {
+	l.mu.Lock()
+	l.calls = append(l.calls, ingressLogCall{
+		err:        err,
+		accountID:  accountID,
+		generation: generation,
+	})
+	l.mu.Unlock()
+}
+
+func (l *ingressLogCapture) Snapshot() []ingressLogCall {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]ingressLogCall(nil), l.calls...)
+}
+
+var _ bridge.ConnectionSink = (*ingressRecordingSink)(nil)

--- a/internal/bridgeadapters/whatsapp/whatsapp.go
+++ b/internal/bridgeadapters/whatsapp/whatsapp.go
@@ -42,6 +42,8 @@ type Adapter struct {
 	markReadRequest     func(string, []string, string, time.Time) error
 	sendMediaRequest    func(string, []byte, string, string, string, string, string) (string, time.Time, error)
 	downloadMediaRef    func(string, whatsapplive.StoredMediaRef, string, string, string) ([]byte, string, error)
+	observeIngress      func(func(whatsapplive.IngressFrame)) func()
+	logIngressError     func(error, string, uint64)
 
 	mu       sync.Mutex
 	current  *run
@@ -72,6 +74,8 @@ func New(accountID string, host *whatsapplive.Bridge) *Adapter {
 		a.markReadRequest = host.MarkReadRequest
 		a.sendMediaRequest = host.SendMediaRequest
 		a.downloadMediaRef = host.DownloadMediaRef
+		a.observeIngress = host.ObserveIngress
+		a.logIngressError = host.LogIngressError
 		host.ObserveLifecycle(a.handleLifecycleEvent)
 	}
 	return a
@@ -430,6 +434,9 @@ func (a *Adapter) Start(
 	a.current = r
 	a.starting = false
 	a.mu.Unlock()
+	if a.observeIngress != nil {
+		r.removeIngress = a.observeIngress(r.handleIngress)
+	}
 
 	go r.coordinate()
 	go r.connect()
@@ -653,6 +660,9 @@ type run struct {
 	readyOnce  sync.Once
 	finishOnce sync.Once
 
+	removeIngress     func()
+	removeIngressOnce sync.Once
+
 	admissionMu sync.Mutex
 	admitting   bool
 	callbacks   sync.WaitGroup
@@ -702,6 +712,7 @@ func (r *run) coordinate() {
 	}
 
 	r.closeAdmission()
+	r.unregisterIngress()
 	r.cancel()
 	r.adapter.disconnect()
 	r.workers.Wait()
@@ -710,6 +721,14 @@ func (r *run) coordinate() {
 	r.done <- terminal
 	close(r.done)
 	close(r.stopped)
+}
+
+func (r *run) unregisterIngress() {
+	r.removeIngressOnce.Do(func() {
+		if r.removeIngress != nil {
+			r.removeIngress()
+		}
+	})
 }
 
 func (r *run) requestFinish(err error) {
@@ -733,6 +752,39 @@ func (r *run) admitCallback() bool {
 	}
 	r.callbacks.Add(1)
 	return true
+}
+
+type ingressErrorRecorder interface {
+	RecordIngressError(accountID string)
+}
+
+func (r *run) handleIngress(frame whatsapplive.IngressFrame) {
+	if !r.admitCallback() {
+		return
+	}
+	defer r.callbacks.Done()
+	if r.sink == nil {
+		return
+	}
+
+	err := r.sink.AppendIngress(context.Background(), bridge.RawIngressRecord{
+		AccountID:    r.request.AccountID,
+		Generation:   r.request.Generation,
+		DedupeKey:    frame.DedupeKey,
+		Codec:        whatsapplive.IngressCodec,
+		CodecVersion: whatsapplive.IngressCodecVersion,
+		ReceivedAt:   frame.ReceivedAt,
+		Payload:      frame.Payload,
+	})
+	if err == nil || errors.Is(err, bridge.ErrStaleGeneration) {
+		return
+	}
+	if recorder, ok := r.sink.(ingressErrorRecorder); ok {
+		recorder.RecordIngressError(r.request.AccountID)
+	}
+	if r.adapter.logIngressError != nil {
+		r.adapter.logIngressError(err, r.request.AccountID, uint64(r.request.Generation))
+	}
 }
 
 func (r *run) handleEvent(event whatsapplive.LifecycleEvent) {

--- a/internal/ingest/counters.go
+++ b/internal/ingest/counters.go
@@ -21,6 +21,7 @@ type CounterSnapshot struct {
 	EmptyStubsSkipped uint64 `json:"empty_stubs_skipped"`
 	ReceiptsSelf      uint64 `json:"receipts_self"`
 	ReceiptsDropped   uint64 `json:"receipts_dropped"`
+	AppendErrors      uint64 `json:"append_errors"`
 	Quarantined       uint64 `json:"quarantined"`
 	StaleReplays      uint64 `json:"stale_replays"`
 	EchoReconciled    uint64 `json:"echo_reconciled"`
@@ -43,6 +44,7 @@ type accountCounters struct {
 	emptyStubsSkipped atomic.Uint64
 	receiptsSelf      atomic.Uint64
 	receiptsDropped   atomic.Uint64
+	appendErrors      atomic.Uint64
 	quarantined       atomic.Uint64
 	staleReplays      atomic.Uint64
 	echoReconciled    atomic.Uint64
@@ -122,6 +124,7 @@ func snapshotCounters(c *accountCounters) CounterSnapshot {
 		EmptyStubsSkipped: c.emptyStubsSkipped.Load(),
 		ReceiptsSelf:      c.receiptsSelf.Load(),
 		ReceiptsDropped:   c.receiptsDropped.Load(),
+		AppendErrors:     c.appendErrors.Load(),
 		Quarantined:       c.quarantined.Load(),
 		StaleReplays:      c.staleReplays.Load(),
 		EchoReconciled:    c.echoReconciled.Load(),

--- a/internal/ingest/review_fixes_test.go
+++ b/internal/ingest/review_fixes_test.go
@@ -191,3 +191,42 @@ func TestWorkerSelfReceiptBeforeConversationIsBenign(t *testing.T) {
 	}
 	workerPathAssertAllProcessed(t, harness.messages)
 }
+
+// Delivered-class self receipts acknowledge outgoing delivery; they say
+// nothing about what the local user has read, so they must not advance the
+// read cursor.
+func TestWorkerDeliveredSelfReceiptDoesNotAdvanceReadCursor(t *testing.T) {
+	harness := newWorkerPathHarness(t, bridge.PlatformWhatsApp, map[string][]bridge.Event{
+		"delivered-self": {{
+			Kind: bridge.EventReceipt,
+			Receipt: &bridge.ReceiptEvent{
+				RemoteConversationID: "whatsapp:15551234567@s.whatsapp.net",
+				RemoteMessageIDs:     []string{"delivered-ack"},
+				Actor:                bridge.IdentityRef{IsSelf: true},
+				Status:               "delivered",
+				OccurredAt:           time.UnixMilli(workerPathNowMS - 50),
+			},
+		}},
+	})
+
+	harness.process(t, "delivered-self")
+
+	snapshot := harness.worker.Counters().Snapshot(workerPathAccountID)
+	if snapshot.ReceiptsDropped != 1 || snapshot.ReceiptsSelf != 0 || snapshot.Quarantined != 0 {
+		t.Fatalf("delivered self-receipt counters = %+v, want dropped=1 self=0", snapshot)
+	}
+	workerPathAssertAllProcessed(t, harness.messages)
+}
+
+func TestSinkRecordIngressErrorCountsPerAccount(t *testing.T) {
+	counters := &Counters{}
+	sink := &Sink{counters: counters}
+	sink.RecordIngressError("account-err")
+	sink.RecordIngressError("account-err")
+	if got := counters.Snapshot("account-err").AppendErrors; got != 2 {
+		t.Fatalf("AppendErrors = %d, want 2", got)
+	}
+	if got := counters.Snapshot("account-other").AppendErrors; got != 0 {
+		t.Fatalf("other-account AppendErrors = %d, want 0", got)
+	}
+}

--- a/internal/ingest/sink.go
+++ b/internal/ingest/sink.go
@@ -35,6 +35,13 @@ type Sink struct {
 
 var _ bridge.ConnectionSink = (*Sink)(nil)
 
+// RecordIngressError counts a capture or append fault surfaced by a transport
+// adapter. The frame itself was logged and dropped at the transport edge; the
+// counter keeps /api/status honest about ingest losses.
+func (s *Sink) RecordIngressError(accountID string) {
+	s.counters.account(accountID).appendErrors.Add(1)
+}
+
 // NewSink constructs a storage-backed ConnectionSink.
 func NewSink(config SinkConfig) (*Sink, error) {
 	if config.Messages == nil {

--- a/internal/ingest/whatsappdecoder.go
+++ b/internal/ingest/whatsappdecoder.go
@@ -354,7 +354,6 @@ func (d *WhatsAppDecoder) decodeReceipt(
 		return nil, nil
 	}
 	actor := whatsAppIdentity(envelope.SenderJID, "", self)
-	actor.IsSelf = self
 	return []bridge.Event{{
 		Kind: bridge.EventReceipt,
 		Receipt: &bridge.ReceiptEvent{

--- a/internal/ingest/whatsappdecoder.go
+++ b/internal/ingest/whatsappdecoder.go
@@ -1,0 +1,671 @@
+package ingest
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+	waHistorySync "go.mau.fi/whatsmeow/proto/waHistorySync"
+	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/whatsapplive"
+)
+
+const (
+	// WhatsAppCodec is the durable capture-time WhatsApp event codec.
+	WhatsAppCodec = whatsapplive.IngressCodec
+	// WhatsAppCodecVersion is the only envelope version understood here.
+	WhatsAppCodecVersion uint32 = whatsapplive.IngressCodecVersion
+)
+
+const (
+	whatsAppFrameMessage     = "message"
+	whatsAppFrameReceipt     = "receipt"
+	whatsAppFrameHistorySync = "history_sync"
+)
+
+// whatsAppFrameEnvelope is the union of the three v1 JSON envelope shapes.
+// Encoding lives at the capture boundary in whatsapplive; this type is only
+// used to parse the durable bytes without consulting any live WhatsApp state.
+type whatsAppFrameEnvelope struct {
+	Kind        string            `json:"kind"`
+	ChatJID     string            `json:"chat_jid"`
+	SenderJID   string            `json:"sender_jid"`
+	MessageID   string            `json:"message_id"`
+	TimestampMS int64             `json:"timestamp_ms"`
+	IsFromMe    bool              `json:"is_from_me"`
+	IsGroup     bool              `json:"is_group"`
+	PushName    string            `json:"push_name"`
+	Mentions    map[string]string `json:"mentions"`
+	ProtoB64    []byte            `json:"proto_b64"`
+	ReceiptType string            `json:"receipt_type"`
+	MessageIDs  []string          `json:"message_ids"`
+}
+
+// WhatsAppDecoderSnapshot exposes deterministic skip classifications that do
+// not produce bridge events (and therefore cannot use the worker's event-drop
+// counters). The snapshot is partitioned by account like the ingest counters.
+type WhatsAppDecoderSnapshot struct {
+	EmptyMessagesSkipped       uint64
+	UnsupportedMessagesSkipped uint64
+	EncryptedReactionsSkipped  uint64
+	UnsupportedReceiptsSkipped uint64
+	InvalidHistoryItemsSkipped uint64
+}
+
+type whatsAppDecoderCounters struct {
+	emptyMessages       atomic.Uint64
+	unsupportedMessages atomic.Uint64
+	encryptedReactions  atomic.Uint64
+	unsupportedReceipts atomic.Uint64
+	invalidHistoryItems atomic.Uint64
+}
+
+// WhatsAppDecoder maps capture-enriched WhatsApp frames to normalized events.
+// It is deliberately store-free: canonical chat JIDs and mention labels must
+// already be present in the durable frame.
+type WhatsAppDecoder struct {
+	mu       sync.RWMutex
+	accounts map[string]*whatsAppDecoderCounters
+}
+
+var _ bridge.Decoder = (*WhatsAppDecoder)(nil)
+
+// NewWhatsAppDecoder returns a v1 decoder. Its result is safe for concurrent
+// Snapshot calls while the single ingest worker decodes frames.
+func NewWhatsAppDecoder() *WhatsAppDecoder { return &WhatsAppDecoder{} }
+
+// NewWhatsAppDecoderRegistration is the self-contained I3 registration seam.
+// I1 intentionally has no mutable/default registry, so the stack owner should
+// append this value to WorkerConfig.Decoders at merge time.
+func NewWhatsAppDecoderRegistration() DecoderRegistration {
+	return DecoderRegistration{
+		Codec:    WhatsAppCodec,
+		Platform: bridge.PlatformWhatsApp,
+		Decoder:  NewWhatsAppDecoder(),
+	}
+}
+
+// Snapshot returns no-event decode classifications for one account.
+func (d *WhatsAppDecoder) Snapshot(accountID string) WhatsAppDecoderSnapshot {
+	if d == nil {
+		return WhatsAppDecoderSnapshot{}
+	}
+	d.mu.RLock()
+	counters := d.accounts[accountID]
+	d.mu.RUnlock()
+	if counters == nil {
+		return WhatsAppDecoderSnapshot{}
+	}
+	return WhatsAppDecoderSnapshot{
+		EmptyMessagesSkipped:       counters.emptyMessages.Load(),
+		UnsupportedMessagesSkipped: counters.unsupportedMessages.Load(),
+		EncryptedReactionsSkipped:  counters.encryptedReactions.Load(),
+		UnsupportedReceiptsSkipped: counters.unsupportedReceipts.Load(),
+		InvalidHistoryItemsSkipped: counters.invalidHistoryItems.Load(),
+	}
+}
+
+func (d *WhatsAppDecoder) account(accountID string) *whatsAppDecoderCounters {
+	d.mu.RLock()
+	counters := d.accounts[accountID]
+	d.mu.RUnlock()
+	if counters != nil {
+		return counters
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.accounts == nil {
+		d.accounts = make(map[string]*whatsAppDecoderCounters)
+	}
+	if counters = d.accounts[accountID]; counters == nil {
+		counters = &whatsAppDecoderCounters{}
+		d.accounts[accountID] = counters
+	}
+	return counters
+}
+
+// Decode parses one capture-time envelope without reaching into the live
+// whatsmeow client, its contact store, or its LID-to-PN mapping.
+func (d *WhatsAppDecoder) Decode(
+	ctx context.Context,
+	record bridge.RawIngressRecord,
+) ([]bridge.Event, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("decode WhatsApp ingress: context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if record.Codec != WhatsAppCodec {
+		return nil, fmt.Errorf(
+			"decode WhatsApp ingress: codec %q is not %q",
+			record.Codec,
+			WhatsAppCodec,
+		)
+	}
+	if record.CodecVersion != WhatsAppCodecVersion {
+		return nil, fmt.Errorf(
+			"decode WhatsApp ingress: codec version %d is unsupported",
+			record.CodecVersion,
+		)
+	}
+
+	var envelope whatsAppFrameEnvelope
+	if err := json.Unmarshal(record.Payload, &envelope); err != nil {
+		return nil, fmt.Errorf("decode WhatsApp ingress envelope: %w", err)
+	}
+	switch envelope.Kind {
+	case whatsAppFrameMessage:
+		return d.decodeMessage(record.AccountID, envelope)
+	case whatsAppFrameReceipt:
+		return d.decodeReceipt(record.AccountID, envelope)
+	case whatsAppFrameHistorySync:
+		return d.decodeHistorySync(record.AccountID, envelope.ProtoB64)
+	default:
+		return nil, fmt.Errorf(
+			"decode WhatsApp ingress envelope: kind %q is unsupported",
+			envelope.Kind,
+		)
+	}
+}
+
+func (d *WhatsAppDecoder) decodeMessage(
+	accountID string,
+	envelope whatsAppFrameEnvelope,
+) ([]bridge.Event, error) {
+	if strings.TrimSpace(envelope.ChatJID) == "" {
+		return nil, fmt.Errorf("decode WhatsApp message: chat_jid is empty")
+	}
+	if strings.TrimSpace(envelope.MessageID) == "" {
+		return nil, fmt.Errorf("decode WhatsApp message: message_id is empty")
+	}
+	if envelope.TimestampMS <= 0 {
+		return nil, fmt.Errorf("decode WhatsApp message: timestamp_ms is not positive")
+	}
+
+	var message waE2E.Message
+	if err := proto.Unmarshal(envelope.ProtoB64, &message); err != nil {
+		return nil, fmt.Errorf("decode WhatsApp message protobuf: %w", err)
+	}
+	return d.decodeMessageProto(accountID, envelope, &message, false)
+}
+
+func (d *WhatsAppDecoder) decodeMessageProto(
+	accountID string,
+	envelope whatsAppFrameEnvelope,
+	message *waE2E.Message,
+	history bool,
+) ([]bridge.Event, error) {
+	conversationID := whatsAppRemoteConversationID(envelope.ChatJID)
+	occurredAt := time.UnixMilli(envelope.TimestampMS)
+	sender := whatsAppIdentity(envelope.SenderJID, envelope.PushName, envelope.IsFromMe)
+
+	if reaction := whatsapplive.ExtractReactionMessage(message); reaction != nil {
+		targetID := strings.TrimSpace(reaction.GetKey().GetID())
+		if targetID == "" {
+			d.account(accountID).unsupportedMessages.Add(1)
+			return nil, nil
+		}
+		action := bridge.ReactionAdd
+		emoji := strings.TrimSpace(reaction.GetText())
+		if emoji == "" {
+			action = bridge.ReactionRemove
+		}
+		return []bridge.Event{{
+			Kind: bridge.EventReaction,
+			Reaction: &bridge.ReactionEvent{
+				RemoteConversationID:  conversationID,
+				TargetRemoteMessageID: targetID,
+				Actor:                 sender,
+				Emoji:                 emoji,
+				Action:                action,
+				OccurredAt:            occurredAt,
+			},
+		}}, nil
+	}
+
+	if protocol := whatsapplive.ExtractProtocolMessage(message); protocol != nil {
+		key := protocol.GetKey()
+		targetID := strings.TrimSpace(key.GetID())
+		switch protocol.GetType() {
+		case waE2E.ProtocolMessage_MESSAGE_EDIT:
+			if targetID == "" || protocol.GetEditedMessage() == nil {
+				d.account(accountID).unsupportedMessages.Add(1)
+				return nil, nil
+			}
+			body := whatsapplive.ExtractMessageBody(protocol.GetEditedMessage())
+			body = FormatWhatsAppMentionedBody(body, envelope.Mentions)
+			if body == "" || body == "[Unsupported message]" {
+				d.account(accountID).unsupportedMessages.Add(1)
+				return nil, nil
+			}
+			return []bridge.Event{{
+				Kind: bridge.EventMessageMutation,
+				MessageMutation: &bridge.MessageMutationEvent{
+					RemoteConversationID: conversationID,
+					RemoteMessageID:      targetID,
+					Kind:                 "edit",
+					Body:                 body,
+					OccurredAt:           occurredAt,
+				},
+			}}, nil
+		case waE2E.ProtocolMessage_REVOKE:
+			// REVOKE is the enum zero value. As in the legacy handler, a real
+			// target key is required before interpreting it as a deletion.
+			if targetID == "" {
+				d.account(accountID).unsupportedMessages.Add(1)
+				return nil, nil
+			}
+			return []bridge.Event{{
+				Kind: bridge.EventMessageMutation,
+				MessageMutation: &bridge.MessageMutationEvent{
+					RemoteConversationID: conversationID,
+					RemoteMessageID:      targetID,
+					Kind:                 "delete",
+					OccurredAt:           occurredAt,
+				},
+			}}, nil
+		default:
+			d.account(accountID).unsupportedMessages.Add(1)
+			return nil, nil
+		}
+	}
+
+	if whatsapplive.HasEncryptedReactionMessage(message) {
+		d.account(accountID).encryptedReactions.Add(1)
+		return nil, nil
+	}
+
+	body := whatsapplive.ExtractMessageBody(message)
+	switch body {
+	case "":
+		d.account(accountID).emptyMessages.Add(1)
+		return nil, nil
+	case "[Unsupported message]":
+		d.account(accountID).unsupportedMessages.Add(1)
+		return nil, nil
+	}
+	body = FormatWhatsAppMentionedBody(body, envelope.Mentions)
+	attachments, err := whatsAppAttachments(message)
+	if err != nil {
+		return nil, err
+	}
+	direction := "incoming"
+	if envelope.IsFromMe {
+		direction = "outgoing"
+	}
+	event := bridge.Event{
+		Kind: bridge.EventMessage,
+		Message: &bridge.MessageEvent{
+			RemoteConversationID: conversationID,
+			RemoteMessageID:      strings.TrimSpace(envelope.MessageID),
+			ClientRequestID:      "",
+			Sender:               sender,
+			Direction:            direction,
+			Body:                 body,
+			Attachments:          attachments,
+			ReplyToRemoteID: strings.TrimPrefix(
+				whatsapplive.ExtractReplyToID(message),
+				"whatsapp:",
+			),
+			OccurredAt: occurredAt,
+		},
+	}
+	if history && event.Message.RemoteMessageID == "" {
+		d.account(accountID).invalidHistoryItems.Add(1)
+		return nil, nil
+	}
+	return []bridge.Event{event}, nil
+}
+
+func (d *WhatsAppDecoder) decodeReceipt(
+	accountID string,
+	envelope whatsAppFrameEnvelope,
+) ([]bridge.Event, error) {
+	if strings.TrimSpace(envelope.ChatJID) == "" {
+		return nil, fmt.Errorf("decode WhatsApp receipt: chat_jid is empty")
+	}
+	if envelope.TimestampMS <= 0 {
+		return nil, fmt.Errorf("decode WhatsApp receipt: timestamp_ms is not positive")
+	}
+	status, self, ok := whatsAppReceiptStatus(envelope.ReceiptType)
+	if !ok || len(envelope.MessageIDs) == 0 {
+		d.account(accountID).unsupportedReceipts.Add(1)
+		return nil, nil
+	}
+	messageIDs := make([]string, 0, len(envelope.MessageIDs))
+	for _, messageID := range envelope.MessageIDs {
+		if messageID = strings.TrimSpace(messageID); messageID != "" {
+			messageIDs = append(messageIDs, messageID)
+		}
+	}
+	if len(messageIDs) == 0 {
+		d.account(accountID).unsupportedReceipts.Add(1)
+		return nil, nil
+	}
+	actor := whatsAppIdentity(envelope.SenderJID, "", self)
+	actor.IsSelf = self
+	return []bridge.Event{{
+		Kind: bridge.EventReceipt,
+		Receipt: &bridge.ReceiptEvent{
+			RemoteConversationID: whatsAppRemoteConversationID(envelope.ChatJID),
+			RemoteMessageIDs:     messageIDs,
+			Actor:                actor,
+			Status:               status,
+			OccurredAt:           time.UnixMilli(envelope.TimestampMS),
+		},
+	}}, nil
+}
+
+func (d *WhatsAppDecoder) decodeHistorySync(
+	accountID string,
+	protoBytes []byte,
+) ([]bridge.Event, error) {
+	var history waHistorySync.HistorySync
+	if err := proto.Unmarshal(protoBytes, &history); err != nil {
+		return nil, fmt.Errorf("decode WhatsApp history sync protobuf: %w", err)
+	}
+	aliases := whatsAppHistoryAliases(&history)
+	pushNames := whatsAppHistoryPushNames(&history, aliases)
+	var events []bridge.Event
+	for _, conversation := range history.GetConversations() {
+		if conversation == nil {
+			d.account(accountID).invalidHistoryItems.Add(1)
+			continue
+		}
+		chatJID := canonicalHistoryJID(conversation.GetID(), conversation.GetPnJID(), aliases)
+		if chatJID == "" {
+			d.account(accountID).invalidHistoryItems.Add(1)
+			continue
+		}
+		for _, item := range conversation.GetMessages() {
+			webMessage := item.GetMessage()
+			if webMessage == nil || webMessage.GetMessage() == nil {
+				d.account(accountID).invalidHistoryItems.Add(1)
+				continue
+			}
+			key := webMessage.GetKey()
+			messageID := strings.TrimSpace(key.GetID())
+			timestamp := int64(webMessage.GetMessageTimestamp())
+			if messageID == "" || timestamp <= 0 {
+				d.account(accountID).invalidHistoryItems.Add(1)
+				continue
+			}
+			// The enclosing conversation is authoritative here: it carries the
+			// capture-time PN alias (`pnJID`) that a message key containing the
+			// older LID form may not. Re-preferring key.remoteJID would undo that
+			// canonicalization inside the pure decoder.
+			messageChatJID := chatJID
+			senderJID := strings.TrimSpace(webMessage.GetParticipant())
+			if senderJID == "" {
+				senderJID = strings.TrimSpace(key.GetParticipant())
+			}
+			if senderJID == "" && !key.GetFromMe() {
+				senderJID = messageChatJID
+			}
+			senderJID = canonicalHistoryJID(senderJID, "", aliases)
+			pushName := strings.TrimSpace(webMessage.GetPushName())
+			if pushName == "" {
+				pushName = pushNames[senderJID]
+			}
+			mentions := whatsAppHistoryMentions(webMessage.GetMessage(), aliases, pushNames)
+			envelope := whatsAppFrameEnvelope{
+				Kind:        whatsAppFrameMessage,
+				ChatJID:     messageChatJID,
+				SenderJID:   senderJID,
+				MessageID:   messageID,
+				TimestampMS: timestamp * 1000,
+				IsFromMe:    key.GetFromMe(),
+				IsGroup:     whatsAppJIDServer(messageChatJID) == types.GroupServer,
+				PushName:    pushName,
+				Mentions:    mentions,
+			}
+			decoded, err := d.decodeMessageProto(
+				accountID,
+				envelope,
+				webMessage.GetMessage(),
+				true,
+			)
+			if err != nil {
+				return nil, err
+			}
+			// HistorySync is an import of message rows. Reactions and mutations
+			// inside the snapshot do not have an ordered target projection here.
+			for _, event := range decoded {
+				if event.Kind == bridge.EventMessage {
+					events = append(events, event)
+				}
+			}
+		}
+	}
+	return events, nil
+}
+
+func whatsAppAttachments(message *waE2E.Message) ([]bridge.Attachment, error) {
+	mediaRef, mediaKey, mimeType, ok := whatsapplive.ExtractStoredMediaRef(message)
+	if !ok {
+		return nil, nil
+	}
+	opaque, err := json.Marshal(struct {
+		Version       int    `json:"v"`
+		Kind          string `json:"kind"`
+		DirectPath    string `json:"direct_path"`
+		FileSHA256    string `json:"file_sha256"`
+		FileEncSHA256 string `json:"file_enc_sha256"`
+		MediaKey      string `json:"media_key"`
+		FileLength    uint64 `json:"file_length"`
+	}{
+		Version:       1,
+		Kind:          "remote",
+		DirectPath:    mediaRef.DirectPath,
+		FileSHA256:    mediaRef.FileSHA256,
+		FileEncSHA256: mediaRef.FileEncSHA256,
+		MediaKey:      hex.EncodeToString(mediaKey),
+		FileLength:    mediaRef.FileLength,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pack WhatsApp media reference: %w", err)
+	}
+	return []bridge.Attachment{{
+		RemoteID:  mediaRef.DirectPath,
+		RemoteRef: opaque,
+		MIME:      strings.TrimSpace(mimeType),
+		Size:      int64(mediaRef.FileLength),
+	}}, nil
+}
+
+func whatsAppRemoteConversationID(chatJID string) string {
+	return "whatsapp:" + strings.TrimSpace(chatJID)
+}
+
+func whatsAppIdentity(jid, name string, self bool) bridge.IdentityRef {
+	jid = strings.TrimSpace(jid)
+	raw := jid
+	if parsed, err := types.ParseJID(jid); err == nil {
+		parsed = parsed.ToNonAD()
+		if parsed.Server == types.DefaultUserServer && allASCIIDigits(parsed.User) {
+			raw = "+" + parsed.User
+		} else {
+			raw = parsed.String()
+		}
+	}
+	return bridge.IdentityRef{
+		Raw:    raw,
+		Name:   strings.TrimSpace(name),
+		IsSelf: self,
+	}
+}
+
+func allASCIIDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func whatsAppReceiptStatus(receiptType string) (status string, self bool, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(receiptType)) {
+	case "delivered":
+		return "delivered", false, true
+	case "sender":
+		// WhatsApp emits sender receipts from another linked device owned by
+		// the current account. This is the specified sender-is-own case.
+		return "delivered", true, true
+	case "read":
+		return "read", false, true
+	case "read_self":
+		return "read", true, true
+	case "played":
+		return "read", false, true
+	case "played_self":
+		return "read", true, true
+	case "server_error":
+		return "failed", false, true
+	default:
+		return "", false, false
+	}
+}
+
+// FormatWhatsAppMentionedBody applies only the pure half of mention
+// formatting. Capture has already resolved each JID to a display label.
+func FormatWhatsAppMentionedBody(body string, mentions map[string]string) string {
+	body = strings.TrimSpace(body)
+	if body == "" || len(mentions) == 0 {
+		return body
+	}
+	type replacement struct {
+		token string
+		value string
+	}
+	seen := make(map[string]struct{}, len(mentions))
+	replacements := make([]replacement, 0, len(mentions))
+	for rawJID, display := range mentions {
+		display = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(display), "@~"))
+		if display == "" {
+			continue
+		}
+		jid := strings.TrimSpace(rawJID)
+		if parsed, err := types.ParseJID(jid); err == nil {
+			jid = strings.TrimSpace(parsed.ToNonAD().User)
+		} else if index := strings.IndexByte(jid, '@'); index >= 0 {
+			jid = strings.TrimSpace(jid[:index])
+		}
+		jid = strings.TrimPrefix(jid, "@")
+		if jid == "" {
+			continue
+		}
+		token := "@" + jid
+		value := "@~" + display
+		if token == value {
+			continue
+		}
+		if _, duplicate := seen[token]; duplicate {
+			continue
+		}
+		seen[token] = struct{}{}
+		replacements = append(replacements, replacement{token: token, value: value})
+	}
+	sort.Slice(replacements, func(i, j int) bool {
+		if len(replacements[i].token) != len(replacements[j].token) {
+			return len(replacements[i].token) > len(replacements[j].token)
+		}
+		return replacements[i].token < replacements[j].token
+	})
+	for _, replacement := range replacements {
+		body = strings.ReplaceAll(body, replacement.token, replacement.value)
+	}
+	return body
+}
+
+func whatsAppHistoryAliases(history *waHistorySync.HistorySync) map[string]string {
+	aliases := make(map[string]string)
+	for _, mapping := range history.GetPhoneNumberToLidMappings() {
+		if mapping == nil {
+			continue
+		}
+		lid := strings.TrimSpace(mapping.GetLidJID())
+		pn := strings.TrimSpace(mapping.GetPnJID())
+		if lid != "" && pn != "" {
+			aliases[lid] = pn
+		}
+	}
+	return aliases
+}
+
+func whatsAppHistoryPushNames(
+	history *waHistorySync.HistorySync,
+	aliases map[string]string,
+) map[string]string {
+	names := make(map[string]string)
+	for _, item := range history.GetPushnames() {
+		if item == nil {
+			continue
+		}
+		id := canonicalHistoryJID(item.GetID(), "", aliases)
+		name := strings.TrimSpace(item.GetPushname())
+		if id != "" && name != "" {
+			names[id] = name
+		}
+	}
+	return names
+}
+
+func canonicalHistoryJID(raw, pn string, aliases map[string]string) string {
+	raw = strings.TrimSpace(raw)
+	pn = strings.TrimSpace(pn)
+	if pn != "" && (raw == "" || whatsAppJIDServer(raw) == types.HiddenUserServer) {
+		raw = pn
+	}
+	if canonical := strings.TrimSpace(aliases[raw]); canonical != "" {
+		raw = canonical
+	}
+	if parsed, err := types.ParseJID(raw); err == nil {
+		return parsed.ToNonAD().String()
+	}
+	return raw
+}
+
+func whatsAppJIDServer(raw string) string {
+	parsed, err := types.ParseJID(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	return parsed.Server
+}
+
+func whatsAppHistoryMentions(
+	message *waE2E.Message,
+	aliases map[string]string,
+	pushNames map[string]string,
+) map[string]string {
+	mentioned := whatsapplive.ExtractMentionedJIDs(message)
+	if len(mentioned) == 0 {
+		return nil
+	}
+	result := make(map[string]string)
+	for _, raw := range mentioned {
+		canonical := canonicalHistoryJID(raw, "", aliases)
+		name := strings.TrimSpace(pushNames[canonical])
+		if name == "" {
+			continue
+		}
+		result[strings.TrimSpace(raw)] = name
+		result[canonical] = name
+	}
+	return result
+}

--- a/internal/ingest/whatsappdecoder_test.go
+++ b/internal/ingest/whatsappdecoder_test.go
@@ -1,0 +1,774 @@
+package ingest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	waCommon "go.mau.fi/whatsmeow/proto/waCommon"
+	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+	waHistorySync "go.mau.fi/whatsmeow/proto/waHistorySync"
+	waWeb "go.mau.fi/whatsmeow/proto/waWeb"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+const (
+	waDecoderAccountID = "whatsapp-decoder-account"
+	waWorkerAccountID  = "whatsapp-worker-account"
+	waCanonicalChatJID = "14155550100@s.whatsapp.net"
+	waSenderJID        = "14155550200@s.whatsapp.net"
+	waTimestampMS      = int64(1_752_777_123_456)
+)
+
+var waWorkerNow = time.Date(2026, 7, 17, 19, 30, 0, 0, time.UTC)
+
+func TestWhatsAppDecoderRegistration(t *testing.T) {
+	t.Parallel()
+
+	registration := NewWhatsAppDecoderRegistration()
+	if registration.Codec != WhatsAppCodec {
+		t.Fatalf("registration codec = %q, want %q", registration.Codec, WhatsAppCodec)
+	}
+	if registration.Platform != bridge.PlatformWhatsApp {
+		t.Fatalf("registration platform = %q, want %q", registration.Platform, bridge.PlatformWhatsApp)
+	}
+	if _, ok := registration.Decoder.(*WhatsAppDecoder); !ok {
+		t.Fatalf("registration decoder type = %T, want *WhatsAppDecoder", registration.Decoder)
+	}
+}
+
+func TestWhatsAppDecoderMessageFrameTable(t *testing.T) {
+	t.Parallel()
+
+	plainEnvelope := waBaseMessageEnvelope()
+	plainEnvelope.MessageID = "plain-message"
+	plainEnvelope.Mentions = map[string]string{
+		"14155550300@s.whatsapp.net": "Ada Lovelace",
+	}
+	plainMessage := &waE2E.Message{
+		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+			Text: proto.String("hello @14155550300"),
+			ContextInfo: &waE2E.ContextInfo{
+				StanzaID:     proto.String("reply-stanza"),
+				MentionedJID: []string{"14155550300@s.whatsapp.net"},
+			},
+		},
+	}
+
+	mediaEnvelope := waBaseMessageEnvelope()
+	mediaEnvelope.MessageID = "media-message"
+	mediaEnvelope.IsFromMe = true
+	mediaEnvelope.SenderJID = "14155550999:7@s.whatsapp.net"
+	mediaMessage := &waE2E.Message{
+		ImageMessage: &waE2E.ImageMessage{
+			Caption:       proto.String("captured photo"),
+			Mimetype:      proto.String("image/jpeg"),
+			DirectPath:    proto.String("/mms/image/decoder-fixture"),
+			FileSHA256:    []byte{0x01, 0x02, 0x03},
+			FileEncSHA256: []byte{0x04, 0x05, 0x06},
+			MediaKey:      []byte{0x07, 0x08, 0x09},
+			FileLength:    proto.Uint64(321),
+		},
+	}
+
+	reactionEnvelope := waBaseMessageEnvelope()
+	reactionEnvelope.MessageID = "reaction-envelope"
+	reactionAdd := &waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{
+		Key:  &waCommon.MessageKey{ID: proto.String("reaction-target")},
+		Text: proto.String("👍"),
+	}}
+	reactionRemove := &waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{
+		Key:  &waCommon.MessageKey{ID: proto.String("reaction-target")},
+		Text: proto.String(""),
+	}}
+
+	tests := []struct {
+		name     string
+		envelope whatsAppFrameEnvelope
+		message  *waE2E.Message
+		check    func(*testing.T, bridge.Event)
+	}{
+		{
+			name:     "plain with canonical chat, reply, and captured mention",
+			envelope: plainEnvelope,
+			message:  plainMessage,
+			check: func(t *testing.T, event bridge.Event) {
+				t.Helper()
+				if event.Kind != bridge.EventMessage || event.Message == nil {
+					t.Fatalf("event = %+v, want MessageEvent", event)
+				}
+				message := event.Message
+				if message.RemoteConversationID != "whatsapp:"+waCanonicalChatJID {
+					t.Fatalf("remote conversation ID = %q, want capture-time JID byte-for-byte", message.RemoteConversationID)
+				}
+				if message.RemoteMessageID != "plain-message" || message.ClientRequestID != "" {
+					t.Fatalf("message IDs = (%q, %q), want (plain-message, empty client request)", message.RemoteMessageID, message.ClientRequestID)
+				}
+				if message.Direction != "incoming" || message.Body != "hello @~Ada Lovelace" {
+					t.Fatalf("message direction/body = (%q, %q), want incoming pure mention formatting", message.Direction, message.Body)
+				}
+				if message.ReplyToRemoteID != "reply-stanza" {
+					t.Fatalf("reply ID = %q, want reply-stanza", message.ReplyToRemoteID)
+				}
+				if message.Sender.Raw != "+14155550200" || message.Sender.Name != "Grace Hopper" || message.Sender.IsSelf {
+					t.Fatalf("sender = %+v, want captured PN identity", message.Sender)
+				}
+				if !message.OccurredAt.Equal(time.UnixMilli(waTimestampMS)) {
+					t.Fatalf("occurred at = %v, want %v", message.OccurredAt, time.UnixMilli(waTimestampMS))
+				}
+			},
+		},
+		{
+			name:     "media packs remote download reference",
+			envelope: mediaEnvelope,
+			message:  mediaMessage,
+			check: func(t *testing.T, event bridge.Event) {
+				t.Helper()
+				if event.Kind != bridge.EventMessage || event.Message == nil {
+					t.Fatalf("event = %+v, want MessageEvent", event)
+				}
+				message := event.Message
+				if message.Direction != "outgoing" || !message.Sender.IsSelf || message.ClientRequestID != "" {
+					t.Fatalf("outgoing media routing = direction %q sender %+v client_request_id %q", message.Direction, message.Sender, message.ClientRequestID)
+				}
+				if message.Body != "captured photo" || len(message.Attachments) != 1 {
+					t.Fatalf("media message = body %q attachments %+v", message.Body, message.Attachments)
+				}
+				attachment := message.Attachments[0]
+				if attachment.RemoteID != "/mms/image/decoder-fixture" || attachment.MIME != "image/jpeg" || attachment.Size != 321 {
+					t.Fatalf("attachment metadata = %+v", attachment)
+				}
+				if err := whatsappadapter.ValidateDownloadOpaque(attachment.RemoteRef); err != nil {
+					t.Fatalf("ValidateDownloadOpaque(): %v; raw=%s", err, attachment.RemoteRef)
+				}
+				var packed struct {
+					Version       int    `json:"v"`
+					Kind          string `json:"kind"`
+					DirectPath    string `json:"direct_path"`
+					FileSHA256    string `json:"file_sha256"`
+					FileEncSHA256 string `json:"file_enc_sha256"`
+					MediaKey      string `json:"media_key"`
+					FileLength    uint64 `json:"file_length"`
+				}
+				if err := json.Unmarshal(attachment.RemoteRef, &packed); err != nil {
+					t.Fatalf("unmarshal packed media reference: %v", err)
+				}
+				if packed.Version != 1 || packed.Kind != "remote" ||
+					packed.DirectPath != "/mms/image/decoder-fixture" ||
+					packed.FileSHA256 != "010203" || packed.FileEncSHA256 != "040506" ||
+					packed.MediaKey != "070809" || packed.FileLength != 321 {
+					t.Fatalf("packed media reference = %+v", packed)
+				}
+			},
+		},
+		{
+			name:     "reaction add",
+			envelope: reactionEnvelope,
+			message:  reactionAdd,
+			check: func(t *testing.T, event bridge.Event) {
+				t.Helper()
+				if event.Kind != bridge.EventReaction || event.Reaction == nil {
+					t.Fatalf("event = %+v, want ReactionEvent", event)
+				}
+				reaction := event.Reaction
+				if reaction.RemoteConversationID != "whatsapp:"+waCanonicalChatJID ||
+					reaction.TargetRemoteMessageID != "reaction-target" ||
+					reaction.Emoji != "👍" || reaction.Action != bridge.ReactionAdd {
+					t.Fatalf("reaction add = %+v", reaction)
+				}
+			},
+		},
+		{
+			name:     "reaction remove",
+			envelope: reactionEnvelope,
+			message:  reactionRemove,
+			check: func(t *testing.T, event bridge.Event) {
+				t.Helper()
+				if event.Kind != bridge.EventReaction || event.Reaction == nil {
+					t.Fatalf("event = %+v, want ReactionEvent", event)
+				}
+				if event.Reaction.Action != bridge.ReactionRemove || event.Reaction.Emoji != "" {
+					t.Fatalf("reaction remove = %+v", event.Reaction)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			decoder := NewWhatsAppDecoder()
+			record, _ := waMessageRecord(t, test.envelope, test.message)
+			events, err := decoder.Decode(context.Background(), record)
+			if err != nil {
+				t.Fatalf("Decode(): %v", err)
+			}
+			if len(events) != 1 {
+				t.Fatalf("Decode() event count = %d, want 1: %+v", len(events), events)
+			}
+			test.check(t, events[0])
+		})
+	}
+}
+
+func TestFormatWhatsAppMentionedBodyIsPureAndDeterministic(t *testing.T) {
+	t.Parallel()
+
+	mentions := map[string]string{
+		"123@s.whatsapp.net":   "@~Short Name",
+		"12345@s.whatsapp.net": "Long Name",
+	}
+	wantMentions := map[string]string{
+		"123@s.whatsapp.net":   "@~Short Name",
+		"12345@s.whatsapp.net": "Long Name",
+	}
+	const body = "@12345 ping @123 and leave @999 alone"
+	const want = "@~Long Name ping @~Short Name and leave @999 alone"
+
+	for attempt := 0; attempt < 2; attempt++ {
+		if got := FormatWhatsAppMentionedBody(body, mentions); got != want {
+			t.Fatalf("FormatWhatsAppMentionedBody() = %q, want %q", got, want)
+		}
+	}
+	if !reflect.DeepEqual(mentions, wantMentions) {
+		t.Fatalf("mention map mutated: got %+v, want %+v", mentions, wantMentions)
+	}
+}
+
+func TestWhatsAppDecoderMutationFrameTable(t *testing.T) {
+	t.Parallel()
+
+	base := waBaseMessageEnvelope()
+	base.Mentions = map[string]string{"14155550300@s.whatsapp.net": "Katherine Johnson"}
+	tests := []struct {
+		name       string
+		message    *waE2E.Message
+		wantKind   string
+		wantTarget string
+		wantBody   string
+	}{
+		{
+			name: "edit",
+			message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{
+				Key:  &waCommon.MessageKey{ID: proto.String("edit-target")},
+				Type: waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(),
+				EditedMessage: &waE2E.Message{
+					ExtendedTextMessage: &waE2E.ExtendedTextMessage{Text: proto.String("edited for @14155550300")},
+				},
+			}},
+			wantKind:   "edit",
+			wantTarget: "edit-target",
+			wantBody:   "edited for @~Katherine Johnson",
+		},
+		{
+			name: "delete",
+			message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{
+				Key:  &waCommon.MessageKey{ID: proto.String("delete-target")},
+				Type: waE2E.ProtocolMessage_REVOKE.Enum(),
+			}},
+			wantKind:   "delete",
+			wantTarget: "delete-target",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			envelope := base
+			envelope.MessageID = test.name + "-envelope"
+			record, _ := waMessageRecord(t, envelope, test.message)
+			events, err := NewWhatsAppDecoder().Decode(context.Background(), record)
+			if err != nil {
+				t.Fatalf("Decode(): %v", err)
+			}
+			if len(events) != 1 || events[0].Kind != bridge.EventMessageMutation || events[0].MessageMutation == nil {
+				t.Fatalf("events = %+v, want one MessageMutationEvent", events)
+			}
+			mutation := events[0].MessageMutation
+			if mutation.RemoteConversationID != "whatsapp:"+waCanonicalChatJID ||
+				mutation.RemoteMessageID != test.wantTarget || mutation.Kind != test.wantKind ||
+				mutation.Body != test.wantBody || !mutation.OccurredAt.Equal(time.UnixMilli(waTimestampMS)) {
+				t.Fatalf("mutation = %+v", mutation)
+			}
+		})
+	}
+}
+
+func TestWhatsAppDecoderSkipClassifications(t *testing.T) {
+	t.Parallel()
+
+	decoder := NewWhatsAppDecoder()
+	tests := []struct {
+		name    string
+		message *waE2E.Message
+	}{
+		{
+			name: "encrypted reaction",
+			message: &waE2E.Message{EncReactionMessage: &waE2E.EncReactionMessage{
+				TargetMessageKey: &waCommon.MessageKey{ID: proto.String("encrypted-target")},
+				EncPayload:       []byte{1, 2, 3},
+				EncIV:            []byte{4, 5, 6},
+			}},
+		},
+		{
+			name: "unsupported",
+			message: &waE2E.Message{SendPaymentMessage: &waE2E.SendPaymentMessage{
+				TransactionData: proto.String("opaque-payment-data"),
+			}},
+		},
+		{name: "empty", message: &waE2E.Message{}},
+	}
+
+	for _, test := range tests {
+		envelope := waBaseMessageEnvelope()
+		envelope.MessageID = "skip-" + test.name
+		record, _ := waMessageRecord(t, envelope, test.message)
+		events, err := decoder.Decode(context.Background(), record)
+		if err != nil {
+			t.Fatalf("Decode(%s): %v", test.name, err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("Decode(%s) events = %+v, want none", test.name, events)
+		}
+	}
+
+	want := WhatsAppDecoderSnapshot{
+		EmptyMessagesSkipped:       1,
+		UnsupportedMessagesSkipped: 1,
+		EncryptedReactionsSkipped:  1,
+	}
+	if got := decoder.Snapshot(waDecoderAccountID); got != want {
+		t.Fatalf("Snapshot() = %+v, want %+v", got, want)
+	}
+	if got := decoder.Snapshot("another-account"); got != (WhatsAppDecoderSnapshot{}) {
+		t.Fatalf("Snapshot(other account) = %+v, want zero", got)
+	}
+}
+
+func TestWhatsAppDecoderReceiptFrameTable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		receiptType string
+		wantStatus  string
+		wantSelf    bool
+	}{
+		{name: "read self", receiptType: "read_self", wantStatus: "read", wantSelf: true},
+		{name: "sender linked device", receiptType: "sender", wantStatus: "delivered", wantSelf: true},
+		{name: "read by other", receiptType: "read", wantStatus: "read", wantSelf: false},
+		{name: "server error", receiptType: "server_error", wantStatus: "failed", wantSelf: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			envelope := whatsAppFrameEnvelope{
+				Kind:        whatsAppFrameReceipt,
+				ChatJID:     waCanonicalChatJID,
+				SenderJID:   waSenderJID,
+				TimestampMS: waTimestampMS,
+				ReceiptType: test.receiptType,
+				MessageIDs:  []string{" first-message ", "second-message"},
+			}
+			events, err := NewWhatsAppDecoder().Decode(
+				context.Background(),
+				waRecord(waJSON(t, envelope)),
+			)
+			if err != nil {
+				t.Fatalf("Decode(): %v", err)
+			}
+			if len(events) != 1 || events[0].Kind != bridge.EventReceipt || events[0].Receipt == nil {
+				t.Fatalf("events = %+v, want one ReceiptEvent", events)
+			}
+			receipt := events[0].Receipt
+			if receipt.RemoteConversationID != "whatsapp:"+waCanonicalChatJID ||
+				receipt.Status != test.wantStatus || receipt.Actor.IsSelf != test.wantSelf ||
+				receipt.Actor.Raw != "+14155550200" ||
+				!reflect.DeepEqual(receipt.RemoteMessageIDs, []string{"first-message", "second-message"}) ||
+				!receipt.OccurredAt.Equal(time.UnixMilli(waTimestampMS)) {
+				t.Fatalf("receipt = %+v", receipt)
+			}
+		})
+	}
+
+	decoder := NewWhatsAppDecoder()
+	unsupported := whatsAppFrameEnvelope{
+		Kind:        whatsAppFrameReceipt,
+		ChatJID:     waCanonicalChatJID,
+		SenderJID:   waSenderJID,
+		TimestampMS: waTimestampMS,
+		ReceiptType: "typing",
+		MessageIDs:  []string{"ignored"},
+	}
+	events, err := decoder.Decode(context.Background(), waRecord(waJSON(t, unsupported)))
+	if err != nil || len(events) != 0 {
+		t.Fatalf("unsupported receipt = events %+v error %v, want skipped", events, err)
+	}
+	if got := decoder.Snapshot(waDecoderAccountID).UnsupportedReceiptsSkipped; got != 1 {
+		t.Fatalf("unsupported receipt count = %d, want 1", got)
+	}
+}
+
+func TestWhatsAppDecoderHistorySyncTwoMessages(t *testing.T) {
+	t.Parallel()
+
+	record := waHistoryRecord(t, waHistoryFixture())
+	events, err := NewWhatsAppDecoder().Decode(context.Background(), record)
+	if err != nil {
+		t.Fatalf("Decode(): %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("history event count = %d, want 2: %+v", len(events), events)
+	}
+	wantIDs := []string{"history-first", "history-second"}
+	wantBodies := []string{"first historical body", "second historical body"}
+	wantDirections := []string{"incoming", "outgoing"}
+	for index, event := range events {
+		if event.Kind != bridge.EventMessage || event.Message == nil {
+			t.Fatalf("history event %d = %+v, want MessageEvent", index, event)
+		}
+		message := event.Message
+		if message.RemoteConversationID != "whatsapp:"+waCanonicalChatJID ||
+			message.RemoteMessageID != wantIDs[index] || message.Body != wantBodies[index] ||
+			message.Direction != wantDirections[index] || message.ClientRequestID != "" {
+			t.Fatalf("history message %d = %+v", index, message)
+		}
+		wantTime := time.UnixMilli(int64(1_700_000_001+index) * 1000)
+		if !message.OccurredAt.Equal(wantTime) {
+			t.Fatalf("history message %d occurred at = %v, want %v", index, message.OccurredAt, wantTime)
+		}
+	}
+}
+
+func TestWhatsAppHistorySyncWorkerProjectsFirstAndImportsSecond(t *testing.T) {
+	harness := newWhatsAppWorkerHarness(t)
+	record := waHistoryRecord(t, waHistoryFixture())
+	record.AccountID = waWorkerAccountID
+	record.DedupeKey = "hist:" + waHash8(record.Payload)
+	record.ReceivedAt = waWorkerNow
+
+	if err := harness.sink.AppendIngress(context.Background(), record); err != nil {
+		t.Fatalf("AppendIngress(): %v", err)
+	}
+	i01WaitFor(t, "WhatsApp history projection/import", func() bool {
+		snapshot := harness.counters.Snapshot(waWorkerAccountID)
+		return snapshot.Projected == 1 && snapshot.Imported == 1 && snapshot.DecodedEvents == 2
+	})
+
+	if got := i01QueryInt64(t, harness.path, `SELECT COUNT(*) FROM inbox`); got != 1 {
+		t.Fatalf("history inbox rows = %d, want 1", got)
+	}
+	if got := i01QueryInt64(t, harness.path, `SELECT COUNT(*) FROM messages`); got != 2 {
+		t.Fatalf("history message rows = %d, want 2", got)
+	}
+	conversation, err := harness.store.GetConversationByRemote(
+		waWorkerAccountID,
+		"whatsapp:"+waCanonicalChatJID,
+	)
+	if err != nil {
+		t.Fatalf("GetConversationByRemote(): %v", err)
+	}
+	for _, remoteID := range []string{"history-first", "history-second"} {
+		if _, err := harness.messages.GetMessageByRemote(
+			context.Background(),
+			waWorkerAccountID,
+			conversation.ConversationID,
+			remoteID,
+		); err != nil {
+			t.Errorf("GetMessageByRemote(%q): %v", remoteID, err)
+		}
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
+func TestWhatsAppIngressDedupeUsesMessageIDAndProtoHash(t *testing.T) {
+	harness := newWhatsAppWorkerHarness(t)
+	envelope := waBaseMessageEnvelope()
+	envelope.MessageID = "dedupe-message"
+	firstRecord, firstProto := waMessageRecord(
+		t,
+		envelope,
+		&waE2E.Message{Conversation: proto.String("body-a")},
+	)
+	firstRecord.AccountID = waWorkerAccountID
+	firstRecord.ReceivedAt = waWorkerNow
+	firstRecord.DedupeKey = "msg:" + envelope.MessageID + ":" + waHash8(firstProto)
+
+	if err := harness.sink.AppendIngress(context.Background(), firstRecord); err != nil {
+		t.Fatalf("AppendIngress(first): %v", err)
+	}
+	i01WaitFor(t, "first WhatsApp message projection", func() bool {
+		return harness.counters.Snapshot(waWorkerAccountID).Projected == 1
+	})
+	if err := harness.sink.AppendIngress(context.Background(), firstRecord); err != nil {
+		t.Fatalf("AppendIngress(exact replay): %v", err)
+	}
+	i01WaitFor(t, "exact WhatsApp replay", func() bool {
+		snapshot := harness.counters.Snapshot(waWorkerAccountID)
+		return snapshot.Deduped == 1 && snapshot.Projected == 2
+	})
+
+	changedRecord, changedProto := waMessageRecord(
+		t,
+		envelope,
+		&waE2E.Message{Conversation: proto.String("body-b")},
+	)
+	changedRecord.AccountID = waWorkerAccountID
+	changedRecord.ReceivedAt = waWorkerNow
+	changedRecord.DedupeKey = "msg:" + envelope.MessageID + ":" + waHash8(changedProto)
+	if firstRecord.DedupeKey == changedRecord.DedupeKey {
+		t.Fatalf("changed protobuf unexpectedly produced the same dedupe key %q", firstRecord.DedupeKey)
+	}
+	if err := harness.sink.AppendIngress(context.Background(), changedRecord); err != nil {
+		t.Fatalf("AppendIngress(changed proto): %v", err)
+	}
+	i01WaitFor(t, "changed WhatsApp content projection", func() bool {
+		snapshot := harness.counters.Snapshot(waWorkerAccountID)
+		return snapshot.Appended == 2 && snapshot.Projected == 3
+	})
+
+	if got := i01QueryInt64(t, harness.path, `SELECT COUNT(*) FROM inbox`); got != 2 {
+		t.Fatalf("inbox rows = %d, want 2 content-distinct rows", got)
+	}
+	if got := i01QueryInt64(t, harness.path, `SELECT COUNT(*) FROM messages`); got != 1 {
+		t.Fatalf("message rows = %d, want one natural-key row", got)
+	}
+	conversation, err := harness.store.GetConversationByRemote(
+		waWorkerAccountID,
+		"whatsapp:"+waCanonicalChatJID,
+	)
+	if err != nil {
+		t.Fatalf("GetConversationByRemote(): %v", err)
+	}
+	message, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		waWorkerAccountID,
+		conversation.ConversationID,
+		envelope.MessageID,
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(): %v", err)
+	}
+	if message.Body != "body-b" {
+		t.Fatalf("message body = %q, want body-b", message.Body)
+	}
+	snapshot := harness.counters.Snapshot(waWorkerAccountID)
+	if snapshot.Appended != 2 || snapshot.Deduped != 1 {
+		t.Fatalf("dedupe counters = %+v, want appended=2 deduped=1", snapshot)
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
+func TestWhatsAppDecoderRejectsMalformedBoundaries(t *testing.T) {
+	t.Parallel()
+
+	validEnvelope := whatsAppFrameEnvelope{
+		Kind:        whatsAppFrameReceipt,
+		ChatJID:     waCanonicalChatJID,
+		SenderJID:   waSenderJID,
+		TimestampMS: waTimestampMS,
+		ReceiptType: "read",
+		MessageIDs:  []string{"message"},
+	}
+	wrongCodec := waRecord(waJSON(t, validEnvelope))
+	wrongCodec.Codec = "whatsapp.other"
+	wrongVersion := waRecord(waJSON(t, validEnvelope))
+	wrongVersion.CodecVersion = WhatsAppCodecVersion + 1
+	invalidProtoEnvelope := waBaseMessageEnvelope()
+	invalidProtoEnvelope.MessageID = "invalid-proto"
+	invalidProtoEnvelope.ProtoB64 = []byte{0xff}
+
+	tests := []struct {
+		name        string
+		record      bridge.RawIngressRecord
+		wantInError string
+	}{
+		{name: "codec", record: wrongCodec, wantInError: "codec"},
+		{name: "version", record: wrongVersion, wantInError: "version"},
+		{name: "JSON payload", record: waRecord([]byte(`{"kind":`)), wantInError: "envelope"},
+		{name: "protobuf payload", record: waRecord(waJSON(t, invalidProtoEnvelope)), wantInError: "protobuf"},
+		{name: "unknown frame kind", record: waRecord(waJSON(t, whatsAppFrameEnvelope{Kind: "future"})), wantInError: "unsupported"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewWhatsAppDecoder().Decode(context.Background(), test.record)
+			if err == nil {
+				t.Fatal("Decode() error = nil, want malformed-frame error")
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(test.wantInError)) {
+				t.Fatalf("Decode() error = %q, want substring %q", err, test.wantInError)
+			}
+		})
+	}
+}
+
+type whatsAppWorkerHarness struct {
+	path     string
+	store    *sqlite.Store
+	messages *sqlite.MessageRepository
+	counters *Counters
+	worker   *Worker
+	sink     *Sink
+}
+
+func newWhatsAppWorkerHarness(t *testing.T) *whatsAppWorkerHarness {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "whatsapp-ingest.sqlite3")
+	store, err := sqlite.Open(path)
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Store.Close(): %v", err)
+		}
+	})
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   waWorkerAccountID,
+		BridgeKey:   "whatsmeow",
+		DisplayName: "WhatsApp ingest decoder test",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: waWorkerNow.UnixMilli(),
+		UpdatedAtMS: waWorkerNow.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	now := func() time.Time { return waWorkerNow }
+	messages, err := sqlite.NewMessageRepository(store, now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	counters := &Counters{}
+	worker, err := NewWorker(WorkerConfig{
+		Store:    store,
+		Messages: messages,
+		Counters: counters,
+		Logger:   zerolog.Nop(),
+		Now:      now,
+		Decoders: []DecoderRegistration{NewWhatsAppDecoderRegistration()},
+	})
+	if err != nil {
+		t.Fatalf("NewWorker(): %v", err)
+	}
+	sink := i01NewSink(t, messages, worker, counters, "whatsapp-inbox")
+	i01StartWorker(t, worker)
+	return &whatsAppWorkerHarness{
+		path:     path,
+		store:    store,
+		messages: messages,
+		counters: counters,
+		worker:   worker,
+		sink:     sink,
+	}
+}
+
+func waBaseMessageEnvelope() whatsAppFrameEnvelope {
+	return whatsAppFrameEnvelope{
+		Kind:        whatsAppFrameMessage,
+		ChatJID:     waCanonicalChatJID,
+		SenderJID:   waSenderJID,
+		MessageID:   "message",
+		TimestampMS: waTimestampMS,
+		PushName:    "Grace Hopper",
+	}
+}
+
+func waMessageRecord(
+	t *testing.T,
+	envelope whatsAppFrameEnvelope,
+	message *waE2E.Message,
+) (bridge.RawIngressRecord, []byte) {
+	t.Helper()
+	protoBytes := waProto(t, message)
+	envelope.Kind = whatsAppFrameMessage
+	envelope.ProtoB64 = protoBytes
+	return waRecord(waJSON(t, envelope)), protoBytes
+}
+
+func waHistoryRecord(t *testing.T, history *waHistorySync.HistorySync) bridge.RawIngressRecord {
+	t.Helper()
+	return waRecord(waJSON(t, whatsAppFrameEnvelope{
+		Kind:     whatsAppFrameHistorySync,
+		ProtoB64: waProto(t, history),
+	}))
+}
+
+func waRecord(payload []byte) bridge.RawIngressRecord {
+	return bridge.RawIngressRecord{
+		AccountID:    waDecoderAccountID,
+		Generation:   7,
+		Codec:        WhatsAppCodec,
+		CodecVersion: WhatsAppCodecVersion,
+		ReceivedAt:   time.UnixMilli(waTimestampMS),
+		Payload:      payload,
+	}
+}
+
+func waJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal(%T): %v", value, err)
+	}
+	return payload
+}
+
+func waProto(t *testing.T, value proto.Message) []byte {
+	t.Helper()
+	payload, err := proto.Marshal(value)
+	if err != nil {
+		t.Fatalf("proto.Marshal(%T): %v", value, err)
+	}
+	return payload
+}
+
+func waHash8(payload []byte) string {
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:4])
+}
+
+func waHistoryFixture() *waHistorySync.HistorySync {
+	message := func(
+		id string,
+		body string,
+		timestamp uint64,
+		fromMe bool,
+		participant string,
+	) *waHistorySync.HistorySyncMsg {
+		return &waHistorySync.HistorySyncMsg{Message: &waWeb.WebMessageInfo{
+			Key: &waCommon.MessageKey{
+				RemoteJID: proto.String(waCanonicalChatJID),
+				FromMe:    proto.Bool(fromMe),
+				ID:        proto.String(id),
+			},
+			Message:          &waE2E.Message{Conversation: proto.String(body)},
+			MessageTimestamp: proto.Uint64(timestamp),
+			Participant:      proto.String(participant),
+			PushName:         proto.String("Historical Sender"),
+		}}
+	}
+	return &waHistorySync.HistorySync{
+		SyncType: waHistorySync.HistorySync_INITIAL_BOOTSTRAP.Enum(),
+		Conversations: []*waHistorySync.Conversation{{
+			ID: proto.String(waCanonicalChatJID),
+			Messages: []*waHistorySync.HistorySyncMsg{
+				message("history-first", "first historical body", 1_700_000_001, false, waSenderJID),
+				message("history-second", "second historical body", 1_700_000_002, true, "14155550999@s.whatsapp.net"),
+			},
+		}},
+	}
+}

--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -481,6 +481,13 @@ func (w *Worker) applyEvents(
 			w.counters.account(accountID).receiptsDropped.Add(1)
 			continue
 		}
+		// Only read-class self receipts advance the read cursor. A delivered
+		// acknowledgement for an outgoing message says nothing about what the
+		// local user has read.
+		if event.Receipt.Status != "read" {
+			w.counters.account(accountID).receiptsDropped.Add(1)
+			continue
+		}
 		applied, err := w.advanceReadCursor(ctx, accountID, platform, *event.Receipt)
 		if err != nil {
 			return err

--- a/internal/whatsapplive/client.go
+++ b/internal/whatsapplive/client.go
@@ -2050,7 +2050,10 @@ func (b *Bridge) captureReceiptIngress(evt *waevents.Receipt) {
 		return
 	}
 	receivedAt := time.Now()
-	chatJID := b.normalizeConversationJID(evt.Chat)
+	// canonicalJID, not normalizeConversationJID: the latter merges legacy
+	// conversation aliases as a side effect, and the legacy receipt path never
+	// touches conversation JIDs. Capture must observe, never mutate.
+	chatJID := b.canonicalJID(evt.Chat)
 	senderJID := b.canonicalJID(evt.Sender)
 	messageIDs := make([]string, len(evt.MessageIDs))
 	for index, id := range evt.MessageIDs {

--- a/internal/whatsapplive/client.go
+++ b/internal/whatsapplive/client.go
@@ -43,6 +43,13 @@ const recentlyLeftGroupTTL = 6 * time.Hour
 const unpairRemoteTimeout = 10 * time.Second
 const unpairStoreTimeout = 10 * time.Second
 
+// IngressCodec is the durable WhatsApp capture codec consumed by the v2
+// ingest worker.
+const IngressCodec = "whatsapp.event"
+
+// IngressCodecVersion is the current version of IngressCodec envelopes.
+const IngressCodecVersion uint32 = 1
+
 var ErrProfilePhotoNotFound = errors.New("whatsapp profile photo not found")
 
 var ErrTemporaryBanActive = errors.New("whatsapp temporary ban is still active")
@@ -198,6 +205,46 @@ type lifecycleObservation struct {
 	callback func(LifecycleEvent)
 }
 
+// IngressFrame is a fully captured WhatsApp transport envelope. Payload owns
+// no whatsmeow pointers and is safe to persist after the callback returns.
+type IngressFrame struct {
+	DedupeKey  string
+	ReceivedAt time.Time
+	Payload    []byte
+}
+
+type ingressObservation struct {
+	id       uint64
+	callback func(IngressFrame)
+}
+
+type whatsappMessageIngressEnvelope struct {
+	Kind        string            `json:"kind"`
+	ChatJID     string            `json:"chat_jid"`
+	SenderJID   string            `json:"sender_jid"`
+	MessageID   string            `json:"message_id"`
+	TimestampMS int64             `json:"timestamp_ms"`
+	IsFromMe    bool              `json:"is_from_me"`
+	IsGroup     bool              `json:"is_group"`
+	PushName    string            `json:"push_name"`
+	Mentions    map[string]string `json:"mentions"`
+	ProtoB64    []byte            `json:"proto_b64"`
+}
+
+type whatsappReceiptIngressEnvelope struct {
+	Kind        string   `json:"kind"`
+	ChatJID     string   `json:"chat_jid"`
+	SenderJID   string   `json:"sender_jid"`
+	ReceiptType string   `json:"receipt_type"`
+	MessageIDs  []string `json:"message_ids"`
+	TimestampMS int64    `json:"timestamp_ms"`
+}
+
+type whatsappHistorySyncIngressEnvelope struct {
+	Kind     string `json:"kind"`
+	ProtoB64 []byte `json:"proto_b64"`
+}
+
 // AccountInfo is the paired identity needed to build supervisor start and
 // pairing results without exposing the underlying whatsmeow client.
 type AccountInfo struct {
@@ -266,9 +313,11 @@ type Bridge struct {
 	// clientGeneration changes whenever resetClientLocked installs a new
 	// whatsmeow client. Event handler closures capture it so callbacks from a
 	// retired client can never affect or terminate the replacement generation.
-	clientGeneration uint64
-	observation      lifecycleObservation
-	nextObserverID   uint64
+	clientGeneration      uint64
+	observation           lifecycleObservation
+	ingressObservation    ingressObservation
+	nextObserverID        uint64
+	nextIngressObserverID uint64
 
 	runtimeMu    sync.Mutex
 	runtimeDB    *sql.DB
@@ -464,6 +513,40 @@ func (b *Bridge) ObserveLifecycle(callback func(LifecycleEvent)) func() {
 		}
 		b.mu.Unlock()
 	}
+}
+
+// ObserveIngress installs the one active durable-ingress observer. The
+// returned removal function cannot clear an observer that replaced it.
+func (b *Bridge) ObserveIngress(callback func(IngressFrame)) func() {
+	b.mu.Lock()
+	b.nextIngressObserverID++
+	id := b.nextIngressObserverID
+	b.ingressObservation = ingressObservation{
+		id:       id,
+		callback: callback,
+	}
+	b.mu.Unlock()
+
+	return func() {
+		b.mu.Lock()
+		if b.ingressObservation.id == id {
+			b.ingressObservation = ingressObservation{}
+		}
+		b.mu.Unlock()
+	}
+}
+
+// LogIngressError records an adapter-side append failure without feeding it
+// back into the retained WhatsApp receive path.
+func (b *Bridge) LogIngressError(err error, accountID string, generation uint64) {
+	if err == nil {
+		return
+	}
+	b.logger.Warn().
+		Err(err).
+		Str("account_id", strings.TrimSpace(accountID)).
+		Uint64("generation", generation).
+		Msg("Failed to append WhatsApp ingress frame")
 }
 
 func (b *Bridge) resetClientLocked() error {
@@ -1893,6 +1976,185 @@ func (b *Bridge) handleEvent(raw any) {
 	b.handleClientEvent(nil, 0, raw)
 }
 
+func (b *Bridge) emitIngress(frame IngressFrame) {
+	b.mu.RLock()
+	observer := b.ingressObservation.callback
+	b.mu.RUnlock()
+	if observer == nil {
+		return
+	}
+	frame.Payload = cloneBytes(frame.Payload)
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				b.logger.Warn().
+					Str("panic", fmt.Sprint(recovered)).
+					Msg("Recovered panic in WhatsApp ingress observer")
+			}
+		}()
+		observer(frame)
+	}()
+}
+
+func (b *Bridge) hasIngressObserver() bool {
+	b.mu.RLock()
+	hasObserver := b.ingressObservation.callback != nil
+	b.mu.RUnlock()
+	return hasObserver
+}
+
+func (b *Bridge) captureMessageIngress(evt *waevents.Message, chatJID watypes.JID) {
+	if !b.hasIngressObserver() {
+		return
+	}
+	receivedAt := time.Now()
+	protoBytes, err := proto.Marshal(evt.Message)
+	if err != nil {
+		b.logIngressCaptureError("message", err)
+		return
+	}
+
+	senderJID := b.canonicalJID(evt.Info.Sender).String()
+	mentionMessage := evt.Message
+	if protocolMessage := extractProtocolMessage(evt.Message); protocolMessage != nil &&
+		protocolMessage.GetType() == waE2E.ProtocolMessage_MESSAGE_EDIT &&
+		protocolMessage.GetEditedMessage() != nil {
+		mentionMessage = protocolMessage.GetEditedMessage()
+	}
+	mentions := b.captureMentionLabels(mentionMessage, chatJID)
+	payload, err := json.Marshal(whatsappMessageIngressEnvelope{
+		Kind:        "message",
+		ChatJID:     chatJID.String(),
+		SenderJID:   senderJID,
+		MessageID:   string(evt.Info.ID),
+		TimestampMS: evt.Info.Timestamp.UnixMilli(),
+		IsFromMe:    evt.Info.IsFromMe,
+		IsGroup:     evt.Info.IsGroup,
+		PushName:    evt.Info.PushName,
+		Mentions:    mentions,
+		ProtoB64:    protoBytes,
+	})
+	if err != nil {
+		b.logIngressCaptureError("message", err)
+		return
+	}
+	b.emitIngress(IngressFrame{
+		DedupeKey:  "msg:" + string(evt.Info.ID) + ":" + ingressHash8(protoBytes),
+		ReceivedAt: receivedAt,
+		Payload:    payload,
+	})
+}
+
+func (b *Bridge) captureReceiptIngress(evt *waevents.Receipt) {
+	if !b.hasIngressObserver() {
+		return
+	}
+	receivedAt := time.Now()
+	chatJID := b.normalizeConversationJID(evt.Chat)
+	senderJID := b.canonicalJID(evt.Sender)
+	messageIDs := make([]string, len(evt.MessageIDs))
+	for index, id := range evt.MessageIDs {
+		messageIDs[index] = string(id)
+	}
+	payload, err := json.Marshal(whatsappReceiptIngressEnvelope{
+		Kind:        "receipt",
+		ChatJID:     chatJID.String(),
+		SenderJID:   senderJID.String(),
+		ReceiptType: ingressReceiptType(evt.Type),
+		MessageIDs:  messageIDs,
+		TimestampMS: evt.Timestamp.UnixMilli(),
+	})
+	if err != nil {
+		b.logIngressCaptureError("receipt", err)
+		return
+	}
+	b.emitIngress(IngressFrame{
+		DedupeKey:  "rcpt:" + ingressHash8(payload),
+		ReceivedAt: receivedAt,
+		Payload:    payload,
+	})
+}
+
+func (b *Bridge) captureHistorySyncIngress(evt *waevents.HistorySync) {
+	if evt == nil || evt.Data == nil || !b.hasIngressObserver() {
+		return
+	}
+	receivedAt := time.Now()
+	protoBytes, err := proto.Marshal(evt.Data)
+	if err != nil {
+		b.logIngressCaptureError("history_sync", err)
+		return
+	}
+	payload, err := json.Marshal(whatsappHistorySyncIngressEnvelope{
+		Kind:     "history_sync",
+		ProtoB64: protoBytes,
+	})
+	if err != nil {
+		b.logIngressCaptureError("history_sync", err)
+		return
+	}
+	b.emitIngress(IngressFrame{
+		DedupeKey:  "hist:" + ingressHash8(payload),
+		ReceivedAt: receivedAt,
+		Payload:    payload,
+	})
+}
+
+func (b *Bridge) captureMentionLabels(msg *waE2E.Message, chatJID watypes.JID) map[string]string {
+	mentions := make(map[string]string)
+	ctx := messageContextInfo(msg)
+	if ctx == nil || len(ctx.GetMentionedJID()) == 0 {
+		return mentions
+	}
+	var convo *db.Conversation
+	if b.store != nil {
+		convo, _ = b.store.GetConversation(waConversationID(chatJID))
+	}
+	for _, raw := range ctx.GetMentionedJID() {
+		jid, err := watypes.ParseJID(strings.TrimSpace(raw))
+		if err != nil {
+			continue
+		}
+		label := b.whatsAppMentionLabel(jid, convo)
+		if label == "" {
+			continue
+		}
+		jid = jid.ToNonAD()
+		if !jid.IsEmpty() {
+			mentions[jid.String()] = label
+		}
+		canonical := b.canonicalJID(jid)
+		if !canonical.IsEmpty() {
+			mentions[canonical.String()] = label
+		}
+	}
+	return mentions
+}
+
+func ingressReceiptType(receiptType watypes.ReceiptType) string {
+	switch receiptType {
+	case watypes.ReceiptTypeDelivered:
+		return "delivered"
+	case watypes.ReceiptTypeReadSelf:
+		return "read_self"
+	case watypes.ReceiptTypePlayedSelf:
+		return "played_self"
+	case watypes.ReceiptTypeServerError:
+		return "server_error"
+	default:
+		return strings.ReplaceAll(string(receiptType), "-", "_")
+	}
+}
+
+func ingressHash8(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:4])
+}
+
+func (b *Bridge) logIngressCaptureError(kind string, err error) {
+	b.logger.Warn().Err(err).Str("kind", kind).Msg("Failed to capture WhatsApp ingress frame")
+}
+
 func (b *Bridge) applyEvent(raw any) {
 	switch evt := raw.(type) {
 	case *waevents.Connected:
@@ -1937,6 +2199,7 @@ func (b *Bridge) applyEvent(raw any) {
 	case *waevents.GroupInfo:
 		b.handleGroupInfo(evt)
 	case *waevents.HistorySync:
+		b.captureHistorySyncIngress(evt)
 		b.handleHistorySync(evt)
 	default:
 		b.logger.Debug().Type("type", evt).Msg("Unhandled WhatsApp event")
@@ -2016,7 +2279,7 @@ func (b *Bridge) handlePairError(err error) {
 // silently dropped, leaving edited text stale and deleted messages present
 // forever. Returns true if the event was an edit/revoke (and thus consumed).
 func (b *Bridge) handleProtocolMessage(evt *waevents.Message) bool {
-	pm := unwrapWhatsAppMessage(evt.Message).GetProtocolMessage()
+	pm := extractProtocolMessage(evt.Message)
 	if pm == nil {
 		return false
 	}
@@ -2074,6 +2337,19 @@ func (b *Bridge) handleMessage(evt *waevents.Message) {
 		return
 	}
 	chatJID := b.normalizeConversationJID(evt.Info.Chat)
+	b.captureMessageIngress(evt, chatJID)
+	b.handleLegacyMessage(evt, chatJID)
+}
+
+func (b *Bridge) handleMessageWithoutIngress(evt *waevents.Message) {
+	if evt == nil || evt.Message == nil {
+		return
+	}
+	chatJID := b.normalizeConversationJID(evt.Info.Chat)
+	b.handleLegacyMessage(evt, chatJID)
+}
+
+func (b *Bridge) handleLegacyMessage(evt *waevents.Message, chatJID watypes.JID) {
 	if evt.Info.IsGroup && b.shouldSuppressLeftGroup(waConversationID(chatJID)) {
 		return
 	}
@@ -2088,7 +2364,7 @@ func (b *Bridge) handleMessage(evt *waevents.Message) {
 	// which we could then feed through handleReactionMessage. For now we
 	// just drop them quietly with a debug log so they don't render as
 	// [Unsupported message] on every reaction in a community thread.
-	if unwrapWhatsAppMessage(evt.Message).GetEncReactionMessage() != nil {
+	if hasEncryptedReactionMessage(evt.Message) {
 		b.logger.Debug().
 			Str("msg_id", string(evt.Info.ID)).
 			Str("chat", evt.Info.Chat.String()).
@@ -2211,6 +2487,7 @@ func (b *Bridge) handleReceipt(evt *waevents.Receipt) {
 	if evt == nil || len(evt.MessageIDs) == 0 {
 		return
 	}
+	b.captureReceiptIngress(evt)
 	nextStatus, ok := receiptStatus(evt.Type)
 	if !ok {
 		return
@@ -2365,7 +2642,7 @@ func (b *Bridge) handleHistorySync(evt *waevents.HistorySync) {
 				b.logger.Debug().Err(err).Msg("Failed to parse WhatsApp history sync message")
 				continue
 			}
-			b.handleMessage(msgEvt)
+			b.handleMessageWithoutIngress(msgEvt)
 		}
 	}
 }
@@ -3342,6 +3619,12 @@ func extractStoredMediaRef(msg *waE2E.Message) (storedMediaRef, []byte, string, 
 	}
 }
 
+// ExtractStoredMediaRef exposes the retained pure media-reference extractor
+// to transport decoders without duplicating WhatsApp proto handling.
+func ExtractStoredMediaRef(msg *waE2E.Message) (StoredMediaRef, []byte, string, bool) {
+	return extractStoredMediaRef(msg)
+}
+
 func encodeBytes(value []byte) string {
 	if len(value) == 0 {
 		return ""
@@ -3571,6 +3854,12 @@ func extractMessageBody(msg *waE2E.Message) string {
 	}
 }
 
+// ExtractMessageBody exposes the retained pure message-body extractor to
+// transport decoders.
+func ExtractMessageBody(msg *waE2E.Message) string {
+	return extractMessageBody(msg)
+}
+
 // locationMessagePlaceholder returns a human-readable body for a LocationMessage,
 // or "" if the message isn't a location. Prefers the name, then the address,
 // then a generic [Location] placeholder. Coordinates are omitted since they're
@@ -3670,12 +3959,59 @@ func extractReactionMessage(msg *waE2E.Message) *waE2E.ReactionMessage {
 	return msg.GetReactionMessage()
 }
 
+// ExtractReactionMessage exposes the retained pure reaction extractor to
+// transport decoders.
+func ExtractReactionMessage(msg *waE2E.Message) *waE2E.ReactionMessage {
+	return extractReactionMessage(msg)
+}
+
 func extractReplyToID(msg *waE2E.Message) string {
 	ctx := messageContextInfo(msg)
 	if ctx == nil || strings.TrimSpace(ctx.GetStanzaID()) == "" {
 		return ""
 	}
 	return "whatsapp:" + strings.TrimSpace(ctx.GetStanzaID())
+}
+
+// ExtractReplyToID exposes the retained pure reply extractor to transport
+// decoders.
+func ExtractReplyToID(msg *waE2E.Message) string {
+	return extractReplyToID(msg)
+}
+
+// ExtractMentionedJIDs returns the WhatsApp JIDs declared by the message's
+// retained ContextInfo extractor.
+func ExtractMentionedJIDs(msg *waE2E.Message) []string {
+	ctx := messageContextInfo(msg)
+	if ctx == nil {
+		return nil
+	}
+	return append([]string(nil), ctx.GetMentionedJID()...)
+}
+
+func extractProtocolMessage(msg *waE2E.Message) *waE2E.ProtocolMessage {
+	msg = unwrapWhatsAppMessage(msg)
+	if msg == nil {
+		return nil
+	}
+	return msg.GetProtocolMessage()
+}
+
+// ExtractProtocolMessage exposes pure protocol-message unwrapping to
+// transport decoders.
+func ExtractProtocolMessage(msg *waE2E.Message) *waE2E.ProtocolMessage {
+	return extractProtocolMessage(msg)
+}
+
+func hasEncryptedReactionMessage(msg *waE2E.Message) bool {
+	msg = unwrapWhatsAppMessage(msg)
+	return msg != nil && msg.GetEncReactionMessage() != nil
+}
+
+// HasEncryptedReactionMessage reports whether msg contains the encrypted
+// reaction form that the retained bridge cannot decode yet.
+func HasEncryptedReactionMessage(msg *waE2E.Message) bool {
+	return hasEncryptedReactionMessage(msg)
 }
 
 func (b *Bridge) messageMentionsOwnAccount(msg *waE2E.Message) bool {

--- a/internal/whatsapplive/client.go
+++ b/internal/whatsapplive/client.go
@@ -2004,6 +2004,14 @@ func (b *Bridge) hasIngressObserver() bool {
 }
 
 func (b *Bridge) captureMessageIngress(evt *waevents.Message, chatJID watypes.JID) {
+	// Capture is strictly additive observation: a panic anywhere in the
+	// capture body must not reach the whatsmeow callback or skip the legacy
+	// handling that follows it.
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			b.logIngressCaptureError("message", fmt.Errorf("capture panic: %v", recovered))
+		}
+	}()
 	if !b.hasIngressObserver() {
 		return
 	}
@@ -2046,6 +2054,14 @@ func (b *Bridge) captureMessageIngress(evt *waevents.Message, chatJID watypes.JI
 }
 
 func (b *Bridge) captureReceiptIngress(evt *waevents.Receipt) {
+	// Capture is strictly additive observation: a panic anywhere in the
+	// capture body must not reach the whatsmeow callback or skip the legacy
+	// handling that follows it.
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			b.logIngressCaptureError("receipt", fmt.Errorf("capture panic: %v", recovered))
+		}
+	}()
 	if !b.hasIngressObserver() {
 		return
 	}
@@ -2079,6 +2095,14 @@ func (b *Bridge) captureReceiptIngress(evt *waevents.Receipt) {
 }
 
 func (b *Bridge) captureHistorySyncIngress(evt *waevents.HistorySync) {
+	// Capture is strictly additive observation: a panic anywhere in the
+	// capture body must not reach the whatsmeow callback or skip the legacy
+	// handling that follows it.
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			b.logIngressCaptureError("history_sync", fmt.Errorf("capture panic: %v", recovered))
+		}
+	}()
 	if evt == nil || evt.Data == nil || !b.hasIngressObserver() {
 		return
 	}

--- a/internal/whatsapplive/ingress_test.go
+++ b/internal/whatsapplive/ingress_test.go
@@ -1,0 +1,408 @@
+package whatsapplive
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	waCommon "go.mau.fi/whatsmeow/proto/waCommon"
+	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+	waHistorySync "go.mau.fi/whatsmeow/proto/waHistorySync"
+	waWeb "go.mau.fi/whatsmeow/proto/waWeb"
+	wastore "go.mau.fi/whatsmeow/store"
+	watypes "go.mau.fi/whatsmeow/types"
+	waevents "go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+func TestObserveIngressIsSingleSlotAndRemovalCannotClearReplacement(t *testing.T) {
+	bridge := &Bridge{}
+	var firstCalls, secondCalls int
+	removeFirst := bridge.ObserveIngress(func(IngressFrame) {
+		firstCalls++
+	})
+	removeSecond := bridge.ObserveIngress(func(frame IngressFrame) {
+		secondCalls++
+		frame.Payload[0] = 'X'
+	})
+
+	// Removing the replaced observer must leave the current slot installed.
+	removeFirst()
+	payload := []byte("payload")
+	bridge.emitIngress(IngressFrame{DedupeKey: "one", Payload: payload})
+	if firstCalls != 0 || secondCalls != 1 {
+		t.Fatalf("observer calls = first %d, second %d; want 0, 1", firstCalls, secondCalls)
+	}
+	if string(payload) != "payload" {
+		t.Fatalf("observer mutated caller payload: %q", payload)
+	}
+
+	removeSecond()
+	removeSecond()
+	bridge.emitIngress(IngressFrame{DedupeKey: "two", Payload: []byte("ignored")})
+	if secondCalls != 1 {
+		t.Fatalf("removed observer calls = %d, want 1", secondCalls)
+	}
+}
+
+func TestMessageIngressCaptureExactEnvelopeMentionsAndDedupe(t *testing.T) {
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	groupJID := watypes.NewJID("120363019999999999", watypes.GroupServer)
+	mentionedLID := watypes.NewJID("134149377675278", watypes.HiddenUserServer)
+	mentionedPN := watypes.NewJID("15551230000", watypes.DefaultUserServer)
+	if err := store.UpsertConversation(&db.Conversation{
+		ConversationID: waConversationID(groupJID),
+		Name:           "Alias Group",
+		IsGroup:        true,
+		Participants:   `[{"name":"Max Ghenis","number":"+15551230000"}]`,
+		SourcePlatform: "whatsapp",
+	}); err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+
+	ownJID := watypes.NewJID("15550009999", watypes.DefaultUserServer)
+	bridge := &Bridge{
+		store: store,
+		client: &whatsmeow.Client{Store: &wastore.Device{
+			ID: &ownJID,
+			LIDs: &testLIDStore{
+				NoopStore: wastore.NoopStore{},
+				lidToPN: map[string]watypes.JID{
+					mentionedLID.String(): mentionedPN,
+				},
+			},
+		}},
+	}
+	var frames []IngressFrame
+	bridge.ObserveIngress(func(frame IngressFrame) {
+		frames = append(frames, frame)
+	})
+
+	event := &waevents.Message{
+		Info: watypes.MessageInfo{
+			MessageSource: watypes.MessageSource{
+				Chat:     groupJID,
+				Sender:   watypes.NewJID("15551234567", watypes.DefaultUserServer),
+				IsGroup:  true,
+				IsFromMe: false,
+			},
+			ID:        "dedupe-message",
+			PushName:  "Jenn",
+			Timestamp: time.UnixMilli(1775002000000),
+		},
+		Message: &waE2E.Message{ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+			Text: proto.String("hello @134149377675278"),
+			ContextInfo: &waE2E.ContextInfo{
+				MentionedJID: []string{mentionedLID.String()},
+			},
+		}},
+	}
+	bridge.handleMessage(event)
+	bridge.handleMessage(event)
+
+	changed := proto.Clone(event.Message).(*waE2E.Message)
+	changed.ExtendedTextMessage.Text = proto.String("changed @134149377675278")
+	changedEvent := *event
+	changedEvent.Message = changed
+	bridge.handleMessage(&changedEvent)
+
+	if len(frames) != 3 {
+		t.Fatalf("captured frames = %d, want 3", len(frames))
+	}
+	protoBytes, err := proto.Marshal(event.Message)
+	if err != nil {
+		t.Fatalf("proto.Marshal(): %v", err)
+	}
+	wantPayload := fmt.Sprintf(
+		`{"kind":"message","chat_jid":"120363019999999999@g.us","sender_jid":"15551234567@s.whatsapp.net","message_id":"dedupe-message","timestamp_ms":1775002000000,"is_from_me":false,"is_group":true,"push_name":"Jenn","mentions":{"134149377675278@lid":"Max","15551230000@s.whatsapp.net":"Max"},"proto_b64":%q}`,
+		base64.StdEncoding.EncodeToString(protoBytes),
+	)
+	if got := string(frames[0].Payload); got != wantPayload {
+		t.Fatalf("message payload:\n got: %s\nwant: %s", got, wantPayload)
+	}
+	wantDedupe := "msg:dedupe-message:" + ingressHash8(protoBytes)
+	if frames[0].DedupeKey != wantDedupe || frames[1].DedupeKey != wantDedupe {
+		t.Fatalf("identical dedupe keys = %q, %q; want %q", frames[0].DedupeKey, frames[1].DedupeKey, wantDedupe)
+	}
+	if frames[2].DedupeKey == wantDedupe {
+		t.Fatalf("changed proto reused dedupe key %q", wantDedupe)
+	}
+	for index, frame := range frames {
+		if frame.ReceivedAt.IsZero() {
+			t.Fatalf("frame %d ReceivedAt is zero", index)
+		}
+	}
+}
+
+func TestMessageIngressCanonicalizesConversationJIDAtCapture(t *testing.T) {
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	chatLID := watypes.NewJID("134149377675279", watypes.HiddenUserServer)
+	chatPN := watypes.NewJID("15551230001", watypes.DefaultUserServer)
+	ownJID := watypes.NewJID("15550009999", watypes.DefaultUserServer)
+	bridge := &Bridge{
+		store: store,
+		client: &whatsmeow.Client{Store: &wastore.Device{
+			ID: &ownJID,
+			LIDs: &testLIDStore{
+				NoopStore: wastore.NoopStore{},
+				lidToPN: map[string]watypes.JID{
+					chatLID.String(): chatPN,
+				},
+			},
+		}},
+	}
+	var frame IngressFrame
+	bridge.ObserveIngress(func(captured IngressFrame) { frame = captured })
+	bridge.handleMessage(&waevents.Message{
+		Info: watypes.MessageInfo{
+			MessageSource: watypes.MessageSource{Chat: chatLID, Sender: chatLID},
+			ID:            "canonical-chat",
+			Timestamp:     time.UnixMilli(1775002001000),
+		},
+		Message: &waE2E.Message{Conversation: proto.String("hello")},
+	})
+
+	var envelope whatsappMessageIngressEnvelope
+	if err := json.Unmarshal(frame.Payload, &envelope); err != nil {
+		t.Fatalf("json.Unmarshal(): %v", err)
+	}
+	if envelope.ChatJID != chatPN.String() {
+		t.Fatalf("captured chat_jid = %q, want canonical %q", envelope.ChatJID, chatPN.String())
+	}
+	if envelope.SenderJID != chatPN.String() {
+		t.Fatalf("captured sender_jid = %q, want canonical %q", envelope.SenderJID, chatPN.String())
+	}
+}
+
+func TestMessageIngressResolvesMentionsFromEditedPayload(t *testing.T) {
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	group := watypes.NewJID("120363019999999999", watypes.GroupServer)
+	mentioned := watypes.NewJID("15551230000", watypes.DefaultUserServer)
+	if err := store.UpsertConversation(&db.Conversation{
+		ConversationID: waConversationID(group),
+		Name:           "Edit Group",
+		IsGroup:        true,
+		Participants:   `[{"name":"Max Ghenis","number":"+15551230000"}]`,
+		SourcePlatform: "whatsapp",
+	}); err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+
+	bridge := &Bridge{store: store}
+	var frame IngressFrame
+	bridge.ObserveIngress(func(captured IngressFrame) { frame = captured })
+	bridge.handleMessage(&waevents.Message{
+		Info: watypes.MessageInfo{
+			MessageSource: watypes.MessageSource{
+				Chat:    group,
+				Sender:  watypes.NewJID("15551234567", watypes.DefaultUserServer),
+				IsGroup: true,
+			},
+			ID:        "edit-envelope",
+			Timestamp: time.UnixMilli(1775002500000),
+		},
+		Message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{
+			Type: waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(),
+			Key:  &waCommon.MessageKey{ID: proto.String("edit-target")},
+			EditedMessage: &waE2E.Message{ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+				Text: proto.String("hello @15551230000"),
+				ContextInfo: &waE2E.ContextInfo{
+					MentionedJID: []string{mentioned.String()},
+				},
+			}},
+		}},
+	})
+
+	var envelope whatsappMessageIngressEnvelope
+	if err := json.Unmarshal(frame.Payload, &envelope); err != nil {
+		t.Fatalf("json.Unmarshal(): %v", err)
+	}
+	if got := envelope.Mentions[mentioned.String()]; got != "Max" {
+		t.Fatalf("edit mention label = %q, want Max (all labels: %v)", got, envelope.Mentions)
+	}
+}
+
+func TestReceiptIngressCaptureUsesWireNamesAndPayloadHash(t *testing.T) {
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+	bridge := &Bridge{store: store}
+	var frames []IngressFrame
+	bridge.ObserveIngress(func(frame IngressFrame) { frames = append(frames, frame) })
+
+	chat := watypes.NewJID("15551234567", watypes.DefaultUserServer)
+	sender := watypes.NewJID("15557654321", watypes.DefaultUserServer)
+	timestamp := time.UnixMilli(1775003000000)
+	for _, receiptType := range []watypes.ReceiptType{
+		watypes.ReceiptTypeDelivered,
+		watypes.ReceiptTypeReadSelf,
+	} {
+		bridge.handleReceipt(&waevents.Receipt{
+			MessageSource: watypes.MessageSource{Chat: chat, Sender: sender},
+			MessageIDs:    []watypes.MessageID{"one", "two"},
+			Timestamp:     timestamp,
+			Type:          receiptType,
+		})
+	}
+	if len(frames) != 2 {
+		t.Fatalf("captured receipt frames = %d, want 2", len(frames))
+	}
+	for index, receiptType := range []string{"delivered", "read_self"} {
+		want := fmt.Sprintf(
+			`{"kind":"receipt","chat_jid":"15551234567@s.whatsapp.net","sender_jid":"15557654321@s.whatsapp.net","receipt_type":%q,"message_ids":["one","two"],"timestamp_ms":1775003000000}`,
+			receiptType,
+		)
+		if got := string(frames[index].Payload); got != want {
+			t.Fatalf("receipt %d payload:\n got: %s\nwant: %s", index, got, want)
+		}
+		if got, wantKey := frames[index].DedupeKey, "rcpt:"+ingressHash8(frames[index].Payload); got != wantKey {
+			t.Fatalf("receipt %d dedupe = %q, want %q", index, got, wantKey)
+		}
+	}
+}
+
+func TestHistorySyncIngressCapturesOneFrameWithoutNestedMessageFrames(t *testing.T) {
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	chat := watypes.NewJID("15551234567", watypes.DefaultUserServer)
+	own := watypes.NewJID("15550009999", watypes.DefaultUserServer)
+	data := &waHistorySync.HistorySync{
+		SyncType: waHistorySync.HistorySync_RECENT.Enum(),
+		Conversations: []*waHistorySync.Conversation{{
+			ID: proto.String(chat.String()),
+			Messages: []*waHistorySync.HistorySyncMsg{{Message: &waWeb.WebMessageInfo{
+				Key: &waCommon.MessageKey{
+					RemoteJID: proto.String(chat.String()),
+					FromMe:    proto.Bool(false),
+					ID:        proto.String("history-message"),
+				},
+				Message:          &waE2E.Message{Conversation: proto.String("from history")},
+				MessageTimestamp: proto.Uint64(1775004000),
+				PushName:         proto.String("Jenn"),
+			}}},
+		}},
+	}
+	protoBytes, err := proto.Marshal(data)
+	if err != nil {
+		t.Fatalf("proto.Marshal(): %v", err)
+	}
+	bridge := &Bridge{
+		store:  store,
+		client: &whatsmeow.Client{Store: &wastore.Device{ID: &own}},
+	}
+	var frames []IngressFrame
+	bridge.ObserveIngress(func(frame IngressFrame) { frames = append(frames, frame) })
+	bridge.handleEvent(&waevents.HistorySync{Data: data})
+
+	if len(frames) != 1 {
+		t.Fatalf("captured frames = %d, want exactly one history_sync frame", len(frames))
+	}
+	wantPayload := fmt.Sprintf(
+		`{"kind":"history_sync","proto_b64":%q}`,
+		base64.StdEncoding.EncodeToString(protoBytes),
+	)
+	if got := string(frames[0].Payload); got != wantPayload {
+		t.Fatalf("history payload:\n got: %s\nwant: %s", got, wantPayload)
+	}
+	if got, want := frames[0].DedupeKey, "hist:"+ingressHash8(frames[0].Payload); got != want {
+		t.Fatalf("history dedupe = %q, want %q", got, want)
+	}
+	legacy, err := store.GetMessageByID("whatsapp:history-message")
+	if err != nil {
+		t.Fatalf("GetMessageByID(): %v", err)
+	}
+	if legacy == nil || legacy.Body != "from history" {
+		t.Fatalf("legacy history message = %#v, want retained import", legacy)
+	}
+}
+
+func TestPanickingIngressObserverDoesNotInterruptLegacyMessageHandling(t *testing.T) {
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	messageChanges := 0
+	bridge := &Bridge{
+		store: store,
+		callbacks: Callbacks{OnMessagesChange: func(string) {
+			messageChanges++
+		}},
+	}
+	observerCalls := 0
+	bridge.ObserveIngress(func(IngressFrame) {
+		observerCalls++
+		panic("sink panic")
+	})
+
+	chat := watypes.NewJID("15551234567", watypes.DefaultUserServer)
+	for index := 1; index <= 2; index++ {
+		bridge.handleEvent(&waevents.Message{
+			Info: watypes.MessageInfo{
+				MessageSource: watypes.MessageSource{Chat: chat, Sender: chat},
+				ID:            watypes.MessageID(fmt.Sprintf("panic-message-%d", index)),
+				Timestamp:     time.UnixMilli(1775005000000 + int64(index)),
+			},
+			Message: &waE2E.Message{Conversation: proto.String(fmt.Sprintf("body %d", index))},
+		})
+	}
+
+	if observerCalls != 2 {
+		t.Fatalf("observer calls = %d, want 2", observerCalls)
+	}
+	if messageChanges != 2 {
+		t.Fatalf("legacy message callbacks = %d, want 2", messageChanges)
+	}
+	for index := 1; index <= 2; index++ {
+		message, err := store.GetMessageByID(fmt.Sprintf("whatsapp:panic-message-%d", index))
+		if err != nil {
+			t.Fatalf("GetMessageByID(%d): %v", index, err)
+		}
+		if message == nil || message.Body != fmt.Sprintf("body %d", index) {
+			t.Fatalf("legacy message %d = %#v", index, message)
+		}
+	}
+}
+
+func TestExtractMentionedJIDsReturnsIndependentSlice(t *testing.T) {
+	original := []string{"15551230000@s.whatsapp.net"}
+	message := &waE2E.Message{ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+		ContextInfo: &waE2E.ContextInfo{MentionedJID: original},
+	}}
+	got := ExtractMentionedJIDs(message)
+	if !bytes.Equal([]byte(got[0]), []byte(original[0])) {
+		t.Fatalf("ExtractMentionedJIDs() = %v, want %v", got, original)
+	}
+	got[0] = "mutated"
+	if original[0] != "15551230000@s.whatsapp.net" {
+		t.Fatalf("returned mentions alias proto storage: %v", original)
+	}
+}

--- a/internal/whatsapplive/ingress_test.go
+++ b/internal/whatsapplive/ingress_test.go
@@ -406,3 +406,69 @@ func TestExtractMentionedJIDsReturnsIndependentSlice(t *testing.T) {
 		t.Fatalf("returned mentions alias proto storage: %v", original)
 	}
 }
+
+// Receipt capture must observe the canonical chat JID without mutating the
+// legacy store: normalizeConversationJID merges conversation aliases (deleting
+// the @lid row) as a side effect, and the legacy receipt path never touched
+// conversation JIDs. A receipt for an @lid chat therefore must leave the
+// legacy @lid conversation row exactly where it was.
+func TestReceiptIngressCaptureDoesNotMergeLegacyConversations(t *testing.T) {
+	store, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	chatLID := watypes.NewJID("134149377675280", watypes.HiddenUserServer)
+	chatPN := watypes.NewJID("15551230002", watypes.DefaultUserServer)
+	ownJID := watypes.NewJID("15550009999", watypes.DefaultUserServer)
+	lidConversationID := waConversationID(chatLID)
+	if err := store.UpsertConversation(&db.Conversation{
+		ConversationID: lidConversationID,
+		Name:           "LID alias thread",
+		Participants:   `[]`,
+		SourcePlatform: "whatsapp",
+	}); err != nil {
+		t.Fatalf("seed @lid conversation: %v", err)
+	}
+
+	bridge := &Bridge{
+		store: store,
+		client: &whatsmeow.Client{Store: &wastore.Device{
+			ID: &ownJID,
+			LIDs: &testLIDStore{
+				NoopStore: wastore.NoopStore{},
+				lidToPN: map[string]watypes.JID{
+					chatLID.String(): chatPN,
+				},
+			},
+		}},
+	}
+	var frame IngressFrame
+	bridge.ObserveIngress(func(captured IngressFrame) { frame = captured })
+	bridge.handleReceipt(&waevents.Receipt{
+		MessageSource: watypes.MessageSource{Chat: chatLID, Sender: chatLID},
+		MessageIDs:    []watypes.MessageID{"receipt-target"},
+		Timestamp:     time.UnixMilli(1775003001000),
+		Type:          watypes.ReceiptTypeRead,
+	})
+
+	var envelope whatsappReceiptIngressEnvelope
+	if err := json.Unmarshal(frame.Payload, &envelope); err != nil {
+		t.Fatalf("json.Unmarshal(): %v", err)
+	}
+	if envelope.ChatJID != chatPN.String() {
+		t.Fatalf("captured chat_jid = %q, want canonical %q", envelope.ChatJID, chatPN.String())
+	}
+
+	survived, err := store.GetConversation(lidConversationID)
+	if err != nil {
+		t.Fatalf("GetConversation(@lid): %v", err)
+	}
+	if survived == nil {
+		t.Fatal("legacy @lid conversation row was merged away by receipt capture")
+	}
+	if survived.Name != "LID alias thread" {
+		t.Fatalf("legacy @lid conversation mutated: %+v", survived)
+	}
+}


### PR DESCRIPTION
## What

WhatsApp receive frames now tee into the durable v2 inbox, per `ingest-echo-spec-2026-07-17.md` §2.2/§6/§7. Second of the three platform-decoder PRs (after #126 Google).

- **Capture hook** (`internal/whatsapplive/client.go`): single-slot `ObserveIngress`, invoked from `handleMessage` (before the suppress/reaction/protocol early-returns — the decoder owns skip policy), `handleReceipt`, and `handleHistorySync`. Everything impure resolves at capture: the canonical LID→PN chat JID (the same `normalizeConversationJID` value legacy uses — no `@lid` fork) and mention labels ride in the `whatsapp.event` v1 envelope. Capture bodies and the observer are panic-isolated; legacy handling is byte-identical (the pre-I3 body extracted verbatim, diffed against base).
- **Receipt capture is mutation-free** (adversarial-review BLOCKING-class catch): the initial build canonicalized receipts via `normalizeConversationJID`, whose `MergeConversationIDs` side effect deletes legacy `@lid` conversation rows — on a path legacy never touched. Now uses the read-only `canonicalJID` (identical value); `TestReceiptIngressCaptureDoesNotMergeLegacyConversations` discriminates (reverting the one-liner fails it with the row merged away).
- **Pure decoder** (`internal/ingest/whatsappdecoder.go`): maps per the §2.2 table via one-line exported wrappers over the retained live extractors; `ClientRequestID` is always `""` (WA stanza ids are one-way), so echo can never fire — including on history backfill. History frames decode to n messages (first projected, rest imported). Media refs pack the remote-kind opaque, round-tripped against `whatsapp.ValidateDownloadOpaque`.
- **Registration**: per-generation observer register/unregister with fenced stale rejection (single-slot, replacement-safe unsubscribe). `cmd/v2stack.go` registers the decoder beside Google.

## Review fixes folded in (verdict was SHIP)

1. **`ingest.Sink` implements `RecordIngressError`** — the adapter's append-fault counting was inert in production (the optional interface was satisfied only by the test double). New per-account `append_errors` counter; the Google tee records into it too, so `/api/status` (I5) sees all platforms.
2. **Delivered-class self receipts no longer advance the read cursor** — a delivery ack for an outgoing message says nothing about what the local user read. Only `read`-class self receipts advance; others drop counted.
3. **Capture-side panic recovers** (defense-in-depth beyond the observer wrap) and a dead re-assignment removed.

Known accepted divergences (documented, not bugs): messages from a recently-left group are durably captured though legacy hides them for the 6h TTL (durability by design — the §2.2 skip table governs the decoder, not capture); history-sync `@lid` conversations lacking both `pnJID` and mappings remain the documented post-cutover-merge follow-up.

## Verification

Full `go test -race ./...`: 28 packages green (independently verified outside the sandbox; the two `cmd` listener tests fail only where loopback binds are forbidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
