### PR TITLE
v2-primary runtime selector + v2 read/serving layer (rebuild R5-1)

### DIFF
--- a/cmd/read.go
+++ b/cmd/read.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -12,7 +14,63 @@ import (
 
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/readsource"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2read"
 )
+
+type commandReadSession struct {
+	Reads     readsource.ReadSource
+	DataDir   string
+	StorePath string
+	close     func()
+}
+
+func (s *commandReadSession) Close() {
+	if s != nil && s.close != nil {
+		s.close()
+	}
+}
+
+func openCommandReadSource(
+	logger zerolog.Logger,
+	banner io.Writer,
+) (*commandReadSession, error) {
+	dataDir := app.DefaultDataDir()
+	mode, err := resolveV2RuntimeMode(app.DemoMode(), dataDir)
+	if err != nil {
+		return nil, err
+	}
+	if mode.Primary {
+		storePath := filepath.Join(dataDir, "v2", "store.sqlite3")
+		store, err := sqlite.Open(storePath)
+		if err != nil {
+			return nil, fmt.Errorf("open v2 read store %q: %w", storePath, err)
+		}
+		if banner != nil {
+			fmt.Fprintln(banner, "reading v2 store")
+		}
+		return &commandReadSession{
+			Reads:     v2read.New(store),
+			DataDir:   dataDir,
+			StorePath: storePath,
+			close: func() {
+				_ = store.Close()
+			},
+		}, nil
+	}
+
+	a, err := app.New(logger)
+	if err != nil {
+		return nil, fmt.Errorf("init app: %w", err)
+	}
+	return &commandReadSession{
+		Reads:     a.Store,
+		DataDir:   a.DataDir,
+		StorePath: filepath.Join(a.DataDir, "messages.db"),
+		close:     a.Close,
+	}, nil
+}
 
 // RunRead handles "openmessage read <query> [--limit N] [--phone NUMBER] [--json]".
 //
@@ -49,13 +107,13 @@ func RunRead(logger zerolog.Logger, args ...string) error {
 	}
 	asJSON := hasFlag(rest, "--json")
 
-	a, err := app.New(logger)
+	session, err := openCommandReadSource(logger, os.Stderr)
 	if err != nil {
-		return fmt.Errorf("init app: %w", err)
+		return err
 	}
-	defer a.Close()
+	defer session.Close()
 
-	msgs, err := a.Store.SearchMessagesFiltered(query, filter)
+	msgs, err := session.Reads.SearchMessagesFiltered(query, filter)
 	if err != nil {
 		return fmt.Errorf("search failed: %w", err)
 	}

