### PR TITLE
Ingest observability on /api/status + live ingest smoke (ingest I5)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -28,6 +28,7 @@ import (
 	"github.com/maxghenis/openmessage/internal/db"
 	"github.com/maxghenis/openmessage/internal/googlecookies"
 	"github.com/maxghenis/openmessage/internal/importer"
+	"github.com/maxghenis/openmessage/internal/ingest"
 	"github.com/maxghenis/openmessage/internal/notify"
 	"github.com/maxghenis/openmessage/internal/telemetry"
 	"github.com/maxghenis/openmessage/internal/tools"
@@ -64,6 +65,15 @@ func v2SendWebOptions(stack *v2Stack, enabled bool) *web.V2Options {
 		V2Store:  stack.Store,
 		Blobs:    stack.Blobs,
 		Registry: stack.Registry,
+	}
+}
+
+func v2IngestCountersProvider(stack *v2Stack) func() map[string]ingest.CounterSnapshot {
+	if stack == nil {
+		return nil
+	}
+	return func() map[string]ingest.CounterSnapshot {
+		return stack.Counters.PerAccount()
 	}
 }
 
@@ -567,6 +577,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	a.StartScheduler()
 
 	v2Options := v2SendWebOptions(stack, v2Send)
+	v2IngestCounters := v2IngestCountersProvider(stack)
 
 	httpEnabled := opts.web || opts.mcpSSE
 	if httpEnabled {
@@ -574,6 +585,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		if opts.web {
 			httpHandler = web.APIHandlerWithOptions(a.Store, nil, logger, mcpHTTPHandler, web.APIOptions{
 				V2:                    v2Options,
+				V2IngestCounters:      v2IngestCounters,
 				Client:                a.GetClient,
 				Events:                events,
 				IdentityName:          identityName,

--- a/cmd/serve_tools_test.go
+++ b/cmd/serve_tools_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"testing"
 
+	"github.com/rs/zerolog"
+
 	"github.com/maxghenis/openmessage/internal/bridge"
 	"github.com/maxghenis/openmessage/internal/messaging"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
@@ -65,5 +67,38 @@ func TestV2SendWebOptionsRequiresSendFlag(t *testing.T) {
 	}
 	if got.Service != service || got.V2Store != store || got.Registry != registry {
 		t.Fatal("v2SendWebOptions(stack, true) did not preserve stack dependencies")
+	}
+}
+
+func TestV2IngestCountersProviderRequiresStack(t *testing.T) {
+	if got := v2IngestCountersProvider(nil); got != nil {
+		t.Fatal("v2IngestCountersProvider(nil) returned an enabled provider")
+	}
+
+	stack, err := newV2Stack(v2StackDeps{
+		Logger:  zerolog.Nop(),
+		DataDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("newV2Stack(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := stack.Store.Close(); err != nil {
+			t.Errorf("close v2 store: %v", err)
+		}
+	})
+
+	provider := v2IngestCountersProvider(stack)
+	if provider == nil {
+		t.Fatal("v2IngestCountersProvider(stack) returned nil")
+	}
+	if got := provider(); got == nil || len(got) != 0 {
+		t.Fatalf("provider() = %#v, want an empty per-account snapshot", got)
+	}
+
+	stack.Sink.RecordIngressError("signal:primary")
+	got := provider()
+	if snapshot, ok := got["signal:primary"]; !ok || snapshot.AppendErrors != 1 {
+		t.Fatalf("provider() = %#v, want live signal:primary append_errors=1", got)
 	}
 }

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -223,3 +223,26 @@ briefly show "reconnecting" before it settles (see throttling note above).
   `/api/conversations/<id>/messages`. Don't re-send a user's real message as a
   "test" (duplicate risk on `UNKNOWN`, which is ambiguous about whether it sent);
   if you must test connectivity, get explicit per-send permission.
+- For the ingest cutover checklist, run the [ingest smoke](#ingest-smoke)
+  before switching readers.
+
+### Ingest smoke
+
+Read `curl -s http://127.0.0.1:7007/api/status | jq '.v2_ingest'`. A healthy
+enabled stack reports `enabled: true`; under `per_account`, `appended` grows as
+receive frames arrive, message-bearing frames advance `projected`, and
+`quarantined` remains `0`. An idle WhatsApp or Signal account can legitimately
+stay at zero until a new inbound/history frame arrives.
+
+The manual receive-only check is:
+
+```sh
+LIVE_PLATFORMS=google GOWORK=off go test -tags livetransport \
+  -run TestLiveIngestVerification -v -count=1 -timeout 10m \
+  ./internal/livetransport/
+```
+
+It sends nothing. Add `whatsapp` or `signal` to the comma-separated
+`LIVE_PLATFORMS` list only when that platform will receive a real frame within
+the test deadline; use `LIVE_GOOGLE_CONV`, `LIVE_WHATSAPP_CONV`, or
+`LIVE_SIGNAL_CONV` to override the expected self-thread remote ID.

--- a/internal/livetransport/live_test.go
+++ b/internal/livetransport/live_test.go
@@ -1,16 +1,21 @@
 //go:build livetransport
 
 // Package livetransport is the manual live-verification harness for the v2
-// send pipeline (T1-T3 text, T5a reactions, T5b read receipts, M2b media).
-// It drives the REAL transports against the operator's own live pairing state
-// and sends ONLY to self-recipient threads. It never runs in CI (build tag)
-// and must only run with the OpenMessage app quit (session safety) and with
-// the operator's explicit go-ahead.
+// send and ingest pipelines. It drives the REAL transports against the
+// operator's own live pairing state. The ingest verification is passive and
+// never sends; the send verification sends ONLY to self-recipient threads.
+// Neither runs in CI (build tag), and both require the OpenMessage app to be
+// quit so the harness has sole ownership of the live sessions. The send test
+// additionally requires the operator's explicit go-ahead.
 //
 // Run:
 //
 //	GOWORK=off go test -tags livetransport -run TestLiveSelfSendVerification \
 //	  -v -count=1 -timeout 10m ./internal/livetransport/
+//
+//	LIVE_PLATFORMS=google GOWORK=off go test -tags livetransport \
+//	  -run TestLiveIngestVerification -v -count=1 -timeout 10m \
+//	  ./internal/livetransport/
 package livetransport
 
 import (
@@ -27,31 +32,48 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+	watypes "go.mau.fi/whatsmeow/types"
 
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/bridge"
 	googleadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/google"
 	signaladapter "github.com/maxghenis/openmessage/internal/bridgeadapters/signal"
+	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
+	"github.com/maxghenis/openmessage/internal/ingest"
 	"github.com/maxghenis/openmessage/internal/messaging"
 	"github.com/maxghenis/openmessage/internal/storage/blob"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 )
 
 const (
-	liveDataDirEnv        = "OPENMESSAGES_DATA_DIR"
-	googleAccountID       = "google-primary"
-	signalAccountID       = "signal-primary"
+	liveDataDirEnv               = "OPENMESSAGES_DATA_DIR"
+	googleAccountID              = "google-primary"
+	whatsappAccountID            = "whatsapp-primary"
+	signalAccountID              = "signal-primary"
 	defaultGoogleSelfConvRemote  = "1770"  // live self-thread (canonical, per /api/new-conversation)
 	defaultGoogleAnchorMessageID = "85269" // real anchor message sent via the legacy path
-	signalSelfConvRemote  = "signal:+16506303657"
-	onlineWait            = 90 * time.Second
-	settleWait            = 60 * time.Second
+	signalSelfConvRemote         = "signal:+16506303657"
+	onlineWait                   = 90 * time.Second
+	settleWait                   = 60 * time.Second
+	ingestWait                   = 2 * time.Minute
 )
+
+type liveIngestTransport struct {
+	name                   string
+	accountID              string
+	bridgeKey              string
+	displayName            string
+	platform               bridge.Platform
+	adapter                bridge.Adapter
+	codec                  string
+	selfRemoteConversation string
+}
 
 type wallClock struct{}
 
@@ -79,6 +101,379 @@ func livePolicy() bridge.Policy {
 		MaxBackoff:         30 * time.Second,
 		MaxSameFingerprint: 3,
 	}
+}
+
+// TestLiveIngestVerification is deliberately receive-only. Selecting a
+// platform means the operator expects its real receive path to produce a
+// message-bearing frame during ingestWait. Google normally does this during
+// startup sync; idle WhatsApp and Signal accounts need a genuinely inbound or
+// history frame and may otherwise remain at zero.
+func TestLiveIngestVerification(t *testing.T) {
+	selected := liveIngestPlatforms(t)
+	dataDir := os.Getenv(liveDataDirEnv)
+	if dataDir == "" {
+		dataDir = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "OpenMessage")
+		os.Setenv(liveDataDirEnv, dataDir)
+	}
+	if selected["google"] {
+		if _, err := os.Stat(filepath.Join(dataDir, "session.json")); err != nil {
+			t.Fatalf("live Google data dir not found or unpaired: %v", err)
+		}
+	}
+
+	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
+	a, err := app.New(logger)
+	if err != nil {
+		t.Fatalf("app.New(): %v", err)
+	}
+	defer a.Close()
+
+	transports := make([]liveIngestTransport, 0, len(selected))
+	if selected["google"] {
+		adapter := googleadapter.New(googleAccountID, a, func() bool { return false })
+		a.SetGoogleLifecycleNotifier(adapter)
+		transports = append(transports, liveIngestTransport{
+			name:                   "google",
+			accountID:              googleAccountID,
+			bridgeKey:              "google_messages",
+			displayName:            "Google Messages",
+			platform:               bridge.PlatformGoogle,
+			adapter:                adapter,
+			codec:                  ingest.GoogleCodec,
+			selfRemoteConversation: envOr("LIVE_GOOGLE_CONV", defaultGoogleSelfConvRemote),
+		})
+	}
+	if selected["whatsapp"] {
+		whatsappBridge, err := a.InitializeWhatsApp()
+		if err != nil {
+			t.Fatalf("InitializeWhatsApp(): %v", err)
+		}
+		paired := whatsappBridge.PairedAccount()
+		if !paired.Paired {
+			t.Fatal("WhatsApp is selected in LIVE_PLATFORMS but is not paired")
+		}
+		selfConversation := os.Getenv("LIVE_WHATSAPP_CONV")
+		if selfConversation == "" {
+			jid, err := watypes.ParseJID(paired.JID)
+			if err != nil {
+				t.Fatalf("parse paired WhatsApp JID %q: %v", paired.JID, err)
+			}
+			selfConversation = "whatsapp:" + jid.ToNonAD().String()
+		}
+		adapter := whatsappadapter.New(whatsappAccountID, whatsappBridge)
+		a.SetWhatsAppLifecycleNotifier(adapter)
+		transports = append(transports, liveIngestTransport{
+			name:                   "whatsapp",
+			accountID:              whatsappAccountID,
+			bridgeKey:              "whatsmeow",
+			displayName:            "WhatsApp",
+			platform:               bridge.PlatformWhatsApp,
+			adapter:                adapter,
+			codec:                  ingest.WhatsAppCodec,
+			selfRemoteConversation: selfConversation,
+		})
+	}
+	if selected["signal"] {
+		signalBridge, err := a.EnsureSignal()
+		if err != nil {
+			t.Fatalf("EnsureSignal(): %v", err)
+		}
+		signalStatus := signalBridge.Status()
+		if !signalStatus.Paired {
+			t.Fatal("Signal is selected in LIVE_PLATFORMS but is not paired")
+		}
+		defaultSelfConversation := signalSelfConvRemote
+		if strings.TrimSpace(signalStatus.Account) != "" {
+			defaultSelfConversation = "signal:" + strings.TrimSpace(signalStatus.Account)
+		}
+		adapter := signaladapter.New(signalAccountID, signalBridge)
+		a.SetSignalLifecycleNotifier(adapter)
+		transports = append(transports, liveIngestTransport{
+			name:                   "signal",
+			accountID:              signalAccountID,
+			bridgeKey:              "signal_cli",
+			displayName:            "Signal",
+			platform:               bridge.PlatformSignal,
+			adapter:                adapter,
+			codec:                  ingest.SignalJSONRPCCodec,
+			selfRemoteConversation: envOr("LIVE_SIGNAL_CONV", defaultSelfConversation),
+		})
+	}
+
+	tempDir := t.TempDir()
+	storePath := filepath.Join(tempDir, "v2.sqlite")
+	store, err := sqlite.Open(storePath)
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	defer store.Close()
+	blobs, err := blob.New(filepath.Join(tempDir, "blobs"))
+	if err != nil {
+		t.Fatalf("blob.New(): %v", err)
+	}
+	registry := bridge.NewRegistry()
+	nowMS := time.Now().UnixMilli()
+	for _, transport := range transports {
+		seedLiveAccount(t, store, nowMS, transport)
+		if err := registry.Register(transport.adapter); err != nil {
+			t.Fatalf("register %s adapter: %v", transport.name, err)
+		}
+	}
+	service, err := messaging.NewMessageService(
+		store,
+		registry,
+		blobs,
+		messaging.SystemClock{},
+		messaging.CryptoIDSource{},
+	)
+	if err != nil {
+		t.Fatalf("NewMessageService(): %v", err)
+	}
+	messages, err := sqlite.NewMessageRepository(store, time.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	counters := &ingest.Counters{}
+	worker, err := ingest.NewWorker(ingest.WorkerConfig{
+		Store:        store,
+		Messages:     messages,
+		EchoObserver: service,
+		Counters:     counters,
+		Logger:       logger,
+		Decoders: []ingest.DecoderRegistration{
+			{
+				Codec:    ingest.GoogleCodec,
+				Platform: bridge.PlatformGoogle,
+				Decoder:  ingest.NewGoogleDecoder(counters),
+			},
+			ingest.NewWhatsAppDecoderRegistration(),
+			{
+				Codec:    ingest.SignalJSONRPCCodec,
+				Platform: bridge.PlatformSignal,
+				Decoder:  ingest.NewSignalDecoder(),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ingest.NewWorker(): %v", err)
+	}
+	sink, err := ingest.NewSink(ingest.SinkConfig{
+		Messages: messages,
+		Worker:   worker,
+		Counters: counters,
+	})
+	if err != nil {
+		t.Fatalf("ingest.NewSink(): %v", err)
+	}
+	workerCtx, cancelWorker := context.WithCancel(context.Background())
+	workerDone := make(chan error, 1)
+	go func() { workerDone <- worker.Run(workerCtx) }()
+	defer func() {
+		cancelWorker()
+		if err := <-workerDone; err != nil {
+			t.Errorf("ingest worker stopped: %v", err)
+		}
+	}()
+
+	supervisors := make(map[string]*bridge.Supervisor, len(transports))
+	for _, transport := range transports {
+		supervisor, err := bridge.NewSupervisor(
+			transport.accountID,
+			transport.platform,
+			transport.adapter,
+			livePolicy(),
+			wallClock{},
+			wallRandom{},
+			bridge.WithConnectionSink(sink),
+		)
+		if err != nil {
+			t.Fatalf("%s NewSupervisor(): %v", transport.name, err)
+		}
+		supervisors[transport.name] = supervisor
+		defer stopSupervisor(t, supervisor, transport.name)
+	}
+	for _, transport := range transports {
+		startSupervisor(t, supervisors[transport.name], transport.name)
+	}
+	for _, transport := range transports {
+		if !waitOnline(t, supervisors[transport.name], transport.name) {
+			t.Fatalf("selected %s transport did not come online", transport.name)
+		}
+	}
+
+	raw := openRawV2Store(t, storePath)
+	defer raw.Close()
+	deadline := time.Now().Add(ingestWait)
+	pending := make(map[string]liveIngestTransport, len(transports))
+	for _, transport := range transports {
+		pending[transport.accountID] = transport
+	}
+	for len(pending) > 0 && time.Now().Before(deadline) {
+		for accountID, transport := range pending {
+			snapshot := counters.Snapshot(accountID)
+			if snapshot.Quarantined != 0 {
+				t.Fatalf("%s ingest quarantined frames while waiting: %+v", transport.name, snapshot)
+			}
+			if snapshot.Appended == 0 || snapshot.Projected == 0 {
+				continue
+			}
+			projectedRows, err := countLiveIngestMessages(
+				raw,
+				transport.accountID,
+				transport.selfRemoteConversation,
+			)
+			if err != nil {
+				t.Fatalf("count %s self-thread messages while waiting: %v", transport.name, err)
+			}
+			if projectedRows > 0 {
+				t.Logf(
+					"INGEST [%s] counters ready with %d self-thread rows: %+v",
+					transport.name,
+					projectedRows,
+					snapshot,
+				)
+				delete(pending, accountID)
+			}
+		}
+		if len(pending) > 0 {
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+	if len(pending) > 0 {
+		for _, transport := range pending {
+			projectedRows, err := countLiveIngestMessages(raw, transport.accountID, transport.selfRemoteConversation)
+			t.Logf(
+				"INGEST [%s] timed out with counters=%+v self_thread_rows=%d query_error=%v",
+				transport.name,
+				counters.Snapshot(transport.accountID),
+				projectedRows,
+				err,
+			)
+		}
+		t.Fatalf("selected live ingest platforms did not append and project a self-thread row within %s", ingestWait)
+	}
+
+	for _, transport := range transports {
+		snapshot := counters.Snapshot(transport.accountID)
+		if snapshot.Quarantined != 0 {
+			t.Fatalf("%s ingest quarantined = %d, want 0", transport.name, snapshot.Quarantined)
+		}
+		var inboxRows int
+		if err := raw.QueryRowContext(
+			context.Background(),
+			`SELECT COUNT(*) FROM inbox WHERE account_id = ? AND codec = ?`,
+			transport.accountID,
+			transport.codec,
+		).Scan(&inboxRows); err != nil {
+			t.Fatalf("count %s inbox rows: %v", transport.name, err)
+		}
+		if inboxRows == 0 {
+			t.Fatalf("%s appended counters advanced without an inbox row using codec %q", transport.name, transport.codec)
+		}
+
+		projectedRows, err := countLiveIngestMessages(
+			raw,
+			transport.accountID,
+			transport.selfRemoteConversation,
+		)
+		if err != nil {
+			t.Fatalf("count %s self-thread messages: %v", transport.name, err)
+		}
+		if projectedRows == 0 {
+			t.Fatalf(
+				"%s projected no messages for live self-thread %q (counters=%+v)",
+				transport.name,
+				transport.selfRemoteConversation,
+				snapshot,
+			)
+		}
+		t.Logf(
+			"INGEST [%s] verified inbox=%d self_thread_messages=%d quarantined=0",
+			transport.name,
+			inboxRows,
+			projectedRows,
+		)
+	}
+}
+
+func liveIngestPlatforms(t *testing.T) map[string]bool {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv("LIVE_PLATFORMS"))
+	if raw == "" {
+		t.Skip("set LIVE_PLATFORMS=google,whatsapp,signal to select passive ingest legs")
+	}
+	selected := make(map[string]bool)
+	for _, field := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		name := strings.ToLower(strings.TrimSpace(field))
+		switch name {
+		case "all":
+			selected["google"] = true
+			selected["whatsapp"] = true
+			selected["signal"] = true
+		case "google", "whatsapp", "signal":
+			selected[name] = true
+		default:
+			t.Fatalf("LIVE_PLATFORMS contains unsupported platform %q", field)
+		}
+	}
+	if len(selected) == 0 {
+		t.Fatal("LIVE_PLATFORMS selected no platforms")
+	}
+	return selected
+}
+
+func seedLiveAccount(t *testing.T, store *sqlite.Store, nowMS int64, transport liveIngestTransport) {
+	t.Helper()
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   transport.accountID,
+		BridgeKey:   transport.bridgeKey,
+		DisplayName: transport.displayName,
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: nowMS,
+		UpdatedAtMS: nowMS,
+	}); err != nil {
+		t.Fatalf("UpsertAccount(%s): %v", transport.accountID, err)
+	}
+}
+
+func openRawV2Store(t *testing.T, dbPath string) *sql.DB {
+	t.Helper()
+	query := make(url.Values)
+	query.Add("_pragma", "busy_timeout(5000)")
+	query.Add("_pragma", "foreign_keys(ON)")
+	raw, err := sql.Open("sqlite", (&url.URL{
+		Scheme:   "file",
+		Path:     filepath.ToSlash(dbPath),
+		RawQuery: query.Encode(),
+	}).String())
+	if err != nil {
+		t.Fatalf("open raw v2 store: %v", err)
+	}
+	if err := raw.PingContext(context.Background()); err != nil {
+		raw.Close()
+		t.Fatalf("ping raw v2 store: %v", err)
+	}
+	return raw
+}
+
+func countLiveIngestMessages(raw *sql.DB, accountID, remoteConversationID string) (int, error) {
+	var count int
+	err := raw.QueryRowContext(
+		context.Background(),
+		`SELECT COUNT(*)
+		 FROM messages AS m
+		 JOIN conversations AS c
+		   ON c.account_id = m.account_id
+		  AND c.conversation_id = m.conversation_id
+		 WHERE m.account_id = ? AND c.remote_conversation_id = ?`,
+		accountID,
+		remoteConversationID,
+	).Scan(&count)
+	return count, err
 }
 
 func TestLiveSelfSendVerification(t *testing.T) {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -27,6 +27,7 @@ import (
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/client"
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/ingest"
 	"github.com/maxghenis/openmessage/internal/media"
 	"github.com/maxghenis/openmessage/internal/messaging"
 	"github.com/maxghenis/openmessage/internal/story"
@@ -81,6 +82,7 @@ type UnpairFunc func() error
 // APIOptions holds optional callbacks for the API handler.
 type APIOptions struct {
 	V2                    *V2Options
+	V2IngestCounters      func() map[string]ingest.CounterSnapshot
 	Client                func() *client.Client
 	Events                *EventBroker
 	EventHeartbeat        time.Duration
@@ -269,9 +271,19 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	}
 
 	statusPayload := func(connected bool) map[string]any {
+		v2IngestPerAccount := map[string]ingest.CounterSnapshot{}
+		if opts.V2IngestCounters != nil {
+			if snapshots := opts.V2IngestCounters(); snapshots != nil {
+				v2IngestPerAccount = snapshots
+			}
+		}
 		payload := map[string]any{
 			"connected": connected,
 			"v2_send":   opts.V2 != nil,
+			"v2_ingest": map[string]any{
+				"enabled":     opts.V2IngestCounters != nil,
+				"per_account": v2IngestPerAccount,
+			},
 		}
 		if strings.TrimSpace(opts.IdentityName) != "" {
 			payload["identity_name"] = strings.TrimSpace(opts.IdentityName)

--- a/internal/web/apiv1_test.go
+++ b/internal/web/apiv1_test.go
@@ -9,12 +9,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
 
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/ingest"
 	"github.com/maxghenis/openmessage/internal/media"
 	"github.com/maxghenis/openmessage/internal/messaging"
 	"github.com/maxghenis/openmessage/internal/storage/blob"
@@ -84,6 +86,66 @@ func TestStatusReportsV2SendAvailability(t *testing.T) {
 			}
 			if got, ok := payload["v2_send"].(bool); !ok || got != test.want {
 				t.Fatalf("v2_send = %#v, want %t", payload["v2_send"], test.want)
+			}
+		})
+	}
+}
+
+func TestStatusReportsV2IngestCounters(t *testing.T) {
+	tests := []struct {
+		name           string
+		provider       func() map[string]ingest.CounterSnapshot
+		wantEnabled    bool
+		wantPerAccount map[string]ingest.CounterSnapshot
+	}{
+		{
+			name:           "disabled",
+			wantPerAccount: map[string]ingest.CounterSnapshot{},
+		},
+		{
+			name: "enabled",
+			provider: func() map[string]ingest.CounterSnapshot {
+				return map[string]ingest.CounterSnapshot{
+					"google:primary": {
+						Appended:      7,
+						DecodedEvents: 6,
+						Projected:     5,
+						Quarantined:   1,
+					},
+				}
+			},
+			wantEnabled: true,
+			wantPerAccount: map[string]ingest.CounterSnapshot{
+				"google:primary": {
+					Appended:      7,
+					DecodedEvents: 6,
+					Projected:     5,
+					Quarantined:   1,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts := newV1RecorderHarness(t, APIOptions{V2IngestCounters: test.provider})
+			resp := ts.do(t, httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/status", nil))
+			defer resp.Body.Close()
+
+			var payload struct {
+				V2Ingest struct {
+					Enabled    bool                              `json:"enabled"`
+					PerAccount map[string]ingest.CounterSnapshot `json:"per_account"`
+				} `json:"v2_ingest"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload.V2Ingest.Enabled != test.wantEnabled {
+				t.Fatalf("v2_ingest.enabled = %t, want %t", payload.V2Ingest.Enabled, test.wantEnabled)
+			}
+			if !reflect.DeepEqual(payload.V2Ingest.PerAccount, test.wantPerAccount) {
+				t.Fatalf("v2_ingest.per_account = %#v, want %#v", payload.V2Ingest.PerAccount, test.wantPerAccount)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Final ingest-slice PR — makes ingest health visible and adds the cutover-day smoke check, per `ingest-echo-spec-2026-07-17.md` §7.

- **`/api/status` v2_ingest section** (`internal/web/api.go`): `{enabled, per_account: {<account>: CounterSnapshot}}` beside `v2_send`. Counters read live per request from the ingest worker's per-account totals via a provider func plumbed from `serve.go` (`v2IngestCountersProvider(stack)`). Stack off → `enabled:false`, no accounts. Both states pinned by `TestStatusReportsV2IngestCounters`.
- **`TestLiveIngestVerification`** (`internal/livetransport/live_test.go`, behind the existing `//go:build livetransport` tag): with the v2 stack up over a temp store and real transports connected, waits for `appended>0 && projected>0` on the enabled platforms, then asserts the projected rows exist in the v2 store with `quarantined==0`. Receive-side only — no sending. Compiles under the tag (verified).
- **Runbook** (`docs/agent-runbook.md`): reading the counters as the cutover ingest-smoke check (appended growing, quarantined 0).
- **CLI unchanged**: `openmessage status --json` reads the store directly, not `/api/status` — correctly no change (Sol flagged and justified this).

## Verification

Full `go test -race ./...`: 28 packages green. `go build -tags livetransport ./internal/livetransport/` clean. Independently verified outside the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
