### PR TITLE
Signal receive ingest: capture-time contact resolution + pure decoder (ingest I4)

### DIFF
--- a/cmd/v2stack.go
+++ b/cmd/v2stack.go
@@ -215,6 +215,11 @@ func newV2Stack(deps v2StackDeps) (_ *v2Stack, resultErr error) {
 				Decoder:  ingest.NewGoogleDecoder(counters),
 			},
 			ingest.NewWhatsAppDecoderRegistration(),
+			{
+				Codec:    ingest.SignalJSONRPCCodec,
+				Platform: bridge.PlatformSignal,
+				Decoder:  ingest.NewSignalDecoder(),
+			},
 		},
 	})
 	if err != nil {

--- a/internal/bridgeadapters/signal/signal.go
+++ b/internal/bridgeadapters/signal/signal.go
@@ -13,14 +13,17 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
 	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/ingest"
 	"github.com/maxghenis/openmessage/internal/signallive"
 )
 
 type poller interface {
+	ObserveIngress(func(account string, line []byte, resolvedSource string, resolvedDestination string)) func()
 	StartPoller(context.Context) (signallive.PollerRun, error)
 	SendTextRequest(string, string, string) (int64, error)
 	SendReactionRequest(string, string, string, string, string) error
@@ -55,8 +58,9 @@ type decodedSignalDownloadRef struct {
 // Adapter owns Signal connection generations while retaining signallive's
 // existing signal-cli receive loop and all legacy operation paths.
 type Adapter struct {
-	accountID string
-	poller    poller
+	accountID       string
+	poller          poller
+	ingressFailures atomic.Uint64
 
 	mu       sync.Mutex
 	current  *run
@@ -487,14 +491,56 @@ func (a *Adapter) Start(
 	a.starting = true
 	a.mu.Unlock()
 	installed := false
+	var unregisterIngress func()
 	defer func() {
 		if installed {
 			return
+		}
+		if unregisterIngress != nil {
+			unregisterIngress()
 		}
 		a.mu.Lock()
 		a.starting = false
 		a.mu.Unlock()
 	}()
+
+	unregisterIngress = a.poller.ObserveIngress(func(
+		account string,
+		line []byte,
+		resolvedSource string,
+		resolvedDestination string,
+	) {
+		if sink == nil {
+			return
+		}
+		record, ephemeral, err := ingest.BuildSignalIngress(
+			req.AccountID,
+			req.Generation,
+			account,
+			line,
+			resolvedSource,
+			resolvedDestination,
+			time.Now(),
+		)
+		if err != nil {
+			a.recordIngressFailure(err)
+			return
+		}
+		if ephemeral != nil {
+			if err := sink.EmitEphemeral(context.Background(), *ephemeral); err != nil {
+				a.recordIngressFailure(err)
+			}
+			return
+		}
+		if record != nil {
+			if err := sink.AppendIngress(context.Background(), *record); err != nil {
+				a.recordIngressFailure(err)
+			}
+		}
+	})
+	if unregisterIngress == nil {
+		unregisterIngress = func() {}
+	}
 
 	pollerRun, err := a.poller.StartPoller(ctx)
 	if err != nil {
@@ -514,6 +560,7 @@ func (a *Adapter) Start(
 		request:      req,
 		sink:         sink,
 		poller:       pollerRun,
+		unregister:   unregisterIngress,
 		ready:        pollerRun.Ready(),
 		done:         make(chan error, 1),
 		stopped:      make(chan struct{}),
@@ -529,6 +576,16 @@ func (a *Adapter) Start(
 
 	go r.coordinate(ctx)
 	return r, nil
+}
+
+func (a *Adapter) recordIngressFailure(err error) {
+	if a == nil || err == nil || errors.Is(err, bridge.ErrStaleGeneration) {
+		return
+	}
+	a.ingressFailures.Add(1)
+	if reporter, ok := a.poller.(interface{ ReportIngressError(error) }); ok {
+		reporter.ReportIngressError(err)
+	}
 }
 
 // ReportError lets unchanged App-level signal-cli send paths surface a local
@@ -671,14 +728,15 @@ func classifyPollerExit(exit signallive.PollerExit) error {
 }
 
 type run struct {
-	adapter *Adapter
-	request bridge.StartRequest
-	sink    bridge.ConnectionSink
-	poller  signallive.PollerRun
-	ready   <-chan struct{}
-	done    chan error
-	stopped chan struct{}
-	finish  chan struct{}
+	adapter    *Adapter
+	request    bridge.StartRequest
+	sink       bridge.ConnectionSink
+	poller     signallive.PollerRun
+	unregister func()
+	ready      <-chan struct{}
+	done       chan error
+	stopped    chan struct{}
+	finish     chan struct{}
 
 	finishOnce sync.Once
 	terminalMu sync.Mutex
@@ -772,6 +830,9 @@ func (r *run) coordinate(ctx context.Context) {
 	}
 
 	r.closeAdmission()
+	if r.unregister != nil {
+		r.unregister()
+	}
 	// Poller.Done reports the retained receive/link loop's exit. Stop is its
 	// token-bound join; host-scoped metadata remains joined by Bridge.Close.
 	_ = r.poller.Stop(context.Background())

--- a/internal/bridgeadapters/signal/signal_test.go
+++ b/internal/bridgeadapters/signal/signal_test.go
@@ -3,6 +3,7 @@ package signal
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"runtime"
@@ -874,6 +875,208 @@ func TestRunTranslatesRetainedPollerSignals(t *testing.T) {
 	}
 }
 
+func TestAdapterRegistersIngressBeforeStartPollerAndUnregistersAtTerminal(t *testing.T) {
+	poller := newFakePoller()
+	poller.startAccount = "+15551230000"
+	poller.startLine = []byte(`{"account":"+15551230000","envelope":{"sourceServiceId":"9f4b50e3-ebf2-413c-a856-161756a6161a","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"startup WAL"}}}`)
+	poller.startResolvedSource = "+15551234567"
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	sink := &recordingSink{ingress: make(chan bridge.RawIngressRecord, 1)}
+
+	run, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "signal-primary",
+		Generation: 17,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start(): %v", err)
+	}
+	record := receiveValue(t, sink.ingress, "startup Signal ingress")
+	if record.AccountID != "signal-primary" || record.Generation != 17 ||
+		record.Codec != "signal.jsonrpc" || record.CodecVersion != 1 {
+		t.Fatalf("startup ingress = %+v, want stamped generation and Signal codec", record)
+	}
+	var frame struct {
+		Line                json.RawMessage `json:"line"`
+		ResolvedSource      string          `json:"resolved_source"`
+		ResolvedDestination string          `json:"resolved_destination"`
+	}
+	if err := json.Unmarshal(record.Payload, &frame); err != nil {
+		t.Fatalf("json.Unmarshal(Signal frame): %v", err)
+	}
+	if !bytes.Equal(frame.Line, poller.startLine) || frame.ResolvedSource != "+15551234567" ||
+		frame.ResolvedDestination != "" {
+		t.Fatalf("captured frame = %+v, want raw line plus canonical source", frame)
+	}
+	if record.DedupeKey != "env:9f4b50e3-ebf2-413c-a856-161756a6161a:1700000000123" {
+		t.Fatalf("dedupe key = %q, want raw ACI identity", record.DedupeKey)
+	}
+
+	poller.mu.Lock()
+	order := append([]string(nil), poller.startOrder...)
+	poller.mu.Unlock()
+	if len(order) < 2 || order[0] != "observe" || order[1] != "start" {
+		t.Fatalf("poller order = %v, want observer registered before StartPoller", order)
+	}
+
+	stopAdapterRun(t, run)
+	poller.mu.Lock()
+	observer := poller.ingress
+	unregistered := poller.unregistered
+	poller.mu.Unlock()
+	if observer != nil || unregistered != 1 {
+		t.Fatalf("terminal observer = %v unregister calls = %d, want cleared exactly once", observer != nil, unregistered)
+	}
+}
+
+func TestAdapterRoutesTypingOnlyIngressToEphemeralSink(t *testing.T) {
+	poller := newFakePoller()
+	poller.startAccount = "+15551230000"
+	poller.startLine = []byte(`{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","timestamp":1700000000123,"typingMessage":{"action":"started"}}}`)
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	sink := &recordingSink{
+		ingress:   make(chan bridge.RawIngressRecord, 1),
+		ephemeral: make(chan bridge.EphemeralEvent, 1),
+	}
+
+	run, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "signal-primary",
+		Generation: 23,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start(): %v", err)
+	}
+	t.Cleanup(func() { stopAdapterRun(t, run) })
+	event := receiveValue(t, sink.ephemeral, "Signal typing event")
+	if event.AccountID != "signal-primary" || event.Generation != 23 ||
+		event.Typing == nil || event.Typing.RemoteConversationID != "signal:+15551234567" {
+		t.Fatalf("typing event = %+v, want stamped ephemeral Signal event", event)
+	}
+	select {
+	case record := <-sink.ingress:
+		t.Fatalf("typing-only envelope appended durable ingress: %+v", record)
+	default:
+	}
+}
+
+func TestAdapterIngressFailureDoesNotTerminateGeneration(t *testing.T) {
+	poller := newFakePoller()
+	poller.startAccount = "+15551230000"
+	poller.startLine = []byte(`{"account":"+15551230000","envelope":{"source":"+15551234567","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"legacy continues"}}}`)
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	wantErr := errors.New("durable sink unavailable")
+	sink := &recordingSink{
+		ingress:   make(chan bridge.RawIngressRecord, 1),
+		appendErr: wantErr,
+	}
+
+	run, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "signal-primary",
+		Generation: 31,
+	}, sink)
+	if err != nil {
+		t.Fatalf("Start(): %v", err)
+	}
+	t.Cleanup(func() { stopAdapterRun(t, run) })
+	receiveValue(t, sink.ingress, "failed durable append")
+	if got := adapter.ingressFailures.Load(); got != 1 {
+		t.Fatalf("ingress failure count = %d, want 1", got)
+	}
+	poller.mu.Lock()
+	reported := append([]error(nil), poller.ingressErrors...)
+	poller.mu.Unlock()
+	if len(reported) != 1 || !errors.Is(reported[0], wantErr) {
+		t.Fatalf("reported ingress errors = %v, want %v", reported, wantErr)
+	}
+	select {
+	case terminal := <-run.Done():
+		t.Fatalf("ingress failure terminated generation: %v", terminal)
+	default:
+	}
+}
+
+func TestAdapterStartFailureUnregistersIngress(t *testing.T) {
+	poller := newFakePoller()
+	poller.startErr = errors.New("poller start failed")
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+
+	run, err := adapter.Start(context.Background(), bridge.StartRequest{
+		AccountID:  "signal-primary",
+		Generation: 1,
+	}, &recordingSink{})
+	if run != nil {
+		t.Fatalf("Start() run = %T, want nil", run)
+	}
+	assertOpError(t, err, bridge.FailureTransient, "signal_start_failed")
+	poller.mu.Lock()
+	observer := poller.ingress
+	unregistered := poller.unregistered
+	poller.mu.Unlock()
+	if observer != nil || unregistered != 1 {
+		t.Fatalf("failed-start observer = %v unregister calls = %d, want cleared once", observer != nil, unregistered)
+	}
+}
+
+func TestStaleSignalIngressCallbackIsBenignAtGenerationFence(t *testing.T) {
+	poller := newFakePoller()
+	adapter := &Adapter{accountID: "signal-primary", poller: poller}
+	clock := newManualClock(signalAdapterTestEpoch)
+	downstream := &recordingSink{ingress: make(chan bridge.RawIngressRecord, 2)}
+	supervisor, err := bridge.NewSupervisor(
+		"signal-primary",
+		bridge.PlatformSignal,
+		adapter,
+		signalSupervisorTestPolicy(),
+		clock,
+		midpointRandom{},
+		bridge.WithConnectionSink(downstream),
+	)
+	if err != nil {
+		t.Fatalf("NewSupervisor(): %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), signalAdapterTestTimeout)
+		defer cancel()
+		if err := supervisor.Stop(ctx); err != nil {
+			t.Errorf("Supervisor.Stop(): %v", err)
+		}
+	})
+
+	startSupervisor(t, supervisor)
+	firstRun := readyNextGeneration(t, supervisor, poller, 1)
+	poller.mu.Lock()
+	oldObserver := poller.ingressHistory[0]
+	poller.mu.Unlock()
+	firstRun.complete(signallive.PollerExit{
+		Kind:        signallive.PollerFailureTransient,
+		Operation:   "receive",
+		Fingerprint: signallive.SignalReceiveFailureFingerprint,
+		Err:         errors.New("retry generation"),
+	})
+	backoff := awaitSnapshot(t, supervisor, "generation one backoff", func(snapshot bridge.Snapshot) bool {
+		return snapshot.State == bridge.StateBackoff && snapshot.Generation == 1
+	})
+	clock.Advance(backoff.RetryAt.Sub(clock.Now()))
+	readyNextGeneration(t, supervisor, poller, 2)
+
+	oldObserver(
+		"+15551230000",
+		[]byte(`{"account":"+15551230000","envelope":{"source":"+15551234567","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"late generation one"}}}`),
+		"",
+		"",
+	)
+	select {
+	case record := <-downstream.ingress:
+		t.Fatalf("stale generation reached downstream sink: %+v", record)
+	case <-time.After(25 * time.Millisecond):
+	}
+	if got := adapter.ingressFailures.Load(); got != 0 {
+		t.Fatalf("benign stale callback counted as ingress failure: %d", got)
+	}
+	if snapshot := supervisor.Snapshot(); snapshot.State != bridge.StateOnline || snapshot.Generation != 2 {
+		t.Fatalf("snapshot after stale callback = %+v, want online generation 2", snapshot)
+	}
+}
+
 func TestAdapterStartIsSingleFlight(t *testing.T) {
 	poller := newFakePoller()
 	poller.startEntered = make(chan struct{}, 1)
@@ -1285,27 +1488,38 @@ func TestSupervisorLeavesExpiredPairingUnpairedWithoutReconnectChurn(t *testing.
 }
 
 type fakePoller struct {
-	mu             sync.Mutex
-	starts         int
-	runs           []*fakePollerRun
-	started        chan *fakePollerRun
-	startEntered   chan struct{}
-	startRelease   chan struct{}
-	applied        []signallive.PollerExit
-	fingerprint    string
-	status         signallive.StatusSnapshot
-	textCalls      []fakeTextRequest
-	textTimestamp  int64
-	textErr        error
-	reactionCalls  []fakeReactionRequest
-	reactionErr    error
-	mediaCalls     []fakeMediaRequest
-	mediaTimestamp int64
-	mediaErr       error
-	downloadCalls  []fakeDownloadRequest
-	downloadData   []byte
-	downloadMIME   string
-	downloadErr    error
+	mu                       sync.Mutex
+	ingressID                uint64
+	ingress                  func(account string, line []byte, resolvedSource string, resolvedDestination string)
+	ingressHistory           []func(account string, line []byte, resolvedSource string, resolvedDestination string)
+	unregistered             int
+	startAccount             string
+	startLine                []byte
+	startResolvedSource      string
+	startResolvedDestination string
+	startOrder               []string
+	startErr                 error
+	ingressErrors            []error
+	starts                   int
+	runs                     []*fakePollerRun
+	started                  chan *fakePollerRun
+	startEntered             chan struct{}
+	startRelease             chan struct{}
+	applied                  []signallive.PollerExit
+	fingerprint              string
+	status                   signallive.StatusSnapshot
+	textCalls                []fakeTextRequest
+	textTimestamp            int64
+	textErr                  error
+	reactionCalls            []fakeReactionRequest
+	reactionErr              error
+	mediaCalls               []fakeMediaRequest
+	mediaTimestamp           int64
+	mediaErr                 error
+	downloadCalls            []fakeDownloadRequest
+	downloadData             []byte
+	downloadMIME             string
+	downloadErr              error
 }
 
 type fakeTextRequest struct {
@@ -1355,12 +1569,52 @@ func newFakePoller() *fakePoller {
 	return &fakePoller{started: make(chan *fakePollerRun, 16)}
 }
 
+func (p *fakePoller) ObserveIngress(observer func(
+	account string,
+	line []byte,
+	resolvedSource string,
+	resolvedDestination string,
+)) func() {
+	p.mu.Lock()
+	p.ingressID++
+	registrationID := p.ingressID
+	p.ingress = observer
+	p.ingressHistory = append(p.ingressHistory, observer)
+	p.startOrder = append(p.startOrder, "observe")
+	p.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			p.mu.Lock()
+			p.unregistered++
+			if p.ingressID == registrationID {
+				p.ingress = nil
+			}
+			p.mu.Unlock()
+		})
+	}
+}
+
 func (p *fakePoller) StartPoller(ctx context.Context) (signallive.PollerRun, error) {
 	p.mu.Lock()
 	p.starts++
 	entered := p.startEntered
 	release := p.startRelease
+	observer := p.ingress
+	startAccount := p.startAccount
+	startLine := bytes.Clone(p.startLine)
+	startResolvedSource := p.startResolvedSource
+	startResolvedDestination := p.startResolvedDestination
+	startErr := p.startErr
+	p.startOrder = append(p.startOrder, "start")
 	p.mu.Unlock()
+	if observer != nil && len(startLine) > 0 {
+		observer(startAccount, startLine, startResolvedSource, startResolvedDestination)
+	}
+	if startErr != nil {
+		return nil, startErr
+	}
 	if entered != nil {
 		select {
 		case entered <- struct{}{}:
@@ -1385,6 +1639,12 @@ func (p *fakePoller) StartPoller(ctx context.Context) (signallive.PollerRun, err
 		return nil, ctx.Err()
 	}
 	return run, nil
+}
+
+func (p *fakePoller) ReportIngressError(err error) {
+	p.mu.Lock()
+	p.ingressErrors = append(p.ingressErrors, err)
+	p.mu.Unlock()
 }
 
 func (p *fakePoller) Status() signallive.StatusSnapshot {
@@ -1628,12 +1888,26 @@ type recordedBeat struct {
 }
 
 type recordingSink struct {
-	beats chan recordedBeat
+	beats        chan recordedBeat
+	ingress      chan bridge.RawIngressRecord
+	ephemeral    chan bridge.EphemeralEvent
+	appendErr    error
+	ephemeralErr error
 }
 
-func (*recordingSink) AppendIngress(context.Context, bridge.RawIngressRecord) error { return nil }
+func (s *recordingSink) AppendIngress(_ context.Context, record bridge.RawIngressRecord) error {
+	if s.ingress != nil {
+		s.ingress <- record
+	}
+	return s.appendErr
+}
 
-func (*recordingSink) EmitEphemeral(context.Context, bridge.EphemeralEvent) error { return nil }
+func (s *recordingSink) EmitEphemeral(_ context.Context, event bridge.EphemeralEvent) error {
+	if s.ephemeral != nil {
+		s.ephemeral <- event
+	}
+	return s.ephemeralErr
+}
 
 func (s *recordingSink) Beat(generation bridge.Generation, at time.Time, detail string) {
 	s.beats <- recordedBeat{generation: generation, at: at, detail: detail}

--- a/internal/ingest/signaldecoder.go
+++ b/internal/ingest/signaldecoder.go
@@ -1,0 +1,462 @@
+package ingest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/signallive"
+	"github.com/maxghenis/openmessage/internal/v2keys"
+)
+
+const (
+	SignalJSONRPCCodec        = "signal.jsonrpc"
+	SignalJSONRPCCodecVersion = uint32(1)
+	signalTypingLifetime      = 10 * time.Second
+)
+
+type signalJSONRPCFrame struct {
+	Account             string          `json:"account"`
+	Line                json.RawMessage `json:"line"`
+	ResolvedSource      string          `json:"resolved_source"`
+	ResolvedDestination string          `json:"resolved_destination"`
+}
+
+type signalDownloadOpaqueV1 struct {
+	Version        int    `json:"v"`
+	Kind           string `json:"kind"`
+	AttachmentID   string `json:"att_id"`
+	ConversationID string `json:"conversation_id"`
+}
+
+// SignalDecoder projects the byte-preserving signal.jsonrpc v1 codec into the
+// normalized bridge event contract.
+type SignalDecoder struct{}
+
+var _ bridge.Decoder = (*SignalDecoder)(nil)
+
+// NewSignalDecoder constructs the Signal durable-ingress decoder.
+func NewSignalDecoder() *SignalDecoder {
+	return &SignalDecoder{}
+}
+
+// BuildSignalIngress classifies a captured Signal line before durable append.
+// Typing-only envelopes become ephemeral events; every other parsed envelope
+// becomes one byte-preserving signal.jsonrpc record.
+func BuildSignalIngress(
+	accountID string,
+	generation bridge.Generation,
+	signalAccount string,
+	line []byte,
+	resolvedSource string,
+	resolvedDestination string,
+	receivedAt time.Time,
+) (*bridge.RawIngressRecord, *bridge.EphemeralEvent, error) {
+	resolvedAccount, env, err := signallive.ParseReceiveEnvelope(signalAccount, line)
+	if err != nil {
+		return nil, nil, fmt.Errorf("classify Signal ingress: %w", err)
+	}
+	resolvedAccount = strings.TrimSpace(resolvedAccount)
+	if resolvedAccount == "" {
+		return nil, nil, fmt.Errorf("classify Signal ingress: account is empty")
+	}
+	if signalTypingOnly(&env) {
+		source := resolvedSignalAddress(resolvedSource, signallive.EnvelopeSource(&env))
+		groupID := ""
+		if env.TypingMessage.GroupInfo != nil {
+			groupID = strings.TrimSpace(env.TypingMessage.GroupInfo.GroupID)
+		}
+		return nil, &bridge.EphemeralEvent{
+			AccountID:  accountID,
+			Generation: generation,
+			Typing: &bridge.TypingEvent{
+				RemoteConversationID: signallive.SignalConversationID(source, groupID),
+				Actor: bridge.IdentityRef{
+					Raw:  source,
+					Name: strings.TrimSpace(env.SourceName),
+				},
+				Typing:    strings.EqualFold(strings.TrimSpace(env.TypingMessage.Action), "started"),
+				ExpiresAt: receivedAt.Add(signalTypingLifetime),
+			},
+		}, nil
+	}
+
+	payload, err := marshalSignalJSONRPCFrame(
+		resolvedAccount,
+		line,
+		resolvedSource,
+		resolvedDestination,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &bridge.RawIngressRecord{
+		AccountID:    accountID,
+		Generation:   generation,
+		DedupeKey:    signalDedupeKey(line),
+		Codec:        SignalJSONRPCCodec,
+		CodecVersion: SignalJSONRPCCodecVersion,
+		ReceivedAt:   receivedAt,
+		Payload:      payload,
+	}, nil, nil
+}
+
+func signalTypingOnly(env *signallive.Envelope) bool {
+	return env != nil && env.TypingMessage != nil && env.DataMessage == nil &&
+		env.EditMessage == nil &&
+		(env.SyncMessage == nil || env.SyncMessage.SentMessage == nil)
+}
+
+func marshalSignalJSONRPCFrame(
+	account string,
+	line []byte,
+	resolvedSource string,
+	resolvedDestination string,
+) ([]byte, error) {
+	if !json.Valid(line) {
+		return nil, fmt.Errorf("encode Signal ingress: line is not valid JSON")
+	}
+	encodedAccount, err := json.Marshal(account)
+	if err != nil {
+		return nil, fmt.Errorf("encode Signal ingress account: %w", err)
+	}
+	encodedSource, err := json.Marshal(strings.TrimSpace(resolvedSource))
+	if err != nil {
+		return nil, fmt.Errorf("encode Signal ingress resolved source: %w", err)
+	}
+	encodedDestination, err := json.Marshal(strings.TrimSpace(resolvedDestination))
+	if err != nil {
+		return nil, fmt.Errorf("encode Signal ingress resolved destination: %w", err)
+	}
+	payload := make([]byte, 0, len(encodedAccount)+len(line)+len(encodedSource)+len(encodedDestination)+64)
+	payload = append(payload, `{"account":`...)
+	payload = append(payload, encodedAccount...)
+	payload = append(payload, `,"line":`...)
+	payload = append(payload, line...)
+	payload = append(payload, `,"resolved_source":`...)
+	payload = append(payload, encodedSource...)
+	payload = append(payload, `,"resolved_destination":`...)
+	payload = append(payload, encodedDestination...)
+	payload = append(payload, '}')
+	return payload, nil
+}
+
+func signalDedupeKey(line []byte) string {
+	var probe struct {
+		Envelope signallive.Envelope `json:"envelope"`
+		Result   *struct {
+			Envelope signallive.Envelope `json:"envelope"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(line, &probe); err == nil {
+		envelope := probe.Envelope
+		if envelope.Timestamp == 0 && strings.TrimSpace(signallive.EnvelopeSource(&envelope)) == "" && probe.Result != nil {
+			envelope = probe.Result.Envelope
+		}
+		if source := strings.TrimSpace(signallive.EnvelopeSource(&envelope)); source != "" && envelope.Timestamp != 0 {
+			// Dedupe deliberately uses the raw envelope address. Contact resolution
+			// can drift between live delivery and WAL recovery; the raw key absorbs
+			// an exact replay before that drift can mint a divergent projection.
+			return "env:" + source + ":" + strconv.FormatInt(envelope.Timestamp, 10)
+		}
+	}
+	sum := sha256.Sum256(line)
+	return "line:" + hex.EncodeToString(sum[:8])
+}
+
+func resolvedSignalAddress(resolved string, raw string) string {
+	if resolved = strings.TrimSpace(resolved); resolved != "" {
+		return resolved
+	}
+	return strings.TrimSpace(raw)
+}
+
+func (d *SignalDecoder) Decode(
+	_ context.Context,
+	record bridge.RawIngressRecord,
+) ([]bridge.Event, error) {
+	if record.Codec != SignalJSONRPCCodec {
+		return nil, fmt.Errorf("decode Signal ingress: codec %q is not %q", record.Codec, SignalJSONRPCCodec)
+	}
+	if record.CodecVersion != SignalJSONRPCCodecVersion {
+		return nil, fmt.Errorf("decode Signal ingress: unsupported codec version %d", record.CodecVersion)
+	}
+	var frame signalJSONRPCFrame
+	if err := json.Unmarshal(record.Payload, &frame); err != nil {
+		return nil, fmt.Errorf("decode Signal ingress frame: %w", err)
+	}
+	frame.Account = strings.TrimSpace(frame.Account)
+	if frame.Account == "" {
+		return nil, fmt.Errorf("decode Signal ingress frame: account is empty")
+	}
+	if len(frame.Line) == 0 {
+		return nil, fmt.Errorf("decode Signal ingress frame: line is missing")
+	}
+	account, env, err := signallive.ParseReceiveEnvelope(frame.Account, frame.Line)
+	if err != nil {
+		return nil, fmt.Errorf("decode Signal receive line: %w", err)
+	}
+	account = strings.TrimSpace(account)
+	if account == "" {
+		account = frame.Account
+	}
+	source := resolvedSignalAddress(frame.ResolvedSource, signallive.EnvelopeSource(&env))
+	destination := ""
+	if env.SyncMessage != nil {
+		destination = resolvedSignalAddress(
+			frame.ResolvedDestination,
+			signallive.SentTarget(env.SyncMessage.SentMessage),
+		)
+	}
+
+	events := make([]bridge.Event, 0, 3)
+	if env.EditMessage != nil {
+		event, err := decodeSignalEdit(account, &env, source)
+		if err != nil {
+			return nil, err
+		}
+		if event != nil {
+			events = append(events, *event)
+		}
+	}
+	if env.DataMessage != nil {
+		event, err := decodeSignalData(account, &env, source)
+		if err != nil {
+			return nil, err
+		}
+		if event != nil {
+			events = append(events, *event)
+		}
+	}
+	if env.SyncMessage != nil && env.SyncMessage.SentMessage != nil {
+		event, err := decodeSignalSent(account, &env, destination)
+		if err != nil {
+			return nil, err
+		}
+		if event != nil {
+			events = append(events, *event)
+		}
+	}
+	return events, nil
+}
+
+func decodeSignalData(
+	account string,
+	env *signallive.Envelope,
+	source string,
+) (*bridge.Event, error) {
+	message := env.DataMessage
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return nil, nil
+	}
+	groupID := ""
+	if message.GroupInfo != nil {
+		groupID = strings.TrimSpace(message.GroupInfo.GroupID)
+	}
+	conversationID := signallive.SignalConversationID(source, groupID)
+	if message.Reaction != nil {
+		occurredAt := env.Timestamp
+		if occurredAt == 0 {
+			occurredAt = message.Timestamp
+		}
+		return decodeSignalReaction(account, conversationID, source, strings.TrimSpace(env.SourceName), message.Reaction, occurredAt, false), nil
+	}
+	if signallive.AddressesMatch(source, account) {
+		return nil, nil
+	}
+	timestamp := message.Timestamp
+	if timestamp == 0 {
+		timestamp = env.Timestamp
+	}
+	if timestamp <= 0 {
+		return nil, fmt.Errorf("decode Signal data message: timestamp is not positive")
+	}
+	attachments, err := signalAttachments(conversationID, message.Attachments)
+	if err != nil {
+		return nil, err
+	}
+	return &bridge.Event{
+		Kind: bridge.EventMessage,
+		Message: &bridge.MessageEvent{
+			RemoteConversationID: conversationID,
+			RemoteMessageID:      v2keys.SignalIncomingSourceID(conversationID, source, timestamp),
+			Sender: bridge.IdentityRef{
+				Raw:  source,
+				Name: strings.TrimSpace(env.SourceName),
+			},
+			Direction:   "incoming",
+			Body:        message.DisplayBody(),
+			Attachments: attachments,
+			OccurredAt:  time.UnixMilli(timestamp),
+		},
+	}, nil
+}
+
+func decodeSignalEdit(
+	account string,
+	env *signallive.Envelope,
+	source string,
+) (*bridge.Event, error) {
+	edit := env.EditMessage
+	if edit.DataMessage == nil {
+		return nil, nil
+	}
+	source = strings.TrimSpace(source)
+	if source == "" || signallive.AddressesMatch(source, account) {
+		return nil, nil
+	}
+	groupID := ""
+	if edit.DataMessage.GroupInfo != nil {
+		groupID = strings.TrimSpace(edit.DataMessage.GroupInfo.GroupID)
+	}
+	conversationID := signallive.SignalConversationID(source, groupID)
+	if edit.TargetSentTimestamp <= 0 {
+		return nil, fmt.Errorf("decode Signal edit message: target timestamp is not positive")
+	}
+	occurredAt := edit.DataMessage.Timestamp
+	if occurredAt == 0 {
+		occurredAt = env.Timestamp
+	}
+	return &bridge.Event{
+		Kind: bridge.EventMessageMutation,
+		MessageMutation: &bridge.MessageMutationEvent{
+			RemoteConversationID: conversationID,
+			RemoteMessageID: v2keys.SignalIncomingSourceID(
+				conversationID,
+				source,
+				edit.TargetSentTimestamp,
+			),
+			Kind:       "edit",
+			Body:       edit.DataMessage.DisplayBody(),
+			OccurredAt: time.UnixMilli(occurredAt),
+		},
+	}, nil
+}
+
+func decodeSignalSent(
+	account string,
+	env *signallive.Envelope,
+	target string,
+) (*bridge.Event, error) {
+	sent := env.SyncMessage.SentMessage
+	// Sent-message edits are retained by the legacy path but have no specified
+	// v2 remote-id mapping in this slice; keep the durable frame and emit no
+	// projection until that mapping is defined.
+	if sent.EditMessage != nil {
+		return nil, nil
+	}
+	groupID := ""
+	if sent.GroupInfo != nil {
+		groupID = strings.TrimSpace(sent.GroupInfo.GroupID)
+	}
+	target = strings.TrimSpace(target)
+	if target == "" && groupID == "" {
+		return nil, nil
+	}
+	conversationID := signallive.SignalConversationID(target, groupID)
+	if sent.Reaction != nil {
+		occurredAt := env.Timestamp
+		if occurredAt == 0 {
+			occurredAt = sent.Timestamp
+		}
+		return decodeSignalReaction(account, conversationID, account, "", sent.Reaction, occurredAt, true), nil
+	}
+	timestamp := sent.Timestamp
+	if timestamp == 0 {
+		timestamp = env.Timestamp
+	}
+	if timestamp <= 0 {
+		return nil, fmt.Errorf("decode Signal sent message: timestamp is not positive")
+	}
+	attachments, err := signalAttachments(conversationID, sent.Attachments)
+	if err != nil {
+		return nil, err
+	}
+	return &bridge.Event{
+		Kind: bridge.EventMessage,
+		Message: &bridge.MessageEvent{
+			RemoteConversationID: conversationID,
+			RemoteMessageID:      strconv.FormatInt(timestamp, 10),
+			Sender:               bridge.IdentityRef{Raw: account, IsSelf: true},
+			Direction:            "outgoing",
+			Body:                 sent.DisplayBody(),
+			Attachments:          attachments,
+			OccurredAt:           time.UnixMilli(timestamp),
+		},
+	}, nil
+}
+
+func decodeSignalReaction(
+	account string,
+	conversationID string,
+	actor string,
+	actorName string,
+	reaction *signallive.Reaction,
+	timestamp int64,
+	actorIsSelf bool,
+) *bridge.Event {
+	targetTimestamp := signallive.ReactionTargetTimestamp(reaction)
+	if targetTimestamp <= 0 {
+		return nil
+	}
+	targetAuthor := strings.TrimSpace(signallive.ReactionTargetAuthor(reaction, account))
+	targetRemoteID := v2keys.SignalIncomingSourceID(conversationID, targetAuthor, targetTimestamp)
+	if signallive.AddressesMatch(targetAuthor, account) {
+		targetRemoteID = strconv.FormatInt(targetTimestamp, 10)
+	}
+	action := bridge.ReactionAdd
+	if reaction.IsRemove {
+		action = bridge.ReactionRemove
+	}
+	return &bridge.Event{
+		Kind: bridge.EventReaction,
+		Reaction: &bridge.ReactionEvent{
+			RemoteConversationID:  conversationID,
+			TargetRemoteMessageID: targetRemoteID,
+			Actor: bridge.IdentityRef{
+				Raw:    strings.TrimSpace(actor),
+				Name:   strings.TrimSpace(actorName),
+				IsSelf: actorIsSelf,
+			},
+			Emoji:      strings.TrimSpace(reaction.Emoji),
+			Action:     action,
+			OccurredAt: time.UnixMilli(timestamp),
+		},
+	}
+}
+
+func signalAttachments(
+	conversationID string,
+	attachments []signallive.Attachment,
+) ([]bridge.Attachment, error) {
+	result := make([]bridge.Attachment, 0, len(attachments))
+	for _, attachment := range attachments {
+		attachmentID := strings.TrimSpace(attachment.ID)
+		if attachmentID == "" {
+			continue
+		}
+		remoteRef, err := json.Marshal(signalDownloadOpaqueV1{
+			Version:        1,
+			Kind:           "remote",
+			AttachmentID:   attachmentID,
+			ConversationID: conversationID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("encode Signal attachment %q: %w", attachmentID, err)
+		}
+		result = append(result, bridge.Attachment{
+			RemoteID:  attachmentID,
+			RemoteRef: remoteRef,
+			Filename:  strings.TrimSpace(attachment.Filename),
+			MIME:      strings.TrimSpace(attachment.ContentType),
+		})
+	}
+	return result, nil
+}

--- a/internal/ingest/signaldecoder_roundtrip_test.go
+++ b/internal/ingest/signaldecoder_roundtrip_test.go
@@ -1,0 +1,68 @@
+package ingest_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	signaladapter "github.com/maxghenis/openmessage/internal/bridgeadapters/signal"
+	"github.com/maxghenis/openmessage/internal/ingest"
+)
+
+func TestSignalAttachmentRemoteRefRoundTripsThroughAdapter(t *testing.T) {
+	line := []byte(`{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"groupInfo":{"groupId":"group-token"},"attachments":[{"contentType":"image/png","id":"raw-att-42","filename":"photo.png"}]}}}`)
+	record, ephemeral, err := ingest.BuildSignalIngress(
+		"signal-primary",
+		5,
+		"+15551230000",
+		line,
+		"",
+		"",
+		time.UnixMilli(1_700_000_010_000),
+	)
+	if err != nil {
+		t.Fatalf("BuildSignalIngress(): %v", err)
+	}
+	if record == nil || ephemeral != nil {
+		t.Fatalf("classification = (%+v, %+v), want durable", record, ephemeral)
+	}
+	events, err := (&ingest.SignalDecoder{}).Decode(context.Background(), *record)
+	if err != nil {
+		t.Fatalf("Decode(): %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != bridge.EventMessage ||
+		events[0].Message == nil || len(events[0].Message.Attachments) != 1 {
+		t.Fatalf("events = %+v, want one message attachment", events)
+	}
+	attachment := events[0].Message.Attachments[0]
+	if attachment.RemoteID != "raw-att-42" || strings.Contains(string(attachment.RemoteRef), "signalatt:") {
+		t.Fatalf("attachment = %+v, want raw attachment ID without legacy prefix", attachment)
+	}
+	var opaque struct {
+		Version        int    `json:"v"`
+		Kind           string `json:"kind"`
+		AttachmentID   string `json:"att_id"`
+		ConversationID string `json:"conversation_id"`
+	}
+	if err := json.Unmarshal(attachment.RemoteRef, &opaque); err != nil {
+		t.Fatalf("json.Unmarshal(RemoteRef): %v", err)
+	}
+	if opaque.Version != 1 || opaque.Kind != "remote" ||
+		opaque.AttachmentID != "raw-att-42" ||
+		opaque.ConversationID != "signal-group:group-token" {
+		t.Fatalf("RemoteRef = %+v, want complete Signal remote v1 shape", opaque)
+	}
+	if err := signaladapter.ValidateDownloadOpaque(attachment.RemoteRef); err != nil {
+		t.Fatalf("ValidateDownloadOpaque(decoder RemoteRef): %v", err)
+	}
+}
+
+func TestSignalAttachmentRemoteRefRejectsMissingConversationID(t *testing.T) {
+	missingConversation := []byte(`{"v":1,"kind":"remote","att_id":"raw-att-42"}`)
+	if err := signaladapter.ValidateDownloadOpaque(missingConversation); err == nil {
+		t.Fatal("ValidateDownloadOpaque() accepted remote ref without conversation_id")
+	}
+}

--- a/internal/ingest/signaldecoder_test.go
+++ b/internal/ingest/signaldecoder_test.go
@@ -1,0 +1,1014 @@
+package ingest
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	legacydb "github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/migration"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2keys"
+	"github.com/rs/zerolog"
+)
+
+const (
+	signalDecoderAccountID = "signal-primary"
+	signalSelf             = "+15551230000"
+)
+
+var signalDecoderReceivedAt = time.Date(2026, time.July, 17, 15, 30, 0, 0, time.UTC)
+
+func TestSignalDecoderGoldenEnvelopes(t *testing.T) {
+	const sourceACI = "11111111-2222-3333-4444-555555555555"
+	directConversation := "signal:+15551234567"
+	rawACIConversation := "signal:" + sourceACI
+	groupConversation := "signal-group:group-token"
+	directTimestamp := int64(1_700_000_000_123)
+	groupTimestamp := int64(1_700_000_001_123)
+	editTargetTimestamp := int64(1_700_000_000_123)
+	sentTimestamp := int64(1_700_000_002_123)
+	reactionTimestamp := int64(1_700_000_003_123)
+	targetTimestamp := int64(1_700_000_000_999)
+
+	groupRemoteRef := mustSignalJSON(t, signalDownloadOpaqueV1{
+		Version:        1,
+		Kind:           "remote",
+		AttachmentID:   "att-42",
+		ConversationID: groupConversation,
+	})
+	sentRemoteRef := mustSignalJSON(t, signalDownloadOpaqueV1{
+		Version:        1,
+		Kind:           "remote",
+		AttachmentID:   "sent-att-7",
+		ConversationID: groupConversation,
+	})
+	directSentRemoteRef := mustSignalJSON(t, signalDownloadOpaqueV1{
+		Version:        1,
+		Kind:           "remote",
+		AttachmentID:   "sent-att-direct",
+		ConversationID: directConversation,
+	})
+	directInboundRemoteRef := mustSignalJSON(t, signalDownloadOpaqueV1{
+		Version:        1,
+		Kind:           "remote",
+		AttachmentID:   "inbound-att-direct",
+		ConversationID: directConversation,
+	})
+
+	tests := []struct {
+		name                string
+		line                string
+		resolvedSource      string
+		resolvedDestination string
+		want                []bridge.Event
+	}{
+		{
+			name: "inbound direct prefers e164 source and displays body",
+			line: `{"account":"+15551230000","envelope":{"source":"11111111-2222-3333-4444-555555555555","sourceNumber":"+15551234567","sourceName":"Taylor","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"  hello from Signal  "}}}`,
+			want: []bridge.Event{{
+				Kind: bridge.EventMessage,
+				Message: &bridge.MessageEvent{
+					RemoteConversationID: directConversation,
+					RemoteMessageID: v2keys.SignalIncomingSourceID(
+						directConversation,
+						"+15551234567",
+						directTimestamp,
+					),
+					Sender:      bridge.IdentityRef{Raw: "+15551234567", Name: "Taylor"},
+					Direction:   "incoming",
+					Body:        "hello from Signal",
+					Attachments: []bridge.Attachment{},
+					OccurredAt:  time.UnixMilli(directTimestamp),
+				},
+			}},
+		},
+		{
+			name: "inbound ACI group attachment uses raw id and placeholder",
+			line: `{"account":"+15551230000","envelope":{"sourceServiceId":"11111111-2222-3333-4444-555555555555","sourceName":"ACI Taylor","timestamp":1700000001123,"dataMessage":{"timestamp":1700000001123,"groupInfo":{"groupId":"group-token","groupName":"Friends"},"attachments":[{"contentType":"video/mp4","id":"att-42","filename":"clip.mp4"}]}}}`,
+			want: []bridge.Event{{
+				Kind: bridge.EventMessage,
+				Message: &bridge.MessageEvent{
+					RemoteConversationID: groupConversation,
+					RemoteMessageID: v2keys.SignalIncomingSourceID(
+						groupConversation,
+						"11111111-2222-3333-4444-555555555555",
+						groupTimestamp,
+					),
+					Sender: bridge.IdentityRef{
+						Raw:  "11111111-2222-3333-4444-555555555555",
+						Name: "ACI Taylor",
+					},
+					Direction: "incoming",
+					Body:      "[Video]",
+					Attachments: []bridge.Attachment{{
+						RemoteID:  "att-42",
+						RemoteRef: groupRemoteRef,
+						Filename:  "clip.mp4",
+						MIME:      "video/mp4",
+					}},
+					OccurredAt: time.UnixMilli(groupTimestamp),
+				},
+			}},
+		},
+		{
+			name: "inbound direct ACI falls back to raw identity",
+			line: `{"account":"+15551230000","envelope":{"sourceServiceId":"11111111-2222-3333-4444-555555555555","sourceName":"ACI Taylor","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"raw fallback"}}}`,
+			want: []bridge.Event{{
+				Kind: bridge.EventMessage,
+				Message: &bridge.MessageEvent{
+					RemoteConversationID: rawACIConversation,
+					RemoteMessageID: v2keys.SignalIncomingSourceID(
+						rawACIConversation,
+						sourceACI,
+						directTimestamp,
+					),
+					Sender:      bridge.IdentityRef{Raw: sourceACI, Name: "ACI Taylor"},
+					Direction:   "incoming",
+					Body:        "raw fallback",
+					Attachments: []bridge.Attachment{},
+					OccurredAt:  time.UnixMilli(directTimestamp),
+				},
+			}},
+		},
+		{
+			name:           "inbound direct ACI capture resolution matches legacy ids",
+			line:           `{"account":"+15551230000","envelope":{"sourceServiceId":"11111111-2222-3333-4444-555555555555","sourceName":"ACI Taylor","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"resolved convergence","attachments":[{"contentType":"image/png","id":"inbound-att-direct","filename":"resolved-inbound.png"}]}}}`,
+			resolvedSource: "+15551234567",
+			want: []bridge.Event{{
+				Kind: bridge.EventMessage,
+				Message: &bridge.MessageEvent{
+					RemoteConversationID: directConversation,
+					RemoteMessageID: v2keys.SignalIncomingSourceID(
+						directConversation,
+						"+15551234567",
+						directTimestamp,
+					),
+					Sender:    bridge.IdentityRef{Raw: "+15551234567", Name: "ACI Taylor"},
+					Direction: "incoming",
+					Body:      "resolved convergence",
+					Attachments: []bridge.Attachment{{
+						RemoteID:  "inbound-att-direct",
+						RemoteRef: directInboundRemoteRef,
+						Filename:  "resolved-inbound.png",
+						MIME:      "image/png",
+					}},
+					OccurredAt: time.UnixMilli(directTimestamp),
+				},
+			}},
+		},
+		{
+			name:           "inbound ACI group attachment uses captured resolution",
+			line:           `{"account":"+15551230000","envelope":{"sourceServiceId":"11111111-2222-3333-4444-555555555555","sourceName":"ACI Taylor","timestamp":1700000001123,"dataMessage":{"timestamp":1700000001123,"groupInfo":{"groupId":"group-token","groupName":"Friends"},"attachments":[{"contentType":"video/mp4","id":"att-42","filename":"clip.mp4"}]}}}`,
+			resolvedSource: "+15551234567",
+			want: []bridge.Event{{
+				Kind: bridge.EventMessage,
+				Message: &bridge.MessageEvent{
+					RemoteConversationID: groupConversation,
+					RemoteMessageID: v2keys.SignalIncomingSourceID(
+						groupConversation,
+						"+15551234567",
+						groupTimestamp,
+					),
+					Sender: bridge.IdentityRef{
+						Raw:  "+15551234567",
+						Name: "ACI Taylor",
+					},
+					Direction: "incoming",
+					Body:      "[Video]",
+					Attachments: []bridge.Attachment{{
+						RemoteID:  "att-42",
+						RemoteRef: groupRemoteRef,
+						Filename:  "clip.mp4",
+						MIME:      "video/mp4",
+					}},
+					OccurredAt: time.UnixMilli(groupTimestamp),
+				},
+			}},
+		},
+		{
+			name: "inbound reaction",
+			line: `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","sourceName":"Taylor","timestamp":1700000003123,"dataMessage":{"timestamp":1700000003123,"reaction":{"emoji":"👍","target":{"timestamp":1700000000999,"authorNumber":"+15557654321"},"isRemove":true}}}}`,
+			want: []bridge.Event{{
+				Kind: bridge.EventReaction,
+				Reaction: &bridge.ReactionEvent{
+					RemoteConversationID: directConversation,
+					TargetRemoteMessageID: v2keys.SignalIncomingSourceID(
+						directConversation,
+						"+15557654321",
+						targetTimestamp,
+					),
+					Actor:      bridge.IdentityRef{Raw: "+15551234567", Name: "Taylor"},
+					Emoji:      "👍",
+					Action:     bridge.ReactionRemove,
+					OccurredAt: time.UnixMilli(reactionTimestamp),
+				},
+			}},
+		},
+		{
+			name: "incoming edit targets incoming sha1 key",
+			line: `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","sourceName":"Taylor","timestamp":1700000004123,"editMessage":{"targetSentTimestamp":1700000000123,"dataMessage":{"timestamp":1700000004123,"message":"edited body"}}}}`,
+			want: []bridge.Event{{
+				Kind: bridge.EventMessageMutation,
+				MessageMutation: &bridge.MessageMutationEvent{
+					RemoteConversationID: directConversation,
+					RemoteMessageID: v2keys.SignalIncomingSourceID(
+						directConversation,
+						"+15551234567",
+						editTargetTimestamp,
+					),
+					Kind:       "edit",
+					Body:       "edited body",
+					OccurredAt: time.UnixMilli(1_700_000_004_123),
+				},
+			}},
+		},
+		{
+			name: "outgoing group sync uses timestamp key and self sender",
+			line: `{"account":"+15551230000","envelope":{"sourceNumber":"+15551230000","timestamp":1700000002123,"syncMessage":{"sentMessage":{"timestamp":1700000002123,"groupInfo":{"groupId":"group-token"},"message":"sent body","attachments":[{"contentType":"image/jpeg","id":"sent-att-7","filename":"photo.jpg"}]}}}}`,
+			want: []bridge.Event{{
+				Kind: bridge.EventMessage,
+				Message: &bridge.MessageEvent{
+					RemoteConversationID: groupConversation,
+					RemoteMessageID:      "1700000002123",
+					Sender:               bridge.IdentityRef{Raw: signalSelf, IsSelf: true},
+					Direction:            "outgoing",
+					Body:                 "sent body",
+					Attachments: []bridge.Attachment{{
+						RemoteID:  "sent-att-7",
+						RemoteRef: sentRemoteRef,
+						Filename:  "photo.jpg",
+						MIME:      "image/jpeg",
+					}},
+					OccurredAt: time.UnixMilli(sentTimestamp),
+				},
+			}},
+		},
+		{
+			name:                "outgoing direct ACI uses captured destination for conversation and media ref",
+			line:                `{"account":"+15551230000","envelope":{"sourceNumber":"+15551230000","timestamp":1700000002123,"syncMessage":{"sentMessage":{"timestamp":1700000002123,"destinationServiceId":"11111111-2222-3333-4444-555555555555","message":"resolved destination","attachments":[{"contentType":"image/png","id":"sent-att-direct","filename":"resolved.png"}]}}}}`,
+			resolvedDestination: "+15551234567",
+			want: []bridge.Event{{
+				Kind: bridge.EventMessage,
+				Message: &bridge.MessageEvent{
+					RemoteConversationID: directConversation,
+					RemoteMessageID:      "1700000002123",
+					Sender:               bridge.IdentityRef{Raw: signalSelf, IsSelf: true},
+					Direction:            "outgoing",
+					Body:                 "resolved destination",
+					Attachments: []bridge.Attachment{{
+						RemoteID:  "sent-att-direct",
+						RemoteRef: directSentRemoteRef,
+						Filename:  "resolved.png",
+						MIME:      "image/png",
+					}},
+					OccurredAt: time.UnixMilli(sentTimestamp),
+				},
+			}},
+		},
+		{
+			name: "outgoing reaction targets timestamp-native self message",
+			line: `{"account":"+15551230000","envelope":{"sourceNumber":"+15551230000","timestamp":1700000003123,"syncMessage":{"sentMessage":{"destinationNumber":"+15551234567","reaction":{"emoji":"🔥","targetSentTimestamp":1700000000999,"targetAuthorNumber":"+15551230000"}}}}}`,
+			want: []bridge.Event{{
+				Kind: bridge.EventReaction,
+				Reaction: &bridge.ReactionEvent{
+					RemoteConversationID:  directConversation,
+					TargetRemoteMessageID: "1700000000999",
+					Actor:                 bridge.IdentityRef{Raw: signalSelf, IsSelf: true},
+					Emoji:                 "🔥",
+					Action:                bridge.ReactionAdd,
+					OccurredAt:            time.UnixMilli(reactionTimestamp),
+				},
+			}},
+		},
+		{
+			name: "result-wrapped inbound envelope",
+			line: `{"result":{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","sourceName":"Taylor","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"wrapped"}}}}`,
+			want: []bridge.Event{{
+				Kind: bridge.EventMessage,
+				Message: &bridge.MessageEvent{
+					RemoteConversationID: directConversation,
+					RemoteMessageID: v2keys.SignalIncomingSourceID(
+						directConversation,
+						"+15551234567",
+						directTimestamp,
+					),
+					Sender:      bridge.IdentityRef{Raw: "+15551234567", Name: "Taylor"},
+					Direction:   "incoming",
+					Body:        "wrapped",
+					Attachments: []bridge.Attachment{},
+					OccurredAt:  time.UnixMilli(directTimestamp),
+				},
+			}},
+		},
+	}
+
+	decoder := &SignalDecoder{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			record, ephemeral, err := BuildSignalIngress(
+				signalDecoderAccountID,
+				9,
+				signalSelf,
+				[]byte(test.line),
+				test.resolvedSource,
+				test.resolvedDestination,
+				signalDecoderReceivedAt,
+			)
+			if err != nil {
+				t.Fatalf("BuildSignalIngress(): %v", err)
+			}
+			if ephemeral != nil || record == nil {
+				t.Fatalf("BuildSignalIngress() = (%v, %+v), want durable record", record, ephemeral)
+			}
+			got, err := decoder.Decode(context.Background(), *record)
+			if err != nil {
+				t.Fatalf("Decode(): %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("Decode() =\n%#v\nwant\n%#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSignalDecoderSkipsNonProjectingEnvelopes(t *testing.T) {
+	tests := []struct {
+		name           string
+		line           string
+		resolvedSource string
+		wantEvents     int
+	}{
+		{
+			name: "from-me data",
+			line: `{"account":"+15551230000","envelope":{"sourceNumber":"+15551230000","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"duplicate sync path"}}}`,
+		},
+		{
+			name:           "from-me ACI data resolved to account",
+			line:           `{"account":"+15551230000","envelope":{"sourceServiceId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"duplicate ACI sync path"}}}`,
+			resolvedSource: signalSelf,
+		},
+		{
+			name: "receipt only",
+			line: `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","timestamp":1700000000123,"receiptMessage":{"when":1700000000123}}}`,
+		},
+		{
+			name: "all nil",
+			line: `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","timestamp":1700000000123}}`,
+		},
+		{
+			name: "missing inbound source",
+			line: `{"account":"+15551230000","envelope":{"timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"quarantined by legacy"}}}`,
+		},
+		{
+			name: "missing sent target",
+			line: `{"account":"+15551230000","envelope":{"sourceNumber":"+15551230000","timestamp":1700000000123,"syncMessage":{"sentMessage":{"timestamp":1700000000123,"message":"no destination"}}}}`,
+		},
+		{
+			name:       "incoming projection control",
+			line:       `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"decoder is active"}}}`,
+			wantEvents: 1,
+		},
+	}
+	decoder := NewSignalDecoder()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			record, ephemeral, err := BuildSignalIngress(
+				signalDecoderAccountID,
+				1,
+				signalSelf,
+				[]byte(test.line),
+				test.resolvedSource,
+				"",
+				signalDecoderReceivedAt,
+			)
+			if err != nil {
+				t.Fatalf("BuildSignalIngress(): %v", err)
+			}
+			if ephemeral != nil || record == nil {
+				t.Fatalf("classification = (%v, %+v), want durable non-projecting record", record, ephemeral)
+			}
+			events, err := decoder.Decode(context.Background(), *record)
+			if err != nil {
+				t.Fatalf("Decode(): %v", err)
+			}
+			if len(events) != test.wantEvents {
+				t.Fatalf("Decode() = %+v, want %d events", events, test.wantEvents)
+			}
+		})
+	}
+}
+
+func TestBuildSignalIngressTypingOnlyIsEphemeral(t *testing.T) {
+	line := []byte(`{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","sourceName":"Taylor","timestamp":1700000000123,"typingMessage":{"action":"started","groupInfo":{"groupId":"typing-group"}}}}`)
+	record, ephemeral, err := BuildSignalIngress(
+		signalDecoderAccountID,
+		77,
+		signalSelf,
+		line,
+		"",
+		"",
+		signalDecoderReceivedAt,
+	)
+	if err != nil {
+		t.Fatalf("BuildSignalIngress(): %v", err)
+	}
+	if record != nil || ephemeral == nil || ephemeral.Typing == nil {
+		t.Fatalf("classification = (%+v, %+v), want typing-only ephemeral", record, ephemeral)
+	}
+	if ephemeral.AccountID != signalDecoderAccountID || ephemeral.Generation != 77 ||
+		ephemeral.Typing.RemoteConversationID != "signal-group:typing-group" ||
+		ephemeral.Typing.Actor.Raw != "+15551234567" ||
+		ephemeral.Typing.Actor.Name != "Taylor" || !ephemeral.Typing.Typing ||
+		!ephemeral.Typing.ExpiresAt.Equal(signalDecoderReceivedAt.Add(signalTypingLifetime)) {
+		t.Fatalf("ephemeral = %+v, want fully mapped typing event", ephemeral)
+	}
+}
+
+func TestSignalJSONRPCCodecPreservesLineBytesAndDedupeKeys(t *testing.T) {
+	line := []byte(`{ "account" : "+15551230000", "envelope" : { "source" : "+15551234567", "timestamp" : 1700000000123 } }`)
+	record, ephemeral, err := BuildSignalIngress(
+		signalDecoderAccountID,
+		3,
+		signalSelf,
+		line,
+		"+15551234567",
+		"+15550009999",
+		signalDecoderReceivedAt,
+	)
+	if err != nil {
+		t.Fatalf("BuildSignalIngress(): %v", err)
+	}
+	if ephemeral != nil || record == nil {
+		t.Fatalf("classification = (%+v, %+v), want durable", record, ephemeral)
+	}
+	var frame signalJSONRPCFrame
+	if err := json.Unmarshal(record.Payload, &frame); err != nil {
+		t.Fatalf("json.Unmarshal(codec frame): %v", err)
+	}
+	if frame.Account != signalSelf || !reflect.DeepEqual([]byte(frame.Line), line) {
+		t.Fatalf("codec frame = account %q line %q, want byte-preserved %q", frame.Account, frame.Line, line)
+	}
+	if frame.ResolvedSource != "+15551234567" || frame.ResolvedDestination != "+15550009999" {
+		t.Fatalf("codec resolutions = (%q, %q), want capture-time values", frame.ResolvedSource, frame.ResolvedDestination)
+	}
+	if record.DedupeKey != "env:+15551234567:1700000000123" {
+		t.Fatalf("DedupeKey = %q, want envelope source/timestamp", record.DedupeKey)
+	}
+	resultWrapped := []byte(`{"result":{"account":"+15551230000","envelope":{"source":"+15557654321","timestamp":1700000000456}}}`)
+	if got := signalDedupeKey(resultWrapped); got != "env:+15557654321:1700000000456" {
+		t.Fatalf("signalDedupeKey(result wrapper) = %q, want result envelope key", got)
+	}
+	aciOnly := []byte(`{"account":"+15551230000","envelope":{"sourceServiceId":"11111111-2222-3333-4444-555555555555","timestamp":1700000000789}}`)
+	if got := signalDedupeKey(aciOnly); got != "env:11111111-2222-3333-4444-555555555555:1700000000789" {
+		t.Fatalf("signalDedupeKey(ACI-only) = %q, want raw envelope key", got)
+	}
+
+	malformed := []byte("not-json with exact bytes")
+	sum := sha256.Sum256(malformed)
+	wantFallback := "line:" + hex.EncodeToString(sum[:8])
+	if got := signalDedupeKey(malformed); got != wantFallback {
+		t.Fatalf("signalDedupeKey(malformed) = %q, want %q", got, wantFallback)
+	}
+	sourceless := []byte(`{"envelope":{"timestamp":1700000000123}}`)
+	sourcelessSum := sha256.Sum256(sourceless)
+	sourcelessFallback := "line:" + hex.EncodeToString(sourcelessSum[:8])
+	if got := signalDedupeKey(sourceless); got != sourcelessFallback {
+		t.Fatalf("signalDedupeKey(sourceless) = %q, want %q", got, sourcelessFallback)
+	}
+}
+
+func TestNewSignalDecoder(t *testing.T) {
+	if decoder := NewSignalDecoder(); decoder == nil {
+		t.Fatal("NewSignalDecoder() returned nil")
+	}
+}
+
+func TestSignalWALReplayDedupeThroughRealWorker(t *testing.T) {
+	harness := newSignalWorkerHarness(t, "dedupe.sqlite3")
+	line := []byte(`{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","source":"+15551234567","sourceName":"Taylor","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"live then WAL replay"}}}`)
+	record := mustBuildSignalRecord(t, line)
+	if err := harness.sink.AppendIngress(context.Background(), record); err != nil {
+		t.Fatalf("AppendIngress(live): %v", err)
+	}
+	if err := harness.sink.AppendIngress(context.Background(), record); err != nil {
+		t.Fatalf("AppendIngress(WAL replay): %v", err)
+	}
+	harness.start(t)
+
+	conversationID := v2keys.DeriveID("conversation", signalDecoderAccountID, "signal:+15551234567")
+	remoteMessageID := v2keys.SignalIncomingSourceID(
+		"signal:+15551234567",
+		"+15551234567",
+		1_700_000_000_123,
+	)
+	waitSignalCondition(t, "deduplicated Signal projection", func() bool {
+		message, err := harness.messages.GetMessageByRemote(
+			context.Background(),
+			signalDecoderAccountID,
+			conversationID,
+			remoteMessageID,
+		)
+		return err == nil && message.Body == "live then WAL replay" &&
+			harness.counters.Snapshot(signalDecoderAccountID).Deduped == 1
+	})
+	if got := countSignalRows(t, harness.path, "inbox"); got != 1 {
+		t.Fatalf("inbox rows = %d, want one exact replay frame", got)
+	}
+	if got := countSignalRows(t, harness.path, "messages"); got != 1 {
+		t.Fatalf("message rows = %d, want one projected message", got)
+	}
+}
+
+func TestSignalResolutionDriftReplayDedupeThroughRealWorker(t *testing.T) {
+	harness := newSignalWorkerHarness(t, "resolution-drift.sqlite3")
+	line := []byte(`{"account":"+15551230000","envelope":{"sourceServiceId":"11111111-2222-3333-4444-555555555555","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"stable raw replay"}}}`)
+	first, firstEphemeral, err := BuildSignalIngress(
+		signalDecoderAccountID,
+		1,
+		signalSelf,
+		line,
+		"+15551234567",
+		"",
+		signalDecoderReceivedAt,
+	)
+	if err != nil || first == nil || firstEphemeral != nil {
+		t.Fatalf("BuildSignalIngress(first resolution) = (%+v, %+v, %v), want durable", first, firstEphemeral, err)
+	}
+	second, secondEphemeral, err := BuildSignalIngress(
+		signalDecoderAccountID,
+		1,
+		signalSelf,
+		line,
+		"+15557654321",
+		"",
+		signalDecoderReceivedAt,
+	)
+	if err != nil || second == nil || secondEphemeral != nil {
+		t.Fatalf("BuildSignalIngress(drifted resolution) = (%+v, %+v, %v), want durable", second, secondEphemeral, err)
+	}
+	if first.DedupeKey != second.DedupeKey || reflect.DeepEqual(first.Payload, second.Payload) {
+		t.Fatalf("drifted records = keys (%q, %q), payload equality %v; want stable raw key and distinct frames", first.DedupeKey, second.DedupeKey, reflect.DeepEqual(first.Payload, second.Payload))
+	}
+	if err := harness.sink.AppendIngress(context.Background(), *first); err != nil {
+		t.Fatalf("AppendIngress(first): %v", err)
+	}
+	if err := harness.sink.AppendIngress(context.Background(), *second); err != nil {
+		t.Fatalf("AppendIngress(drifted replay): %v", err)
+	}
+	if got := countSignalRows(t, harness.path, "inbox"); got != 1 {
+		t.Fatalf("inbox rows = %d, want one raw-keyed frame after resolution drift", got)
+	}
+}
+
+func TestSignalRecoveryGuardFrameRemainsDurableThroughRealWorker(t *testing.T) {
+	harness := newSignalWorkerHarness(t, "recovery-guard.sqlite3")
+	harness.start(t)
+	line := []byte(`{"account":"+15551230000","envelope":{"timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"legacy quarantines missing source"}}}`)
+	record := mustBuildSignalRecord(t, line)
+	if err := harness.sink.AppendIngress(context.Background(), record); err != nil {
+		t.Fatalf("AppendIngress(): %v", err)
+	}
+	waitSignalCondition(t, "non-projecting recovery frame processing", func() bool {
+		unprocessed, err := harness.messages.Unprocessed(context.Background())
+		return err == nil && len(unprocessed) == 0
+	})
+	if got := countSignalRows(t, harness.path, "inbox"); got != 1 {
+		t.Fatalf("inbox rows = %d, want one durable recovery-guard frame", got)
+	}
+	if got := countSignalRows(t, harness.path, "messages"); got != 0 {
+		t.Fatalf("message rows = %d, want no projection for missing source", got)
+	}
+	snapshot := harness.counters.Snapshot(signalDecoderAccountID)
+	if snapshot.Appended != 1 || snapshot.DecodedEvents != 0 ||
+		snapshot.Projected != 0 || snapshot.Quarantined != 0 {
+		t.Fatalf("recovery frame counters = %+v, want durable no-event processing", snapshot)
+	}
+}
+
+func TestSignalOutgoingAliasConvergesThroughRealDecoderAndWorker(t *testing.T) {
+	const (
+		remoteConversationID = "signal:+16505550100"
+		conversationID       = "migrated-signal-conversation"
+		timestamp            = int64(1_700_000_006_000)
+		migratedMessageID    = "migrated-signal-message"
+	)
+	harness := newSignalWorkerHarness(t, "alias.sqlite3")
+	seedSignalConversation(t, harness.store, conversationID, remoteConversationID)
+	alias := v2keys.SignalLocalAlias(remoteConversationID, timestamp)
+	seedSignalMessage(
+		t,
+		harness.messages,
+		migratedMessageID,
+		conversationID,
+		alias,
+		"migrated body",
+		timestamp,
+	)
+	harness.start(t)
+
+	line := []byte(`{"account":"+15551230000","envelope":{"sourceNumber":"+15551230000","timestamp":1700000006000,"syncMessage":{"sentMessage":{"timestamp":1700000006000,"destinationServiceId":"7a81fd95-20f1-4437-86e2-d5c93ba18851","message":"outgoing sync replay"}}}}`)
+	record := mustBuildSignalRecordWithResolutions(t, line, "", "+16505550100")
+	if err := harness.sink.AppendIngress(context.Background(), record); err != nil {
+		t.Fatalf("AppendIngress(): %v", err)
+	}
+	waitSignalCondition(t, "Signal outgoing alias convergence", func() bool {
+		message, err := harness.messages.GetMessageByRemote(
+			context.Background(), signalDecoderAccountID, conversationID, alias,
+		)
+		return err == nil && message.Body == "outgoing sync replay"
+	})
+
+	message, err := harness.messages.GetMessageByRemote(
+		context.Background(), signalDecoderAccountID, conversationID, alias,
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(alias): %v", err)
+	}
+	if message.MessageID != migratedMessageID || message.RemoteMessageID != alias {
+		t.Fatalf("converged message = %+v, want migrated PK and alias", message)
+	}
+	if _, err := harness.messages.GetMessageByRemote(
+		context.Background(), signalDecoderAccountID, conversationID, "1700000006000",
+	); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("timestamp lookup error = %v, want ErrNotFound", err)
+	}
+	if got := countSignalRows(t, harness.path, "messages"); got != 1 {
+		t.Fatalf("message rows = %d, want one converged alias row", got)
+	}
+}
+
+func TestSignalMigrationOutputConvergesWithLiveDecoder(t *testing.T) {
+	const (
+		remoteConversationID = "signal:+16505550100"
+		timestamp            = int64(1_700_000_006_000)
+		legacyMessageID      = "signal:local:053fa0da59a9c2dee79cc0a2b18e4599ad080bf8"
+	)
+	root := t.TempDir()
+	legacyPath := filepath.Join(root, "legacy.sqlite3")
+	legacy, err := legacydb.New(legacyPath)
+	if err != nil {
+		t.Fatalf("legacydb.New(): %v", err)
+	}
+	if err := legacy.UpsertConversation(&legacydb.Conversation{
+		ConversationID: remoteConversationID,
+		Name:           "Signal fixture",
+		Participants:   `[]`,
+		LastMessageTS:  timestamp,
+		SourcePlatform: "signal",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(): %v", err)
+	}
+	if err := legacy.UpsertMessage(&legacydb.Message{
+		MessageID:      legacyMessageID,
+		ConversationID: remoteConversationID,
+		SenderName:     "Me",
+		Body:           "migration output seed",
+		TimestampMS:    timestamp,
+		Status:         "sent",
+		IsFromMe:       true,
+		SourcePlatform: "signal",
+	}); err != nil {
+		t.Fatalf("UpsertMessage(): %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("legacy.Close(): %v", err)
+	}
+
+	stagedPath := filepath.Join(root, "staged.sqlite3")
+	report, err := migration.Transform(context.Background(), migration.Options{
+		SourcePath:      legacyPath,
+		TempStorePath:   stagedPath,
+		TempBlobPath:    filepath.Join(root, "staged-blobs"),
+		TargetPath:      filepath.Join(root, "canonical"),
+		TargetStorePath: filepath.Join(root, "canonical", "store.sqlite3"),
+		Check:           true,
+	})
+	if err != nil {
+		t.Fatalf("migration.Transform(): %v (report=%+v)", err, report)
+	}
+	if !report.OK || report.SignalLocalRows != 1 {
+		t.Fatalf("migration report = %+v, want one Signal local row", report)
+	}
+
+	store, err := sqlite.Open(stagedPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open(staged): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close staged store: %v", err)
+		}
+	})
+	conversation, err := store.GetConversationByRemote(signalDecoderAccountID, remoteConversationID)
+	if err != nil {
+		t.Fatalf("GetConversationByRemote(migrated): %v", err)
+	}
+	messages, err := sqlite.NewMessageRepository(store, func() time.Time { return signalDecoderReceivedAt })
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	migratedRemoteID, migratedMessageID := migratedSignalMessageKeys(
+		t,
+		stagedPath,
+		conversation.ConversationID,
+	)
+	if !strings.HasPrefix(migratedRemoteID, "local:") {
+		t.Fatalf("migration remote_message_id = %q, want local alias", migratedRemoteID)
+	}
+
+	harness := newSignalWorkerHarnessForStore(t, stagedPath, store, messages)
+	harness.start(t)
+	line := []byte(`{"account":"+15551230000","envelope":{"sourceNumber":"+15551230000","timestamp":1700000006000,"syncMessage":{"sentMessage":{"timestamp":1700000006000,"destinationNumber":"+16505550100","message":"live decoder replay"}}}}`)
+	record := mustBuildSignalRecord(t, line)
+	if err := harness.sink.AppendIngress(context.Background(), record); err != nil {
+		t.Fatalf("AppendIngress(live replay): %v", err)
+	}
+	waitSignalCondition(t, "migration-to-live convergence", func() bool {
+		message, err := messages.GetMessageByRemote(
+			context.Background(),
+			signalDecoderAccountID,
+			conversation.ConversationID,
+			migratedRemoteID,
+		)
+		return err == nil && message.Body == "live decoder replay"
+	})
+
+	message, err := messages.GetMessageByRemote(
+		context.Background(),
+		signalDecoderAccountID,
+		conversation.ConversationID,
+		migratedRemoteID,
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(migration alias): %v", err)
+	}
+	if message.MessageID != migratedMessageID {
+		t.Fatalf("message PK = %q, want migration output PK %q", message.MessageID, migratedMessageID)
+	}
+	if _, err := messages.GetMessageByRemote(
+		context.Background(),
+		signalDecoderAccountID,
+		conversation.ConversationID,
+		"1700000006000",
+	); !errors.Is(err, sqlite.ErrNotFound) {
+		t.Fatalf("timestamp lookup error = %v, want ErrNotFound", err)
+	}
+	if got := countSignalRows(t, stagedPath, "messages"); got != 1 {
+		t.Fatalf("migrated store message rows = %d, want exactly one", got)
+	}
+}
+
+type signalWorkerHarness struct {
+	path     string
+	store    *sqlite.Store
+	messages *sqlite.MessageRepository
+	counters *Counters
+	worker   *Worker
+	sink     *Sink
+	started  bool
+}
+
+func newSignalWorkerHarness(t *testing.T, filename string) *signalWorkerHarness {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), filename)
+	store, err := sqlite.Open(path)
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Store.Close(): %v", err)
+		}
+	})
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   signalDecoderAccountID,
+		BridgeKey:   "signal_cli",
+		DisplayName: "Signal",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: signalDecoderReceivedAt.UnixMilli(),
+		UpdatedAtMS: signalDecoderReceivedAt.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	messages, err := sqlite.NewMessageRepository(store, func() time.Time { return signalDecoderReceivedAt })
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	return newSignalWorkerHarnessForStore(t, path, store, messages)
+}
+
+func newSignalWorkerHarnessForStore(
+	t *testing.T,
+	path string,
+	store *sqlite.Store,
+	messages *sqlite.MessageRepository,
+) *signalWorkerHarness {
+	t.Helper()
+	counters := &Counters{}
+	worker, err := NewWorker(WorkerConfig{
+		Store:    store,
+		Messages: messages,
+		Counters: counters,
+		Logger:   zerolog.Nop(),
+		Now:      func() time.Time { return signalDecoderReceivedAt },
+		Decoders: []DecoderRegistration{{
+			Codec:    SignalJSONRPCCodec,
+			Platform: bridge.PlatformSignal,
+			Decoder:  NewSignalDecoder(),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewWorker(): %v", err)
+	}
+	var nextID atomic.Uint64
+	sink, err := NewSink(SinkConfig{
+		Messages: messages,
+		Worker:   worker,
+		Counters: counters,
+		IDs: messaging.IDSourceFunc(func() (string, error) {
+			return fmt.Sprintf("signal-inbox-%04d", nextID.Add(1)), nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewSink(): %v", err)
+	}
+	return &signalWorkerHarness{
+		path: path, store: store, messages: messages,
+		counters: counters, worker: worker, sink: sink,
+	}
+}
+
+func (h *signalWorkerHarness) start(t *testing.T) {
+	t.Helper()
+	if h.started {
+		t.Fatal("signal worker harness started twice")
+	}
+	h.started = true
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- h.worker.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Worker.Run(): %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("Worker.Run() did not stop")
+		}
+	})
+}
+
+func mustBuildSignalRecord(t *testing.T, line []byte) bridge.RawIngressRecord {
+	t.Helper()
+	return mustBuildSignalRecordWithResolutions(t, line, "", "")
+}
+
+func mustBuildSignalRecordWithResolutions(
+	t *testing.T,
+	line []byte,
+	resolvedSource string,
+	resolvedDestination string,
+) bridge.RawIngressRecord {
+	t.Helper()
+	record, ephemeral, err := BuildSignalIngress(
+		signalDecoderAccountID,
+		1,
+		signalSelf,
+		line,
+		resolvedSource,
+		resolvedDestination,
+		signalDecoderReceivedAt,
+	)
+	if err != nil {
+		t.Fatalf("BuildSignalIngress(): %v", err)
+	}
+	if record == nil || ephemeral != nil {
+		t.Fatalf("BuildSignalIngress() = (%+v, %+v), want durable", record, ephemeral)
+	}
+	return *record
+}
+
+func mustSignalJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal(): %v", err)
+	}
+	return raw
+}
+
+func seedSignalConversation(
+	t *testing.T,
+	store *sqlite.Store,
+	conversationID string,
+	remoteConversationID string,
+) {
+	t.Helper()
+	if err := store.UpsertConversation(sqlite.Conversation{
+		ConversationID:       conversationID,
+		AccountID:            signalDecoderAccountID,
+		RemoteConversationID: remoteConversationID,
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Signal fixture",
+		NotificationMode:     sqlite.NotificationModeAll,
+		LastMessageAtMS:      signalDecoderReceivedAt.UnixMilli(),
+		MetadataJSON:         `{}`,
+		CreatedAtMS:          signalDecoderReceivedAt.UnixMilli(),
+		UpdatedAtMS:          signalDecoderReceivedAt.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("UpsertConversation(): %v", err)
+	}
+}
+
+func seedSignalMessage(
+	t *testing.T,
+	messages *sqlite.MessageRepository,
+	messageID string,
+	conversationID string,
+	remoteMessageID string,
+	body string,
+	occurredAtMS int64,
+) {
+	t.Helper()
+	if err := messages.ImportMessage(context.Background(), sqlite.MessageProjection{
+		Message: sqlite.Message{
+			MessageID:       messageID,
+			ConversationID:  conversationID,
+			AccountID:       signalDecoderAccountID,
+			RemoteMessageID: remoteMessageID,
+			Direction:       sqlite.MessageDirectionOutgoing,
+			Body:            body,
+			State:           sqlite.MessageStateActive,
+			OccurredAtMS:    occurredAtMS,
+		},
+	}); err != nil {
+		t.Fatalf("ImportMessage(): %v", err)
+	}
+}
+
+func waitSignalCondition(t *testing.T, description string, ready func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for !ready() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", description)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func countSignalRows(t *testing.T, path, table string) int {
+	t.Helper()
+	if table != "inbox" && table != "messages" {
+		t.Fatalf("unsupported count table %q", table)
+	}
+	database, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open(%s): %v", table, err)
+	}
+	defer database.Close()
+	var count int
+	query := "SELECT COUNT(*) FROM " + table + " WHERE account_id = ?"
+	if err := database.QueryRow(query, signalDecoderAccountID).Scan(&count); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return count
+}
+
+func migratedSignalMessageKeys(
+	t *testing.T,
+	path string,
+	conversationID string,
+) (remoteMessageID string, messageID string) {
+	t.Helper()
+	database, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open(migrated): %v", err)
+	}
+	defer database.Close()
+	if err := database.QueryRow(`
+		SELECT remote_message_id, message_id
+		FROM messages
+		WHERE account_id = ? AND conversation_id = ?
+	`, signalDecoderAccountID, conversationID).Scan(&remoteMessageID, &messageID); err != nil {
+		t.Fatalf("query migrated Signal message: %v", err)
+	}
+	return remoteMessageID, messageID
+}