--- a/cmd/read_test.go
+++ b/cmd/read_test.go
@@ -1,9 +1,135 @@
 package cmd
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 )
+
+func TestOpenCommandReadSourceSelectsLegacyByDefault(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
+	t.Setenv("OPENMESSAGES_DEMO", "0")
+	t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
+	t.Setenv("OPENMESSAGES_V2_PRIMARY", "0")
+	t.Setenv("OPENMESSAGES_V2_SEND", "0")
+	t.Setenv("OPENMESSAGES_V2_INGEST", "0")
+
+	legacy, err := db.New(filepath.Join(dataDir, "messages.db"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	if err := legacy.UpsertConversation(&db.Conversation{
+		ConversationID: "legacy-conversation",
+		Name:           "Legacy conversation",
+		SourcePlatform: "sms",
+	}); err != nil {
+		legacy.Close()
+		t.Fatalf("UpsertConversation(): %v", err)
+	}
+	legacy.Close()
+
+	var banner bytes.Buffer
+	session, err := openCommandReadSource(zerolog.Nop(), &banner)
+	if err != nil {
+		t.Fatalf("openCommandReadSource(): %v", err)
+	}
+	defer session.Close()
+	conversation, err := session.Reads.GetConversation("legacy-conversation")
+	if err != nil {
+		t.Fatalf("GetConversation(): %v", err)
+	}
+	if conversation == nil || conversation.Name != "Legacy conversation" {
+		t.Fatalf("legacy conversation = %+v", conversation)
+	}
+	if session.StorePath != filepath.Join(dataDir, "messages.db") {
+		t.Fatalf("StorePath = %q, want legacy path", session.StorePath)
+	}
+	if banner.Len() != 0 {
+		t.Fatalf("legacy-primary banner = %q, want empty", banner.String())
+	}
+}
+
+func TestOpenCommandReadSourceSelectsV2AndAnnouncesIt(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
+	t.Setenv("OPENMESSAGES_DEMO", "0")
+	t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
+	t.Setenv("OPENMESSAGES_V2_PRIMARY", "1")
+	t.Setenv("OPENMESSAGES_V2_SEND", "")
+	t.Setenv("OPENMESSAGES_V2_INGEST", "")
+
+	v2Dir := filepath.Join(dataDir, "v2")
+	if err := os.MkdirAll(v2Dir, 0o700); err != nil {
+		t.Fatalf("create v2 dir: %v", err)
+	}
+	storePath := filepath.Join(v2Dir, "store.sqlite3")
+	store, err := sqlite.Open(storePath)
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	nowMS := time.Now().UnixMilli()
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   "google-primary",
+		BridgeKey:   "google_messages",
+		DisplayName: "Google Messages",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  "{}",
+		CreatedAtMS: nowMS,
+		UpdatedAtMS: nowMS,
+	}); err != nil {
+		store.Close()
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	if err := store.UpsertConversation(sqlite.Conversation{
+		ConversationID:       "v2-conversation",
+		AccountID:            "google-primary",
+		RemoteConversationID: "remote-v2-conversation",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "V2 conversation",
+		NotificationMode:     sqlite.NotificationModeAll,
+		MetadataJSON:         "{}",
+		CreatedAtMS:          nowMS,
+		UpdatedAtMS:          nowMS,
+	}); err != nil {
+		store.Close()
+		t.Fatalf("UpsertConversation(): %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close v2 seed store: %v", err)
+	}
+
+	var banner bytes.Buffer
+	session, err := openCommandReadSource(zerolog.Nop(), &banner)
+	if err != nil {
+		t.Fatalf("openCommandReadSource(): %v", err)
+	}
+	defer session.Close()
+	conversation, err := session.Reads.GetConversation("v2-conversation")
+	if err != nil {
+		t.Fatalf("GetConversation(): %v", err)
+	}
+	if conversation == nil || conversation.Name != "V2 conversation" || conversation.SourcePlatform != "sms" {
+		t.Fatalf("v2 conversation = %+v", conversation)
+	}
+	if session.StorePath != storePath {
+		t.Fatalf("StorePath = %q, want %q", session.StorePath, storePath)
+	}
+	if banner.String() != "reading v2 store\n" {
+		t.Fatalf("v2-primary banner = %q", banner.String())
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "messages.db")); !os.IsNotExist(err) {
+		t.Fatalf("v2-primary CLI touched legacy store: %v", err)
+	}
+}
 
 func TestParseDayBound(t *testing.T) {
 	if ms, err := parseDayBound("", false); err != nil || ms != 0 {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -30,8 +30,10 @@ import (
 	"github.com/maxghenis/openmessage/internal/importer"
 	"github.com/maxghenis/openmessage/internal/ingest"
 	"github.com/maxghenis/openmessage/internal/notify"
+	"github.com/maxghenis/openmessage/internal/readsource"
 	"github.com/maxghenis/openmessage/internal/telemetry"
 	"github.com/maxghenis/openmessage/internal/tools"
+	"github.com/maxghenis/openmessage/internal/v2read"
 	"github.com/maxghenis/openmessage/internal/web"
 	"github.com/maxghenis/openmessage/internal/whatsapplive"
 )
@@ -105,6 +107,15 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	restoreEnv := configureServeEnv(opts)
 	defer restoreEnv()
 
+	isDemo := app.DemoMode()
+	v2Mode, err := resolveV2RuntimeMode(isDemo, app.DefaultDataDir())
+	if err != nil {
+		return err
+	}
+	v2Primary := v2Mode.Primary
+	v2Send := v2Mode.Send
+	v2Ingest := v2Mode.Ingest
+
 	a, err := app.New(logger)
 	if err != nil {
 		return fmt.Errorf("init app: %w", err)
@@ -122,9 +133,6 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	}
 	listenAddr := net.JoinHostPort(host, port)
 	baseURL := "http://" + net.JoinHostPort(publicHost(host), port)
-	isDemo := app.DemoMode()
-	v2Send := v2SendEnabled()
-	v2Ingest := v2IngestEnabled()
 
 	events := web.NewEventBroker()
 	isConnected := func() bool {
@@ -173,7 +181,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		if v2Send || v2Ingest {
 			stack, err = newV2Stack(v2StackDeps{
 				Logger:  logger,
-				DataDir: app.DefaultDataDir(),
+				DataDir: a.DataDir,
 				Google:  googleLifecycle,
 			})
 			if err != nil {
@@ -390,8 +398,9 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	}
 
 	if stack != nil {
-		stopV2Stack = stack.Start(context.Background(), a.Store, events)
+		stopV2Stack = stack.Start(context.Background(), a.Store, events, v2Primary)
 		logger.Info().
+			Bool("primary", v2Primary).
 			Bool("send", v2Send).
 			Bool("ingest", v2Ingest).
 			Msg("V2 stack enabled")
@@ -520,6 +529,14 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		}
 	}()
 
+	var reads readsource.ReadSource = a.Store
+	if v2Primary {
+		if stack == nil {
+			return errors.New("v2-primary selected but the v2 stack is unavailable")
+		}
+		reads = v2read.New(stack.Store)
+	}
+
 	// Create MCP server
 	mcpSrv := mcpserver.NewMCPServer(
 		"openmessage",
@@ -530,7 +547,15 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	if !v2Send {
 		v2SendStack = nil
 	}
-	tools.Register(mcpSrv, a, mcpV2Dependencies(v2SendStack)...)
+	var mcpV2 *tools.V2Dependencies
+	if dependencies := mcpV2Dependencies(v2SendStack); len(dependencies) > 0 {
+		mcpV2 = dependencies[0]
+	}
+	tools.RegisterWithOptions(mcpSrv, a, tools.Options{
+		Reads:     reads,
+		V2Primary: v2Primary,
+		V2:        mcpV2,
+	})
 
 	var mcpHTTPHandler http.Handler
 	if opts.mcpSSE {
@@ -574,7 +599,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	}
 
 	// Background loop that sends due scheduled ("send later") messages.
-	a.StartScheduler()
+	startLegacyScheduler(v2Primary, a.StartScheduler)
 
 	v2Options := v2SendWebOptions(stack, v2Send)
 	v2IngestCounters := v2IngestCountersProvider(stack)
@@ -586,6 +611,8 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 			httpHandler = web.APIHandlerWithOptions(a.Store, nil, logger, mcpHTTPHandler, web.APIOptions{
 				V2:                    v2Options,
 				V2IngestCounters:      v2IngestCounters,
+				Reads:                 reads,
+				V2Primary:             v2Primary,
 				Client:                a.GetClient,
 				Events:                events,
 				IdentityName:          identityName,

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -41,6 +41,109 @@ func TestInitializeWhatsAppForServeSkipsSupervisorOnInitializationError(t *testi
 	}
 }
 
+func TestRunServeV2PrimaryFailsFast(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		send          string
+		ingest        string
+		errorContains string
+	}{
+		{
+			name:          "demo mode",
+			args:          []string{"--demo", "--mcp-stdio"},
+			errorContains: "OPENMESSAGES_V2_PRIMARY is not available in demo mode",
+		},
+		{
+			name:          "explicit send conflict",
+			args:          []string{"--mcp-stdio"},
+			send:          "0",
+			errorContains: "OPENMESSAGES_V2_PRIMARY requires v2 send and ingest",
+		},
+		{
+			name:          "explicit ingest conflict",
+			args:          []string{"--mcp-stdio"},
+			ingest:        "0",
+			errorContains: "OPENMESSAGES_V2_PRIMARY requires v2 send and ingest",
+		},
+		{
+			name:          "migrated store absent",
+			args:          []string{"--mcp-stdio"},
+			errorContains: "run: openmessage migrate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
+			t.Setenv("OPENMESSAGES_DEMO", "0")
+			t.Setenv("OPENMESSAGES_V2_PRIMARY", "1")
+			t.Setenv("OPENMESSAGES_V2_SEND", tt.send)
+			t.Setenv("OPENMESSAGES_V2_INGEST", tt.ingest)
+			t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
+			t.Setenv("OPENMESSAGES_MACOS_NOTIFICATIONS", "0")
+			t.Setenv("OPENMESSAGE_TELEMETRY", "0")
+
+			err := RunServe(zerolog.Nop(), tt.args...)
+			if err == nil {
+				t.Fatal("RunServe() succeeded, want startup error")
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Fatalf("RunServe() error = %q, want %q", err, tt.errorContains)
+			}
+			if tt.name == "migrated store absent" {
+				wantPath := filepath.Join(dataDir, "v2", "store.sqlite3")
+				if !strings.Contains(err.Error(), wantPath) {
+					t.Fatalf("RunServe() error = %q, want store path %q", err, wantPath)
+				}
+				if _, statErr := os.Stat(filepath.Join(dataDir, "v2")); !os.IsNotExist(statErr) {
+					t.Fatalf("absent-store refusal created v2 state: %v", statErr)
+				}
+				if _, statErr := os.Stat(filepath.Join(dataDir, "messages.db")); !os.IsNotExist(statErr) {
+					t.Fatalf("absent-store refusal touched the legacy store: %v", statErr)
+				}
+			}
+		})
+	}
+}
+
+func TestRunServeV2PrimaryRejectsCorruptPresentStoreWithoutFallback(t *testing.T) {
+	dataDir := t.TempDir()
+	v2Dir := filepath.Join(dataDir, "v2")
+	if err := os.MkdirAll(v2Dir, 0o700); err != nil {
+		t.Fatalf("create v2 dir: %v", err)
+	}
+	storePath := filepath.Join(v2Dir, "store.sqlite3")
+	corrupt := []byte("not a sqlite database")
+	if err := os.WriteFile(storePath, corrupt, 0o600); err != nil {
+		t.Fatalf("write corrupt store: %v", err)
+	}
+	t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
+	t.Setenv("OPENMESSAGES_DEMO", "0")
+	t.Setenv("OPENMESSAGES_V2_PRIMARY", "1")
+	t.Setenv("OPENMESSAGES_V2_SEND", "")
+	t.Setenv("OPENMESSAGES_V2_INGEST", "")
+	t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
+	t.Setenv("OPENMESSAGES_MACOS_NOTIFICATIONS", "0")
+	t.Setenv("OPENMESSAGE_TELEMETRY", "0")
+
+	err := RunServe(zerolog.Nop(), "--mcp-stdio")
+	if err == nil || !strings.Contains(err.Error(), "init v2 stack") {
+		t.Fatalf("RunServe() error = %v, want corrupt v2 store startup failure", err)
+	}
+	got, readErr := os.ReadFile(storePath)
+	if readErr != nil {
+		t.Fatalf("read corrupt sentinel: %v", readErr)
+	}
+	if !bytes.Equal(got, corrupt) {
+		t.Fatalf("corrupt v2 store was replaced: got %q, want %q", got, corrupt)
+	}
+	if _, statErr := os.Stat(filepath.Join(v2Dir, "blobs")); !os.IsNotExist(statErr) {
+		t.Fatalf("corrupt-store refusal continued into v2 blob setup: %v", statErr)
+	}
+}
+
 func TestHTTPServerSurvivesIndependently(t *testing.T) {
 	// Mirrors the RunServe architecture: HTTP server in a goroutine
 	// stays alive even when the "main" blocking call returns.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/db"
 )
 
@@ -25,13 +23,13 @@ import (
 func RunStatus(logger zerolog.Logger, args ...string) error {
 	asJSON := hasFlag(args, "--json")
 
-	a, err := app.New(logger)
+	session, err := openCommandReadSource(logger, os.Stderr)
 	if err != nil {
-		return fmt.Errorf("init app: %w", err)
+		return err
 	}
-	defer a.Close()
+	defer session.Close()
 
-	stats, err := a.Store.PlatformStats()
+	stats, err := session.Reads.PlatformStats()
 	if err != nil {
 		return fmt.Errorf("platform stats: %w", err)
 	}
@@ -46,10 +44,10 @@ func RunStatus(logger zerolog.Logger, args ...string) error {
 		}
 	}
 
-	dbPath := filepath.Join(a.DataDir, "messages.db")
+	dbPath := session.StorePath
 
 	if asJSON {
-		return writeStatusJSON(dbPath, a.DataDir, total, stats)
+		return writeStatusJSON(dbPath, session.DataDir, total, stats)
 	}
 
 	fmt.Printf("OpenMessage store — %s\n", dbPath)

--- a/cmd/v2stack.go
+++ b/cmd/v2stack.go
@@ -60,12 +60,79 @@ func v2IngestEnabled() bool {
 	return v2FlagEnabled("OPENMESSAGES_V2_INGEST")
 }
 
+func v2PrimaryEnabled() bool {
+	return v2FlagEnabled("OPENMESSAGES_V2_PRIMARY")
+}
+
 func v2FlagEnabled(name string) bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
 	case "1", "true", "yes", "on":
 		return true
 	default:
 		return false
+	}
+}
+
+type v2RuntimeMode struct {
+	Primary bool
+	Send    bool
+	Ingest  bool
+}
+
+func resolveV2RuntimeMode(isDemo bool, dataDir string) (v2RuntimeMode, error) {
+	mode := v2RuntimeMode{
+		Primary: v2PrimaryEnabled(),
+		Send:    v2SendEnabled(),
+		Ingest:  v2IngestEnabled(),
+	}
+	if !mode.Primary {
+		return mode, nil
+	}
+	if isDemo {
+		return v2RuntimeMode{}, errors.New("OPENMESSAGES_V2_PRIMARY is not available in demo mode")
+	}
+	if v2FlagExplicitlyDisabled("OPENMESSAGES_V2_SEND") ||
+		v2FlagExplicitlyDisabled("OPENMESSAGES_V2_INGEST") {
+		return v2RuntimeMode{}, errors.New("OPENMESSAGES_V2_PRIMARY requires v2 send and ingest; unset OPENMESSAGES_V2_SEND=0/OPENMESSAGES_V2_INGEST=0")
+	}
+
+	storePath := filepath.Join(dataDir, "v2", "store.sqlite3")
+	info, err := os.Stat(storePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return v2RuntimeMode{}, fmt.Errorf("v2-primary selected but no migrated store at %s; run: openmessage migrate", storePath)
+		}
+		return v2RuntimeMode{}, fmt.Errorf("v2-primary selected but cannot access migrated store at %s: %w", storePath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return v2RuntimeMode{}, fmt.Errorf("v2-primary selected but no migrated store at %s; run: openmessage migrate", storePath)
+	}
+
+	mode.Send = true
+	mode.Ingest = true
+	return mode, nil
+}
+
+func v2FlagExplicitlyDisabled(name string) bool {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "0", "false", "no", "off":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldStartLegacyScheduler(v2Primary bool) bool {
+	return !v2Primary
+}
+
+func startLegacyScheduler(v2Primary bool, start func()) {
+	if shouldStartLegacyScheduler(v2Primary) && start != nil {
+		start()
 	}
 }
 
@@ -252,20 +319,20 @@ func newV2Stack(deps v2StackDeps) (_ *v2Stack, resultErr error) {
 	return stack, nil
 }
 
-func (s *v2Stack) Start(ctx context.Context, legacy *db.Store, events v2wire.EventPublisher) (stop func()) {
+func (s *v2Stack) Start(
+	ctx context.Context,
+	legacy *db.Store,
+	events v2wire.EventPublisher,
+	v2Primary bool,
+) (stop func()) {
 	runCtx, cancel := context.WithCancel(ctx)
-	projector := &v2wire.Projector{
-		V2Store: s.Store,
-		Outbox:  s.outbox,
-		Legacy:  legacy,
-		Blobs:   s.Blobs,
-		Events:  events,
-		Service: s.Service,
-		Logger:  s.logger,
-	}
 
 	var runWG sync.WaitGroup
-	runWG.Add(3)
+	runnerCount := 2
+	if !v2Primary {
+		runnerCount++
+	}
+	runWG.Add(runnerCount)
 	go func() {
 		defer runWG.Done()
 		if err := s.worker.Run(runCtx); err != nil && !errors.Is(err, context.Canceled) {
@@ -278,12 +345,23 @@ func (s *v2Stack) Start(ctx context.Context, legacy *db.Store, events v2wire.Eve
 			s.logger.Error().Err(err).Msg("V2 message dispatcher stopped")
 		}
 	}()
-	go func() {
-		defer runWG.Done()
-		if err := projector.Run(runCtx); err != nil && !errors.Is(err, context.Canceled) {
-			s.logger.Error().Err(err).Msg("V2 legacy projector stopped")
+	if !v2Primary {
+		projector := &v2wire.Projector{
+			V2Store: s.Store,
+			Outbox:  s.outbox,
+			Legacy:  legacy,
+			Blobs:   s.Blobs,
+			Events:  events,
+			Service: s.Service,
+			Logger:  s.logger,
 		}
-	}()
+		go func() {
+			defer runWG.Done()
+			if err := projector.Run(runCtx); err != nil && !errors.Is(err, context.Canceled) {
+				s.logger.Error().Err(err).Msg("V2 legacy projector stopped")
+			}
+		}()
+	}
 
 	var stopOnce sync.Once
 	return func() {

--- a/cmd/v2stack_test.go
+++ b/cmd/v2stack_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -17,7 +18,9 @@ import (
 	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
 	"github.com/maxghenis/openmessage/internal/db"
 	"github.com/maxghenis/openmessage/internal/ingest"
+	"github.com/maxghenis/openmessage/internal/messaging"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2wire"
 	"github.com/maxghenis/openmessage/internal/web"
 )
 
@@ -88,6 +91,178 @@ func TestV2IngestEnabled(t *testing.T) {
 				t.Fatalf("v2IngestEnabled() = %t, want %t for %q", got, tt.want, tt.value)
 			}
 		})
+	}
+}
+
+func TestV2PrimaryEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "empty", value: "", want: false},
+		{name: "zero", value: "0", want: false},
+		{name: "unknown", value: "enabled", want: false},
+		{name: "one", value: "1", want: true},
+		{name: "true", value: "true", want: true},
+		{name: "yes", value: "yes", want: true},
+		{name: "on", value: "on", want: true},
+		{name: "case and whitespace insensitive", value: "  TrUe\t", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OPENMESSAGES_V2_PRIMARY", tt.value)
+			if got := v2PrimaryEnabled(); got != tt.want {
+				t.Fatalf("v2PrimaryEnabled() = %t, want %t for %q", got, tt.want, tt.value)
+			}
+		})
+	}
+}
+
+func TestResolveV2RuntimeMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		demo          bool
+		primary       string
+		send          string
+		ingest        string
+		createStore   bool
+		want          v2RuntimeMode
+		errorContains string
+	}{
+		{
+			name: "legacy primary defaults unchanged",
+			want: v2RuntimeMode{},
+		},
+		{
+			name: "legacy primary preserves independent send",
+			send: "1",
+			want: v2RuntimeMode{Send: true},
+		},
+		{
+			name:   "legacy primary preserves independent ingest",
+			ingest: "1",
+			want:   v2RuntimeMode{Ingest: true},
+		},
+		{
+			name:          "primary rejects demo",
+			demo:          true,
+			primary:       "1",
+			errorContains: "OPENMESSAGES_V2_PRIMARY is not available in demo mode",
+		},
+		{
+			name:          "primary rejects explicit send off",
+			primary:       "1",
+			send:          "0",
+			errorContains: "OPENMESSAGES_V2_PRIMARY requires v2 send and ingest; unset OPENMESSAGES_V2_SEND=0/OPENMESSAGES_V2_INGEST=0",
+		},
+		{
+			name:          "primary rejects explicit ingest off",
+			primary:       "1",
+			ingest:        "0",
+			errorContains: "OPENMESSAGES_V2_PRIMARY requires v2 send and ingest; unset OPENMESSAGES_V2_SEND=0/OPENMESSAGES_V2_INGEST=0",
+		},
+		{
+			name:          "primary refuses an absent migrated store",
+			primary:       "1",
+			errorContains: "v2-primary selected but no migrated store at ",
+		},
+		{
+			name:        "primary implies send and ingest",
+			primary:     "1",
+			createStore: true,
+			want:        v2RuntimeMode{Primary: true, Send: true, Ingest: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			t.Setenv("OPENMESSAGES_V2_PRIMARY", tt.primary)
+			t.Setenv("OPENMESSAGES_V2_SEND", tt.send)
+			t.Setenv("OPENMESSAGES_V2_INGEST", tt.ingest)
+			if tt.createStore {
+				v2Dir := filepath.Join(dataDir, "v2")
+				if err := os.MkdirAll(v2Dir, 0o700); err != nil {
+					t.Fatalf("create v2 dir: %v", err)
+				}
+				store, err := sqlite.Open(filepath.Join(v2Dir, "store.sqlite3"))
+				if err != nil {
+					t.Fatalf("create v2 store: %v", err)
+				}
+				if err := store.Close(); err != nil {
+					t.Fatalf("close v2 store: %v", err)
+				}
+			}
+
+			got, err := resolveV2RuntimeMode(tt.demo, dataDir)
+			if tt.errorContains != "" {
+				if err == nil {
+					t.Fatalf("resolveV2RuntimeMode() succeeded, want error containing %q", tt.errorContains)
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Fatalf("resolveV2RuntimeMode() error = %q, want %q", err, tt.errorContains)
+				}
+				if strings.Contains(tt.name, "absent migrated store") {
+					wantPath := filepath.Join(dataDir, "v2", "store.sqlite3")
+					if !strings.Contains(err.Error(), wantPath) || !strings.Contains(err.Error(), "run: openmessage migrate") {
+						t.Fatalf("absent-store error = %q, want path %q and migrate command", err, wantPath)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveV2RuntimeMode(): %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveV2RuntimeMode() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveV2RuntimeModeRejectsNonRegularStoreWithoutReplacingIt(t *testing.T) {
+	dataDir := t.TempDir()
+	storePath := filepath.Join(dataDir, "v2", "store.sqlite3")
+	if err := os.MkdirAll(storePath, 0o700); err != nil {
+		t.Fatalf("create directory at store path: %v", err)
+	}
+	t.Setenv("OPENMESSAGES_V2_PRIMARY", "1")
+	t.Setenv("OPENMESSAGES_V2_SEND", "")
+	t.Setenv("OPENMESSAGES_V2_INGEST", "")
+
+	_, err := resolveV2RuntimeMode(false, dataDir)
+	if err == nil || !strings.Contains(err.Error(), "no migrated store") ||
+		!strings.Contains(err.Error(), "run: openmessage migrate") {
+		t.Fatalf("resolveV2RuntimeMode() error = %v", err)
+	}
+	info, statErr := os.Stat(storePath)
+	if statErr != nil {
+		t.Fatalf("stat sentinel after refusal: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Fatalf("non-regular store sentinel was replaced: mode=%v", info.Mode())
+	}
+}
+
+func TestLegacySchedulerGuard(t *testing.T) {
+	if !shouldStartLegacyScheduler(false) {
+		t.Fatal("legacy-primary must start the legacy scheduler")
+	}
+	if shouldStartLegacyScheduler(true) {
+		t.Fatal("v2-primary must not start the legacy scheduler")
+	}
+
+	starts := 0
+	start := func() { starts++ }
+	startLegacyScheduler(false, start)
+	if starts != 1 {
+		t.Fatalf("legacy-primary scheduler starts = %d, want 1", starts)
+	}
+	startLegacyScheduler(true, start)
+	if starts != 1 {
+		t.Fatalf("v2-primary scheduler starts = %d, want unchanged at 1", starts)
 	}
 }
 
@@ -302,7 +477,7 @@ func TestV2StackFreshGoogleIngressReachesWorker(t *testing.T) {
 		t.Fatalf("db.New(): %v", err)
 	}
 	defer legacy.Close()
-	stop := stack.Start(context.Background(), legacy, web.NewEventBroker())
+	stop := stack.Start(context.Background(), legacy, web.NewEventBroker(), false)
 	defer stop()
 
 	if err := stack.Sink.AppendIngress(context.Background(), bridge.RawIngressRecord{
@@ -346,7 +521,7 @@ func TestV2StackStopJoinsRunAndClosesStore(t *testing.T) {
 	}
 	defer legacy.Close()
 
-	stop := stack.Start(context.Background(), legacy, web.NewEventBroker())
+	stop := stack.Start(context.Background(), legacy, web.NewEventBroker(), false)
 	stopped := make(chan struct{})
 	go func() {
 		stop()
@@ -361,6 +536,154 @@ func TestV2StackStopJoinsRunAndClosesStore(t *testing.T) {
 	if _, err := stack.Store.ListAccounts(); err == nil {
 		t.Fatal("v2 store remains usable after stack stop")
 	}
+}
+
+func TestV2PrimaryStackDoesNotStartLegacyProjector(t *testing.T) {
+	var logs bytes.Buffer
+	stack, err := newV2Stack(v2StackDeps{
+		Logger:  zerolog.New(&logs),
+		DataDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("newV2Stack(): %v", err)
+	}
+
+	// A nil legacy store makes Projector.Run fail synchronously. If the
+	// v2-primary branch accidentally starts it, the runner logs that failure
+	// before Stop joins all goroutines.
+	stop := stack.Start(context.Background(), nil, web.NewEventBroker(), true)
+	stop()
+	if strings.Contains(logs.String(), "V2 legacy projector stopped") {
+		t.Fatalf("v2-primary started the legacy projector:\n%s", logs.String())
+	}
+}
+
+func TestLegacyPrimaryStackStillStartsLegacyProjector(t *testing.T) {
+	var logs bytes.Buffer
+	stack, err := newV2Stack(v2StackDeps{
+		Logger:  zerolog.New(&logs),
+		DataDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("newV2Stack(): %v", err)
+	}
+
+	// The nil legacy store is a sentinel: the legacy-primary projector must
+	// start, reject it, and log before Stop joins the runners.
+	stop := stack.Start(context.Background(), nil, web.NewEventBroker(), false)
+	stop()
+	if !strings.Contains(logs.String(), "V2 legacy projector stopped") {
+		t.Fatalf("legacy-primary did not start the legacy projector:\n%s", logs.String())
+	}
+}
+
+func TestV2PrimaryStackRunsWorkerAndDispatcherWithoutProjector(t *testing.T) {
+	stack, err := newV2Stack(v2StackDeps{
+		Logger:  zerolog.Nop(),
+		DataDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("newV2Stack(): %v", err)
+	}
+	adapter := &v2PrimaryTextAdapter{requests: make(chan bridge.TextRequest, 1)}
+	if err := stack.RegisterAdapter(adapter); err != nil {
+		stack.Store.Close()
+		t.Fatalf("RegisterAdapter(): %v", err)
+	}
+	nowMS := time.Now().UnixMilli()
+	if err := stack.Store.UpsertConversation(sqlite.Conversation{
+		ConversationID:       "v2-primary-conversation",
+		AccountID:            adapter.AccountID(),
+		RemoteConversationID: "remote-v2-primary-conversation",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "V2 primary",
+		NotificationMode:     sqlite.NotificationModeAll,
+		MetadataJSON:         "{}",
+		CreatedAtMS:          nowMS,
+		UpdatedAtMS:          nowMS,
+	}); err != nil {
+		stack.Store.Close()
+		t.Fatalf("UpsertConversation(): %v", err)
+	}
+	submission, err := v2wire.SubmitTextV2(context.Background(), v2wire.NativeDeps{
+		V2: stack.Store, Service: stack.Service, Registry: stack.Registry,
+	}, v2wire.TextInput{
+		ConversationID: "v2-primary-conversation",
+		Body:           "dispatch while primary",
+		IdempotencyKey: "v2-primary-dispatch",
+	})
+	if err != nil {
+		stack.Store.Close()
+		t.Fatalf("SubmitTextV2(): %v", err)
+	}
+
+	stop := stack.Start(context.Background(), nil, web.NewEventBroker(), true)
+	defer stop()
+	if err := stack.Sink.AppendIngress(context.Background(), bridge.RawIngressRecord{
+		AccountID:    adapter.AccountID(),
+		Generation:   1,
+		DedupeKey:    "v2-primary-malformed",
+		Codec:        ingest.GoogleCodec,
+		CodecVersion: ingest.GoogleCodecVersion,
+		ReceivedAt:   time.Now(),
+		Payload:      []byte("{"),
+	}); err != nil {
+		t.Fatalf("AppendIngress(): %v", err)
+	}
+
+	var sent *bridge.TextRequest
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if sent == nil {
+			select {
+			case request := <-adapter.requests:
+				sent = &request
+			default:
+			}
+		}
+		delivery, deliveryErr := stack.Service.Get(context.Background(), submission.OutboxID)
+		quarantined := stack.Counters.Snapshot(adapter.AccountID()).Quarantined == 1
+		if sent != nil && deliveryErr == nil && delivery.State == messaging.OutboxConfirmed && quarantined {
+			if sent.Body != "dispatch while primary" ||
+				sent.Conversation.RemoteID != "remote-v2-primary-conversation" {
+				t.Fatalf("dispatched request = %+v", *sent)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	delivery, deliveryErr := stack.Service.Get(context.Background(), submission.OutboxID)
+	t.Fatalf(
+		"v2-primary runners did not settle: sent=%v delivery=%+v err=%v counters=%+v",
+		sent != nil,
+		delivery,
+		deliveryErr,
+		stack.Counters.Snapshot(adapter.AccountID()),
+	)
+}
+
+type v2PrimaryTextAdapter struct {
+	requests chan bridge.TextRequest
+}
+
+func (*v2PrimaryTextAdapter) AccountID() string         { return googleAccountID }
+func (*v2PrimaryTextAdapter) Platform() bridge.Platform { return bridge.PlatformGoogle }
+func (*v2PrimaryTextAdapter) Start(
+	context.Context,
+	bridge.StartRequest,
+	bridge.ConnectionSink,
+) (bridge.Run, error) {
+	return nil, nil
+}
+func (a *v2PrimaryTextAdapter) SendText(
+	_ context.Context,
+	request bridge.TextRequest,
+) (bridge.SendResult, error) {
+	a.requests <- request
+	return bridge.SendResult{
+		RemoteMessageID: "remote-v2-primary-message",
+		EchoExpected:    false,
+	}, nil
 }
 
 func assertPrivateDirectory(t *testing.T, path string) {

--- a/internal/readsource/readsource.go
+++ b/internal/readsource/readsource.go
@@ -1,0 +1,24 @@
+// Package readsource defines the canonical conversation and message read seam.
+package readsource
+
+import "github.com/maxghenis/openmessage/internal/db"
+
+// ReadSource is the subset of the legacy store consumed by canonical read
+// surfaces. Its signatures intentionally match *db.Store so legacy-primary
+// callers use the existing store without an adapter.
+type ReadSource interface {
+	ListConversations(limit int) ([]*db.Conversation, error)
+	GetConversation(id string) (*db.Conversation, error)
+	GetMessagesByConversation(conversationID string, limit int) ([]*db.Message, error)
+	GetMessagesByConversationBefore(conversationID string, beforeMS int64, beforeID string, limit int) ([]*db.Message, error)
+	GetMessagesByConversationAfter(conversationID string, afterMS int64, afterID string, limit int) ([]*db.Message, error)
+	GetMessagesAroundMessage(conversationID, messageID string, before, after int) ([]*db.Message, error)
+	SearchMessagesFiltered(query string, filter db.SearchFilter) ([]*db.Message, error)
+	PlatformStats() ([]db.PlatformStat, error)
+	MessageCount(sourcePlatform string) (int, error)
+	ConversationCount(sourcePlatform string) (int, error)
+	LatestTimestamp(sourcePlatform string) (int64, error)
+	LatestConversationPreviews(ids []string) (map[string]string, error)
+}
+
+var _ ReadSource = (*db.Store)(nil)

--- a/internal/storage/sqlite/messages.go
+++ b/internal/storage/sqlite/messages.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -55,6 +56,18 @@ type Message struct {
 	OccurredAtMS     int64
 	CreatedAtMS      int64
 	UpdatedAtMS      int64
+}
+
+// SearchQuery narrows a bounded message-body LIKE query. Zero values leave a
+// field unconstrained, and a non-positive Limit uses the legacy default of 20.
+// SenderCanonicalValue corresponds to db.SearchFilter.Phone at the read seam.
+type SearchQuery struct {
+	AccountID            string
+	ConversationID       string
+	SenderCanonicalValue string
+	SinceMS              int64
+	UntilMS              int64
+	Limit                int
 }
 
 // MessageProjection describes a normalized message and its attachments.
@@ -280,6 +293,231 @@ func (r *MessageRepository) GetMessageByRemote(
 		)
 	}
 	return message, nil
+}
+
+// ListMessagesByConversation returns a newest-first page. beforeMS == 0
+// selects the latest page; otherwise beforeID is the deterministic tie cursor.
+func (r *MessageRepository) ListMessagesByConversation(
+	ctx context.Context,
+	conversationID string,
+	beforeMS int64,
+	beforeID string,
+	limit int,
+) ([]Message, error) {
+	if limit <= 0 {
+		return []Message{}, nil
+	}
+	query := `
+		SELECT ` + messageColumns + `
+		FROM messages
+		WHERE conversation_id = ?
+		ORDER BY occurred_at_ms DESC, message_id DESC
+		LIMIT ?
+	`
+	args := []any{conversationID, limit}
+	if beforeMS > 0 {
+		query = `
+			SELECT ` + messageColumns + `
+			FROM messages
+			WHERE conversation_id = ? AND occurred_at_ms < ?
+			ORDER BY occurred_at_ms DESC, message_id DESC
+			LIMIT ?
+		`
+		args = []any{conversationID, beforeMS, limit}
+		if beforeID != "" {
+			query = `
+				SELECT ` + messageColumns + `
+				FROM messages
+				WHERE conversation_id = ?
+				  AND (occurred_at_ms < ? OR (occurred_at_ms = ? AND message_id < ?))
+				ORDER BY occurred_at_ms DESC, message_id DESC
+				LIMIT ?
+			`
+			args = []any{conversationID, beforeMS, beforeMS, beforeID, limit}
+		}
+	}
+	rows, err := r.store.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list messages for conversation %q: %w", conversationID, err)
+	}
+	messages, err := collectRows(rows, scanMessage)
+	if err != nil {
+		return nil, fmt.Errorf("list messages for conversation %q: %w", conversationID, err)
+	}
+	return messages, nil
+}
+
+// ListMessagesByConversationAfter returns an oldest-first page after the
+// supplied timestamp and optional deterministic tie cursor.
+func (r *MessageRepository) ListMessagesByConversationAfter(
+	ctx context.Context,
+	conversationID string,
+	afterMS int64,
+	afterID string,
+	limit int,
+) ([]Message, error) {
+	if limit <= 0 {
+		return []Message{}, nil
+	}
+	query := `
+		SELECT ` + messageColumns + `
+		FROM messages
+		WHERE conversation_id = ? AND occurred_at_ms > ?
+		ORDER BY occurred_at_ms ASC, message_id ASC
+		LIMIT ?
+	`
+	args := []any{conversationID, afterMS, limit}
+	if afterID != "" {
+		query = `
+			SELECT ` + messageColumns + `
+			FROM messages
+			WHERE conversation_id = ?
+			  AND (occurred_at_ms > ? OR (occurred_at_ms = ? AND message_id > ?))
+			ORDER BY occurred_at_ms ASC, message_id ASC
+			LIMIT ?
+		`
+		args = []any{conversationID, afterMS, afterMS, afterID, limit}
+	}
+	rows, err := r.store.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list messages after cursor for conversation %q: %w", conversationID, err)
+	}
+	messages, err := collectRows(rows, scanMessage)
+	if err != nil {
+		return nil, fmt.Errorf("list messages after cursor for conversation %q: %w", conversationID, err)
+	}
+	return messages, nil
+}
+
+// ListMessagesAroundMessage returns the anchor and its neighboring messages in
+// chronological order. Missing anchors and cross-conversation anchors wrap
+// ErrNotFound.
+func (r *MessageRepository) ListMessagesAroundMessage(
+	ctx context.Context,
+	conversationID string,
+	messageID string,
+	before int,
+	after int,
+) ([]Message, error) {
+	if before < 0 {
+		before = 0
+	}
+	if after < 0 {
+		after = 0
+	}
+	if before == 0 {
+		before = 40
+	}
+	if after == 0 {
+		after = 40
+	}
+
+	anchor, err := r.GetMessage(ctx, messageID)
+	if err != nil {
+		return nil, err
+	}
+	if anchor.ConversationID != conversationID {
+		return nil, fmt.Errorf("message %q in conversation %q: %w", messageID, conversationID, ErrNotFound)
+	}
+
+	beforeRows, err := r.store.db.QueryContext(ctx, `
+		SELECT `+messageColumns+`
+		FROM messages
+		WHERE conversation_id = ?
+		  AND (occurred_at_ms < ? OR (occurred_at_ms = ? AND message_id < ?))
+		ORDER BY occurred_at_ms DESC, message_id DESC
+		LIMIT ?
+	`, conversationID, anchor.OccurredAtMS, anchor.OccurredAtMS, anchor.MessageID, before)
+	if err != nil {
+		return nil, fmt.Errorf("list messages before %q: %w", messageID, err)
+	}
+	beforeMessages, err := collectRows(beforeRows, scanMessage)
+	if err != nil {
+		return nil, fmt.Errorf("list messages before %q: %w", messageID, err)
+	}
+
+	afterRows, err := r.store.db.QueryContext(ctx, `
+		SELECT `+messageColumns+`
+		FROM messages
+		WHERE conversation_id = ?
+		  AND (occurred_at_ms > ? OR (occurred_at_ms = ? AND message_id > ?))
+		ORDER BY occurred_at_ms ASC, message_id ASC
+		LIMIT ?
+	`, conversationID, anchor.OccurredAtMS, anchor.OccurredAtMS, anchor.MessageID, after)
+	if err != nil {
+		return nil, fmt.Errorf("list messages after %q: %w", messageID, err)
+	}
+	afterMessages, err := collectRows(afterRows, scanMessage)
+	if err != nil {
+		return nil, fmt.Errorf("list messages after %q: %w", messageID, err)
+	}
+
+	result := make([]Message, 0, len(beforeMessages)+1+len(afterMessages))
+	for i := len(beforeMessages) - 1; i >= 0; i-- {
+		result = append(result, beforeMessages[i])
+	}
+	result = append(result, anchor)
+	result = append(result, afterMessages...)
+	return result, nil
+}
+
+// SearchMessages performs the R5 substring-compatible LIKE scan. FTS and
+// relevance ranking are intentionally deferred; rows are ordered by recency
+// with message ID as a deterministic tie-breaker.
+func (r *MessageRepository) SearchMessages(
+	ctx context.Context,
+	query string,
+	filter SearchQuery,
+) ([]Message, error) {
+	if filter.Limit <= 0 {
+		filter.Limit = 20
+	}
+	if filter.SinceMS > 0 && filter.UntilMS > 0 && filter.UntilMS < filter.SinceMS {
+		filter.SinceMS, filter.UntilMS = filter.UntilMS, filter.SinceMS
+	}
+
+	conditions := []string{"m.body LIKE '%' || ? || '%'"}
+	args := []any{query}
+	if filter.AccountID != "" {
+		conditions = append(conditions, "m.account_id = ?")
+		args = append(args, filter.AccountID)
+	}
+	if filter.ConversationID != "" {
+		conditions = append(conditions, "m.conversation_id = ?")
+		args = append(args, filter.ConversationID)
+	}
+	if filter.SenderCanonicalValue != "" {
+		conditions = append(conditions, "i.canonical_value = ?")
+		args = append(args, filter.SenderCanonicalValue)
+	}
+	if filter.SinceMS > 0 {
+		conditions = append(conditions, "m.occurred_at_ms >= ?")
+		args = append(args, filter.SinceMS)
+	}
+	if filter.UntilMS > 0 {
+		conditions = append(conditions, "m.occurred_at_ms <= ?")
+		args = append(args, filter.UntilMS)
+	}
+	args = append(args, filter.Limit)
+
+	statement := `
+		SELECT ` + prefixedMessageColumns("m") + `
+		FROM messages AS m
+		LEFT JOIN identities AS i
+		  ON i.account_id = m.account_id AND i.identity_id = m.sender_identity_id
+		WHERE ` + strings.Join(conditions, " AND ") + `
+		ORDER BY m.occurred_at_ms DESC, m.message_id DESC
+		LIMIT ?
+	`
+	rows, err := r.store.db.QueryContext(ctx, statement, args...)
+	if err != nil {
+		return nil, fmt.Errorf("search messages: %w", err)
+	}
+	messages, err := collectRows(rows, scanMessage)
+	if err != nil {
+		return nil, fmt.Errorf("search messages: %w", err)
+	}
+	return messages, nil
 }
 
 // ImportMessage atomically upserts a historical normalized message by remote
@@ -626,6 +864,21 @@ const messageColumns = `
 	occurred_at_ms,
 	created_at_ms,
 	updated_at_ms`
+
+func prefixedMessageColumns(alias string) string {
+	return alias + `.message_id,
+	` + alias + `.conversation_id,
+	` + alias + `.account_id,
+	` + alias + `.remote_message_id,
+	` + alias + `.sender_identity_id,
+	` + alias + `.direction,
+	` + alias + `.body,
+	` + alias + `.reply_to_remote_id,
+	` + alias + `.state,
+	` + alias + `.occurred_at_ms,
+	` + alias + `.created_at_ms,
+	` + alias + `.updated_at_ms`
+}
 
 func scanMessage(row rowScanner) (Message, error) {
 	var message Message

--- a/internal/storage/sqlite/messages_test.go
+++ b/internal/storage/sqlite/messages_test.go
@@ -210,6 +210,227 @@ func TestImportMessageSupportsBothDirectionsWithoutInbox(t *testing.T) {
 	}
 }
 
+func TestListMessagesByConversationPaginationAndAround(t *testing.T) {
+	store, repository := openMessageTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
+	)
+	seedMessageAccount(t, store, "account-a", "google_messages")
+	seedMessageAccount(t, store, "account-b", "whatsmeow")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	seedMessageConversation(t, store, "conversation-b", "account-b")
+
+	importMessage := func(id, conversationID, accountID string, occurredAtMS int64) {
+		t.Helper()
+		message := messageTestMessage(id, conversationID, accountID, "remote-"+id, nil)
+		message.OccurredAtMS = occurredAtMS
+		if err := repository.ImportMessage(context.Background(), MessageProjection{Message: message}); err != nil {
+			t.Fatalf("ImportMessage(%q): %v", id, err)
+		}
+	}
+	for _, item := range []struct {
+		id string
+		ts int64
+	}{
+		{id: "message-old", ts: 100},
+		{id: "message-tie-a", ts: 200},
+		{id: "message-tie-b", ts: 200},
+		{id: "message-new", ts: 300},
+		{id: "message-newest", ts: 400},
+	} {
+		importMessage(item.id, "conversation-a", "account-a", item.ts)
+	}
+	importMessage("message-other", "conversation-b", "account-b", 1_000)
+
+	assertIDs := func(name string, got []Message, want ...string) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("%s IDs = %d rows %+v, want %d %v", name, len(got), got, len(want), want)
+		}
+		for i, wantID := range want {
+			if got[i].MessageID != wantID {
+				t.Fatalf("%s ID %d = %q, want %q", name, i, got[i].MessageID, wantID)
+			}
+		}
+	}
+
+	latest, err := repository.ListMessagesByConversation(
+		context.Background(), "conversation-a", 0, "", 3,
+	)
+	if err != nil {
+		t.Fatalf("ListMessagesByConversation(latest): %v", err)
+	}
+	assertIDs("latest", latest, "message-newest", "message-new", "message-tie-b")
+
+	before, err := repository.ListMessagesByConversation(
+		context.Background(), "conversation-a", 200, "message-tie-b", 10,
+	)
+	if err != nil {
+		t.Fatalf("ListMessagesByConversation(before cursor): %v", err)
+	}
+	assertIDs("before cursor", before, "message-tie-a", "message-old")
+
+	strictlyBefore, err := repository.ListMessagesByConversation(
+		context.Background(), "conversation-a", 200, "", 10,
+	)
+	if err != nil {
+		t.Fatalf("ListMessagesByConversation(before timestamp): %v", err)
+	}
+	assertIDs("before timestamp", strictlyBefore, "message-old")
+
+	after, err := repository.ListMessagesByConversationAfter(
+		context.Background(), "conversation-a", 200, "message-tie-a", 10,
+	)
+	if err != nil {
+		t.Fatalf("ListMessagesByConversationAfter(cursor): %v", err)
+	}
+	assertIDs("after cursor", after, "message-tie-b", "message-new", "message-newest")
+
+	strictlyAfter, err := repository.ListMessagesByConversationAfter(
+		context.Background(), "conversation-a", 200, "", 10,
+	)
+	if err != nil {
+		t.Fatalf("ListMessagesByConversationAfter(timestamp): %v", err)
+	}
+	assertIDs("after timestamp", strictlyAfter, "message-new", "message-newest")
+
+	around, err := repository.ListMessagesAroundMessage(
+		context.Background(), "conversation-a", "message-tie-b", 2, 2,
+	)
+	if err != nil {
+		t.Fatalf("ListMessagesAroundMessage(): %v", err)
+	}
+	assertIDs(
+		"around",
+		around,
+		"message-old",
+		"message-tie-a",
+		"message-tie-b",
+		"message-new",
+		"message-newest",
+	)
+
+	for _, test := range []struct {
+		name           string
+		conversationID string
+		messageID      string
+	}{
+		{name: "missing anchor", conversationID: "conversation-a", messageID: "missing"},
+		{name: "wrong conversation", conversationID: "conversation-b", messageID: "message-tie-b"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := repository.ListMessagesAroundMessage(
+				context.Background(), test.conversationID, test.messageID, 1, 1,
+			)
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("ListMessagesAroundMessage() error = %v, want ErrNotFound", err)
+			}
+		})
+	}
+}
+
+func TestSearchMessagesLIKEFiltersAndOrdersDeterministically(t *testing.T) {
+	store, repository := openMessageTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
+	)
+	seedMessageAccount(t, store, "account-a", "google_messages")
+	seedMessageAccount(t, store, "account-b", "whatsmeow")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	seedMessageConversation(t, store, "conversation-a-other", "account-a")
+	seedMessageConversation(t, store, "conversation-b", "account-b")
+
+	identities := []Identity{
+		repositoryTestIdentity("alice-a", "account-a", "+15550000001"),
+		repositoryTestIdentity("bob-a", "account-a", "+15550000002"),
+		repositoryTestIdentity("alice-b", "account-b", "+15550000001"),
+	}
+	for _, identity := range identities {
+		mustRepositoryWrite(t, "UpsertIdentity", store.UpsertIdentity(identity))
+	}
+
+	importMessage := func(id, conversationID, accountID, body, senderID string, occurredAtMS int64) {
+		t.Helper()
+		message := messageTestMessage(
+			id,
+			conversationID,
+			accountID,
+			"remote-"+id,
+			pointer(senderID),
+		)
+		message.Body = body
+		message.OccurredAtMS = occurredAtMS
+		if err := repository.ImportMessage(context.Background(), MessageProjection{Message: message}); err != nil {
+			t.Fatalf("ImportMessage(%q): %v", id, err)
+		}
+	}
+	importMessage("message-old", "conversation-a", "account-a", "Needle oldest", "alice-a", 100)
+	importMessage("message-middle", "conversation-a", "account-a", "needle middle", "bob-a", 200)
+	importMessage("message-new", "conversation-a", "account-a", "NEEDLE newest", "alice-a", 300)
+	importMessage("message-other-conversation", "conversation-a-other", "account-a", "needle elsewhere", "alice-a", 400)
+	importMessage("message-other-account", "conversation-b", "account-b", "needle cross-account", "alice-b", 500)
+	importMessage("message-no-match", "conversation-b", "account-b", "haystack", "alice-b", 600)
+
+	assertSearch := func(name string, query SearchQuery, want ...string) {
+		t.Helper()
+		got, err := repository.SearchMessages(context.Background(), "needle", query)
+		if err != nil {
+			t.Fatalf("%s SearchMessages(): %v", name, err)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("%s results = %+v, want IDs %v", name, got, want)
+		}
+		for i, wantID := range want {
+			if got[i].MessageID != wantID {
+				t.Fatalf("%s result %d = %q, want %q", name, i, got[i].MessageID, wantID)
+			}
+		}
+	}
+
+	assertSearch(
+		"global limit",
+		SearchQuery{Limit: 3},
+		"message-other-account",
+		"message-other-conversation",
+		"message-new",
+	)
+	assertSearch(
+		"account",
+		SearchQuery{AccountID: "account-a", Limit: 10},
+		"message-other-conversation",
+		"message-new",
+		"message-middle",
+		"message-old",
+	)
+	assertSearch(
+		"conversation",
+		SearchQuery{ConversationID: "conversation-a", Limit: 10},
+		"message-new",
+		"message-middle",
+		"message-old",
+	)
+	assertSearch(
+		"sender canonical value",
+		SearchQuery{SenderCanonicalValue: "+15550000001", Limit: 10},
+		"message-other-account",
+		"message-other-conversation",
+		"message-new",
+		"message-old",
+	)
+	assertSearch(
+		"time range",
+		SearchQuery{SinceMS: 150, UntilMS: 350, Limit: 10},
+		"message-new",
+		"message-middle",
+	)
+	assertSearch(
+		"reversed time range",
+		SearchQuery{SinceMS: 350, UntilMS: 150, Limit: 10},
+		"message-new",
+		"message-middle",
+	)
+}
+
 func TestImportMessageIsIdempotentByRemoteIDAndPersistsAttachments(t *testing.T) {
 	clock := newMessageTestClock(messageTestTimeMS)
 	store, repository := openMessageTestRepository(t, clock.Now)

--- a/internal/storage/sqlite/repositories.go
+++ b/internal/storage/sqlite/repositories.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 
 	moderncsqlite "modernc.org/sqlite"
 )
@@ -747,6 +748,37 @@ func (s *Store) ListConversationsByRecency(accountID string) ([]Conversation, er
 	conversations, err := collectRows(rows, scanConversation)
 	if err != nil {
 		return nil, fmt.Errorf("list conversations for account %q by recency: %w", accountID, err)
+	}
+	return conversations, nil
+}
+
+// ListConversationsByRecencyAllAccounts merges every account's recency list,
+// orders the result deterministically, and returns at most limit rows.
+func (s *Store) ListConversationsByRecencyAllAccounts(limit int) ([]Conversation, error) {
+	if limit <= 0 {
+		return []Conversation{}, nil
+	}
+	accounts, err := s.ListAccounts()
+	if err != nil {
+		return nil, fmt.Errorf("list conversations across accounts: %w", err)
+	}
+
+	conversations := make([]Conversation, 0)
+	for _, account := range accounts {
+		accountConversations, err := s.ListConversationsByRecency(account.AccountID)
+		if err != nil {
+			return nil, fmt.Errorf("list conversations across accounts: %w", err)
+		}
+		conversations = append(conversations, accountConversations...)
+	}
+	sort.Slice(conversations, func(i, j int) bool {
+		if conversations[i].LastMessageAtMS != conversations[j].LastMessageAtMS {
+			return conversations[i].LastMessageAtMS > conversations[j].LastMessageAtMS
+		}
+		return conversations[i].ConversationID < conversations[j].ConversationID
+	})
+	if len(conversations) > limit {
+		conversations = conversations[:limit]
 	}
 	return conversations, nil
 }

--- a/internal/storage/sqlite/repositories_test.go
+++ b/internal/storage/sqlite/repositories_test.go
@@ -411,6 +411,63 @@ func TestListConversationsByRecencyScopesOrdersAndBreaksTies(t *testing.T) {
 	assertRepositoryEqual(t, "recency ordered conversations", got, want)
 }
 
+func TestListConversationsByRecencyAllAccountsMergesOrdersAndLimits(t *testing.T) {
+	store := openRepositoryTestStore(t)
+	accountA := repositoryTestAccount("account-a")
+	accountA.BridgeKey = "google_messages"
+	accountB := repositoryTestAccount("account-b")
+	accountB.BridgeKey = "whatsmeow"
+	mustRepositoryWrite(t, "UpsertAccount A", store.UpsertAccount(accountA))
+	mustRepositoryWrite(t, "UpsertAccount B", store.UpsertAccount(accountB))
+
+	conversation := func(id, accountID string, recency int64) Conversation {
+		return Conversation{
+			ConversationID:       id,
+			AccountID:            accountID,
+			RemoteConversationID: "remote-" + id,
+			Kind:                 ConversationKindDirect,
+			Title:                id,
+			NotificationMode:     NotificationModeAll,
+			LastMessageAtMS:      recency,
+			MetadataJSON:         `{}`,
+			CreatedAtMS:          repositoryTestTimeMS,
+			UpdatedAtMS:          repositoryTestTimeMS,
+		}
+	}
+	for _, item := range []Conversation{
+		conversation("conversation-old-a", accountA.AccountID, 100),
+		conversation("conversation-new-b", accountB.AccountID, 400),
+		conversation("conversation-tie-b", accountB.AccountID, 300),
+		conversation("conversation-tie-a", accountA.AccountID, 300),
+		conversation("conversation-middle-a", accountA.AccountID, 200),
+	} {
+		mustRepositoryWrite(t, "UpsertConversation", store.UpsertConversation(item))
+	}
+
+	got, err := store.ListConversationsByRecencyAllAccounts(4)
+	mustRepositoryRead(t, "ListConversationsByRecencyAllAccounts", err)
+	wantIDs := []string{
+		"conversation-new-b",
+		"conversation-tie-a",
+		"conversation-tie-b",
+		"conversation-middle-a",
+	}
+	if len(got) != len(wantIDs) {
+		t.Fatalf("cross-account conversations = %d, want %d: %+v", len(got), len(wantIDs), got)
+	}
+	for i, wantID := range wantIDs {
+		if got[i].ConversationID != wantID {
+			t.Fatalf("cross-account conversation %d = %q, want %q", i, got[i].ConversationID, wantID)
+		}
+	}
+
+	empty, err := store.ListConversationsByRecencyAllAccounts(0)
+	mustRepositoryRead(t, "ListConversationsByRecencyAllAccounts zero limit", err)
+	if len(empty) != 0 {
+		t.Fatalf("zero-limit cross-account conversations = %+v, want empty", empty)
+	}
+}
+
 func TestReplaceConversationParticipantsRejectsInvalidBatchesAtomically(t *testing.T) {
 	store := openRepositoryTestStore(t)
 	accountA := repositoryTestAccount("account-a")

--- a/internal/tools/get_conversation.go
+++ b/internal/tools/get_conversation.go
@@ -21,7 +21,8 @@ func getConversationTool() mcp.Tool {
 	)
 }
 
-func getConversationHandler(a *app.App) server.ToolHandlerFunc {
+func getConversationHandler(a *app.App, configured ...Options) server.ToolHandlerFunc {
+	options := resolvedOptions(a, configured)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
 		convID := strArg(args, "conversation_id")
@@ -30,12 +31,14 @@ func getConversationHandler(a *app.App) server.ToolHandlerFunc {
 		}
 		limit := intArg(args, "limit", 50)
 
-		msgs, err := a.Store.GetMessagesByConversation(convID, limit)
+		// In v2-primary the conversation list emits v2 ids, so this "read a
+		// thread" tool must resolve against the same store the ids came from.
+		msgs, err := options.Reads.GetMessagesByConversation(convID, limit)
 		if err != nil {
 			return errorResult(fmt.Sprintf("query failed: %v", err)), nil
 		}
 
-		conv, convErr := a.Store.GetConversation(convID)
+		conv, convErr := options.Reads.GetConversation(convID)
 
 		if len(msgs) == 0 {
 			return structuredResult(map[string]any{

--- a/internal/tools/get_messages.go
+++ b/internal/tools/get_messages.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/db"
 )
 
 func getMessagesTool() mcp.Tool {
@@ -24,7 +25,8 @@ func getMessagesTool() mcp.Tool {
 	)
 }
 
-func getMessagesHandler(a *app.App) server.ToolHandlerFunc {
+func getMessagesHandler(a *app.App, configured ...Options) server.ToolHandlerFunc {
+	options := resolvedOptions(a, configured)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
 		phone := strArg(args, "phone_number")
@@ -46,7 +48,24 @@ func getMessagesHandler(a *app.App) server.ToolHandlerFunc {
 			beforeMS = t.Add(24*time.Hour - time.Millisecond).UnixMilli()
 		}
 
-		msgs, err := a.Store.GetMessages(phone, afterMS, beforeMS, limit)
+		var (
+			msgs []*db.Message
+			err  error
+		)
+		if options.V2Primary {
+			// v2 has no separate unscoped-list query. An empty substring query is
+			// deliberately LIKE '%%', with the same filters and recency ordering.
+			msgs, err = options.Reads.SearchMessagesFiltered("", db.SearchFilter{
+				Phone:   phone,
+				SinceMS: afterMS,
+				UntilMS: beforeMS,
+				Limit:   limit,
+			})
+		} else {
+			// Keep the legacy call exact: unlike filtered search, GetMessages does
+			// not add message_id as a timestamp tie-breaker.
+			msgs, err = a.Store.GetMessages(phone, afterMS, beforeMS, limit)
+		}
 		if err != nil {
 			return errorResult(fmt.Sprintf("query failed: %v", err)), nil
 		}

--- a/internal/tools/get_status.go
+++ b/internal/tools/get_status.go
@@ -13,6 +13,13 @@ import (
 	"github.com/maxghenis/openmessage/internal/whatsapplive"
 )
 
+type platformStatSummary struct {
+	Platform         string `json:"platform"`
+	Count            int    `json:"count"`
+	LatestMS         int64  `json:"latest_ms"`
+	LatestReceivedMS int64  `json:"latest_received_ms"`
+}
+
 var (
 	googleStatus = func(a *app.App) app.GoogleStatusSnapshot {
 		return a.GoogleStatus()
@@ -33,9 +40,26 @@ func getStatusTool() mcp.Tool {
 	)
 }
 
-func getStatusHandler(a *app.App) server.ToolHandlerFunc {
+func getStatusHandler(a *app.App, configured ...Options) server.ToolHandlerFunc {
+	options := resolvedOptions(a, configured)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		var sb strings.Builder
+		var storedPlatforms []platformStatSummary
+		if options.V2Primary {
+			stats, err := options.Reads.PlatformStats()
+			if err != nil {
+				return errorResult(fmt.Sprintf("query serving store status: %v", err)), nil
+			}
+			storedPlatforms = make([]platformStatSummary, 0, len(stats))
+			for _, stat := range stats {
+				storedPlatforms = append(storedPlatforms, platformStatSummary{
+					Platform:         stat.Platform,
+					Count:            stat.Count,
+					LatestMS:         stat.LatestMS,
+					LatestReceivedMS: stat.LatestRecvMS,
+				})
+			}
+		}
 
 		google := googleStatus(a)
 		whatsApp := whatsAppStatus(a)
@@ -87,13 +111,28 @@ func getStatusHandler(a *app.App) server.ToolHandlerFunc {
 			fmt.Fprintf(&sb, "  Last error: %s\n", signal.LastError)
 		}
 
+		if options.V2Primary {
+			sb.WriteString("\nServing store (v2):\n")
+			if len(storedPlatforms) == 0 {
+				sb.WriteString("  No messages stored\n")
+			} else {
+				for _, stat := range storedPlatforms {
+					fmt.Fprintf(&sb, "  %s: %d messages\n", stat.Platform, stat.Count)
+				}
+			}
+		}
+
 		fmt.Fprintf(&sb, "Data dir: %s\n", a.DataDir)
-		return structuredResult(map[string]any{
+		payload := map[string]any{
 			"overall_connected": overallConnected,
 			"google":            google,
 			"whatsapp":          whatsApp,
 			"signal":            signal,
 			"data_dir":          a.DataDir,
-		}, sb.String()), nil
+		}
+		if options.V2Primary {
+			payload["stored_platforms"] = storedPlatforms
+		}
+		return structuredResult(payload, sb.String()), nil
 	}
 }

--- a/internal/tools/list_conversations.go
+++ b/internal/tools/list_conversations.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -23,7 +24,8 @@ func listConversationsTool() mcp.Tool {
 	)
 }
 
-func listConversationsHandler(a *app.App) server.ToolHandlerFunc {
+func listConversationsHandler(a *app.App, configured ...Options) server.ToolHandlerFunc {
+	options := resolvedOptions(a, configured)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
 		limit := intArg(args, "limit", 20)
@@ -31,10 +33,30 @@ func listConversationsHandler(a *app.App) server.ToolHandlerFunc {
 
 		var convs []*db.Conversation
 		var err error
-		if platform != "" {
+		if !options.V2Primary && platform != "" {
 			convs, err = a.Store.ListConversationsByPlatform(platform, limit)
-		} else {
+		} else if !options.V2Primary {
 			convs, err = a.Store.ListConversations(limit)
+		} else if platform == "" {
+			convs, err = options.Reads.ListConversations(limit)
+		} else if limit <= 0 {
+			convs = []*db.Conversation{}
+		} else {
+			// ReadSource intentionally mirrors only the canonical legacy methods;
+			// filter the v2 cross-account recency result here rather than widening
+			// the cutover seam with a platform-specific convenience query.
+			var candidates []*db.Conversation
+			candidates, err = options.Reads.ListConversations(math.MaxInt)
+			if err == nil {
+				for _, conversation := range candidates {
+					if conversation != nil && normalizedPlatform(conversation.SourcePlatform) == normalizedPlatform(platform) {
+						convs = append(convs, conversation)
+						if len(convs) >= limit {
+							break
+						}
+					}
+				}
+			}
 		}
 		if err != nil {
 			return errorResult(fmt.Sprintf("query failed: %v", err)), nil

--- a/internal/tools/r5_routing_test.go
+++ b/internal/tools/r5_routing_test.go
@@ -1,0 +1,313 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/readsource"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+type toolRoutingReadSource struct {
+	readsource.ReadSource
+	listCalls    int
+	searchCalls  int
+	statusCalls  int
+	getConvCalls int
+	lastQuery   string
+	lastFilter  db.SearchFilter
+}
+
+func (s *toolRoutingReadSource) ListConversations(limit int) ([]*db.Conversation, error) {
+	s.listCalls++
+	return []*db.Conversation{{
+		ConversationID: "v2-conversation",
+		Name:           "V2 Conversation",
+		SourcePlatform: "sms",
+		LastMessageTS:  200,
+	}}, nil
+}
+
+func (s *toolRoutingReadSource) SearchMessagesFiltered(query string, filter db.SearchFilter) ([]*db.Message, error) {
+	s.searchCalls++
+	s.lastQuery = query
+	s.lastFilter = filter
+	return []*db.Message{{
+		MessageID:      "v2-message",
+		ConversationID: "v2-conversation",
+		SenderName:     "V2 Alice",
+		Body:           "v2 routed body",
+		TimestampMS:    200,
+		SourcePlatform: "sms",
+	}}, nil
+}
+
+func (s *toolRoutingReadSource) PlatformStats() ([]db.PlatformStat, error) {
+	s.statusCalls++
+	return []db.PlatformStat{{Platform: "sms", Count: 7, LatestMS: 200, LatestRecvMS: 100}}, nil
+}
+
+func (s *toolRoutingReadSource) GetMessagesByConversation(conversationID string, limit int) ([]*db.Message, error) {
+	s.getConvCalls++
+	return []*db.Message{{
+		MessageID:      "v2-thread-message",
+		ConversationID: conversationID,
+		SenderName:     "V2 Thread Sender",
+		Body:           "v2 thread body",
+		TimestampMS:    200,
+		SourcePlatform: "sms",
+	}}, nil
+}
+
+func (s *toolRoutingReadSource) GetConversation(id string) (*db.Conversation, error) {
+	return &db.Conversation{ConversationID: id, Name: "V2 Thread", SourcePlatform: "sms"}, nil
+}
+
+func TestR5MCPReadHandlersUseConfiguredSource(t *testing.T) {
+	a := testApp(t)
+	reads := &toolRoutingReadSource{}
+	options := Options{Reads: reads, V2Primary: true}
+
+	t.Run("list conversations", func(t *testing.T) {
+		result, err := listConversationsHandler(a, options)(context.Background(), toolRequest(nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.IsError || !strings.Contains(resultText(t, result), "V2 Conversation") {
+			t.Fatalf("unexpected result: %#v", result)
+		}
+		if reads.listCalls != 1 {
+			t.Fatalf("ListConversations calls = %d, want 1", reads.listCalls)
+		}
+	})
+
+	t.Run("get messages", func(t *testing.T) {
+		result, err := getMessagesHandler(a, options)(context.Background(), toolRequest(map[string]any{
+			"phone_number": "+15551230000",
+			"after":        "1970-01-01",
+			"limit":        float64(12),
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.IsError || !strings.Contains(resultText(t, result), "v2 routed body") {
+			t.Fatalf("unexpected result: %#v", result)
+		}
+		if reads.lastQuery != "" || reads.lastFilter.Phone != "+15551230000" || reads.lastFilter.Limit != 12 {
+			t.Fatalf("get_messages filter = %#v, query=%q", reads.lastFilter, reads.lastQuery)
+		}
+	})
+
+	t.Run("search messages", func(t *testing.T) {
+		result, err := searchMessagesHandler(a, options)(context.Background(), toolRequest(map[string]any{
+			"query":        "routed",
+			"phone_number": "+15551230000",
+			"limit":        float64(9),
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.IsError || !strings.Contains(resultText(t, result), "v2 routed body") {
+			t.Fatalf("unexpected result: %#v", result)
+		}
+		if reads.lastQuery != "routed" || reads.lastFilter.Phone != "+15551230000" || reads.lastFilter.Limit != 9 {
+			t.Fatalf("search_messages filter = %#v, query=%q", reads.lastFilter, reads.lastQuery)
+		}
+	})
+}
+
+func TestR5LegacyGetMessagesKeepsExactStoreQueryAndFormatting(t *testing.T) {
+	a := testApp(t)
+	for _, message := range []*db.Message{
+		{MessageID: "same-time-a", ConversationID: "legacy", SenderName: "Alice", Body: "first", TimestampMS: 1234},
+		{MessageID: "same-time-b", ConversationID: "legacy", SenderName: "Bob", Body: "second", TimestampMS: 1234},
+	} {
+		if err := a.Store.UpsertMessage(message); err != nil {
+			t.Fatal(err)
+		}
+	}
+	reads := &toolRoutingReadSource{}
+	result, err := getMessagesHandler(a, Options{Reads: reads})(context.Background(), toolRequest(map[string]any{
+		"limit": float64(20),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reads.searchCalls != 0 {
+		t.Fatalf("legacy get_messages used the replacement search path %d times", reads.searchCalls)
+	}
+	wantMessages, err := a.Store.GetMessages("", 0, 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var want strings.Builder
+	want.WriteString(messagePreamble)
+	for _, message := range wantMessages {
+		want.WriteString(formatMessageLine(message))
+		want.WriteByte('\n')
+	}
+	if got := resultText(t, result); got != want.String() {
+		t.Fatalf("legacy result changed\n got: %q\nwant: %q", got, want.String())
+	}
+}
+
+func TestR5MCPGetStatusReadsV2CoverageWithoutChangingLegacyShape(t *testing.T) {
+	a := testApp(t)
+	reads := &toolRoutingReadSource{}
+
+	legacy, err := getStatusHandler(a, Options{Reads: reads})(context.Background(), toolRequest(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyPayload := structuredMap(t, legacy)
+	if _, exists := legacyPayload["stored_platforms"]; exists {
+		t.Fatalf("legacy result gained v2-only field: %#v", legacyPayload)
+	}
+	if reads.statusCalls != 0 {
+		t.Fatalf("legacy get_status called configured source %d times", reads.statusCalls)
+	}
+
+	v2, err := getStatusHandler(a, Options{Reads: reads, V2Primary: true})(context.Background(), toolRequest(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v2.IsError {
+		t.Fatalf("unexpected v2 tool error: %#v", v2)
+	}
+	payload := structuredMap(t, v2)
+	stats, ok := payload["stored_platforms"].([]platformStatSummary)
+	if !ok || len(stats) != 1 || stats[0].Platform != "sms" || stats[0].Count != 7 {
+		t.Fatalf("stored_platforms = %#v", payload["stored_platforms"])
+	}
+	if reads.statusCalls != 1 {
+		t.Fatalf("v2 get_status calls = %d, want 1", reads.statusCalls)
+	}
+}
+
+func TestR5MCPPersonStoryAndVizToolsUnavailableInV2Primary(t *testing.T) {
+	a := testApp(t)
+	mcpServer := server.NewMCPServer("r5-routing", "test")
+	RegisterWithOptions(mcpServer, a, Options{Reads: a.Store, V2Primary: true})
+
+	for _, name := range []string{
+		"get_person_messages",
+		"get_person_messages_range",
+		"conversation_stats",
+		"generate_story",
+		"person_stats",
+		"generate_person_story",
+		"generate_viz",
+		"render_story",
+	} {
+		t.Run(name, func(t *testing.T) {
+			registered := mcpServer.GetTool(name)
+			if registered == nil {
+				t.Fatalf("tool %q was not registered", name)
+			}
+			result, err := registered.Handler(context.Background(), toolRequest(nil))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.IsError {
+				t.Fatalf("tool %q did not return an MCP error", name)
+			}
+			if got := resultText(t, result); got != "not available while v2 is the serving store" {
+				t.Fatalf("tool %q error = %q", name, got)
+			}
+		})
+	}
+}
+
+func TestR5MCPV2PrimarySubmitUsesNativeConversationID(t *testing.T) {
+	harness := newV2ToolHarness(t)
+	harness.deps.V2Primary = true
+	nowMS := time.Now().UnixMilli()
+	if err := harness.deps.V2Store.UpsertAccount(sqlite.Account{
+		AccountID:   "google-primary",
+		BridgeKey:   "google_messages",
+		DisplayName: "Google",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  "{}",
+		CreatedAtMS: nowMS,
+		UpdatedAtMS: nowMS,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	const conversationID = "v2-native-tool-conversation"
+	if err := harness.deps.V2Store.UpsertConversation(sqlite.Conversation{
+		ConversationID:       conversationID,
+		AccountID:            "google-primary",
+		RemoteConversationID: "remote-v2-native-tool-conversation",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Native tool thread",
+		NotificationMode:     sqlite.NotificationModeAll,
+		MetadataJSON:         "{}",
+		CreatedAtMS:          nowMS,
+		UpdatedAtMS:          nowMS,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := sendToConversationHandler(harness.app, &harness.deps)(context.Background(), toolRequest(map[string]any{
+		"conversation_id": conversationID,
+		"message":         "native tool route",
+		"idempotency_key": "native-tool-route-key",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("native tool route returned error: %#v", result)
+	}
+	if conversation, _ := harness.app.Store.GetConversation(conversationID); conversation != nil {
+		t.Fatalf("native tool route unexpectedly created legacy conversation: %+v", conversation)
+	}
+}
+
+func toolRequest(arguments map[string]any) mcp.CallToolRequest {
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = arguments
+	return req
+}
+
+func resultText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatal("tool result has no content")
+	}
+	content, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("tool content = %T, want text", result.Content[0])
+	}
+	return content.Text
+}
+
+func TestR5GetConversationRoutesToConfiguredSource(t *testing.T) {
+	a := testApp(t)
+	reads := &toolRoutingReadSource{}
+	// v2-primary emits v2 conversation ids; get_conversation must resolve them
+	// against the same store, not the legacy store (which lacks that id).
+	result, err := getConversationHandler(a, Options{Reads: reads, V2Primary: true})(
+		context.Background(),
+		toolRequest(map[string]any{"conversation_id": "v2-conversation"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("get_conversation errored: %#v", result)
+	}
+	if reads.getConvCalls != 1 {
+		t.Fatalf("GetMessagesByConversation via configured source = %d, want 1", reads.getConvCalls)
+	}
+	if text := resultText(t, result); !strings.Contains(text, "v2 thread body") {
+		t.Fatalf("result did not come from the configured v2 source: %q", text)
+	}
+}

--- a/internal/tools/search_messages.go
+++ b/internal/tools/search_messages.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/db"
 )
 
 func searchMessagesTool() mcp.Tool {
@@ -23,7 +24,8 @@ func searchMessagesTool() mcp.Tool {
 	)
 }
 
-func searchMessagesHandler(a *app.App) server.ToolHandlerFunc {
+func searchMessagesHandler(a *app.App, configured ...Options) server.ToolHandlerFunc {
+	options := resolvedOptions(a, configured)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
 		query := strArg(args, "query")
@@ -33,7 +35,15 @@ func searchMessagesHandler(a *app.App) server.ToolHandlerFunc {
 		phone := strArg(args, "phone_number")
 		limit := intArg(args, "limit", 20)
 
-		msgs, err := a.Store.SearchMessages(query, phone, limit)
+		var (
+			msgs []*db.Message
+			err  error
+		)
+		if options.V2Primary {
+			msgs, err = options.Reads.SearchMessagesFiltered(query, db.SearchFilter{Phone: phone, Limit: limit})
+		} else {
+			msgs, err = a.Store.SearchMessages(query, phone, limit)
+		}
 		if err != nil {
 			return errorResult(fmt.Sprintf("search failed: %v", err)), nil
 		}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -10,13 +11,47 @@ import (
 
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/readsource"
 )
 
+// Options selects the canonical read source and optional durable-send seam.
+// Zero-value options preserve the legacy-primary behavior.
+type Options struct {
+	Reads     readsource.ReadSource
+	V2Primary bool
+	V2        *V2Dependencies
+}
+
 func Register(s *server.MCPServer, a *app.App, v2 ...*V2Dependencies) {
-	configuredV2 := activeV2(v2)
-	s.AddTool(getMessagesTool(), getMessagesHandler(a))
-	s.AddTool(getConversationTool(), getConversationHandler(a))
-	s.AddTool(searchMessagesTool(), searchMessagesHandler(a))
+	var configuredV2 *V2Dependencies
+	if len(v2) > 0 {
+		configuredV2 = v2[0]
+	}
+	RegisterWithOptions(s, a, Options{Reads: a.Store, V2: configuredV2})
+}
+
+// RegisterWithOptions registers the MCP surface against an explicit serving
+// store. Register remains as the compatibility entry point for legacy callers.
+func RegisterWithOptions(s *server.MCPServer, a *app.App, options Options) {
+	if options.Reads == nil {
+		options.Reads = a.Store
+	}
+	configuredV2 := activeV2([]*V2Dependencies{options.V2})
+	v2Primary := options.V2Primary
+	if configuredV2 != nil && configuredV2.V2Primary {
+		v2Primary = true
+	}
+	if configuredV2 != nil && v2Primary != configuredV2.V2Primary {
+		configuredCopy := *configuredV2
+		configuredCopy.V2Primary = v2Primary
+		configuredV2 = &configuredCopy
+	}
+	options.V2Primary = v2Primary
+	options.V2 = configuredV2
+
+	s.AddTool(getMessagesTool(), getMessagesHandler(a, options))
+	s.AddTool(getConversationTool(), getConversationHandler(a, options))
+	s.AddTool(searchMessagesTool(), searchMessagesHandler(a, options))
 	if configuredV2 == nil {
 		s.AddTool(sendMessageTool(), sendMessageHandler(a))
 		s.AddTool(sendToConversationTool(), sendToConversationHandler(a))
@@ -28,26 +63,48 @@ func Register(s *server.MCPServer, a *app.App, v2 ...*V2Dependencies) {
 	}
 	s.AddTool(reactToMessageTool(), reactToMessageHandler(a))
 	s.AddTool(setMessageTranscriptTool(), setMessageTranscriptHandler(a))
-	s.AddTool(listConversationsTool(), listConversationsHandler(a))
+	s.AddTool(listConversationsTool(), listConversationsHandler(a, options))
 	s.AddTool(listContactsTool(), listContactsHandler(a))
 	s.AddTool(resolveContactRoutesTool(), resolveContactRoutesHandler(a))
-	s.AddTool(getStatusTool(), getStatusHandler(a))
+	s.AddTool(getStatusTool(), getStatusHandler(a, options))
 	s.AddTool(draftMessageTool(), draftMessageHandler(a))
 	s.AddTool(downloadMediaTool(), downloadMediaHandler(a))
 	s.AddTool(importMessagesTool(), importMessagesHandler(a))
-	s.AddTool(getPersonMessagesTool(), getPersonMessagesHandler(a))
-	s.AddTool(conversationStatsTool(), conversationStatsHandler(a))
-	s.AddTool(generateStoryTool(), generateStoryHandler(a))
-	s.AddTool(personStatsTool(), personStatsHandler(a))
-	s.AddTool(generatePersonStoryTool(), generatePersonStoryHandler(a))
-	s.AddTool(generateVizTool(), generateVizHandler(a))
-	s.AddTool(getPersonMessagesRangeTool(), getPersonMessagesRangeHandler(a))
-	s.AddTool(renderStoryTool(), renderStoryHandler(a))
+	s.AddTool(getPersonMessagesTool(), unavailableInV2Primary(v2Primary, getPersonMessagesHandler(a)))
+	s.AddTool(conversationStatsTool(), unavailableInV2Primary(v2Primary, conversationStatsHandler(a)))
+	s.AddTool(generateStoryTool(), unavailableInV2Primary(v2Primary, generateStoryHandler(a)))
+	s.AddTool(personStatsTool(), unavailableInV2Primary(v2Primary, personStatsHandler(a)))
+	s.AddTool(generatePersonStoryTool(), unavailableInV2Primary(v2Primary, generatePersonStoryHandler(a)))
+	s.AddTool(generateVizTool(), unavailableInV2Primary(v2Primary, generateVizHandler(a)))
+	s.AddTool(getPersonMessagesRangeTool(), unavailableInV2Primary(v2Primary, getPersonMessagesRangeHandler(a)))
+	s.AddTool(renderStoryTool(), unavailableInV2Primary(v2Primary, renderStoryHandler(a)))
 	if configuredV2 == nil {
 		s.AddTool(sendGroupMessageTool(), sendGroupMessageHandler(a))
 	} else {
 		s.AddTool(sendGroupMessageTool(true), sendGroupMessageHandler(a, configuredV2))
 	}
+}
+
+const unavailableWhileV2Serving = "not available while v2 is the serving store"
+
+func unavailableInV2Primary(primary bool, legacy server.ToolHandlerFunc) server.ToolHandlerFunc {
+	if !primary {
+		return legacy
+	}
+	return func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return errorResult(unavailableWhileV2Serving), nil
+	}
+}
+
+func resolvedOptions(a *app.App, configured []Options) Options {
+	options := Options{Reads: a.Store}
+	if len(configured) > 0 {
+		options = configured[0]
+		if options.Reads == nil {
+			options.Reads = a.Store
+		}
+	}
+	return options
 }
 
 func strArg(args map[string]any, key string) string {

--- a/internal/tools/v2.go
+++ b/internal/tools/v2.go
@@ -21,10 +21,11 @@ import (
 // tools. A nil/disabled value leaves their legacy descriptors and handlers
 // untouched.
 type V2Dependencies struct {
-	Enabled  bool
-	Service  *messaging.MessageService
-	V2Store  *sqlite.Store
-	Registry bridge.Registry
+	Enabled   bool
+	V2Primary bool
+	Service   *messaging.MessageService
+	V2Store   *sqlite.Store
+	Registry  bridge.Registry
 }
 
 const v2DeliveryDescription = " With v2 sending enabled, this waits for a settled delivery result. Every result includes outbox_id and idempotency_key. If settled is false (the wait was interrupted or the app is retrying automatically), the message is still durably queued and the app finishes sending it in the background: never send it again in response. An uncertain result means the transport may have accepted the message; do not retry automatically. Send again only as a deliberate new intent, reusing the returned idempotency_key when repeating the exact same send after a lost response."
@@ -51,11 +52,22 @@ func (v *V2Dependencies) submitDeps(a *app.App) v2wire.Deps {
 	}
 }
 
+func (v *V2Dependencies) nativeDeps() v2wire.NativeDeps {
+	return v2wire.NativeDeps{
+		V2:       v.V2Store,
+		Service:  v.Service,
+		Registry: v.Registry,
+	}
+}
+
 func (v *V2Dependencies) submitText(
 	ctx context.Context,
 	a *app.App,
 	input v2wire.TextInput,
 ) (messaging.Submission, error) {
+	if v.V2Primary {
+		return v2wire.SubmitTextV2(ctx, v.nativeDeps(), input)
+	}
 	return v2wire.SubmitText(ctx, v.submitDeps(a), input)
 }
 
@@ -64,6 +76,9 @@ func (v *V2Dependencies) submitMedia(
 	a *app.App,
 	input v2wire.MediaInput,
 ) (messaging.Submission, error) {
+	if v.V2Primary {
+		return v2wire.SubmitMediaV2(ctx, v.nativeDeps(), input)
+	}
 	return v2wire.SubmitMedia(ctx, v.submitDeps(a), input)
 }
 

--- a/internal/v2read/conversations.go
+++ b/internal/v2read/conversations.go
@@ -1,0 +1,53 @@
+package v2read
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+// ListConversations returns v2 conversations in cross-account recency order.
+func (s *Source) ListConversations(limit int) ([]*db.Conversation, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	conversations, err := s.store.ListConversationsByRecencyAllAccounts(limit)
+	if err != nil {
+		return nil, err
+	}
+	accounts, err := s.accountIndex()
+	if err != nil {
+		return nil, fmt.Errorf("list conversations: %w", err)
+	}
+	mapped := make([]*db.Conversation, 0, len(conversations))
+	for _, conversation := range conversations {
+		dto, err := s.mapConversation(conversation, accounts)
+		if err != nil {
+			return nil, err
+		}
+		mapped = append(mapped, dto)
+	}
+	return mapped, nil
+}
+
+// GetConversation returns one v2 conversation as the canonical legacy DTO.
+func (s *Source) GetConversation(id string) (*db.Conversation, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	conversation, err := s.store.GetConversation(id)
+	if errors.Is(err, sqlite.ErrNotFound) {
+		return nil, sql.ErrNoRows
+	}
+	if err != nil {
+		return nil, err
+	}
+	accounts, err := s.accountIndex()
+	if err != nil {
+		return nil, fmt.Errorf("get conversation %q: %w", id, err)
+	}
+	return s.mapConversation(conversation, accounts)
+}

--- a/internal/v2read/map.go
+++ b/internal/v2read/map.go
@@ -1,0 +1,193 @@
+package v2read
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+type participantDTO struct {
+	Name   string `json:"name"`
+	Number string `json:"number"`
+}
+
+func platformForBridgeKey(bridgeKey string) string {
+	bridgeKey = strings.TrimSpace(bridgeKey)
+	switch bridgeKey {
+	case "google_messages":
+		return "sms"
+	case "whatsmeow":
+		return "whatsapp"
+	case "signal_cli":
+		return "signal"
+	case "gchat", "imessage":
+		return bridgeKey
+	default:
+		return bridgeKey
+	}
+}
+
+func (s *Source) accountIndex() (map[string]sqlite.Account, error) {
+	accounts, err := s.store.ListAccounts()
+	if err != nil {
+		return nil, err
+	}
+	index := make(map[string]sqlite.Account, len(accounts))
+	for _, account := range accounts {
+		index[account.AccountID] = account
+	}
+	return index, nil
+}
+
+func (s *Source) mapConversation(
+	conversation sqlite.Conversation,
+	accounts map[string]sqlite.Account,
+) (*db.Conversation, error) {
+	account, ok := accounts[conversation.AccountID]
+	if !ok {
+		return nil, fmt.Errorf(
+			"map conversation %q: account %q is missing",
+			conversation.ConversationID,
+			conversation.AccountID,
+		)
+	}
+	participants, err := s.participantsJSON(conversation.ConversationID)
+	if err != nil {
+		return nil, err
+	}
+	return &db.Conversation{
+		ConversationID:   conversation.ConversationID,
+		Name:             conversation.Title,
+		IsGroup:          conversation.Kind == sqlite.ConversationKindGroup,
+		Participants:     participants,
+		LastMessageTS:    conversation.LastMessageAtMS,
+		UnreadCount:      0,
+		SourcePlatform:   platformForBridgeKey(account.BridgeKey),
+		IsFavorite:       conversation.IsFavorite,
+		NotificationMode: string(conversation.NotificationMode),
+	}, nil
+}
+
+func (s *Source) participantsJSON(conversationID string) (string, error) {
+	participants, err := s.store.ListParticipants(conversationID)
+	if err != nil {
+		return "", fmt.Errorf("map conversation %q participants: %w", conversationID, err)
+	}
+	dtos := make([]participantDTO, 0, len(participants))
+	for _, participant := range participants {
+		identity, err := s.store.GetIdentity(participant.IdentityID)
+		if err != nil {
+			return "", fmt.Errorf(
+				"map conversation %q participant %q: %w",
+				conversationID,
+				participant.IdentityID,
+				err,
+			)
+		}
+		name := strings.TrimSpace(participant.DisplayName)
+		if name == "" {
+			name = identity.DisplayName
+		}
+		dtos = append(dtos, participantDTO{
+			Name:   name,
+			Number: identity.CanonicalValue,
+		})
+	}
+	encoded, err := json.Marshal(dtos)
+	if err != nil {
+		return "", fmt.Errorf("map conversation %q participants: %w", conversationID, err)
+	}
+	return string(encoded), nil
+}
+
+func (s *Source) mapMessages(
+	messages []sqlite.Message,
+) ([]*db.Message, error) {
+	accounts, err := s.accountIndex()
+	if err != nil {
+		return nil, fmt.Errorf("map messages: %w", err)
+	}
+	mapped := make([]*db.Message, 0, len(messages))
+	for _, message := range messages {
+		dto, err := s.mapMessage(message, accounts)
+		if err != nil {
+			return nil, err
+		}
+		mapped = append(mapped, dto)
+	}
+	return mapped, nil
+}
+
+func (s *Source) mapMessage(
+	message sqlite.Message,
+	accounts map[string]sqlite.Account,
+) (*db.Message, error) {
+	account, ok := accounts[message.AccountID]
+	if !ok {
+		return nil, fmt.Errorf(
+			"map message %q: account %q is missing",
+			message.MessageID,
+			message.AccountID,
+		)
+	}
+	dto := &db.Message{
+		MessageID:      message.MessageID,
+		ConversationID: message.ConversationID,
+		Body:           message.Body,
+		TimestampMS:    message.OccurredAtMS,
+		IsFromMe:       message.Direction == sqlite.MessageDirectionOutgoing,
+		SourcePlatform: platformForBridgeKey(account.BridgeKey),
+		SourceID:       message.RemoteMessageID,
+	}
+	if message.SenderIdentityID != nil {
+		identity, err := s.store.GetIdentity(*message.SenderIdentityID)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"map message %q sender %q: %w",
+				message.MessageID,
+				*message.SenderIdentityID,
+				err,
+			)
+		}
+		dto.SenderNumber = identity.CanonicalValue
+		dto.SenderName = identity.DisplayName
+	}
+	if message.ReplyToRemoteID != nil {
+		dto.ReplyToID = *message.ReplyToRemoteID
+	}
+	attachment, ok, err := s.messageAttachment(context.Background(), message.MessageID)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		dto.MediaID = fmt.Sprintf("v2msg:%s:%d", message.MessageID, attachment.Ordinal)
+		dto.MimeType = attachment.MIME
+	}
+	return dto, nil
+}
+
+func (s *Source) messageAttachment(
+	ctx context.Context,
+	messageID string,
+) (sqlite.MessageAttachment, bool, error) {
+	// R2 historical migration and every current decoder number attachments from
+	// zero, so ordinal zero is the canonical legacy MediaID representative.
+	attachment, err := s.attachments.GetForDownload(ctx, messageID, 0)
+	if errors.Is(err, sql.ErrNoRows) {
+		return sqlite.MessageAttachment{}, false, nil
+	}
+	if err != nil {
+		return sqlite.MessageAttachment{}, false, fmt.Errorf(
+			"map message %q attachment: %w",
+			messageID,
+			err,
+		)
+	}
+	return attachment, true, nil
+}

--- a/internal/v2read/messages.go
+++ b/internal/v2read/messages.go
@@ -1,0 +1,118 @@
+package v2read
+
+import (
+	"context"
+	"errors"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+// GetMessagesByConversation returns the latest v2 messages newest-first.
+func (s *Source) GetMessagesByConversation(
+	conversationID string,
+	limit int,
+) ([]*db.Message, error) {
+	return s.getMessagesBefore(conversationID, 0, "", limit)
+}
+
+// GetMessagesByConversationBefore returns a newest-first cursor page.
+func (s *Source) GetMessagesByConversationBefore(
+	conversationID string,
+	beforeMS int64,
+	beforeID string,
+	limit int,
+) ([]*db.Message, error) {
+	return s.getMessagesBefore(conversationID, beforeMS, beforeID, limit)
+}
+
+func (s *Source) getMessagesBefore(
+	conversationID string,
+	beforeMS int64,
+	beforeID string,
+	limit int,
+) ([]*db.Message, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	messages, err := s.messages.ListMessagesByConversation(
+		context.Background(), conversationID, beforeMS, beforeID, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return s.mapMessages(messages)
+}
+
+// GetMessagesByConversationAfter returns an oldest-first cursor page.
+func (s *Source) GetMessagesByConversationAfter(
+	conversationID string,
+	afterMS int64,
+	afterID string,
+	limit int,
+) ([]*db.Message, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	messages, err := s.messages.ListMessagesByConversationAfter(
+		context.Background(), conversationID, afterMS, afterID, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return s.mapMessages(messages)
+}
+
+// GetMessagesAroundMessage returns a chronological window including anchor.
+func (s *Source) GetMessagesAroundMessage(
+	conversationID string,
+	messageID string,
+	before int,
+	after int,
+) ([]*db.Message, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	messages, err := s.messages.ListMessagesAroundMessage(
+		context.Background(), conversationID, messageID, before, after,
+	)
+	if errors.Is(err, sqlite.ErrNotFound) {
+		return nil, db.ErrMessageNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return s.mapMessages(messages)
+}
+
+func (s *Source) walkConversationMessages(
+	conversationID string,
+	visit func(sqlite.Message),
+) error {
+	var beforeMS int64
+	var beforeID string
+	for {
+		page, err := s.messages.ListMessagesByConversation(
+			context.Background(),
+			conversationID,
+			beforeMS,
+			beforeID,
+			sourceMessagePageSize,
+		)
+		if err != nil {
+			return err
+		}
+		for _, message := range page {
+			visit(message)
+		}
+		if len(page) < sourceMessagePageSize {
+			return nil
+		}
+		last := page[len(page)-1]
+		if last.OccurredAtMS == beforeMS && last.MessageID == beforeID {
+			return errors.New("v2 read message pagination did not advance")
+		}
+		beforeMS = last.OccurredAtMS
+		beforeID = last.MessageID
+	}
+}

--- a/internal/v2read/search.go
+++ b/internal/v2read/search.go
@@ -1,0 +1,31 @@
+package v2read
+
+import (
+	"context"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+// SearchMessagesFiltered performs a bounded LIKE substring scan. R5 preserves
+// substring matching and deterministic recency order; FTS relevance ranking is
+// explicitly deferred to S8.
+func (s *Source) SearchMessagesFiltered(
+	query string,
+	filter db.SearchFilter,
+) ([]*db.Message, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	messages, err := s.messages.SearchMessages(context.Background(), query, sqlite.SearchQuery{
+		ConversationID:       filter.ConversationID,
+		SenderCanonicalValue: filter.Phone,
+		SinceMS:              filter.SinceMS,
+		UntilMS:              filter.UntilMS,
+		Limit:                filter.Limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s.mapMessages(messages)
+}

--- a/internal/v2read/source.go
+++ b/internal/v2read/source.go
@@ -1,0 +1,42 @@
+// Package v2read adapts the clean-slate SQLite store to the canonical legacy
+// read DTOs. Search is deliberately LIKE-based in R5; FTS/ranking is deferred.
+package v2read
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/readsource"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+const sourceMessagePageSize = 200
+
+// Source reads canonical conversation/message DTOs from a v2 store.
+type Source struct {
+	store       *sqlite.Store
+	messages    *sqlite.MessageRepository
+	attachments *sqlite.MessageAttachmentRepository
+}
+
+// New constructs a v2 canonical read source. A nil store is retained as an
+// invalid source so callers receive method errors rather than a constructor
+// panic; production wiring always passes an opened store.
+func New(store *sqlite.Store) *Source {
+	source := &Source{store: store}
+	if store == nil {
+		return source
+	}
+	source.messages, _ = sqlite.NewMessageRepository(store, time.Now)
+	source.attachments, _ = sqlite.NewMessageAttachmentRepository(store, time.Now)
+	return source
+}
+
+func (s *Source) ready() error {
+	if s == nil || s.store == nil || s.messages == nil || s.attachments == nil {
+		return fmt.Errorf("v2 read source: store is nil")
+	}
+	return nil
+}
+
+var _ readsource.ReadSource = (*Source)(nil)

--- a/internal/v2read/source_test.go
+++ b/internal/v2read/source_test.go
@@ -1,0 +1,586 @@
+package v2read
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/readsource"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+const sourceTestTimeMS int64 = 2_000_000_000_000
+
+var _ readsource.ReadSource = (*Source)(nil)
+
+func TestSourceMapsConversationAndMessagesToLegacyDTOs(t *testing.T) {
+	store, messages, source := openSourceTestStore(t)
+	seedSourceAccount(t, store, "google-account", "google_messages")
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conversation-google",
+		AccountID:            "google-account",
+		RemoteConversationID: "remote-google",
+		Kind:                 sqlite.ConversationKindGroup,
+		Title:                "Byte-exact group",
+		NotificationMode:     sqlite.NotificationModeMuted,
+		IsFavorite:           true,
+		LastMessageAtMS:      300,
+	})
+	identity := sqlite.Identity{
+		IdentityID:     "identity-alice",
+		AccountID:      "google-account",
+		Kind:           sqlite.IdentityKind("e164"),
+		CanonicalValue: "+15550000001",
+		RawValue:       "+1 (555) 000-0001",
+		DisplayName:    "Alice",
+		MetadataJSON:   `{}`,
+		CreatedAtMS:    sourceTestTimeMS,
+		UpdatedAtMS:    sourceTestTimeMS,
+	}
+	if err := store.UpsertIdentity(identity); err != nil {
+		t.Fatalf("UpsertIdentity(): %v", err)
+	}
+	if err := store.ReplaceConversationParticipants(
+		"conversation-google",
+		[]sqlite.ConversationParticipant{{
+			AccountID:      "google-account",
+			ConversationID: "conversation-google",
+			IdentityID:     identity.IdentityID,
+			Role:           sqlite.ParticipantRoleMember,
+			DisplayName:    "Alice in group",
+			IsActive:       true,
+		}},
+	); err != nil {
+		t.Fatalf("ReplaceConversationParticipants(): %v", err)
+	}
+
+	replyRemoteID := "remote-parent"
+	incoming := sqlite.Message{
+		MessageID:        "message-incoming",
+		ConversationID:   "conversation-google",
+		AccountID:        "google-account",
+		RemoteMessageID:  "remote-incoming",
+		SenderIdentityID: stringPointer(identity.IdentityID),
+		Direction:        sqlite.MessageDirectionIncoming,
+		Body:             "body\x00kept byte-for-byte",
+		ReplyToRemoteID:  &replyRemoteID,
+		State:            sqlite.MessageStateEdited,
+		OccurredAtMS:     200,
+	}
+	size := int64(123)
+	importSourceMessage(t, messages, incoming, sqlite.MessageAttachment{
+		Ordinal:   0,
+		RemoteID:  "remote-media",
+		RemoteRef: []byte("opaque"),
+		Filename:  "photo.png",
+		MIME:      "image/png",
+		SizeBytes: &size,
+	})
+	outgoing := sqlite.Message{
+		MessageID:       "message-outgoing",
+		ConversationID:  "conversation-google",
+		AccountID:       "google-account",
+		RemoteMessageID: "remote-outgoing",
+		Direction:       sqlite.MessageDirectionOutgoing,
+		Body:            "sent by me",
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    300,
+	}
+	importSourceMessage(t, messages, outgoing)
+
+	conversation, err := source.GetConversation("conversation-google")
+	if err != nil {
+		t.Fatalf("GetConversation(): %v", err)
+	}
+	if conversation.ConversationID != "conversation-google" ||
+		conversation.Name != "Byte-exact group" ||
+		!conversation.IsGroup ||
+		conversation.LastMessageTS != 300 ||
+		conversation.SourcePlatform != "sms" ||
+		!conversation.IsFavorite ||
+		conversation.NotificationMode != "muted" ||
+		conversation.UnreadCount != 0 ||
+		conversation.Tab != "" {
+		t.Fatalf("mapped conversation = %+v", conversation)
+	}
+	if _, err := source.GetConversation("missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetConversation(missing) error = %v, want sql.ErrNoRows", err)
+	}
+	var participants []struct {
+		Name   string `json:"name"`
+		Number string `json:"number"`
+	}
+	if err := json.Unmarshal([]byte(conversation.Participants), &participants); err != nil {
+		t.Fatalf("decode Participants %q: %v", conversation.Participants, err)
+	}
+	if got, want := participants, []struct {
+		Name   string `json:"name"`
+		Number string `json:"number"`
+	}{{Name: "Alice in group", Number: "+15550000001"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("participants = %+v, want %+v", got, want)
+	}
+
+	gotMessages, err := source.GetMessagesByConversation("conversation-google", 10)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversation(): %v", err)
+	}
+	if len(gotMessages) != 2 {
+		t.Fatalf("mapped messages = %d, want 2: %+v", len(gotMessages), gotMessages)
+	}
+	gotOutgoing := gotMessages[0]
+	if gotOutgoing.MessageID != outgoing.MessageID ||
+		!gotOutgoing.IsFromMe ||
+		gotOutgoing.SenderName != "" ||
+		gotOutgoing.SenderNumber != "" ||
+		gotOutgoing.SourcePlatform != "sms" ||
+		gotOutgoing.SourceID != outgoing.RemoteMessageID {
+		t.Fatalf("mapped outgoing = %+v", gotOutgoing)
+	}
+	gotIncoming := gotMessages[1]
+	if gotIncoming.MessageID != incoming.MessageID ||
+		gotIncoming.ConversationID != incoming.ConversationID ||
+		gotIncoming.Body != incoming.Body ||
+		gotIncoming.TimestampMS != incoming.OccurredAtMS ||
+		gotIncoming.IsFromMe ||
+		gotIncoming.SenderName != identity.DisplayName ||
+		gotIncoming.SenderNumber != identity.CanonicalValue ||
+		gotIncoming.SourcePlatform != "sms" ||
+		gotIncoming.SourceID != incoming.RemoteMessageID ||
+		gotIncoming.ReplyToID != replyRemoteID ||
+		gotIncoming.MediaID != "v2msg:message-incoming:0" ||
+		gotIncoming.MimeType != "image/png" ||
+		gotIncoming.Status != "" ||
+		gotIncoming.Reactions != "" {
+		t.Fatalf("mapped incoming = %+v", gotIncoming)
+	}
+}
+
+func TestSourceCrossAccountRecencyPaginationAndLIKEFilters(t *testing.T) {
+	store, messages, source := openSourceTestStore(t)
+	seedSourceAccount(t, store, "google-account", "google_messages")
+	seedSourceAccount(t, store, "whatsapp-account", "whatsmeow")
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conversation-google",
+		AccountID:            "google-account",
+		RemoteConversationID: "remote-google",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Google",
+		NotificationMode:     sqlite.NotificationModeAll,
+		LastMessageAtMS:      500,
+	})
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conversation-whatsapp",
+		AccountID:            "whatsapp-account",
+		RemoteConversationID: "remote-whatsapp",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "WhatsApp",
+		NotificationMode:     sqlite.NotificationModeAll,
+		LastMessageAtMS:      500,
+	})
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conversation-old",
+		AccountID:            "google-account",
+		RemoteConversationID: "remote-old",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Old",
+		NotificationMode:     sqlite.NotificationModeAll,
+		LastMessageAtMS:      100,
+	})
+	for _, identity := range []sqlite.Identity{
+		{
+			IdentityID:     "alice-google",
+			AccountID:      "google-account",
+			Kind:           sqlite.IdentityKind("e164"),
+			CanonicalValue: "+15550000001",
+			RawValue:       "+15550000001",
+			DisplayName:    "Alice",
+			MetadataJSON:   `{}`,
+			CreatedAtMS:    sourceTestTimeMS,
+			UpdatedAtMS:    sourceTestTimeMS,
+		},
+		{
+			IdentityID:     "bob-google",
+			AccountID:      "google-account",
+			Kind:           sqlite.IdentityKind("e164"),
+			CanonicalValue: "+15550000002",
+			RawValue:       "+15550000002",
+			DisplayName:    "Bob",
+			MetadataJSON:   `{}`,
+			CreatedAtMS:    sourceTestTimeMS,
+			UpdatedAtMS:    sourceTestTimeMS,
+		},
+	} {
+		if err := store.UpsertIdentity(identity); err != nil {
+			t.Fatalf("UpsertIdentity(%q): %v", identity.IdentityID, err)
+		}
+	}
+
+	for _, item := range []struct {
+		id       string
+		ts       int64
+		body     string
+		senderID string
+	}{
+		{id: "message-old", ts: 100, body: "Needle oldest", senderID: "alice-google"},
+		{id: "message-tie-a", ts: 200, body: "needle from Bob", senderID: "bob-google"},
+		{id: "message-tie-b", ts: 200, body: "NEEDLE from Alice", senderID: "alice-google"},
+		{id: "message-new", ts: 300, body: "needle newest", senderID: "alice-google"},
+	} {
+		importSourceMessage(t, messages, sqlite.Message{
+			MessageID:        item.id,
+			ConversationID:   "conversation-google",
+			AccountID:        "google-account",
+			RemoteMessageID:  "remote-" + item.id,
+			SenderIdentityID: stringPointer(item.senderID),
+			Direction:        sqlite.MessageDirectionIncoming,
+			Body:             item.body,
+			State:            sqlite.MessageStateActive,
+			OccurredAtMS:     item.ts,
+		})
+	}
+
+	conversations, err := source.ListConversations(3)
+	if err != nil {
+		t.Fatalf("ListConversations(): %v", err)
+	}
+	assertConversationIDs(
+		t,
+		conversations,
+		"conversation-google",
+		"conversation-whatsapp",
+		"conversation-old",
+	)
+
+	latest, err := source.GetMessagesByConversation("conversation-google", 3)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversation(): %v", err)
+	}
+	assertMessageIDs(t, latest, "message-new", "message-tie-b", "message-tie-a")
+	before, err := source.GetMessagesByConversationBefore(
+		"conversation-google", 200, "message-tie-b", 10,
+	)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversationBefore(): %v", err)
+	}
+	assertMessageIDs(t, before, "message-tie-a", "message-old")
+	after, err := source.GetMessagesByConversationAfter(
+		"conversation-google", 200, "message-tie-a", 10,
+	)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversationAfter(): %v", err)
+	}
+	assertMessageIDs(t, after, "message-tie-b", "message-new")
+	around, err := source.GetMessagesAroundMessage(
+		"conversation-google", "message-tie-b", 2, 1,
+	)
+	if err != nil {
+		t.Fatalf("GetMessagesAroundMessage(): %v", err)
+	}
+	assertMessageIDs(t, around, "message-old", "message-tie-a", "message-tie-b", "message-new")
+	if _, err := source.GetMessagesAroundMessage(
+		"conversation-whatsapp", "message-tie-b", 1, 1,
+	); !errors.Is(err, db.ErrMessageNotFound) {
+		t.Fatalf("wrong-conversation around error = %v, want db.ErrMessageNotFound", err)
+	}
+
+	searchResults, err := source.SearchMessagesFiltered("needle", db.SearchFilter{
+		Phone:          "+15550000001",
+		ConversationID: "conversation-google",
+		SinceMS:        150,
+		UntilMS:        350,
+		Limit:          10,
+	})
+	if err != nil {
+		t.Fatalf("SearchMessagesFiltered(): %v", err)
+	}
+	assertMessageIDs(t, searchResults, "message-new", "message-tie-b")
+}
+
+func TestSourceStatsCountsLatestAndPreviewsPageAllMessages(t *testing.T) {
+	store, messages, source := openSourceTestStore(t)
+	seedSourceAccount(t, store, "google-account", "google_messages")
+	seedSourceAccount(t, store, "whatsapp-account", "whatsmeow")
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conversation-google",
+		AccountID:            "google-account",
+		RemoteConversationID: "remote-google",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Google",
+		NotificationMode:     sqlite.NotificationModeAll,
+		LastMessageAtMS:      1_000,
+	})
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conversation-google-empty",
+		AccountID:            "google-account",
+		RemoteConversationID: "remote-google-empty",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Empty",
+		NotificationMode:     sqlite.NotificationModeAll,
+	})
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conversation-whatsapp",
+		AccountID:            "whatsapp-account",
+		RemoteConversationID: "remote-whatsapp",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "WhatsApp",
+		NotificationMode:     sqlite.NotificationModeAll,
+		LastMessageAtMS:      2_000,
+	})
+
+	for index := 0; index < sourceMessagePageSize+1; index++ {
+		direction := sqlite.MessageDirectionIncoming
+		if index == sourceMessagePageSize {
+			direction = sqlite.MessageDirectionOutgoing
+		}
+		body := fmt.Sprintf("message %03d", index)
+		if index == sourceMessagePageSize {
+			body = "  Latest\n  outgoing   preview  "
+		}
+		importSourceMessage(t, messages, sqlite.Message{
+			MessageID:       fmt.Sprintf("google-message-%03d", index),
+			ConversationID:  "conversation-google",
+			AccountID:       "google-account",
+			RemoteMessageID: fmt.Sprintf("remote-google-%03d", index),
+			Direction:       direction,
+			Body:            body,
+			State:           sqlite.MessageStateActive,
+			OccurredAtMS:    int64(index + 1),
+		})
+	}
+	whatsapp := sqlite.Message{
+		MessageID:       "whatsapp-message",
+		ConversationID:  "conversation-whatsapp",
+		AccountID:       "whatsapp-account",
+		RemoteMessageID: "remote-whatsapp-message",
+		Direction:       sqlite.MessageDirectionIncoming,
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    2_000,
+	}
+	importSourceMessage(t, messages, whatsapp, sqlite.MessageAttachment{
+		Ordinal:   0,
+		RemoteID:  "remote-video",
+		RemoteRef: []byte("video-ref"),
+		Filename:  "clip.mp4",
+		MIME:      "video/mp4",
+	})
+
+	wantSMSMessages := sourceMessagePageSize + 1
+	for _, test := range []struct {
+		platform string
+		want     int
+	}{
+		{platform: "", want: wantSMSMessages + 1},
+		{platform: "sms", want: wantSMSMessages},
+		{platform: "whatsapp", want: 1},
+		{platform: "signal", want: 0},
+	} {
+		got, err := source.MessageCount(test.platform)
+		if err != nil {
+			t.Fatalf("MessageCount(%q): %v", test.platform, err)
+		}
+		if got != test.want {
+			t.Fatalf("MessageCount(%q) = %d, want %d", test.platform, got, test.want)
+		}
+	}
+	for _, test := range []struct {
+		platform string
+		want     int
+	}{
+		{platform: "", want: 3},
+		{platform: "sms", want: 2},
+		{platform: "whatsapp", want: 1},
+		{platform: "signal", want: 0},
+	} {
+		got, err := source.ConversationCount(test.platform)
+		if err != nil {
+			t.Fatalf("ConversationCount(%q): %v", test.platform, err)
+		}
+		if got != test.want {
+			t.Fatalf("ConversationCount(%q) = %d, want %d", test.platform, got, test.want)
+		}
+	}
+	latestSMS, err := source.LatestTimestamp("sms")
+	if err != nil {
+		t.Fatalf("LatestTimestamp(sms): %v", err)
+	}
+	if latestSMS != int64(sourceMessagePageSize+1) {
+		t.Fatalf("LatestTimestamp(sms) = %d, want %d", latestSMS, sourceMessagePageSize+1)
+	}
+	latestMissing, err := source.LatestTimestamp("signal")
+	if err != nil {
+		t.Fatalf("LatestTimestamp(signal): %v", err)
+	}
+	if latestMissing != 0 {
+		t.Fatalf("LatestTimestamp(signal) = %d, want 0", latestMissing)
+	}
+
+	stats, err := source.PlatformStats()
+	if err != nil {
+		t.Fatalf("PlatformStats(): %v", err)
+	}
+	wantStats := []db.PlatformStat{
+		{Platform: "whatsapp", Count: 1, LatestMS: 2_000, LatestRecvMS: 2_000},
+		{
+			Platform:     "sms",
+			Count:        wantSMSMessages,
+			LatestMS:     int64(sourceMessagePageSize + 1),
+			LatestRecvMS: int64(sourceMessagePageSize),
+		},
+	}
+	if !reflect.DeepEqual(stats, wantStats) {
+		t.Fatalf("PlatformStats() = %+v, want %+v", stats, wantStats)
+	}
+
+	previews, err := source.LatestConversationPreviews([]string{
+		" conversation-google ",
+		"conversation-whatsapp",
+		"conversation-google-empty",
+		"conversation-google",
+		"",
+	})
+	if err != nil {
+		t.Fatalf("LatestConversationPreviews(): %v", err)
+	}
+	wantPreviews := map[string]string{
+		"conversation-google":   "You: Latest outgoing preview",
+		"conversation-whatsapp": "Video",
+	}
+	if !reflect.DeepEqual(previews, wantPreviews) {
+		t.Fatalf("LatestConversationPreviews() = %#v, want %#v", previews, wantPreviews)
+	}
+}
+
+func TestPlatformForBridgeKey(t *testing.T) {
+	for _, test := range []struct {
+		bridgeKey string
+		want      string
+	}{
+		{bridgeKey: "google_messages", want: "sms"},
+		{bridgeKey: "whatsmeow", want: "whatsapp"},
+		{bridgeKey: "signal_cli", want: "signal"},
+		{bridgeKey: "gchat", want: "gchat"},
+		{bridgeKey: "imessage", want: "imessage"},
+		{bridgeKey: "custom_bridge", want: "custom_bridge"},
+	} {
+		t.Run(test.bridgeKey, func(t *testing.T) {
+			if got := platformForBridgeKey(test.bridgeKey); got != test.want {
+				t.Fatalf("platformForBridgeKey(%q) = %q, want %q", test.bridgeKey, got, test.want)
+			}
+		})
+	}
+}
+
+func openSourceTestStore(t *testing.T) (*sqlite.Store, *sqlite.MessageRepository, *Source) {
+	t.Helper()
+	store, err := sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("store.Close(): %v", err)
+		}
+	})
+	messages, err := sqlite.NewMessageRepository(
+		store,
+		func() time.Time { return time.UnixMilli(sourceTestTimeMS) },
+	)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	return store, messages, New(store)
+}
+
+func seedSourceAccount(t *testing.T, store *sqlite.Store, accountID, bridgeKey string) {
+	t.Helper()
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   accountID,
+		BridgeKey:   bridgeKey,
+		DisplayName: accountID,
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: sourceTestTimeMS,
+		UpdatedAtMS: sourceTestTimeMS,
+	}); err != nil {
+		t.Fatalf("UpsertAccount(%q): %v", accountID, err)
+	}
+}
+
+func seedSourceConversation(t *testing.T, store *sqlite.Store, conversation sqlite.Conversation) {
+	t.Helper()
+	if conversation.MetadataJSON == "" {
+		conversation.MetadataJSON = `{}`
+	}
+	if conversation.CreatedAtMS == 0 {
+		conversation.CreatedAtMS = sourceTestTimeMS
+	}
+	if conversation.UpdatedAtMS == 0 {
+		conversation.UpdatedAtMS = sourceTestTimeMS
+	}
+	if err := store.UpsertConversation(conversation); err != nil {
+		t.Fatalf("UpsertConversation(%q): %v", conversation.ConversationID, err)
+	}
+}
+
+func importSourceMessage(
+	t *testing.T,
+	repository *sqlite.MessageRepository,
+	message sqlite.Message,
+	attachments ...sqlite.MessageAttachment,
+) {
+	t.Helper()
+	if err := repository.ImportMessage(context.Background(), sqlite.MessageProjection{
+		Message:     message,
+		Attachments: attachments,
+	}); err != nil {
+		t.Fatalf("ImportMessage(%q): %v", message.MessageID, err)
+	}
+}
+
+func assertConversationIDs(t *testing.T, conversations []*db.Conversation, want ...string) {
+	t.Helper()
+	if len(conversations) != len(want) {
+		t.Fatalf("conversation IDs = %d rows %+v, want %d %v", len(conversations), conversations, len(want), want)
+	}
+	for i, wantID := range want {
+		if conversations[i].ConversationID != wantID {
+			t.Fatalf("conversation ID %d = %q, want %q", i, conversations[i].ConversationID, wantID)
+		}
+	}
+}
+
+func assertMessageIDs(t *testing.T, messages []*db.Message, want ...string) {
+	t.Helper()
+	if len(messages) != len(want) {
+		t.Fatalf("message IDs = %d rows %+v, want %d %v", len(messages), messages, len(want), want)
+	}
+	for i, wantID := range want {
+		if messages[i].MessageID != wantID {
+			t.Fatalf("message ID %d = %q, want %q", i, messages[i].MessageID, wantID)
+		}
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func TestFormatLastMessagePreviewMatchesLegacyRules(t *testing.T) {
+	long := strings.Repeat("界", 130)
+	got := formatLastMessagePreview(long, "", "", false)
+	if runes := []rune(got); len(runes) != 120 || runes[len(runes)-1] != '…' {
+		t.Fatalf("long preview = %q (%d runes), want 120 runes ending ellipsis", got, len([]rune(got)))
+	}
+	if got := formatLastMessagePreview("", "v2msg:m:0", "audio/ogg", true); got != "You: Audio" {
+		t.Fatalf("audio preview = %q, want %q", got, "You: Audio")
+	}
+}

--- a/internal/v2read/stats.go
+++ b/internal/v2read/stats.go
@@ -1,0 +1,238 @@
+package v2read
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+// MessageCount returns all message rows or those whose account maps to the
+// requested legacy source platform.
+func (s *Source) MessageCount(sourcePlatform string) (int, error) {
+	if err := s.ready(); err != nil {
+		return 0, err
+	}
+	accounts, err := s.store.ListAccounts()
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, account := range accounts {
+		if sourcePlatform != "" && platformForBridgeKey(account.BridgeKey) != sourcePlatform {
+			continue
+		}
+		conversations, err := s.store.ListConversationsByRecency(account.AccountID)
+		if err != nil {
+			return 0, err
+		}
+		for _, conversation := range conversations {
+			if err := s.walkConversationMessages(conversation.ConversationID, func(sqlite.Message) {
+				count++
+			}); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return count, nil
+}
+
+// ConversationCount returns all conversations or those mapped to one legacy
+// source platform.
+func (s *Source) ConversationCount(sourcePlatform string) (int, error) {
+	if err := s.ready(); err != nil {
+		return 0, err
+	}
+	accounts, err := s.store.ListAccounts()
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, account := range accounts {
+		if sourcePlatform != "" && platformForBridgeKey(account.BridgeKey) != sourcePlatform {
+			continue
+		}
+		conversations, err := s.store.ListConversationsByRecency(account.AccountID)
+		if err != nil {
+			return 0, err
+		}
+		count += len(conversations)
+	}
+	return count, nil
+}
+
+// LatestTimestamp returns the newest message timestamp for sourcePlatform.
+func (s *Source) LatestTimestamp(sourcePlatform string) (int64, error) {
+	if err := s.ready(); err != nil {
+		return 0, err
+	}
+	accounts, err := s.store.ListAccounts()
+	if err != nil {
+		return 0, err
+	}
+	var latest int64
+	for _, account := range accounts {
+		if platformForBridgeKey(account.BridgeKey) != sourcePlatform {
+			continue
+		}
+		conversations, err := s.store.ListConversationsByRecency(account.AccountID)
+		if err != nil {
+			return 0, err
+		}
+		for _, conversation := range conversations {
+			messages, err := s.messages.ListMessagesByConversation(
+				context.Background(), conversation.ConversationID, 0, "", 1,
+			)
+			if err != nil {
+				return 0, err
+			}
+			if len(messages) > 0 && messages[0].OccurredAtMS > latest {
+				latest = messages[0].OccurredAtMS
+			}
+		}
+	}
+	return latest, nil
+}
+
+// PlatformStats summarizes v2 messages under their legacy platform labels.
+func (s *Source) PlatformStats() ([]db.PlatformStat, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	accounts, err := s.store.ListAccounts()
+	if err != nil {
+		return nil, err
+	}
+	byPlatform := make(map[string]*db.PlatformStat)
+	for _, account := range accounts {
+		platform := platformForBridgeKey(account.BridgeKey)
+		if strings.TrimSpace(platform) == "" {
+			platform = "unknown"
+		}
+		conversations, err := s.store.ListConversationsByRecency(account.AccountID)
+		if err != nil {
+			return nil, err
+		}
+		for _, conversation := range conversations {
+			if err := s.walkConversationMessages(conversation.ConversationID, func(message sqlite.Message) {
+				stat := byPlatform[platform]
+				if stat == nil {
+					stat = &db.PlatformStat{Platform: platform}
+					byPlatform[platform] = stat
+				}
+				stat.Count++
+				if message.OccurredAtMS > stat.LatestMS {
+					stat.LatestMS = message.OccurredAtMS
+				}
+				if message.Direction == sqlite.MessageDirectionIncoming &&
+					message.OccurredAtMS > stat.LatestRecvMS {
+					stat.LatestRecvMS = message.OccurredAtMS
+				}
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+	stats := make([]db.PlatformStat, 0, len(byPlatform))
+	for _, stat := range byPlatform {
+		stats = append(stats, *stat)
+	}
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].LatestMS != stats[j].LatestMS {
+			return stats[i].LatestMS > stats[j].LatestMS
+		}
+		return stats[i].Platform < stats[j].Platform
+	})
+	return stats, nil
+}
+
+// LatestConversationPreviews formats each requested conversation's latest v2
+// message exactly like the legacy store's preview formatter.
+func (s *Source) LatestConversationPreviews(ids []string) (map[string]string, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	unique := make([]string, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	previews := make(map[string]string, len(unique))
+	for _, conversationID := range unique {
+		messages, err := s.messages.ListMessagesByConversation(
+			context.Background(), conversationID, 0, "", 1,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(messages) == 0 {
+			continue
+		}
+		message := messages[0]
+		attachment, hasAttachment, err := s.messageAttachment(
+			context.Background(), message.MessageID,
+		)
+		if err != nil {
+			return nil, err
+		}
+		mediaID := ""
+		mimeType := ""
+		if hasAttachment {
+			mediaID = "v2msg:" + message.MessageID + ":0"
+			mimeType = attachment.MIME
+		}
+		previews[conversationID] = formatLastMessagePreview(
+			message.Body,
+			mediaID,
+			mimeType,
+			message.Direction == sqlite.MessageDirectionOutgoing,
+		)
+	}
+	return previews, nil
+}
+
+func formatLastMessagePreview(body, mediaID, mimeType string, isFromMe bool) string {
+	const previewRuneLimit = 120
+
+	preview := strings.Join(strings.Fields(body), " ")
+	if preview == "" && strings.TrimSpace(mediaID) != "" {
+		switch {
+		case strings.HasPrefix(strings.ToLower(mimeType), "image/"):
+			preview = "Photo"
+		case strings.HasPrefix(strings.ToLower(mimeType), "video/"):
+			preview = "Video"
+		case strings.HasPrefix(strings.ToLower(mimeType), "audio/"):
+			preview = "Audio"
+		default:
+			preview = "Attachment"
+		}
+	}
+	if preview == "" {
+		return ""
+	}
+	if isFromMe {
+		preview = "You: " + preview
+	}
+	return truncateRunes(preview, previewRuneLimit)
+}
+
+func truncateRunes(value string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit-1]) + "…"
+}

--- a/internal/v2wire/submit_native.go
+++ b/internal/v2wire/submit_native.go
@@ -1,0 +1,172 @@
+package v2wire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+// NativeDeps are the v2 store and services needed to submit using v2-native
+// conversation and message IDs. Unlike Deps, this path has no legacy store.
+type NativeDeps struct {
+	V2       *sqlite.Store
+	Service  *messaging.MessageService
+	Registry bridge.Registry
+}
+
+// SubmitTextV2 resolves the account from an existing v2 conversation and
+// submits directly to the durable messaging service without mirroring legacy
+// state.
+func SubmitTextV2(
+	ctx context.Context,
+	deps NativeDeps,
+	input TextInput,
+) (messaging.Submission, error) {
+	if err := validateNativeSubmitDeps(ctx, deps); err != nil {
+		return messaging.Submission{}, err
+	}
+	conversation, err := deps.V2.GetConversation(input.ConversationID)
+	if err != nil {
+		return messaging.Submission{}, fmt.Errorf(
+			"resolve v2 conversation %q: %w",
+			input.ConversationID,
+			err,
+		)
+	}
+	if !deps.Registry.Capabilities(conversation.AccountID).TextSend {
+		return messaging.Submission{}, fmt.Errorf(
+			"%w: account %q does not support text sends",
+			ErrPlatformNotSendable,
+			conversation.AccountID,
+		)
+	}
+
+	replyToMessageID, err := validateNativeReplyTarget(
+		ctx,
+		deps.V2,
+		input.ReplyToID,
+		conversation.AccountID,
+		conversation.ConversationID,
+	)
+	if err != nil {
+		return messaging.Submission{}, err
+	}
+	return deps.Service.SendText(ctx, messaging.SendTextCommand{
+		CommonCommand: messaging.CommonCommand{
+			AccountID:      conversation.AccountID,
+			ConversationID: conversation.ConversationID,
+			IdempotencyKey: input.IdempotencyKey,
+			NotBefore:      input.NotBefore,
+		},
+		Body:             input.Body,
+		ReplyToMessageID: replyToMessageID,
+	})
+}
+
+// SubmitMediaV2 is the streaming media counterpart to SubmitTextV2.
+func SubmitMediaV2(
+	ctx context.Context,
+	deps NativeDeps,
+	input MediaInput,
+) (messaging.Submission, error) {
+	if err := validateNativeSubmitDeps(ctx, deps); err != nil {
+		return messaging.Submission{}, err
+	}
+	conversation, err := deps.V2.GetConversation(input.ConversationID)
+	if err != nil {
+		return messaging.Submission{}, fmt.Errorf(
+			"resolve v2 conversation %q: %w",
+			input.ConversationID,
+			err,
+		)
+	}
+	if !deps.Registry.Capabilities(conversation.AccountID).MediaSend {
+		return messaging.Submission{}, fmt.Errorf(
+			"%w: account %q does not support media sends",
+			ErrPlatformNotSendable,
+			conversation.AccountID,
+		)
+	}
+
+	replyToMessageID, err := validateNativeReplyTarget(
+		ctx,
+		deps.V2,
+		input.ReplyToID,
+		conversation.AccountID,
+		conversation.ConversationID,
+	)
+	if err != nil {
+		return messaging.Submission{}, err
+	}
+	return deps.Service.SendMedia(ctx, messaging.SendMediaCommand{
+		CommonCommand: messaging.CommonCommand{
+			AccountID:      conversation.AccountID,
+			ConversationID: conversation.ConversationID,
+			IdempotencyKey: input.IdempotencyKey,
+			NotBefore:      input.NotBefore,
+		},
+		Content:          input.Content,
+		Filename:         input.Filename,
+		MIME:             input.MIME,
+		Caption:          input.Caption,
+		ReplyToMessageID: replyToMessageID,
+	})
+}
+
+func validateNativeSubmitDeps(ctx context.Context, deps NativeDeps) error {
+	if ctx == nil {
+		return errors.New("submit v2 message: context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("submit v2 message: %w", err)
+	}
+	if deps.V2 == nil {
+		return errors.New("submit v2 message: v2 store is nil")
+	}
+	if deps.Service == nil {
+		return errors.New("submit v2 message: service is nil")
+	}
+	if deps.Registry == nil {
+		return errors.New("submit v2 message: registry is nil")
+	}
+	return nil
+}
+
+func validateNativeReplyTarget(
+	ctx context.Context,
+	store *sqlite.Store,
+	messageID string,
+	accountID string,
+	conversationID string,
+) (string, error) {
+	if messageID == "" {
+		return "", nil
+	}
+	repository, err := sqlite.NewMessageRepository(store, time.Now)
+	if err != nil {
+		return "", fmt.Errorf("validate v2 reply target %q: %w", messageID, err)
+	}
+	target, err := repository.GetMessage(ctx, messageID)
+	if err != nil {
+		return "", fmt.Errorf(
+			"%w: load v2 message %q: %v",
+			ErrReplyTargetUnavailable,
+			messageID,
+			err,
+		)
+	}
+	if target.AccountID != accountID || target.ConversationID != conversationID {
+		return "", fmt.Errorf(
+			"%w: v2 message %q belongs to conversation %q",
+			ErrReplyTargetUnavailable,
+			messageID,
+			target.ConversationID,
+		)
+	}
+	return target.MessageID, nil
+}

--- a/internal/v2wire/submit_native_test.go
+++ b/internal/v2wire/submit_native_test.go
@@ -1,0 +1,314 @@
+package v2wire
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func TestSubmitTextV2ResolvesAccountFromV2ConversationAndForwardsCommand(t *testing.T) {
+	v2 := openV2TestStore(t)
+	seedNativeConversation(t, v2, "native-account", "v2-conversation")
+	projectV2TestMessage(t, v2, sqlite.Message{
+		MessageID:       "v2-parent",
+		ConversationID:  "v2-conversation",
+		AccountID:       "native-account",
+		RemoteMessageID: "remote-parent",
+		Direction:       sqlite.MessageDirectionIncoming,
+		Body:            "parent",
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    1_900_000_000_000,
+	})
+	registry := submitTestRegistry{caps: map[string]bridge.CapabilitySet{
+		"native-account": {TextSend: true},
+	}}
+	service := newSubmitTestService(t, v2, registry, nil)
+	notBefore := time.Now().Add(2 * time.Hour).Truncate(time.Millisecond)
+
+	submission, err := SubmitTextV2(context.Background(), NativeDeps{
+		V2: v2, Service: service, Registry: registry,
+	}, TextInput{
+		ConversationID: "v2-conversation",
+		Body:           "native reply",
+		ReplyToID:      "v2-parent",
+		IdempotencyKey: "native-text-key",
+		NotBefore:      notBefore,
+	})
+	if err != nil {
+		t.Fatalf("SubmitTextV2(): %v", err)
+	}
+	if submission.State != messaging.OutboxQueued || submission.ScheduledFor.UnixMilli() != notBefore.UnixMilli() {
+		t.Fatalf("submission = %+v, want queued at %v", submission, notBefore)
+	}
+	deduplicated, err := SubmitTextV2(context.Background(), NativeDeps{
+		V2: v2, Service: service, Registry: registry,
+	}, TextInput{
+		ConversationID: "v2-conversation",
+		Body:           "native reply",
+		ReplyToID:      "v2-parent",
+		IdempotencyKey: "native-text-key",
+		NotBefore:      notBefore,
+	})
+	if err != nil {
+		t.Fatalf("SubmitTextV2(deduplicate): %v", err)
+	}
+	if !deduplicated.Deduplicated ||
+		deduplicated.OutboxID != submission.OutboxID ||
+		deduplicated.LocalMessageID != submission.LocalMessageID {
+		t.Fatalf("deduplicated submission = %+v, want identities from %+v", deduplicated, submission)
+	}
+
+	repository, err := sqlite.NewMessageRepository(v2, time.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	message, err := repository.GetMessage(context.Background(), submission.LocalMessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(): %v", err)
+	}
+	if message.AccountID != "native-account" ||
+		message.ConversationID != "v2-conversation" ||
+		message.Body != "native reply" ||
+		message.ReplyToRemoteID == nil ||
+		*message.ReplyToRemoteID != "remote-parent" {
+		t.Fatalf("optimistic message = %+v", message)
+	}
+}
+
+func TestSubmitMediaV2ResolvesAccountFromV2ConversationAndForwardsCommand(t *testing.T) {
+	v2 := openV2TestStore(t)
+	seedNativeConversation(t, v2, "native-media-account", "v2-media-conversation")
+	projectV2TestMessage(t, v2, sqlite.Message{
+		MessageID:       "v2-media-parent",
+		ConversationID:  "v2-media-conversation",
+		AccountID:       "native-media-account",
+		RemoteMessageID: "remote-media-parent",
+		Direction:       sqlite.MessageDirectionIncoming,
+		Body:            "media parent",
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    1_900_000_000_001,
+	})
+	registry := submitTestRegistry{caps: map[string]bridge.CapabilitySet{
+		"native-media-account": {MediaSend: true},
+	}}
+	blobs, err := blob.New(filepath.Join(t.TempDir(), "blobs"))
+	if err != nil {
+		t.Fatalf("blob.New(): %v", err)
+	}
+	service := newSubmitTestService(t, v2, registry, blobs)
+	content := []byte("native media bytes")
+	notBefore := time.Now().Add(3 * time.Hour).Truncate(time.Millisecond)
+
+	submission, err := SubmitMediaV2(context.Background(), NativeDeps{
+		V2: v2, Service: service, Registry: registry,
+	}, MediaInput{
+		ConversationID: "v2-media-conversation",
+		Content:        bytes.NewReader(content),
+		Filename:       "native.jpg",
+		MIME:           "image/jpeg",
+		Caption:        "native caption",
+		ReplyToID:      "v2-media-parent",
+		IdempotencyKey: "native-media-key",
+		NotBefore:      notBefore,
+	})
+	if err != nil {
+		t.Fatalf("SubmitMediaV2(): %v", err)
+	}
+	if submission.State != messaging.OutboxQueued || submission.ScheduledFor.UnixMilli() != notBefore.UnixMilli() {
+		t.Fatalf("submission = %+v, want queued at %v", submission, notBefore)
+	}
+
+	repository, err := sqlite.NewMessageRepository(v2, time.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	message, err := repository.GetMessage(context.Background(), submission.LocalMessageID)
+	if err != nil {
+		t.Fatalf("GetMessage(): %v", err)
+	}
+	if message.AccountID != "native-media-account" ||
+		message.ConversationID != "v2-media-conversation" ||
+		message.Body != "native caption" ||
+		message.ReplyToRemoteID == nil ||
+		*message.ReplyToRemoteID != "remote-media-parent" {
+		t.Fatalf("optimistic message = %+v", message)
+	}
+
+	outbox, err := sqlite.NewOutboxRepository(v2, time.Now)
+	if err != nil {
+		t.Fatalf("NewOutboxRepository(): %v", err)
+	}
+	attachment, err := outbox.GetOutboxAttachment(context.Background(), submission.OutboxID)
+	if err != nil {
+		t.Fatalf("GetOutboxAttachment(): %v", err)
+	}
+	if attachment.Filename != "native.jpg" ||
+		attachment.MIME != "image/jpeg" ||
+		attachment.SizeBytes != int64(len(content)) {
+		t.Fatalf("attachment = %+v", attachment)
+	}
+	reader, err := blobs.Open(blob.BlobRef{Hash: attachment.BlobHash})
+	if err != nil {
+		t.Fatalf("blobs.Open(): %v", err)
+	}
+	defer reader.Close()
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll(blob): %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("blob = %q, want %q", got, content)
+	}
+}
+
+func TestSubmitV2RejectsMissingCapabilitiesBeforeEnqueue(t *testing.T) {
+	tests := []struct {
+		name   string
+		submit func(context.Context, NativeDeps) error
+	}{
+		{
+			name: "text",
+			submit: func(ctx context.Context, deps NativeDeps) error {
+				_, err := SubmitTextV2(ctx, deps, TextInput{
+					ConversationID: "v2-conversation",
+					Body:           "must not enqueue",
+					IdempotencyKey: "unsupported-text-key",
+				})
+				return err
+			},
+		},
+		{
+			name: "media",
+			submit: func(ctx context.Context, deps NativeDeps) error {
+				_, err := SubmitMediaV2(ctx, deps, MediaInput{
+					ConversationID: "v2-conversation",
+					Content:        bytes.NewReader([]byte("must not enqueue")),
+					IdempotencyKey: "unsupported-media-key",
+				})
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v2 := openV2TestStore(t)
+			seedNativeConversation(t, v2, "native-account", "v2-conversation")
+			registry := submitTestRegistry{caps: map[string]bridge.CapabilitySet{}}
+			service := newSubmitTestService(t, v2, registry, nil)
+
+			err := test.submit(context.Background(), NativeDeps{
+				V2: v2, Service: service, Registry: registry,
+			})
+			if !errors.Is(err, ErrPlatformNotSendable) {
+				t.Fatalf("submit error = %v, want ErrPlatformNotSendable", err)
+			}
+			pending, listErr := service.ListPending(context.Background(), messaging.ListPendingQuery{Limit: 10})
+			if listErr != nil {
+				t.Fatalf("ListPending(): %v", listErr)
+			}
+			if len(pending) != 0 {
+				t.Fatalf("pending = %+v, want empty", pending)
+			}
+		})
+	}
+}
+
+func TestSubmitTextV2ValidatesReplyTargetByV2MessageID(t *testing.T) {
+	v2 := openV2TestStore(t)
+	seedNativeConversation(t, v2, "native-account", "conversation-a")
+	seedNativeConversation(t, v2, "native-account", "conversation-b")
+	projectV2TestMessage(t, v2, sqlite.Message{
+		MessageID:       "parent-in-b",
+		ConversationID:  "conversation-b",
+		AccountID:       "native-account",
+		RemoteMessageID: "remote-parent-in-b",
+		Direction:       sqlite.MessageDirectionIncoming,
+		Body:            "parent",
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    1_900_000_000_000,
+	})
+	registry := submitTestRegistry{caps: map[string]bridge.CapabilitySet{
+		"native-account": {TextSend: true},
+	}}
+	service := newSubmitTestService(t, v2, registry, nil)
+
+	for _, replyToID := range []string{"parent-in-b", "missing-v2-message"} {
+		t.Run(replyToID, func(t *testing.T) {
+			_, err := SubmitTextV2(context.Background(), NativeDeps{
+				V2: v2, Service: service, Registry: registry,
+			}, TextInput{
+				ConversationID: "conversation-a",
+				Body:           "reply",
+				ReplyToID:      replyToID,
+				IdempotencyKey: "reply-" + replyToID,
+			})
+			if !errors.Is(err, ErrReplyTargetUnavailable) {
+				t.Fatalf("SubmitTextV2() error = %v, want ErrReplyTargetUnavailable", err)
+			}
+		})
+	}
+}
+
+func TestSubmitV2ValidatesDependenciesBeforeReadingConversation(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  context.Context
+		deps NativeDeps
+	}{
+		{name: "nil context", deps: NativeDeps{}},
+		{name: "nil store", ctx: context.Background(), deps: NativeDeps{}},
+		{name: "nil service", ctx: context.Background(), deps: NativeDeps{V2: openV2TestStore(t)}},
+		{
+			name: "nil registry",
+			ctx:  context.Background(),
+			deps: NativeDeps{V2: openV2TestStore(t), Service: &messaging.MessageService{}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := SubmitTextV2(test.ctx, test.deps, TextInput{ConversationID: "does-not-matter"})
+			if err == nil {
+				t.Fatal("SubmitTextV2() succeeded, want dependency error")
+			}
+		})
+	}
+}
+
+func seedNativeConversation(t *testing.T, store *sqlite.Store, accountID, conversationID string) {
+	t.Helper()
+	nowMS := time.Now().UnixMilli()
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   accountID,
+		BridgeKey:   "native-test",
+		DisplayName: accountID,
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  "{}",
+		CreatedAtMS: nowMS,
+		UpdatedAtMS: nowMS,
+	}); err != nil {
+		t.Fatalf("UpsertAccount(%q): %v", accountID, err)
+	}
+	if err := store.UpsertConversation(sqlite.Conversation{
+		ConversationID:       conversationID,
+		AccountID:            accountID,
+		RemoteConversationID: "remote-" + conversationID,
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                conversationID,
+		NotificationMode:     sqlite.NotificationModeAll,
+		MetadataJSON:         "{}",
+		CreatedAtMS:          nowMS,
+		UpdatedAtMS:          nowMS,
+	}); err != nil {
+		t.Fatalf("UpsertConversation(%q): %v", conversationID, err)
+	}
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	"embed"
@@ -30,6 +31,8 @@ import (
 	"github.com/maxghenis/openmessage/internal/ingest"
 	"github.com/maxghenis/openmessage/internal/media"
 	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/readsource"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 	"github.com/maxghenis/openmessage/internal/story"
 	"github.com/maxghenis/openmessage/internal/whatsapplive"
 )
@@ -83,6 +86,8 @@ type UnpairFunc func() error
 type APIOptions struct {
 	V2                    *V2Options
 	V2IngestCounters      func() map[string]ingest.CounterSnapshot
+	Reads                 readsource.ReadSource
+	V2Primary             bool
 	Client                func() *client.Client
 	Events                *EventBroker
 	EventHeartbeat        time.Duration
@@ -154,7 +159,11 @@ func APIHandler(store *db.Store, cli *client.Client, logger zerolog.Logger, mcpH
 
 func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.Logger, mcpHandler http.Handler, opts APIOptions) http.Handler {
 	mux := http.NewServeMux()
-	registerV1Routes(mux, store, logger, opts.V2)
+	reads := opts.Reads
+	if reads == nil {
+		reads = store
+	}
+	registerV1Routes(mux, store, logger, opts.V2, opts.V2Primary)
 	diagnosticsStartedAt := time.Now()
 	getClient := func() *client.Client {
 		if opts.Client != nil {
@@ -231,7 +240,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		if freshnessValue != nil && time.Since(freshnessComputed) < 30*time.Second {
 			return freshnessValue
 		}
-		stats, err := store.PlatformStats()
+		stats, err := reads.PlatformStats()
 		if err != nil {
 			return freshnessValue // keep last good value on error
 		}
@@ -380,22 +389,22 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		msgCounts := map[string]int{}
 		latestByPlatform := map[string]int64{}
 
-		totalConversations, err := store.ConversationCount("")
+		totalConversations, err := reads.ConversationCount("")
 		if err == nil {
 			payload["conversation_count"] = totalConversations
 		}
-		totalMessages, err := store.MessageCount("")
+		totalMessages, err := reads.MessageCount("")
 		if err == nil {
 			payload["message_count"] = totalMessages
 		}
 		for _, platform := range platforms {
-			if count, err := store.ConversationCount(platform); err == nil && count > 0 {
+			if count, err := reads.ConversationCount(platform); err == nil && count > 0 {
 				convCounts[platform] = count
 			}
-			if count, err := store.MessageCount(platform); err == nil && count > 0 {
+			if count, err := reads.MessageCount(platform); err == nil && count > 0 {
 				msgCounts[platform] = count
 			}
-			if latest, err := store.LatestTimestamp(platform); err == nil && latest > 0 {
+			if latest, err := reads.LatestTimestamp(platform); err == nil && latest > 0 {
 				latestByPlatform[platform] = latest
 			}
 		}
@@ -796,7 +805,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 
 	mux.HandleFunc("/api/conversations", func(w http.ResponseWriter, r *http.Request) {
 		limit := queryIntClamped(r, "limit", 50, 500)
-		convos, err := store.ListConversations(limit)
+		convos, err := reads.ListConversations(limit)
 		if err != nil {
 			httpError(w, "list conversations: "+err.Error(), 500)
 			return
@@ -804,8 +813,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		if convos == nil {
 			convos = []*db.Conversation{}
 		}
-		enrichUnifiedConversationIdentities(store, convos)
-		if err := enrichConversationPreviews(store, convos); err != nil {
+		if !opts.V2Primary {
+			enrichUnifiedConversationIdentities(store, convos)
+		}
+		if err := enrichConversationPreviews(reads, convos); err != nil {
 			httpError(w, "conversation previews: "+err.Error(), 500)
 			return
 		}
@@ -919,7 +930,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 				return
 			}
 			limit := queryIntClamped(r, "limit", 50, 100)
-			msgs, err := store.SearchMessagesFiltered(q, db.SearchFilter{
+			msgs, err := reads.SearchMessagesFiltered(q, db.SearchFilter{
 				ConversationID: convID,
 				Limit:          limit,
 			})
@@ -943,7 +954,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 				httpError(w, "message_id is required", 400)
 				return
 			}
-			msgs, err := store.GetMessagesAroundMessage(convID, messageID, queryIntClamped(r, "before", 40, 200), queryIntClamped(r, "after", 40, 200))
+			msgs, err := reads.GetMessagesAroundMessage(convID, messageID, queryIntClamped(r, "before", 40, 200), queryIntClamped(r, "after", 40, 200))
 			if err != nil {
 				if errors.Is(err, db.ErrMessageNotFound) {
 					httpError(w, "message not found", 404)
@@ -982,11 +993,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		var err error
 		switch {
 		case afterMS > 0:
-			msgs, err = store.GetMessagesByConversationAfter(convID, afterMS, afterID, limit)
+			msgs, err = reads.GetMessagesByConversationAfter(convID, afterMS, afterID, limit)
 		case beforeMS > 0:
-			msgs, err = store.GetMessagesByConversationBefore(convID, beforeMS, beforeID, limit)
+			msgs, err = reads.GetMessagesByConversationBefore(convID, beforeMS, beforeID, limit)
 		default:
-			msgs, err = store.GetMessagesByConversation(convID, limit)
+			msgs, err = reads.GetMessagesByConversation(convID, limit)
 		}
 		if err != nil {
 			httpError(w, "get messages: "+err.Error(), 500)
@@ -1431,17 +1442,24 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			return
 		}
 		limit := queryIntClamped(r, "limit", 50, 500)
-		msgs, err := store.SearchMessages(q, "", limit)
+		msgs, err := reads.SearchMessagesFiltered(q, db.SearchFilter{Limit: limit})
 		if err != nil {
 			httpError(w, "search: "+err.Error(), 500)
 			return
 		}
-		convos, err := store.SearchConversationsByMetadata(q, limit)
-		if err != nil {
-			httpError(w, "search: "+err.Error(), 500)
-			return
+		var (
+			convos        []*db.Conversation
+			identityStore *db.Store
+		)
+		if !opts.V2Primary {
+			convos, err = store.SearchConversationsByMetadata(q, limit)
+			if err != nil {
+				httpError(w, "search: "+err.Error(), 500)
+				return
+			}
+			identityStore = store
 		}
-		results := mergeSearchResults(store, msgs, convos, limit)
+		results := mergeSearchResults(reads, identityStore, msgs, convos, limit)
 		writeJSON(w, results)
 	})
 
@@ -1542,6 +1560,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	mux.HandleFunc("/api/send", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			httpError(w, "method not allowed", 405)
+			return
+		}
+		if opts.V2Primary {
+			httpError(w, "v2 primary: use /api/v1/outbox", http.StatusConflict)
 			return
 		}
 		var req struct {
@@ -1796,6 +1818,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "method not allowed", 405)
 			return
 		}
+		if opts.V2Primary {
+			httpError(w, "v2 primary: use /api/v1/outbox", http.StatusConflict)
+			return
+		}
 		var req struct {
 			ConversationID string `json:"conversation_id"`
 			URL            string `json:"url"`
@@ -1830,6 +1856,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "method not allowed", 405)
 			return
 		}
+		if opts.V2Primary {
+			httpError(w, "v2 primary: use /api/v1/outbox", http.StatusConflict)
+			return
+		}
 		if !parseBoundedMultipartForm(w, r) {
 			return
 		}
@@ -1858,6 +1888,17 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		msgID := strings.TrimPrefix(r.URL.Path, "/api/media/")
 		if msgID == "" {
 			httpError(w, "message_id required", 400)
+			return
+		}
+		if opts.V2Primary {
+			if opts.V2 == nil || opts.V2.V2Store == nil || opts.V2.Media == nil {
+				httpError(w, "v2 media not available", http.StatusServiceUnavailable)
+				return
+			}
+			if err := writeV2MessageMediaResponse(r.Context(), w, opts.V2, msgID); err != nil {
+				code, message := v1ErrorResponse(err)
+				httpError(w, message, code)
+			}
 			return
 		}
 		msg, err := store.GetMessageByID(msgID)
@@ -2240,6 +2281,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "method not allowed", 405)
 			return
 		}
+		if opts.V2Primary {
+			httpError(w, "v2 primary: use /api/v1/outbox", http.StatusConflict)
+			return
+		}
 		var req struct {
 			DraftID string `json:"draft_id"`
 			Body    string `json:"body"`
@@ -2410,6 +2455,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	})
 
 	mux.HandleFunc("/api/stats/", func(w http.ResponseWriter, r *http.Request) {
+		if opts.V2Primary {
+			httpError(w, "stats are unavailable in v2-primary mode", 409)
+			return
+		}
 		convID := strings.TrimPrefix(r.URL.Path, "/api/stats/")
 		if convID == "" {
 			httpError(w, "conversation_id required", 400)
@@ -2429,6 +2478,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	})
 
 	mux.HandleFunc("/api/story/", func(w http.ResponseWriter, r *http.Request) {
+		if opts.V2Primary {
+			httpError(w, "story generation is unavailable in v2-primary mode", 409)
+			return
+		}
 		convID := strings.TrimPrefix(r.URL.Path, "/api/story/")
 		if convID == "" {
 			httpError(w, "conversation_id required", 400)
@@ -2988,10 +3041,13 @@ func splitHostPortDefault(hostport, defaultPort string) (string, string, bool) {
 	return u.Hostname(), port, true
 }
 
-func mergeSearchResults(store *db.Store, msgs []*db.Message, convos []*db.Conversation, limit int) []SearchResult {
+func mergeSearchResults(reads readsource.ReadSource, identityStore *db.Store, msgs []*db.Message, convos []*db.Conversation, limit int) []SearchResult {
 	results := make([]SearchResult, 0, limit)
 	seen := make(map[string]struct{}, limit)
-	identityIndex := loadUnifiedIdentityIndex(store)
+	var identityIndex map[string]unifiedConversationIdentity
+	if identityStore != nil {
+		identityIndex = loadUnifiedIdentityIndex(identityStore)
+	}
 
 	appendResult := func(result SearchResult) {
 		if _, ok := seen[result.ConversationID]; ok {
@@ -3002,7 +3058,7 @@ func mergeSearchResults(store *db.Store, msgs []*db.Message, convos []*db.Conver
 	}
 
 	for _, msg := range msgs {
-		conv, err := store.GetConversation(msg.ConversationID)
+		conv, err := reads.GetConversation(msg.ConversationID)
 		if err != nil || conv == nil {
 			continue
 		}
@@ -3014,7 +3070,7 @@ func mergeSearchResults(store *db.Store, msgs []*db.Message, convos []*db.Conver
 			continue
 		}
 		preview := ""
-		msgs, err := store.GetMessagesByConversation(conv.ConversationID, 1)
+		msgs, err := reads.GetMessagesByConversation(conv.ConversationID, 1)
 		if err == nil && len(msgs) > 0 {
 			preview = searchPreviewForMessage(msgs[0])
 		}
@@ -3053,7 +3109,7 @@ type conversationParticipant struct {
 	IsMeCamel bool   `json:"isMe"`
 }
 
-func enrichConversationPreviews(store *db.Store, convos []*db.Conversation) error {
+func enrichConversationPreviews(reads readsource.ReadSource, convos []*db.Conversation) error {
 	ids := make([]string, 0, len(convos))
 	for _, conv := range convos {
 		if conv == nil {
@@ -3061,7 +3117,7 @@ func enrichConversationPreviews(store *db.Store, convos []*db.Conversation) erro
 		}
 		ids = append(ids, conv.ConversationID)
 	}
-	previews, err := store.LatestConversationPreviews(ids)
+	previews, err := reads.LatestConversationPreviews(ids)
 	if err != nil {
 		return err
 	}
@@ -3277,6 +3333,37 @@ func scheduledID() string {
 	b := make([]byte, 8)
 	_, _ = rand.Read(b)
 	return "sched:" + hex.EncodeToString(b)
+}
+
+func writeV2MessageMediaResponse(
+	ctx context.Context,
+	w http.ResponseWriter,
+	v2 *V2Options,
+	messageID string,
+) error {
+	messages, err := sqlite.NewMessageRepository(v2.V2Store, time.Now)
+	if err != nil {
+		return err
+	}
+	message, err := messages.GetMessage(ctx, messageID)
+	if err != nil {
+		return err
+	}
+	descriptor, err := v2.Media.Resolve(ctx, media.DownloadCommand{
+		AccountID: message.AccountID,
+		MessageID: message.MessageID,
+		Ordinal:   0,
+	})
+	if err != nil {
+		return err
+	}
+	reader, err := v2.Media.Open(descriptor.Ref)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	writeDescriptorMediaResponse(w, reader, descriptor)
+	return nil
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/web/apiv1.go
+++ b/internal/web/apiv1.go
@@ -36,9 +36,10 @@ type V2Options struct {
 }
 
 type v1API struct {
-	legacy *db.Store
-	logger zerolog.Logger
-	v2     *V2Options
+	legacy  *db.Store
+	logger  zerolog.Logger
+	v2      *V2Options
+	primary bool
 }
 
 type v1SubmissionResponse struct {
@@ -74,8 +75,8 @@ type v1PendingResponse struct {
 	ErrorCode      string                `json:"error_code,omitempty"`
 }
 
-func registerV1Routes(mux *http.ServeMux, legacy *db.Store, logger zerolog.Logger, v2 *V2Options) {
-	api := &v1API{legacy: legacy, logger: logger, v2: v2}
+func registerV1Routes(mux *http.ServeMux, legacy *db.Store, logger zerolog.Logger, v2 *V2Options, primary bool) {
+	api := &v1API{legacy: legacy, logger: logger, v2: v2, primary: primary}
 
 	mux.HandleFunc("POST /api/v1/outbox/messages", api.submitText)
 	mux.HandleFunc("POST /api/v1/outbox/media", api.submitMedia)
@@ -143,13 +144,19 @@ func (a *v1API) submitText(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	submission, err := v2wire.SubmitText(r.Context(), a.v2Deps(), v2wire.TextInput{
+	input := v2wire.TextInput{
 		ConversationID: conversationID,
 		Body:           request.Body,
 		ReplyToID:      strings.TrimSpace(request.ReplyToID),
 		IdempotencyKey: idempotencyKey,
 		NotBefore:      notBefore,
-	})
+	}
+	var submission messaging.Submission
+	if a.primary {
+		submission, err = v2wire.SubmitTextV2(r.Context(), a.nativeDeps(), input)
+	} else {
+		submission, err = v2wire.SubmitText(r.Context(), a.v2Deps(), input)
+	}
 	if err != nil {
 		a.writeError(w, err)
 		return
@@ -198,7 +205,7 @@ func (a *v1API) submitMedia(w http.ResponseWriter, r *http.Request) {
 		mimeType = "application/octet-stream"
 	}
 
-	submission, err := v2wire.SubmitMedia(r.Context(), a.v2Deps(), v2wire.MediaInput{
+	input := v2wire.MediaInput{
 		ConversationID: conversationID,
 		Content:        file,
 		Filename:       header.Filename,
@@ -207,7 +214,13 @@ func (a *v1API) submitMedia(w http.ResponseWriter, r *http.Request) {
 		ReplyToID:      strings.TrimSpace(r.FormValue("reply_to_id")),
 		IdempotencyKey: idempotencyKey,
 		NotBefore:      notBefore,
-	})
+	}
+	var submission messaging.Submission
+	if a.primary {
+		submission, err = v2wire.SubmitMediaV2(r.Context(), a.nativeDeps(), input)
+	} else {
+		submission, err = v2wire.SubmitMedia(r.Context(), a.v2Deps(), input)
+	}
 	if err != nil {
 		a.writeError(w, err)
 		return
@@ -393,8 +406,17 @@ func (a *v1API) v2Deps() v2wire.Deps {
 	}
 }
 
+func (a *v1API) nativeDeps() v2wire.NativeDeps {
+	return v2wire.NativeDeps{
+		V2:       a.v2.V2Store,
+		Service:  a.v2.Service,
+		Registry: a.v2.Registry,
+	}
+}
+
 func (a *v1API) submitDependenciesAvailable(w http.ResponseWriter) bool {
-	if a.legacy != nil && a.v2.Service != nil && a.v2.V2Store != nil && a.v2.Registry != nil {
+	legacyAvailable := a.primary || a.legacy != nil
+	if legacyAvailable && a.v2.Service != nil && a.v2.V2Store != nil && a.v2.Registry != nil {
 		return true
 	}
 	a.internalUnavailable(w, "v2 submission dependencies are not configured")

--- a/internal/web/r5_routing_test.go
+++ b/internal/web/r5_routing_test.go
@@ -1,0 +1,433 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/media"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/readsource"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+type routingReadSource struct {
+	readsource.ReadSource
+	calls map[string]int
+}
+
+func newRoutingReadSource() *routingReadSource {
+	return &routingReadSource{calls: make(map[string]int)}
+}
+
+func (s *routingReadSource) ListConversations(limit int) ([]*db.Conversation, error) {
+	s.calls["list"]++
+	return []*db.Conversation{{
+		ConversationID: "v2-conversation",
+		Name:           "V2 Alice",
+		LastMessageTS:  200,
+		SourcePlatform: "sms",
+	}}, nil
+}
+
+func (s *routingReadSource) GetConversation(id string) (*db.Conversation, error) {
+	s.calls["conversation"]++
+	return &db.Conversation{
+		ConversationID: id,
+		Name:           "V2 Alice",
+		LastMessageTS:  200,
+		SourcePlatform: "sms",
+	}, nil
+}
+
+func (s *routingReadSource) GetMessagesByConversation(conversationID string, limit int) ([]*db.Message, error) {
+	s.calls["messages"]++
+	return []*db.Message{routingMessage("latest from v2")}, nil
+}
+
+func (s *routingReadSource) GetMessagesByConversationBefore(conversationID string, beforeMS int64, beforeID string, limit int) ([]*db.Message, error) {
+	s.calls["before"]++
+	return []*db.Message{routingMessage("before from v2")}, nil
+}
+
+func (s *routingReadSource) GetMessagesByConversationAfter(conversationID string, afterMS int64, afterID string, limit int) ([]*db.Message, error) {
+	s.calls["after"]++
+	return []*db.Message{routingMessage("after from v2")}, nil
+}
+
+func (s *routingReadSource) GetMessagesAroundMessage(conversationID, messageID string, before, after int) ([]*db.Message, error) {
+	s.calls["around"]++
+	return []*db.Message{routingMessage("around from v2")}, nil
+}
+
+func (s *routingReadSource) SearchMessagesFiltered(query string, filter db.SearchFilter) ([]*db.Message, error) {
+	s.calls["search"]++
+	return []*db.Message{routingMessage("search from v2")}, nil
+}
+
+func (s *routingReadSource) PlatformStats() ([]db.PlatformStat, error) {
+	s.calls["platform_stats"]++
+	return []db.PlatformStat{{Platform: "sms", Count: 42, LatestMS: 200, LatestRecvMS: 100}}, nil
+}
+
+func (s *routingReadSource) MessageCount(sourcePlatform string) (int, error) {
+	s.calls["message_count"]++
+	if sourcePlatform == "" {
+		return 42, nil
+	}
+	if sourcePlatform == "sms" {
+		return 42, nil
+	}
+	return 0, nil
+}
+
+func (s *routingReadSource) ConversationCount(sourcePlatform string) (int, error) {
+	s.calls["conversation_count"]++
+	if sourcePlatform == "" || sourcePlatform == "sms" {
+		return 3, nil
+	}
+	return 0, nil
+}
+
+func (s *routingReadSource) LatestTimestamp(sourcePlatform string) (int64, error) {
+	s.calls["latest_timestamp"]++
+	if sourcePlatform == "sms" {
+		return 200, nil
+	}
+	return 0, nil
+}
+
+func (s *routingReadSource) LatestConversationPreviews(ids []string) (map[string]string, error) {
+	s.calls["previews"]++
+	return map[string]string{"v2-conversation": "preview from v2"}, nil
+}
+
+func routingMessage(body string) *db.Message {
+	return &db.Message{
+		MessageID:      "v2-message",
+		ConversationID: "v2-conversation",
+		Body:           body,
+		TimestampMS:    200,
+		SourcePlatform: "sms",
+	}
+}
+
+func TestR5CanonicalReadRoutesUseConfiguredSource(t *testing.T) {
+	legacy, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+	if err := legacy.UpsertConversation(&db.Conversation{
+		ConversationID: "legacy-conversation",
+		Name:           "Legacy Alice",
+		LastMessageTS:  100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := legacy.UpsertMessage(&db.Message{
+		MessageID:      "legacy-message",
+		ConversationID: "legacy-conversation",
+		Body:           "legacy body",
+		TimestampMS:    100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reads := newRoutingReadSource()
+	handler := APIHandlerWithOptions(legacy, nil, zerolog.Nop(), nil, APIOptions{
+		Reads:     reads,
+		V2Primary: true,
+	})
+
+	tests := []struct {
+		name     string
+		path     string
+		wantBody string
+		wantCall string
+	}{
+		{name: "conversations", path: "/api/conversations", wantBody: "V2 Alice", wantCall: "list"},
+		{name: "messages", path: "/api/conversations/v2-conversation/messages", wantBody: "latest from v2", wantCall: "messages"},
+		{name: "before", path: "/api/conversations/v2-conversation/messages?before=200&before_id=v2-message", wantBody: "before from v2", wantCall: "before"},
+		{name: "after", path: "/api/conversations/v2-conversation/messages?after=200&after_id=v2-message", wantBody: "after from v2", wantCall: "after"},
+		{name: "around", path: "/api/conversations/v2-conversation/messages-around?message_id=v2-message", wantBody: "around from v2", wantCall: "around"},
+		{name: "thread search", path: "/api/conversations/v2-conversation/search?q=search", wantBody: "search from v2", wantCall: "search"},
+		{name: "global search", path: "/api/search?q=search", wantBody: "search from v2", wantCall: "search"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			before := reads.calls[test.wantCall]
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "http://127.0.0.1"+test.path, nil))
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+			}
+			if !strings.Contains(recorder.Body.String(), test.wantBody) {
+				t.Fatalf("body = %s, want content %q", recorder.Body.String(), test.wantBody)
+			}
+			if strings.Contains(recorder.Body.String(), "legacy") {
+				t.Fatalf("body leaked legacy data: %s", recorder.Body.String())
+			}
+			if reads.calls[test.wantCall] <= before {
+				t.Fatalf("configured read source method %q was not called", test.wantCall)
+			}
+		})
+	}
+
+	if reads.calls["previews"] == 0 {
+		t.Fatal("conversation previews did not use configured read source")
+	}
+}
+
+func TestR5LegacySendEndpointsQuiescedInV2Primary(t *testing.T) {
+	legacy, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+	handler := APIHandlerWithOptions(legacy, nil, zerolog.Nop(), nil, APIOptions{V2Primary: true})
+
+	for _, path := range []string{"/api/send", "/api/send-media", "/api/send-gif", "/api/drafts/send"} {
+		t.Run(path, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "http://127.0.0.1"+path, strings.NewReader("{}")))
+			response := recorder.Result()
+			defer response.Body.Close()
+			if response.StatusCode != http.StatusConflict {
+				raw, _ := io.ReadAll(response.Body)
+				t.Fatalf("status = %d, want 409; body=%s", response.StatusCode, raw)
+			}
+			var payload map[string]string
+			if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload["error"] != "v2 primary: use /api/v1/outbox" {
+				t.Fatalf("error = %q", payload["error"])
+			}
+		})
+	}
+}
+
+func TestR5V1SubmitUsesNativeV2ConversationIDInV2Primary(t *testing.T) {
+	harness := newA3Harness(t, false)
+	nowMS := time.Now().UnixMilli()
+	if err := harness.v2.UpsertAccount(sqlite.Account{
+		AccountID:   "google-primary",
+		BridgeKey:   "google_messages",
+		DisplayName: "Google",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  "{}",
+		CreatedAtMS: nowMS,
+		UpdatedAtMS: nowMS,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	const conversationID = "v2-native-conversation"
+	if err := harness.v2.UpsertConversation(sqlite.Conversation{
+		ConversationID:       conversationID,
+		AccountID:            "google-primary",
+		RemoteConversationID: "remote-v2-native-conversation",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Native v2 thread",
+		NotificationMode:     sqlite.NotificationModeAll,
+		MetadataJSON:         "{}",
+		CreatedAtMS:          nowMS,
+		UpdatedAtMS:          nowMS,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := APIHandlerWithOptions(harness.legacy, nil, zerolog.Nop(), nil, APIOptions{
+		V2Primary: true,
+		V2: &V2Options{
+			Service:  harness.service,
+			V2Store:  harness.v2,
+			Registry: harness.registry,
+		},
+	})
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"http://127.0.0.1/api/v1/outbox/messages",
+		strings.NewReader(`{"conversation_id":"v2-native-conversation","body":"native","idempotency_key":"native-route-key"}`),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if legacyConversation, _ := harness.legacy.GetConversation(conversationID); legacyConversation != nil {
+		t.Fatalf("native v2 id unexpectedly created a legacy mirror row: conversation=%+v", legacyConversation)
+	}
+}
+
+func TestR5CanonicalMediaRouteServesV2PrimaryAttachment(t *testing.T) {
+	ctx := context.Background()
+	v2, err := sqlite.Open(filepath.Join(t.TempDir(), "v2.sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = v2.Close() })
+	blobs, err := blob.New(filepath.Join(t.TempDir(), "blobs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("v2 canonical attachment")
+	ref, err := blobs.Put(ctx, bytes.NewReader(content), "text/plain", int64(len(content)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	nowMS := time.Now().UnixMilli()
+	if err := v2.UpsertAccount(sqlite.Account{
+		AccountID:   "google-primary",
+		BridgeKey:   "google_messages",
+		DisplayName: "Google",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  "{}",
+		CreatedAtMS: nowMS,
+		UpdatedAtMS: nowMS,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := v2.UpsertConversation(sqlite.Conversation{
+		ConversationID:       "v2-media-conversation",
+		AccountID:            "google-primary",
+		RemoteConversationID: "remote-v2-media-conversation",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "V2 media",
+		NotificationMode:     sqlite.NotificationModeAll,
+		MetadataJSON:         "{}",
+		CreatedAtMS:          nowMS,
+		UpdatedAtMS:          nowMS,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := sqlite.NewMessageRepository(v2, time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const messageID = "v2-media-message"
+	if err := messages.ImportMessage(ctx, sqlite.MessageProjection{
+		Message: sqlite.Message{
+			MessageID:       messageID,
+			ConversationID:  "v2-media-conversation",
+			AccountID:       "google-primary",
+			RemoteMessageID: "remote-v2-media-message",
+			Direction:       sqlite.MessageDirectionIncoming,
+			State:           sqlite.MessageStateActive,
+			OccurredAtMS:    nowMS,
+		},
+		Attachments: []sqlite.MessageAttachment{{
+			Ordinal:  0,
+			RemoteID: "remote-attachment",
+			Filename: "attachment.txt",
+			MIME:     "text/plain",
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	attachments, err := sqlite.NewMessageAttachmentRepository(v2, time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := attachments.MarkDownloaded(ctx, messageID, 0, ref.Hash, int64(len(content)), "text/plain"); err != nil {
+		t.Fatal(err)
+	}
+	mediaService, err := media.NewService(v2, &a3Registry{accountID: "google-primary"}, blobs, messaging.SystemClock{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+	handler := APIHandlerWithOptions(legacy, nil, zerolog.Nop(), nil, APIOptions{
+		V2Primary: true,
+		V2: &V2Options{
+			V2Store: v2,
+			Media:   mediaService,
+		},
+	})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/media/"+messageID, nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !bytes.Equal(recorder.Body.Bytes(), content) {
+		t.Fatalf("body = %q, want %q", recorder.Body.Bytes(), content)
+	}
+}
+
+func TestR5StatusCountsRouteToConfiguredSourceInV2Primary(t *testing.T) {
+	legacy, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+	// Legacy has one throwaway conversation with a different platform, so if the
+	// handler read legacy the counts would not match the spy's v2 figures.
+	reads := newRoutingReadSource()
+	handler := APIHandlerWithOptions(legacy, nil, zerolog.Nop(), nil, APIOptions{
+		Reads:     reads,
+		V2Primary: true,
+	})
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/diagnostics", nil))
+	response := recorder.Result()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.StatusCode)
+	}
+	var payload struct {
+		MessageCount      int            `json:"message_count"`
+		ConversationCount int            `json:"conversation_count"`
+		MessageCounts     map[string]int `json:"message_counts"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.MessageCount != 42 || payload.ConversationCount != 3 {
+		t.Fatalf("counts = (msg %d, conv %d), want (42, 3) from the v2 source", payload.MessageCount, payload.ConversationCount)
+	}
+	if payload.MessageCounts["sms"] != 42 {
+		t.Fatalf("message_counts[sms] = %d, want 42 from the v2 source", payload.MessageCounts["sms"])
+	}
+	if reads.calls["message_count"] == 0 || reads.calls["conversation_count"] == 0 {
+		t.Fatalf("status did not consult the configured source: calls=%v", reads.calls)
+	}
+}
+
+func TestR5StatsAndStoryUnavailableInV2Primary(t *testing.T) {
+	legacy, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+	handler := APIHandlerWithOptions(legacy, nil, zerolog.Nop(), nil, APIOptions{
+		Reads:     newRoutingReadSource(),
+		V2Primary: true,
+	})
+
+	for _, path := range []string{"http://127.0.0.1/api/stats/v2-conversation", "http://127.0.0.1/api/story/v2-conversation"} {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+		if got := recorder.Result().StatusCode; got != http.StatusConflict {
+			t.Fatalf("%s status = %d, want 409 (unavailable in v2-primary)", path, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

The runtime selector that makes cutover a config change, not a code change — per `r5-selector-it-spec-2026-07-17.md` §2–§5. First of R5's two PRs.

- **Selector** (`cmd/serve.go`, `cmd/v2stack.go`): `OPENMESSAGES_V2_PRIMARY` makes the v2 store the serving store. Fail-fast, evaluated **before `app.New`**: an absent store, a present-but-corrupt store, or a conflicting `V2_SEND=0`/`V2_INGEST=0` refuses the launch with the `migrate` command in the error and touches **neither** store — never a silent fallback to legacy (a silent fallback at cutover would be a data-visibility disaster).
- **`ReadSource` interface** (`internal/readsource`, extracted from `*db.Store`'s existing signatures): legacy-primary keeps `a.Store` unchanged (byte-parity pinned); `internal/v2read.Source` returns the same `db.Message`/`db.Conversation` DTOs so serializers, MCP shapes, and parity assertions stay intact. LIKE-based search (FTS deferred — substring parity documented, not misrepresented as ranking) + a v2 message-list query.
- **Read routing**: the three canonical HTTP endpoints, the MCP read tools, and CLI `read`/`status` all consume the configured source in v2-primary.
- **Send id-space** (§4): a v2-native submit resolves the account from the v2 conversation directly — no mirror legacy-id dependency, so a v2-id send routes correctly.
- **Legacy quiesce** (§5): the legacy scheduler and W3-2 projector don't run in v2-primary (closing the migrated-schedule double-send hazard — both are pinned bidirectionally), legacy send endpoints return 409.

## Adversarial-review fixes (verdict was FIX-FIRST, narrow — core machinery shipped SHIP-quality)

1. **BLOCKING — `get_conversation` routed to legacy.** It read `a.Store` unconditionally, so at cutover every v2 conversation id (which the list emits) returned "No messages found" — silent-empty. Now routes through the configured source; `TestR5GetConversationRoutesToConfiguredSource` pins it (the spy panics if legacy were hit).
2. **SHOULD-FIX — `/api/diagnostics` counts legacy.** `message_count`/`conversation_count`/`latest_by_platform`/freshness read the legacy store; with the projector correctly off, they'd undercount by every post-cutover v2 send and drift over time. Now route through the serving source (the previously-dead `reads.MessageCount`/`ConversationCount`/`LatestTimestamp` interface methods, added for exactly this consumer). Pinned by `TestR5StatusCountsRouteToConfiguredSourceInV2Primary`.
3. **SHOULD-FIX — `/api/stats` + `/api/story` silent-empty.** Their MCP twins were gated `unavailableInV2Primary`; the HTTP twins computed over an empty legacy result. Now return 409, pinned.

Accepted NITs (documented, not fixed — low-risk): a handful of legacy-backed tools (`draft_message`, `download_media`, `react_to_message`, …) remain unwrapped in v2-primary but cleanly error rather than double-send or mislead; the `V2Primary && Reads==nil` footgun is latent-only (serve always wires both); v2 stats walk pages vs a `GROUP BY` (perf); favorited-old threads clamp off the v2 list. These are R9-adjacent and out of R5-1's read-correctness scope.

## Verification

Full `go test -race ./...`: 29 packages green (`internal/readsource` + `internal/v2read` added), independently verified outside the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