--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -40,7 +40,8 @@ type WorkerConfig struct {
 	Logger        zerolog.Logger
 	Now           func() time.Time
 	QueueCapacity int
-	Decoders      []DecoderRegistration
+	// Decoders explicitly defines the codecs this worker can project.
+	Decoders []DecoderRegistration
 }
 
 type registeredDecoder struct {
@@ -68,8 +69,8 @@ type Worker struct {
 	running  atomic.Bool
 }
 
-// NewWorker validates and copies its decoder registry. Run starts no work
-// until explicitly invoked by the owner.
+// NewWorker validates and copies its explicitly configured decoder
+// registrations. Run starts no work until explicitly invoked by the owner.
 func NewWorker(config WorkerConfig) (*Worker, error) {
 	if config.Store == nil {
 		return nil, fmt.Errorf("create ingest worker: store is nil")

--- a/internal/ingest/worker_contract_test.go
+++ b/internal/ingest/worker_contract_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,6 +11,32 @@ import (
 	"github.com/maxghenis/openmessage/internal/messaging"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 )
+
+func TestNewWorkerUsesOnlyConfiguredDecoders(t *testing.T) {
+	store, err := sqlite.Open(filepath.Join(t.TempDir(), "explicit-decoders.sqlite3"))
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Store.Close(): %v", err)
+		}
+	})
+	messages, err := sqlite.NewMessageRepository(store, time.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	worker, err := NewWorker(WorkerConfig{
+		Store:    store,
+		Messages: messages,
+	})
+	if err != nil {
+		t.Fatalf("NewWorker(): %v", err)
+	}
+	if got := len(worker.decoders); got != 0 {
+		t.Fatalf("NewWorker() registered %d implicit decoders, want none", got)
+	}
+}
 
 func TestWorkerOnlyFirstMessageRoutesEchoAndAdditionalMessagesImport(t *testing.T) {
 	recorder := &i01EchoRecorder{}

--- a/internal/signallive/aci_convergence_external_test.go
+++ b/internal/signallive/aci_convergence_external_test.go
@@ -1,0 +1,201 @@
+package signallive_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/ingest"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/signallive"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2keys"
+)
+
+func TestSignalACICaptureDecoderConvergesWithLegacy(t *testing.T) {
+	const (
+		account        = "+15551230000"
+		aci            = "9f4b50e3-ebf2-413c-a856-161756a6161a"
+		resolvedSource = "+15551234567"
+		timestamp      = int64(1_700_000_000_123)
+	)
+	store, err := db.New(filepath.Join(t.TempDir(), "legacy.sqlite3"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Store.Close(): %v", err)
+		}
+	})
+
+	line := []byte(`{"account":"+15551230000","envelope":{"sourceName":"Taylor","sourceServiceId":"9f4b50e3-ebf2-413c-a856-161756a6161a","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"hi from service id"}}}`)
+	captured, processed, err := signallive.CaptureAndProcessReceiveLineForTest(
+		store,
+		t.TempDir(),
+		map[string]string{aci: resolvedSource},
+		account,
+		line,
+	)
+	if err != nil || !processed {
+		t.Fatalf("capture + legacy receive = (%+v, %v, %v), want processed", captured, processed, err)
+	}
+	if captured.ResolvedSource != resolvedSource || captured.ResolvedDestination != "" ||
+		!bytes.Equal(captured.Line, line) {
+		t.Fatalf("captured ingress = %+v, want byte-identical line resolved to %q", captured, resolvedSource)
+	}
+
+	record, ephemeral, err := ingest.BuildSignalIngress(
+		"signal-primary",
+		1,
+		captured.Account,
+		captured.Line,
+		captured.ResolvedSource,
+		captured.ResolvedDestination,
+		time.UnixMilli(timestamp),
+	)
+	if err != nil || record == nil || ephemeral != nil {
+		t.Fatalf("BuildSignalIngress() = (%+v, %+v, %v), want durable", record, ephemeral, err)
+	}
+	events, err := ingest.NewSignalDecoder().Decode(context.Background(), *record)
+	if err != nil {
+		t.Fatalf("Decode(): %v", err)
+	}
+	if len(events) != 1 || events[0].Message == nil {
+		t.Fatalf("Decode() = %+v, want one message", events)
+	}
+
+	legacyMessages, err := store.GetMessagesByConversation("signal:"+resolvedSource, 10)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversation(): %v", err)
+	}
+	if len(legacyMessages) != 1 {
+		t.Fatalf("legacy messages = %+v, want one", legacyMessages)
+	}
+	legacy := legacyMessages[0]
+	decoded := events[0].Message
+	if !bytes.Equal([]byte(decoded.RemoteConversationID), []byte(legacy.ConversationID)) {
+		t.Fatalf("decoder conversation %q != legacy conversation %q", decoded.RemoteConversationID, legacy.ConversationID)
+	}
+	if !bytes.Equal([]byte(decoded.RemoteMessageID), []byte(legacy.SourceID)) {
+		t.Fatalf("decoder message id %q != legacy SourceID %q", decoded.RemoteMessageID, legacy.SourceID)
+	}
+	wantSourceID := v2keys.SignalIncomingSourceID("signal:"+resolvedSource, resolvedSource, timestamp)
+	if legacy.ConversationID != "signal:+15551234567" || legacy.SourceID != wantSourceID {
+		t.Fatalf("legacy keys = (%q, %q), want resolved conversation and sha1 %q", legacy.ConversationID, legacy.SourceID, wantSourceID)
+	}
+}
+
+func TestSignalCaptureReplayDedupeSurvivesContactResolutionDrift(t *testing.T) {
+	const (
+		accountID = "signal-primary"
+		account   = "+15551230000"
+		aci       = "9f4b50e3-ebf2-413c-a856-161756a6161a"
+	)
+	legacy, err := db.New(filepath.Join(t.TempDir(), "legacy.sqlite3"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := legacy.Close(); err != nil {
+			t.Errorf("legacy.Close(): %v", err)
+		}
+	})
+	v2Store, err := sqlite.Open(filepath.Join(t.TempDir(), "v2.sqlite3"))
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := v2Store.Close(); err != nil {
+			t.Errorf("v2 Store.Close(): %v", err)
+		}
+	})
+	now := time.UnixMilli(1_700_000_000_123)
+	if err := v2Store.UpsertAccount(sqlite.Account{
+		AccountID:   accountID,
+		BridgeKey:   "signal_cli",
+		DisplayName: "Signal",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: now.UnixMilli(),
+		UpdatedAtMS: now.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	messages, err := sqlite.NewMessageRepository(v2Store, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	counters := &ingest.Counters{}
+	worker, err := ingest.NewWorker(ingest.WorkerConfig{
+		Store:    v2Store,
+		Messages: messages,
+		Counters: counters,
+	})
+	if err != nil {
+		t.Fatalf("NewWorker(): %v", err)
+	}
+	nextID := 0
+	sink, err := ingest.NewSink(ingest.SinkConfig{
+		Messages: messages,
+		Worker:   worker,
+		Counters: counters,
+		IDs: messaging.IDSourceFunc(func() (string, error) {
+			nextID++
+			return fmt.Sprintf("signal-drift-%d", nextID), nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewSink(): %v", err)
+	}
+
+	line := []byte(`{"account":"+15551230000","envelope":{"sourceServiceId":"9f4b50e3-ebf2-413c-a856-161756a6161a","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"same raw replay"}}}`)
+	contacts := map[string]string{aci: "+15551234567"}
+	for index, resolved := range []string{"+15551234567", "+15557654321"} {
+		contacts[aci] = resolved
+		captured, processed, err := signallive.CaptureAndProcessReceiveLineForTest(
+			legacy,
+			t.TempDir(),
+			contacts,
+			account,
+			line,
+		)
+		if err != nil || !processed {
+			t.Fatalf("capture[%d] = (%+v, %v, %v), want processed", index, captured, processed, err)
+		}
+		if captured.ResolvedSource != resolved || !bytes.Equal(captured.Line, line) {
+			t.Fatalf("capture[%d] = %+v, want same raw line resolved to %q", index, captured, resolved)
+		}
+		record, ephemeral, err := ingest.BuildSignalIngress(
+			accountID,
+			1,
+			captured.Account,
+			captured.Line,
+			captured.ResolvedSource,
+			captured.ResolvedDestination,
+			now,
+		)
+		if err != nil || record == nil || ephemeral != nil {
+			t.Fatalf("BuildSignalIngress[%d] = (%+v, %+v, %v), want durable", index, record, ephemeral, err)
+		}
+		if err := sink.AppendIngress(context.Background(), *record); err != nil {
+			t.Fatalf("AppendIngress[%d]: %v", index, err)
+		}
+	}
+
+	inbox, err := messages.Unprocessed(context.Background())
+	if err != nil {
+		t.Fatalf("Unprocessed(): %v", err)
+	}
+	if len(inbox) != 1 {
+		t.Fatalf("inbox rows = %d, want one raw-keyed replay row", len(inbox))
+	}
+	if snapshot := counters.Snapshot(accountID); snapshot.Appended != 1 || snapshot.Deduped != 1 {
+		t.Fatalf("capture drift counters = %+v, want one append and one dedupe", snapshot)
+	}
+}

--- a/internal/signallive/client.go
+++ b/internal/signallive/client.go
@@ -362,6 +362,9 @@ type Bridge struct {
 	configDir string
 	callbacks Callbacks
 
+	ingressObserver   func(account string, line []byte, resolvedSource string, resolvedDestination string)
+	ingressObserverID uint64
+
 	connected  bool
 	connecting bool
 	pairing    bool
@@ -553,6 +556,76 @@ type signalQuotedMessage struct {
 type signalTypingMessage struct {
 	Action    string           `json:"action"`
 	GroupInfo *signalGroupInfo `json:"groupInfo"`
+}
+
+// Envelope is the pure signal-cli receive envelope shared by the retained
+// legacy receiver and the v2 durable decoder. The alias deliberately keeps a
+// single JSON shape instead of maintaining a second field-by-field parser.
+type Envelope = signalEnvelope
+
+// DataMessage, SentMessage, Reaction, and Attachment expose the nested pure
+// envelope values needed by the v2 decoder without moving transport behavior
+// out of signallive.
+type DataMessage = signalDataMessage
+type SentMessage = signalSentMessage
+type Reaction = signalReaction
+type Attachment = signalAttachment
+
+// ObserveIngress installs the one pre-dispatch Signal receive observer. A
+// later registration supersedes an earlier one; the returned function only
+// removes the registration it created.
+func (b *Bridge) ObserveIngress(observer func(account string, line []byte, resolvedSource string, resolvedDestination string)) func() {
+	if b == nil {
+		return func() {}
+	}
+	b.mu.Lock()
+	b.ingressObserverID++
+	registrationID := b.ingressObserverID
+	b.ingressObserver = observer
+	b.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			b.mu.Lock()
+			if b.ingressObserverID == registrationID {
+				b.ingressObserver = nil
+			}
+			b.mu.Unlock()
+		})
+	}
+}
+
+func (b *Bridge) observeIngress(account string, line []byte, resolvedSource string, resolvedDestination string) {
+	if b == nil {
+		return
+	}
+	b.mu.RLock()
+	observer := b.ingressObserver
+	b.mu.RUnlock()
+	if observer == nil {
+		return
+	}
+	line = bytes.Clone(line)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			b.logger.Warn().
+				Interface("panic", recovered).
+				Bytes("stack", debug.Stack()).
+				Msg("Recovered from panic in Signal ingress observer")
+		}
+	}()
+	observer(account, line, resolvedSource, resolvedDestination)
+}
+
+// ReportIngressError lets the lifecycle adapter log an isolated durable-tee
+// failure through the bridge's configured logger without coupling signallive
+// to the generic bridge package.
+func (b *Bridge) ReportIngressError(err error) {
+	if b == nil || err == nil {
+		return
+	}
+	b.logger.Warn().Err(err).Msg("Signal durable ingress tee failed; legacy receive continued")
 }
 
 func New(configDir string, store *db.Store, logger zerolog.Logger, callbacks Callbacks) (*Bridge, error) {
@@ -1969,26 +2042,19 @@ func (b *Bridge) processReceiveLine(account string, rawLine []byte, allowRecover
 	if line[0] != '{' {
 		return true, nil
 	}
-	var payload signalReceivePayload
-	if err := json.Unmarshal(line, &payload); err != nil {
+	payloadAccount, env, err := ParseReceiveEnvelope(account, line)
+	if err != nil {
 		if allowRecovery {
 			b.recordReceiveRecoveryIssue(account, line, "unmarshal_failed", err)
 		}
 		return false, nil
 	}
-	env := payload.Envelope
-	payloadAccount := strings.TrimSpace(payload.Account)
-	if payload.Result != nil {
-		if payloadAccount == "" {
-			payloadAccount = strings.TrimSpace(payload.Result.Account)
-		}
-		if env.Timestamp == 0 && env.Source == "" && env.SourceNumber == "" && env.SourceUUID == "" && env.SourceServiceID == "" && env.DataMessage == nil && env.EditMessage == nil && env.SyncMessage == nil && env.TypingMessage == nil {
-			env = payload.Result.Envelope
-		}
+	resolvedSource := b.resolveContactAddressAtCapture(signalEnvelopeSource(&env))
+	resolvedDestination := ""
+	if env.SyncMessage != nil {
+		resolvedDestination = b.resolveContactAddressAtCapture(signalSentTarget(env.SyncMessage.SentMessage))
 	}
-	if payloadAccount == "" {
-		payloadAccount = account
-	}
+	b.observeIngress(payloadAccount, line, resolvedSource, resolvedDestination)
 	if reason := signalEnvelopeRecoveryReason(&env); reason != "" {
 		if allowRecovery {
 			b.recordReceiveRecoveryIssue(payloadAccount, line, reason, nil)
@@ -2023,6 +2089,30 @@ func (b *Bridge) processReceiveLine(account string, rawLine []byte, allowRecover
 		}
 	}
 	return true, nil
+}
+
+// ParseReceiveEnvelope decodes the exact receive payload shape used by
+// processReceiveLine, including signal-cli's result-envelope fallback. It is
+// pure so durable decoders can share the retained receiver's JSON contract.
+func ParseReceiveEnvelope(fallbackAccount string, line []byte) (string, Envelope, error) {
+	var payload signalReceivePayload
+	if err := json.Unmarshal(line, &payload); err != nil {
+		return "", Envelope{}, err
+	}
+	env := payload.Envelope
+	payloadAccount := strings.TrimSpace(payload.Account)
+	if payload.Result != nil {
+		if payloadAccount == "" {
+			payloadAccount = strings.TrimSpace(payload.Result.Account)
+		}
+		if env.Timestamp == 0 && env.Source == "" && env.SourceNumber == "" && env.SourceUUID == "" && env.SourceServiceID == "" && env.DataMessage == nil && env.EditMessage == nil && env.SyncMessage == nil && env.TypingMessage == nil {
+			env = payload.Result.Envelope
+		}
+	}
+	if payloadAccount == "" {
+		payloadAccount = fallbackAccount
+	}
+	return payloadAccount, env, nil
 }
 
 func (b *Bridge) recordReceiveRecoveryIssue(account string, rawLine []byte, reason string, err error) {
@@ -3079,6 +3169,24 @@ func (b *Bridge) resolveContactAddress(value string) string {
 	return value
 }
 
+// resolveContactAddressAtCapture resolves only from the already-loaded contact
+// cache. Unlike resolveContactAddress, it must not refresh contacts: capture is
+// on the durable tee boundary, where running signal-cli or mutating legacy
+// state would make observation change receive behavior.
+func (b *Bridge) resolveContactAddressAtCapture(value string) string {
+	value = normalizeSignalAddress(value)
+	if value == "" {
+		return ""
+	}
+	if strings.HasPrefix(value, "+") {
+		return value
+	}
+	b.mu.RLock()
+	resolved := normalizeSignalAddress(b.contactByACI[value])
+	b.mu.RUnlock()
+	return resolved
+}
+
 func (b *Bridge) refreshContacts() {
 	if b == nil {
 		return
@@ -3361,6 +3469,12 @@ func signalConversationID(address, groupID string) string {
 	return "signal:" + normalizeSignalAddress(address)
 }
 
+// SignalConversationID exposes the retained conversation-id mapping as a pure
+// helper for the durable decoder.
+func SignalConversationID(address, groupID string) string {
+	return signalConversationID(address, groupID)
+}
+
 func normalizeSignalAddress(value string) string {
 	return strings.TrimSpace(value)
 }
@@ -3538,6 +3652,12 @@ func signalReactionTargetAuthor(reaction *signalReaction, account string) string
 	)
 }
 
+// ReactionTargetAuthor applies the retained nested/legacy reaction target
+// precedence without duplicating it in the durable decoder.
+func ReactionTargetAuthor(reaction *Reaction, account string) string {
+	return signalReactionTargetAuthor(reaction, account)
+}
+
 func signalReactionTargetTimestamp(reaction *signalReaction) int64 {
 	if reaction == nil {
 		return 0
@@ -3546,6 +3666,11 @@ func signalReactionTargetTimestamp(reaction *signalReaction) int64 {
 		return reaction.TargetSentTimestamp
 	}
 	return reaction.Target.Timestamp
+}
+
+// ReactionTargetTimestamp applies the retained reaction timestamp fallback.
+func ReactionTargetTimestamp(reaction *Reaction) int64 {
+	return signalReactionTargetTimestamp(reaction)
 }
 
 func signalEnvelopeSource(env *signalEnvelope) string {
@@ -3560,6 +3685,11 @@ func signalEnvelopeSource(env *signalEnvelope) string {
 	)
 }
 
+// EnvelopeSource applies the retained E.164/service-id source precedence.
+func EnvelopeSource(env *Envelope) string {
+	return signalEnvelopeSource(env)
+}
+
 func signalSentTarget(sent *signalSentMessage) string {
 	if sent == nil {
 		return ""
@@ -3571,6 +3701,11 @@ func signalSentTarget(sent *signalSentMessage) string {
 		strings.TrimSpace(sent.DestinationServiceID),
 		strings.TrimSpace(sent.Destination),
 	)
+}
+
+// SentTarget applies the retained destination precedence for sync transcripts.
+func SentTarget(sent *SentMessage) string {
+	return signalSentTarget(sent)
 }
 
 func signalEditGroupInfo(edit *signalEditMessage) *signalGroupInfo {
@@ -3668,6 +3803,11 @@ func (m *signalDataMessage) displayBody() string {
 	})
 }
 
+// DisplayBody applies the retained visible-body/placeholder semantics.
+func (m *signalDataMessage) DisplayBody() string {
+	return m.displayBody()
+}
+
 func (m *signalSentMessage) displayBody() string {
 	if m == nil {
 		return signalUnsupportedMessagePlaceholder
@@ -3693,6 +3833,11 @@ func (m *signalSentMessage) displayBody() string {
 		HasAdminDelete:     signalRawMessagePresent(m.AdminDelete),
 		HasGroupUpdate:     signalIsGroupUpdate(m.GroupInfo),
 	})
+}
+
+// DisplayBody applies the retained sent-message body/placeholder semantics.
+func (m *signalSentMessage) DisplayBody() string {
+	return m.displayBody()
 }
 
 func signalUnsupportedContentPlaceholder(attachments []signalAttachment, flags signalUnsupportedContentFlags) string {
@@ -4181,6 +4326,12 @@ func addressesMatch(a, b string) bool {
 	a = normalizeSignalAddress(a)
 	b = normalizeSignalAddress(b)
 	return a != "" && b != "" && strings.EqualFold(a, b)
+}
+
+// AddressesMatch exposes the retained Signal address comparison to the pure
+// durable decoder.
+func AddressesMatch(a, b string) bool {
+	return addressesMatch(a, b)
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/signallive/client_test.go
+++ b/internal/signallive/client_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 )
 
 func TestQRCodeRendersDataURL(t *testing.T) {
@@ -994,6 +995,247 @@ func TestDrainReceiveWALRecoversPendingBatch(t *testing.T) {
 	msgs, _ := store.GetMessagesByConversation("signal:+15551234567", 10)
 	if len(msgs) != 2 {
 		t.Fatalf("want 2 replayed messages, got %d: %+v", len(msgs), msgs)
+	}
+}
+
+func TestDrainReceiveWALReteesIngressReplay(t *testing.T) {
+	store, err := db.New(filepath.Join(t.TempDir(), "messages.db"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	bridge := &Bridge{store: store, logger: zerolog.Nop(), configDir: t.TempDir()}
+	payload := []byte(`{"account":"+15551230000","envelope":{"source":"+15551234567","timestamp":1700000000111,"dataMessage":{"timestamp":1700000000111,"message":"replayed"}}}`)
+	var observedAccounts []string
+	var observedLines [][]byte
+	unregister := bridge.ObserveIngress(func(account string, line []byte, _ string, _ string) {
+		observedAccounts = append(observedAccounts, account)
+		observedLines = append(observedLines, bytes.Clone(line))
+	})
+	defer unregister()
+
+	if processed, err := bridge.processReceiveLine("+15551230000", payload, false); err != nil || !processed {
+		t.Fatalf("processReceiveLine(live) = (%v, %v), want (true, nil)", processed, err)
+	}
+	if err := appendReceiveWAL(bridge.receiveWALPath(), "+15551230000", append(bytes.Clone(payload), '\n')); err != nil {
+		t.Fatalf("appendReceiveWAL(): %v", err)
+	}
+	bridge.drainReceiveWAL("+15551230000")
+
+	if len(observedLines) != 2 {
+		t.Fatalf("ingress observer calls = %d, want live + WAL replay", len(observedLines))
+	}
+	for index := range observedLines {
+		if observedAccounts[index] != "+15551230000" || !bytes.Equal(observedLines[index], payload) {
+			t.Fatalf("observer[%d] = (%q, %s), want resolved account and byte-identical line", index, observedAccounts[index], observedLines[index])
+		}
+	}
+	messages, err := store.GetMessagesByConversation("signal:+15551234567", 10)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversation(): %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("legacy messages after replay = %d, want one", len(messages))
+	}
+}
+
+func TestProcessReceiveLineCapturesResolvedContactAddresses(t *testing.T) {
+	store, err := db.New(filepath.Join(t.TempDir(), "messages.db"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	const (
+		account        = "+15551230000"
+		sourceACI      = "9f4b50e3-ebf2-413c-a856-161756a6161a"
+		resolvedSource = "+15551234567"
+		destinationACI = "7a81fd95-20f1-4437-86e2-d5c93ba18851"
+		resolvedTarget = "+15557654321"
+	)
+	bridge := &Bridge{
+		store:     store,
+		logger:    zerolog.Nop(),
+		configDir: t.TempDir(),
+		contactByACI: map[string]string{
+			sourceACI:      resolvedSource,
+			destinationACI: resolvedTarget,
+		},
+	}
+	type observation struct {
+		account             string
+		line                []byte
+		resolvedSource      string
+		resolvedDestination string
+	}
+	var observations []observation
+	unregister := bridge.ObserveIngress(func(account string, line []byte, resolvedSource string, resolvedDestination string) {
+		observations = append(observations, observation{
+			account:             account,
+			line:                bytes.Clone(line),
+			resolvedSource:      resolvedSource,
+			resolvedDestination: resolvedDestination,
+		})
+	})
+	defer unregister()
+
+	incoming := []byte(`{"account":"+15551230000","envelope":{"sourceName":"Taylor","sourceServiceId":"9f4b50e3-ebf2-413c-a856-161756a6161a","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"incoming"}}}`)
+	outgoing := []byte(`{"account":"+15551230000","envelope":{"timestamp":1700000000222,"syncMessage":{"sentMessage":{"timestamp":1700000000222,"message":"outgoing","destinationServiceId":"7a81fd95-20f1-4437-86e2-d5c93ba18851"}}}}`)
+	for _, line := range [][]byte{incoming, outgoing} {
+		processed, err := bridge.processReceiveLine(account, line, false)
+		if err != nil || !processed {
+			t.Fatalf("processReceiveLine() = (%v, %v), want (true, nil)", processed, err)
+		}
+	}
+
+	if len(observations) != 2 {
+		t.Fatalf("observations = %d, want 2", len(observations))
+	}
+	wants := []observation{
+		{account: account, line: incoming, resolvedSource: resolvedSource},
+		{account: account, line: outgoing, resolvedDestination: resolvedTarget},
+	}
+	for index, want := range wants {
+		got := observations[index]
+		if got.account != want.account || !bytes.Equal(got.line, want.line) ||
+			got.resolvedSource != want.resolvedSource || got.resolvedDestination != want.resolvedDestination {
+			t.Fatalf("observation[%d] = %+v, want %+v", index, got, want)
+		}
+	}
+}
+
+func TestResolveContactAddressAtCaptureIsReadOnly(t *testing.T) {
+	const aci = "9f4b50e3-ebf2-413c-a856-161756a6161a"
+	contacts := map[string]string{aci: "+15551234567"}
+	bridge := &Bridge{contactByACI: contacts}
+	originalRunSignalCLI := runSignalCLI
+	defer func() { runSignalCLI = originalRunSignalCLI }()
+	commandCalls := 0
+	runSignalCLI = func(context.Context, string, ...string) ([]byte, error) {
+		commandCalls++
+		return []byte(`[{"number":"+15557654321","uuid":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}]`), nil
+	}
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "absent", want: ""},
+		{name: "e164", value: "+15550000000", want: "+15550000000"},
+		{name: "cached ACI", value: aci, want: "+15551234567"},
+		{name: "unresolved ACI", value: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bridge.resolveContactAddressAtCapture(tc.value); got != tc.want {
+				t.Fatalf("resolveContactAddressAtCapture(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+	if len(contacts) != 1 || contacts[aci] != "+15551234567" {
+		t.Fatalf("contact cache mutated during capture resolution: %+v", contacts)
+	}
+	if commandCalls != 0 {
+		t.Fatalf("capture resolution ran signal-cli %d times, want no commands", commandCalls)
+	}
+}
+
+func TestProcessReceiveLineCapturesBeforeRecoveryGuard(t *testing.T) {
+	bridge := &Bridge{logger: zerolog.Nop(), configDir: t.TempDir()}
+	payload := []byte(`{"account":"+15551230000","envelope":{"sourceName":"Taylor","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"missing source"}}}`)
+	v2Store, err := sqlite.Open(filepath.Join(t.TempDir(), "v2.sqlite3"))
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	defer v2Store.Close()
+	if err := v2Store.UpsertAccount(sqlite.Account{
+		AccountID:   "signal-primary",
+		BridgeKey:   "signal_cli",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: 1_700_000_000_000,
+		UpdatedAtMS: 1_700_000_000_000,
+	}); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	messages, err := sqlite.NewMessageRepository(v2Store, func() time.Time {
+		return time.UnixMilli(1_700_000_000_000)
+	})
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	var observedAccount string
+	var observedLine []byte
+	var appendErr error
+	unregister := bridge.ObserveIngress(func(account string, line []byte, _ string, _ string) {
+		observedAccount = account
+		observedLine = bytes.Clone(line)
+		_, appendErr = messages.AppendInbox(context.Background(), sqlite.InboxRecord{
+			InboxID:      "missing-source-inbox",
+			AccountID:    "signal-primary",
+			Generation:   1,
+			DedupeKey:    "missing-source-envelope",
+			Codec:        "signal.jsonrpc",
+			CodecVersion: 1,
+			Payload:      bytes.Clone(line),
+		})
+	})
+	defer unregister()
+
+	processed, err := bridge.processReceiveLine("+15550000000", payload, false)
+	if err != nil {
+		t.Fatalf("processReceiveLine(): %v", err)
+	}
+	if processed {
+		t.Fatal("processReceiveLine() processed missing-source envelope, want legacy quarantine")
+	}
+	if observedAccount != "+15551230000" || !bytes.Equal(observedLine, payload) {
+		t.Fatalf("observer = (%q, %s), want resolved account and captured recovery line", observedAccount, observedLine)
+	}
+	if appendErr != nil {
+		t.Fatalf("AppendInbox() from pre-recovery observer: %v", appendErr)
+	}
+	unprocessed, err := messages.Unprocessed(context.Background())
+	if err != nil {
+		t.Fatalf("Unprocessed(): %v", err)
+	}
+	if len(unprocessed) != 1 || unprocessed[0].InboxID != "missing-source-inbox" ||
+		!bytes.Equal(unprocessed[0].Payload, payload) {
+		t.Fatalf("durable recovery frame = %+v, want one byte-identical inbox row", unprocessed)
+	}
+}
+
+func TestProcessReceiveLineRecoversIngressObserverPanicAndPreservesLegacy(t *testing.T) {
+	store, err := db.New(filepath.Join(t.TempDir(), "messages.db"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	bridge := &Bridge{store: store, logger: zerolog.Nop(), configDir: t.TempDir()}
+	payload := []byte(`{"account":"+15551230000","envelope":{"source":"+15551234567","sourceName":"Taylor","timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"legacy survives"}}}`)
+	unregister := bridge.ObserveIngress(func(_ string, line []byte, _ string, _ string) {
+		line[0] = 'X'
+		panic("sink panic")
+	})
+	defer unregister()
+
+	processed, err := bridge.processReceiveLine("+15551230000", payload, false)
+	if err != nil || !processed {
+		t.Fatalf("processReceiveLine() = (%v, %v), want (true, nil)", processed, err)
+	}
+	if payload[0] != '{' {
+		t.Fatalf("observer mutated receive line: %q", payload)
+	}
+	messages, err := store.GetMessagesByConversation("signal:+15551234567", 10)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversation(): %v", err)
+	}
+	if len(messages) != 1 || messages[0].Body != "legacy survives" {
+		t.Fatalf("legacy messages after observer panic = %+v, want stored message", messages)
 	}
 }
 

--- a/internal/signallive/export_test.go
+++ b/internal/signallive/export_test.go
@@ -1,0 +1,52 @@
+package signallive
+
+import (
+	"bytes"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/rs/zerolog"
+)
+
+// CapturedIngressForTest is the capture-boundary value exposed to external
+// integration tests without widening Bridge's production API.
+type CapturedIngressForTest struct {
+	Account             string
+	Line                []byte
+	ResolvedSource      string
+	ResolvedDestination string
+}
+
+// CaptureAndProcessReceiveLineForTest uses the same private contact cache and
+// receive path as the retained legacy handler, returning what its durable tee
+// observed for an external decoder integration test.
+func CaptureAndProcessReceiveLineForTest(
+	store *db.Store,
+	configDir string,
+	contactByACI map[string]string,
+	account string,
+	line []byte,
+) (CapturedIngressForTest, bool, error) {
+	bridge := &Bridge{
+		store:        store,
+		logger:       zerolog.Nop(),
+		configDir:    configDir,
+		contactByACI: contactByACI,
+	}
+	var captured CapturedIngressForTest
+	unregister := bridge.ObserveIngress(func(
+		observedAccount string,
+		observedLine []byte,
+		resolvedSource string,
+		resolvedDestination string,
+	) {
+		captured = CapturedIngressForTest{
+			Account:             observedAccount,
+			Line:                bytes.Clone(observedLine),
+			ResolvedSource:      resolvedSource,
+			ResolvedDestination: resolvedDestination,
+		}
+	})
+	defer unregister()
+	processed, err := bridge.processReceiveLine(account, line, false)
+	return captured, processed, err
+}


### PR DESCRIPTION
## What

Signal receive frames now tee into the durable v2 inbox, per `ingest-echo-spec-2026-07-17.md` §2.3/§4.3/§6/§7. Final platform-decoder PR (completes I2 Google + I3 WhatsApp).

- **Capture hook** (`internal/signallive/client.go`): single-slot `ObserveIngress` in `processReceiveLine`, after `payloadAccount` resolution and **before** the recovery-reason guard — so v2 durably holds even lines legacy quarantines. Typing-only envelopes route to the ephemeral sink. Live receive, WAL drain, and recovery replay all tee through the shared path; the observer is panic-isolated and clones the line; legacy handling after capture is byte-identical.
- **Contact resolution at capture** (the review's BLOCKING fix): the initial decoder keyed off the raw envelope ACI/UUID, while legacy and R2 resolve ACI→+E164 at receive time — so live Signal frames forked a second conversation per contact and duplicated rows on post-cutover replay. Now the capture hook resolves source/target via the read-only contact map and carries `resolved_source`/`resolved_destination` in the `signal.jsonrpc` v1 envelope (mirroring WhatsApp's canonical `chat_jid` enrichment). The pure decoder derives conversation ids, from-me detection, incoming sha1 ids (`v2keys.SignalIncomingSourceID` over the resolved address), the outgoing-alias form, and the media-ref `conversation_id` from the resolved fields, falling back to raw only when resolution is absent (legacy's own fallback).
- **Convergence is proven, not asserted**: `TestSignalACICaptureDecoderConvergesWithLegacy` drives the same ACI-only line through the real legacy receive path AND capture+decoder, asserting byte-equal conversation id (`signal:+15551234567`) and message id. Verified discriminating — forcing the raw-only (pre-fix) path fails it with `signal:<ACI>`.
- **Replay-stable dedupe**: keyed off the raw source + timestamp (deliberately raw — contact resolution can drift between original delivery and a WAL replay; a raw-keyed dedupe absorbs the replay before drift can mint divergent rows), with the sourceless fallback widened to 64-bit. A drift-replay test confirms one inbox row.
- **Outgoing-alias convergence** pinned against real `migration.Transform` output (the migrate-then-ingest fixture).

## Review fixes folded in (verdict was FIX-FIRST)

1. **BLOCKING** — ACI resolution fork (above).
2. **Registry dropped** — the interim `internal/ingest/registry.go` (a process-global mutable registry) is deleted; the Signal decoder registers in the merged serve-level `WorkerConfig.Decoders` slice beside Google and WhatsApp.
3. **Dedupe-key stability** (above).
4. Test-vacuity nit strengthened.

The nested outgoing-edit interpretation (durable, no v2 event — no target/alias mapping exists) is retained and documented.

## Verification

Full `go test -race ./...`: 28 packages green, independently verified outside the sandbox. Rebased onto I3; the only conflict was the decoder slice (all three platforms now register).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
