### PR TITLE
Cutover drain-or-carry + backend integration tests + rehearsal (rebuild R5-2)

### DIFF
--- a/cmd/r5_backend_it_test.go
+++ b/cmd/r5_backend_it_test.go
@@ -1,0 +1,1001 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/rs/zerolog"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+	waE2E "go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/bridgeadapters/scripted"
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/ingest"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/migration"
+	omtools "github.com/maxghenis/openmessage/internal/tools"
+	"github.com/maxghenis/openmessage/internal/v2keys"
+	"github.com/maxghenis/openmessage/internal/v2read"
+	"github.com/maxghenis/openmessage/internal/v2wire"
+	"github.com/maxghenis/openmessage/internal/web"
+	"github.com/maxghenis/openmessage/internal/whatsappmedia"
+)
+
+const (
+	r5GoogleAccountID   = "google-primary"
+	r5WhatsAppAccountID = "whatsapp-primary"
+	r5SignalAccountID   = "signal-primary"
+	r5GChatAccountID    = "gchat-archive"
+	r5IMessageAccountID = "imessage-archive"
+
+	r5GoogleConversation   = "sms-r5-fixture"
+	r5WhatsAppLID          = "whatsapp:r5opaque@lid"
+	r5WhatsAppConversation = "whatsapp:14155550100@s.whatsapp.net"
+	r5SignalACI            = "11111111-2222-3333-4444-555555555555"
+	r5SignalConversation   = "signal:" + r5SignalACI
+	r5SignalGroup          = "signal-group:r5-group-token"
+	r5GChatConversation    = "gchat:r5-thread"
+	r5IMessageConversation = "imessage:r5-chat"
+
+	r5SharedSearchToken = "r5-shared-parity-token"
+)
+
+type r5FixtureMessage struct {
+	LegacyID    string
+	Body        string
+	RemoteID    string
+	FromMe      bool
+	SenderName  string
+	SenderValue string
+}
+
+type r5FixtureConversation struct {
+	LegacyID  string
+	RemoteID  string
+	AccountID string
+	Platform  string
+	Name      string
+	Messages  []r5FixtureMessage
+}
+
+func (conversation r5FixtureConversation) V2ID() string {
+	return v2keys.DeriveID("conversation", conversation.AccountID, conversation.RemoteID)
+}
+
+type r5LegacyFixture struct {
+	DataDir           string
+	StorePath         string
+	BaseMS            int64
+	TotalMessages     int64
+	ConversationCount int
+	PlatformCounts    map[string]int64
+	Conversations     []r5FixtureConversation
+	ScheduledMedia    []byte
+}
+
+// buildR5LegacyFixture constructs the R5 cutover corpus exclusively through
+// the retained legacy writers, then closes the store so backup/migrate see a
+// stopped and checkpointed SQLite family.
+func buildR5LegacyFixture(t *testing.T) r5LegacyFixture {
+	t.Helper()
+
+	dataDir := t.TempDir()
+	storePath := filepath.Join(dataDir, legacyDatabaseName)
+	store, err := db.New(storePath)
+	if err != nil {
+		t.Fatalf("create R5 legacy fixture: %v", err)
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = store.Close()
+		}
+	}()
+
+	base := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC).UnixMilli()
+	conversations := []*db.Conversation{
+		{
+			ConversationID: r5GoogleConversation,
+			Name:           "R5 Google Friend",
+			Participants:   `[{"name":"R5 Google Friend","number":"+15550100001"},{"name":"Me","number":"+15550009999","is_me":true}]`,
+			LastMessageTS:  base + 3_000,
+			UnreadCount:    2,
+			SourcePlatform: "sms",
+		},
+		{
+			ConversationID: r5WhatsAppLID,
+			Name:           "R5 WhatsApp LID alias",
+			Participants:   `[{"name":"R5 WhatsApp Friend","number":"14155550200@s.whatsapp.net"}]`,
+			LastMessageTS:  base + 4_000,
+			SourcePlatform: "whatsapp",
+		},
+		{
+			ConversationID: r5WhatsAppConversation,
+			Name:           "R5 WhatsApp Friend",
+			Participants:   `[{"name":"R5 WhatsApp Friend","number":"14155550200@s.whatsapp.net"},{"name":"Me","number":"14155550999@s.whatsapp.net","is_me":true}]`,
+			LastMessageTS:  base + 5_000,
+			SourcePlatform: "whatsapp",
+		},
+		{
+			ConversationID: r5SignalConversation,
+			Name:           "R5 Signal ACI Friend",
+			Participants:   `[{"name":"R5 Signal ACI Friend","number":"` + r5SignalACI + `"}]`,
+			LastMessageTS:  base + 7_000,
+			SourcePlatform: "signal",
+		},
+		{
+			ConversationID: r5SignalGroup,
+			Name:           "R5 Signal Group",
+			IsGroup:        true,
+			Participants:   `[{"name":"R5 Signal Group Friend","number":"+15550300003"}]`,
+			LastMessageTS:  base + 8_000,
+			SourcePlatform: "signal",
+		},
+		{
+			ConversationID: r5GChatConversation,
+			Name:           "R5 GChat Archive",
+			Participants:   `[{"name":"R5 GChat Friend","email":"friend-r5@example.com"}]`,
+			LastMessageTS:  base + 10_000,
+			SourcePlatform: "gchat",
+		},
+		{
+			ConversationID: r5IMessageConversation,
+			Name:           "R5 iMessage Archive",
+			Participants:   `[{"name":"R5 iMessage Friend","number":"+15550400004"}]`,
+			LastMessageTS:  base + 12_000,
+			SourcePlatform: "imessage",
+		},
+	}
+	for _, conversation := range conversations {
+		if err := store.UpsertConversation(conversation); err != nil {
+			t.Fatalf("seed conversation %q: %v", conversation.ConversationID, err)
+		}
+	}
+
+	whatsAppMediaRef := whatsappmedia.EncodeLocalMediaRef("Media/r5-fixture.webp")
+	if whatsAppMediaRef == "" {
+		t.Fatal("encode WhatsApp fixture media reference: empty result")
+	}
+	legacyMessages := []*db.Message{
+		{
+			MessageID: "google-r5-empty-source", ConversationID: r5GoogleConversation,
+			SenderName: "R5 Google Friend", SenderNumber: "+15550100001",
+			Body: r5SharedSearchToken + " google incoming media", TimestampMS: base + 1_000,
+			Status: "RCS_DELIVERED", MediaID: "google-r5-media", MimeType: "image/jpeg",
+			DecryptionKey: "deadbeef", Reactions: `[{"emoji":"👍","count":1}]`,
+			SourcePlatform: "sms",
+		},
+		{
+			MessageID: "google-r5-explicit-source", ConversationID: r5GoogleConversation,
+			SenderName: "R5 Google Friend", SenderNumber: "+15550100001",
+			Body: "google second incoming byte-exact", TimestampMS: base + 2_000,
+			Status: "RCS_DELIVERED", SourcePlatform: "sms", SourceID: "google-remote-r5-explicit",
+		},
+		{
+			MessageID: "google-r5-outgoing", ConversationID: r5GoogleConversation,
+			SenderName: "Me", SenderNumber: "+15550009999", Body: "google outgoing byte-exact",
+			TimestampMS: base + 3_000, Status: "sent", IsFromMe: true, SourcePlatform: "sms",
+		},
+		{
+			MessageID: "whatsapp:wa-r5-lid", ConversationID: r5WhatsAppLID,
+			SenderName: "R5 WhatsApp Friend", SenderNumber: "14155550200@s.whatsapp.net",
+			Body: r5SharedSearchToken + " whatsapp incoming media", TimestampMS: base + 4_000,
+			Status: "delivered", SourcePlatform: "whatsapp",
+			// Source IDs win verbatim under R2, including a retained platform prefix.
+			SourceID: "whatsapp:wa-r5-explicit-source", MediaID: whatsAppMediaRef, MimeType: "image/webp",
+		},
+		{
+			MessageID: "whatsapp:wa-r5-outgoing", ConversationID: r5WhatsAppConversation,
+			SenderName: "Me", Body: "whatsapp outgoing byte-exact", TimestampMS: base + 5_000,
+			Status: "sent", IsFromMe: true, SourcePlatform: "whatsapp",
+		},
+		{
+			MessageID: "signal:1700000001000", ConversationID: r5SignalConversation,
+			SenderName: "R5 Signal ACI Friend", SenderNumber: r5SignalACI,
+			Body: r5SharedSearchToken + " signal incoming", TimestampMS: base + 6_000,
+			Status: "delivered", SourcePlatform: "signal",
+		},
+		{
+			MessageID: "signal:local:abc123r5", ConversationID: r5SignalConversation,
+			SenderName: "Me", Body: "signal fabricated outgoing byte-exact", TimestampMS: base + 7_000,
+			Status: "sent", IsFromMe: true, SourcePlatform: "signal",
+		},
+		{
+			MessageID: "signal:1700000002000", ConversationID: r5SignalGroup,
+			SenderName: "R5 Signal Group Friend", SenderNumber: "+15550300003",
+			Body: "signal group incoming byte-exact", TimestampMS: base + 8_000,
+			Status: "delivered", SourcePlatform: "signal",
+		},
+		{
+			MessageID: "gchat:r5-message-1", ConversationID: r5GChatConversation,
+			SenderName: "R5 GChat Friend", SenderNumber: "friend-r5@example.com",
+			Body: r5SharedSearchToken + " gchat incoming", TimestampMS: base + 9_000,
+			Status: "delivered", SourcePlatform: "gchat",
+		},
+		{
+			MessageID: "gchat:r5-message-2", ConversationID: r5GChatConversation,
+			SenderName: "Me", Body: "gchat outgoing byte-exact", TimestampMS: base + 10_000,
+			Status: "sent", IsFromMe: true, SourcePlatform: "gchat",
+		},
+		{
+			MessageID: "imessage:r5-message-1", ConversationID: r5IMessageConversation,
+			SenderName: "R5 iMessage Friend", SenderNumber: "+15550400004",
+			Body: r5SharedSearchToken + " imessage incoming", TimestampMS: base + 11_000,
+			Status: "delivered", SourcePlatform: "imessage",
+		},
+		{
+			MessageID: "imessage:r5-message-2", ConversationID: r5IMessageConversation,
+			SenderName: "Me", Body: "imessage outgoing byte-exact", TimestampMS: base + 12_000,
+			Status: "sent", IsFromMe: true, SourcePlatform: "imessage",
+		},
+	}
+	for _, message := range legacyMessages {
+		if err := store.UpsertMessage(message); err != nil {
+			t.Fatalf("seed message %q: %v", message.MessageID, err)
+		}
+	}
+	if err := store.MergeConversationIDs(r5WhatsAppLID, r5WhatsAppConversation); err != nil {
+		t.Fatalf("merge WhatsApp @lid conversation: %v", err)
+	}
+
+	if err := store.UpsertUnifiedContact(&db.UnifiedContact{
+		UnifiedID:   "r5-cross-platform-person",
+		DisplayName: "R5 Unified Friend",
+		Identifiers: `[{"platform":"sms","value":"+15550100001"},{"platform":"signal","value":"` + r5SignalACI + `"}]`,
+	}); err != nil {
+		t.Fatalf("seed unified contact: %v", err)
+	}
+
+	scheduledMedia := []byte("r5 scheduled media bytes\x00\x01")
+	scheduleBase := time.Now().UTC().Add(24 * time.Hour).UnixMilli()
+	scheduled := []*db.ScheduledMessage{
+		{
+			ID: "r5-pending-text", ConversationID: r5GoogleConversation,
+			Body: "r5 pending scheduled text", SendAt: scheduleBase, Status: db.ScheduleStatusPending,
+			CreatedAt: base + 20_000,
+		},
+		{
+			ID: "r5-pending-media", ConversationID: r5WhatsAppConversation,
+			Body: "r5 pending scheduled media caption", ReplyToID: "whatsapp:wa-r5-lid",
+			SendAt: scheduleBase + 1_000, Status: db.ScheduleStatusPending, CreatedAt: base + 21_000,
+			MediaData: scheduledMedia, MediaFilename: "r5-scheduled.bin", MediaMime: "application/octet-stream",
+		},
+		{
+			ID: "r5-sending", ConversationID: r5SignalConversation,
+			Body: "r5 ambiguous sending", SendAt: scheduleBase + 2_000, Status: db.ScheduleStatusSending,
+			CreatedAt: base + 22_000,
+		},
+		{
+			ID: "r5-sent", ConversationID: r5GoogleConversation,
+			Body: "r5 already sent", SendAt: scheduleBase + 3_000, Status: db.ScheduleStatusSent,
+			CreatedAt: base + 23_000, SentMessageID: "google-r5-outgoing",
+		},
+		{
+			ID: "r5-canceled", ConversationID: r5GChatConversation,
+			Body: "r5 canceled", SendAt: scheduleBase + 4_000, Status: db.ScheduleStatusCanceled,
+			CreatedAt: base + 24_000,
+		},
+	}
+	for _, message := range scheduled {
+		if err := store.CreateScheduledMessage(message); err != nil {
+			t.Fatalf("seed scheduled message %q: %v", message.ID, err)
+		}
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("close/checkpoint R5 legacy fixture: %v", err)
+	}
+	closed = true
+
+	fixture := r5LegacyFixture{
+		DataDir:           dataDir,
+		StorePath:         storePath,
+		BaseMS:            base,
+		TotalMessages:     int64(len(legacyMessages)),
+		ConversationCount: 6,
+		PlatformCounts: map[string]int64{
+			"sms": 3, "whatsapp": 2, "signal": 3, "gchat": 2, "imessage": 2,
+		},
+		ScheduledMedia: scheduledMedia,
+		Conversations: []r5FixtureConversation{
+			{
+				LegacyID: r5GoogleConversation, RemoteID: r5GoogleConversation,
+				AccountID: r5GoogleAccountID, Platform: "sms", Name: "R5 Google Friend",
+				Messages: []r5FixtureMessage{
+					{LegacyID: "google-r5-empty-source", RemoteID: "google-r5-empty-source", Body: r5SharedSearchToken + " google incoming media", SenderName: "R5 Unified Friend", SenderValue: "+15550100001"},
+					{LegacyID: "google-r5-explicit-source", RemoteID: "google-remote-r5-explicit", Body: "google second incoming byte-exact", SenderName: "R5 Unified Friend", SenderValue: "+15550100001"},
+					{LegacyID: "google-r5-outgoing", RemoteID: "google-r5-outgoing", Body: "google outgoing byte-exact", FromMe: true},
+				},
+			},
+			{
+				LegacyID: r5WhatsAppConversation, RemoteID: r5WhatsAppConversation,
+				AccountID: r5WhatsAppAccountID, Platform: "whatsapp", Name: "R5 WhatsApp Friend",
+				Messages: []r5FixtureMessage{
+					{LegacyID: "whatsapp:wa-r5-lid", RemoteID: "whatsapp:wa-r5-explicit-source", Body: r5SharedSearchToken + " whatsapp incoming media", SenderName: "R5 WhatsApp Friend", SenderValue: "14155550200@s.whatsapp.net"},
+					{LegacyID: "whatsapp:wa-r5-outgoing", RemoteID: "wa-r5-outgoing", Body: "whatsapp outgoing byte-exact", FromMe: true},
+				},
+			},
+			{
+				LegacyID: r5SignalConversation, RemoteID: r5SignalConversation,
+				AccountID: r5SignalAccountID, Platform: "signal", Name: "R5 Signal ACI Friend",
+				Messages: []r5FixtureMessage{
+					{LegacyID: "signal:1700000001000", RemoteID: "1700000001000", Body: r5SharedSearchToken + " signal incoming", SenderName: "R5 Unified Friend", SenderValue: r5SignalACI},
+					{LegacyID: "signal:local:abc123r5", RemoteID: "local:abc123r5", Body: "signal fabricated outgoing byte-exact", FromMe: true},
+				},
+			},
+			{
+				LegacyID: r5SignalGroup, RemoteID: r5SignalGroup,
+				AccountID: r5SignalAccountID, Platform: "signal", Name: "R5 Signal Group",
+				Messages: []r5FixtureMessage{
+					{LegacyID: "signal:1700000002000", RemoteID: "1700000002000", Body: "signal group incoming byte-exact", SenderName: "R5 Signal Group Friend", SenderValue: "+15550300003"},
+				},
+			},
+			{
+				LegacyID: r5GChatConversation, RemoteID: r5GChatConversation,
+				AccountID: r5GChatAccountID, Platform: "gchat", Name: "R5 GChat Archive",
+				Messages: []r5FixtureMessage{
+					{LegacyID: "gchat:r5-message-1", RemoteID: "r5-message-1", Body: r5SharedSearchToken + " gchat incoming", SenderName: "R5 GChat Friend", SenderValue: "friend-r5@example.com"},
+					{LegacyID: "gchat:r5-message-2", RemoteID: "r5-message-2", Body: "gchat outgoing byte-exact", FromMe: true},
+				},
+			},
+			{
+				LegacyID: r5IMessageConversation, RemoteID: r5IMessageConversation,
+				AccountID: r5IMessageAccountID, Platform: "imessage", Name: "R5 iMessage Archive",
+				Messages: []r5FixtureMessage{
+					{LegacyID: "imessage:r5-message-1", RemoteID: "r5-message-1", Body: r5SharedSearchToken + " imessage incoming", SenderName: "R5 iMessage Friend", SenderValue: "+15550400004"},
+					{LegacyID: "imessage:r5-message-2", RemoteID: "r5-message-2", Body: "imessage outgoing byte-exact", FromMe: true},
+				},
+			},
+		},
+	}
+	return fixture
+}
+
+func r5BackupDependencies(now time.Time) backupDependencies {
+	deps := defaultBackupDependencies()
+	deps.now = func() time.Time { return now }
+	deps.version = "r5-backend-it"
+	deps.commit = "r5-backend-it"
+	deps.modified = false
+	deps.probeURL = "http://127.0.0.1:7007/api/status"
+	deps.httpClient = &http.Client{Transport: r5RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, syscall.ECONNREFUSED
+	})}
+	deps.availableBytes = func(string) (uint64, error) { return math.MaxUint64, nil }
+	return deps
+}
+
+func r5MigrateDependencies(now time.Time) migrateDependencies {
+	deps := defaultMigrateDependencies()
+	deps.now = func() time.Time { return now }
+	deps.version = "r5-backend-it"
+	deps.commit = "r5-backend-it"
+	deps.probeURL = "http://127.0.0.1:7007/api/status"
+	deps.httpClient = &http.Client{Transport: r5RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, syscall.ECONNREFUSED
+	})}
+	deps.availableBytes = func(string) (uint64, error) { return math.MaxUint64, nil }
+	deps.transform = migration.Transform
+	return deps
+}
+
+type r5RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (function r5RoundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func runR5Backup(t *testing.T, dataDir string, now time.Time) backupCommandOutput {
+	t.Helper()
+	t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
+	destination := filepath.Join(dataDir, "migration-backups", now.UTC().Format("20060102T150405Z"))
+	var stdout, stderr bytes.Buffer
+	if err := runBackupCommand(
+		context.Background(),
+		[]string{"--to", destination, "--json"},
+		r5BackupDependencies(now),
+		&stdout,
+		&stderr,
+	); err != nil {
+		t.Fatalf("run real backup: %v\nstderr:\n%s\nstdout:\n%s", err, stderr.String(), stdout.String())
+	}
+	var output backupCommandOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("decode backup command output: %v\n%s", err, stdout.String())
+	}
+	if !output.OK || output.ExitCode != 0 || output.ManifestPath == "" || output.BackupPath == "" {
+		t.Fatalf("backup command output = %+v", output)
+	}
+	return output
+}
+
+func runR5Migrate(
+	t *testing.T,
+	sourceDir string,
+	targetDir string,
+	check bool,
+	now time.Time,
+) migration.Report {
+	t.Helper()
+	args := []string{"--from", sourceDir, "--to", targetDir, "--json"}
+	if check {
+		args = append([]string{"--check"}, args...)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := runMigrateCommand(
+		context.Background(), args, r5MigrateDependencies(now), &stdout, &stderr,
+	); err != nil {
+		t.Fatalf("run real migrate (check=%v): %v\nstderr:\n%s\nstdout:\n%s", check, err, stderr.String(), stdout.String())
+	}
+	var report migration.Report
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode migration integrity report: %v\n%s", err, stdout.String())
+	}
+	return report
+}
+
+func TestR5BackendIntegrationMigratedData(t *testing.T) {
+	fixture := buildR5LegacyFixture(t)
+	now := time.Date(2026, 7, 17, 18, 0, 0, 0, time.UTC)
+
+	t.Run("real backup", func(t *testing.T) {
+		output := runR5Backup(t, fixture.DataDir, now)
+		if output.Counts == nil || output.Counts.Conversations != int64(fixture.ConversationCount) ||
+			output.Counts.Messages != fixture.TotalMessages || output.Counts.UnifiedContacts != 1 ||
+			output.Counts.ScheduledMessages != 5 {
+			t.Fatalf("backup counts = %+v", output.Counts)
+		}
+		manifestBytes, err := os.ReadFile(output.ManifestPath)
+		if err != nil {
+			t.Fatalf("read backup manifest: %v", err)
+		}
+		var manifest backupManifest
+		if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+			t.Fatalf("decode backup manifest: %v", err)
+		}
+		if manifest.Source.QuickCheck != "ok" {
+			t.Fatalf("backup source quick_check = %q, want ok", manifest.Source.QuickCheck)
+		}
+		backupDB, err := db.New(filepath.Join(output.BackupPath, legacyDatabaseName))
+		if err != nil {
+			t.Fatalf("open VACUUM INTO backup: %v", err)
+		}
+		messages, err := backupDB.MessageCount("")
+		closeErr := backupDB.Close()
+		if err != nil || closeErr != nil || int64(messages) != fixture.TotalMessages {
+			t.Fatalf("backup message count/close = %d, %v / %v", messages, err, closeErr)
+		}
+	})
+
+	targetDir := filepath.Join(fixture.DataDir, "v2")
+	checkReport := runR5Migrate(t, fixture.DataDir, targetDir, true, now)
+	assertR5IntegrityReport(t, checkReport, fixture, true)
+	if _, err := os.Stat(filepath.Join(targetDir, v2StoreName)); !os.IsNotExist(err) {
+		t.Fatalf("migrate --check published canonical store: %v", err)
+	}
+
+	publishReport := runR5Migrate(t, fixture.DataDir, targetDir, false, now)
+	assertR5IntegrityReport(t, publishReport, fixture, false)
+	if _, err := os.Stat(filepath.Join(targetDir, v2StoreName)); err != nil {
+		t.Fatalf("published v2 store missing: %v", err)
+	}
+
+	t.Setenv("OPENMESSAGES_DATA_DIR", fixture.DataDir)
+	t.Setenv("OPENMESSAGES_DEMO", "0")
+	t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
+	t.Setenv("OPENMESSAGES_V2_PRIMARY", "1")
+	t.Setenv("OPENMESSAGES_V2_SEND", "")
+	t.Setenv("OPENMESSAGES_V2_INGEST", "")
+
+	// v2StackDeps intentionally remains production-adapter-typed in R5-1. Open
+	// the real migrated stack first, then use its public registration seam for
+	// the hermetic adapters.
+	stack, err := newV2Stack(v2StackDeps{DataDir: fixture.DataDir, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatalf("open migrated v2 stack: %v", err)
+	}
+	t.Cleanup(func() { _ = stack.Store.Close() })
+
+	google := scripted.New(r5GoogleAccountID, bridge.PlatformGoogle)
+	whatsApp := scripted.New(r5WhatsAppAccountID, bridge.PlatformWhatsApp)
+	signal := scripted.New(r5SignalAccountID, bridge.PlatformSignal)
+	for _, adapter := range []bridge.Adapter{google, whatsApp, signal} {
+		if err := stack.RegisterAdapter(adapter); err != nil {
+			t.Fatalf("register scripted %s adapter: %v", adapter.Platform(), err)
+		}
+	}
+
+	legacy, err := db.New(":memory:")
+	if err != nil {
+		t.Fatalf("create inert legacy store for v2-primary surfaces: %v", err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	stopStack := stack.Start(ctx, legacy, nil, true)
+	t.Cleanup(func() {
+		stopStack()
+		cancel()
+	})
+
+	reads := v2read.New(stack.Store)
+	assertR5ReadParity(t, reads, fixture)
+
+	shared, err := reads.SearchMessagesFiltered(r5SharedSearchToken, db.SearchFilter{Limit: 50})
+	if err != nil {
+		t.Fatalf("search migrated v2 data: %v", err)
+	}
+	if len(shared) != 5 {
+		t.Fatalf("shared-token search count = %d, want one result on each platform", len(shared))
+	}
+	platforms := map[string]bool{}
+	for _, message := range shared {
+		platforms[message.SourcePlatform] = true
+	}
+	for _, platform := range []string{"sms", "whatsapp", "signal", "gchat", "imessage"} {
+		if !platforms[platform] {
+			t.Errorf("shared-token search omitted platform %q", platform)
+		}
+	}
+
+	google.EnqueueTextResult(bridge.SendResult{
+		RemoteMessageID: "gm-r5-permanent", AcceptedAt: time.Now(), EchoExpected: true,
+	})
+	googleConversation := fixture.Conversations[0]
+	submission, err := v2wire.SubmitTextV2(context.Background(), v2wire.NativeDeps{
+		V2: stack.Store, Service: stack.Service, Registry: stack.Registry,
+	}, v2wire.TextInput{
+		ConversationID: googleConversation.V2ID(),
+		Body:           "r5 scripted confirmed send",
+		IdempotencyKey: "r5-backend-it-send",
+	})
+	if err != nil {
+		t.Fatalf("submit v2-native scripted send: %v", err)
+	}
+	waitR5(t, "scripted send confirmation", func() bool {
+		delivery, getErr := stack.Service.Get(context.Background(), submission.OutboxID)
+		return getErr == nil && delivery.State == messaging.OutboxConfirmed &&
+			delivery.RemoteMessageID == "gm-r5-permanent"
+	})
+	waitR5(t, "confirmed send visible through v2 read source", func() bool {
+		messages, readErr := reads.GetMessagesByConversation(googleConversation.V2ID(), 100)
+		if readErr != nil {
+			return false
+		}
+		for _, message := range messages {
+			if message.Body == "r5 scripted confirmed send" && message.SourceID == "gm-r5-permanent" && message.IsFromMe {
+				return true
+			}
+		}
+		return false
+	})
+	if requests := google.TextRequests(); len(requests) != 1 ||
+		requests[0].Conversation.RemoteID != r5GoogleConversation ||
+		requests[0].Body != "r5 scripted confirmed send" {
+		t.Fatalf("scripted Google text requests = %+v", requests)
+	}
+
+	ingestBodies := map[string]string{
+		"sms":      "r5 google ingest projected",
+		"whatsapp": "r5 whatsapp ingest projected",
+		"signal":   "r5 signal ingest projected",
+	}
+	for _, record := range r5IngressRecords(t, fixture.BaseMS, ingestBodies) {
+		if err := stack.Sink.AppendIngress(context.Background(), record); err != nil {
+			t.Fatalf("append %s ingress frame: %v", record.Codec, err)
+		}
+	}
+	for platform, body := range ingestBodies {
+		platform, body := platform, body
+		t.Run("ingest "+platform, func(t *testing.T) {
+			waitR5(t, platform+" ingress projection", func() bool {
+				messages, searchErr := reads.SearchMessagesFiltered(body, db.SearchFilter{Limit: 10})
+				return searchErr == nil && len(messages) == 1 && messages[0].Body == body &&
+					messages[0].SourcePlatform == platform && !messages[0].IsFromMe
+			})
+		})
+	}
+
+	webHandler := web.APIHandlerWithOptions(legacy, nil, zerolog.Nop(), nil, web.APIOptions{
+		Reads:     reads,
+		V2Primary: true,
+		V2: &web.V2Options{
+			Service: stack.Service, Media: stack.Media, V2Store: stack.Store,
+			Blobs: stack.Blobs, Registry: stack.Registry,
+		},
+	})
+	downloadedMedia := []byte("r5 scripted migrated attachment bytes\x00\x01")
+	google.EnqueueDownload(downloadedMedia, "r5-google.jpg", "image/jpeg")
+	assertR5HTTPSurfaces(t, webHandler, reads, fixture, downloadedMedia, google)
+	assertR5MCPReadSurfaces(t, legacy, reads, fixture)
+
+	var cliBanner bytes.Buffer
+	cliSession, err := openCommandReadSource(zerolog.Nop(), &cliBanner)
+	if err != nil {
+		t.Fatalf("open v2-primary CLI read source: %v", err)
+	}
+	defer cliSession.Close()
+	if cliBanner.String() != "reading v2 store\n" {
+		t.Fatalf("v2 CLI banner = %q", cliBanner.String())
+	}
+	cliResults, err := cliSession.Reads.SearchMessagesFiltered(r5SharedSearchToken, db.SearchFilter{Limit: 50})
+	if err != nil || len(cliResults) != len(shared) {
+		t.Fatalf("CLI v2 read results = %d, %v; want %d", len(cliResults), err, len(shared))
+	}
+}
+
+func assertR5IntegrityReport(
+	t *testing.T,
+	report migration.Report,
+	fixture r5LegacyFixture,
+	check bool,
+) {
+	t.Helper()
+	if report.Format != migration.ReportFormat || !report.OK || report.Check != check ||
+		!report.Validation.Passed || report.Target.Published == check {
+		t.Fatalf("migration report header = format=%d ok=%v check=%v validation=%v published=%v",
+			report.Format, report.OK, report.Check, report.Validation.Passed, report.Target.Published)
+	}
+	messages := report.TableCounts["messages"]
+	if messages.Legacy != fixture.TotalMessages || messages.V2 != fixture.TotalMessages ||
+		messages.Reconciled != fixture.TotalMessages || messages.ReconciliationRatio != 1 {
+		t.Errorf("message reconciliation = %+v, want %d/%d ratio 1", messages, fixture.TotalMessages, fixture.TotalMessages)
+	}
+	if len(report.MessageCollisions) != 0 {
+		t.Errorf("message collisions = %+v, want none", report.MessageCollisions)
+	}
+	wantAccounts := map[string]string{
+		"sms": r5GoogleAccountID, "whatsapp": r5WhatsAppAccountID,
+		"signal": r5SignalAccountID, "gchat": r5GChatAccountID, "imessage": r5IMessageAccountID,
+	}
+	for platform, want := range fixture.PlatformCounts {
+		got := report.PlatformCounts[platform]
+		if got.AccountID != wantAccounts[platform] || got.Legacy != want || got.V2 != want ||
+			got.ReconciliationRatio != 1 {
+			t.Errorf("platform reconciliation %s = %+v, want account %q and %d/%d ratio 1",
+				platform, got, wantAccounts[platform], want, want)
+		}
+	}
+	if report.Identities.Created != 8 || report.Identities.PeopleCreated != 1 ||
+		report.Identities.LinksByProvenance["explicit"] != 2 ||
+		report.Identities.UnunifiedIdentities != 6 {
+		t.Errorf("identity report = %+v", report.Identities)
+	}
+	// The current transformer defines PendingToOutbox as every pending row,
+	// including the one media row; the exact fixture total is therefore two.
+	if report.Schedule.LegacyTotal != 5 || report.Schedule.PendingToOutbox != 2 ||
+		report.Schedule.PendingMedia != 1 || report.Schedule.AmbiguousSending != 1 ||
+		report.Schedule.SkippedSent != 1 || report.Schedule.SkippedCanceled != 1 ||
+		report.Schedule.SkippedFailed != 0 || report.Schedule.OptimisticOnlyRows != 1 {
+		t.Errorf("schedule report = %+v", report.Schedule)
+	}
+	if report.Dropped.ReactionsBearingMessages != 1 {
+		t.Errorf("reactions-bearing messages = %d, want 1", report.Dropped.ReactionsBearingMessages)
+	}
+	if report.ReadState.ConversationsWithUnreadCount != 1 || report.ReadState.LossyWarning == "" {
+		t.Errorf("read-state report = %+v", report.ReadState)
+	}
+	if report.SignalLocalRows != 1 {
+		t.Errorf("signal_local_rows = %d, want 1", report.SignalLocalRows)
+	}
+	if report.Target.Counts["accounts"] != 5 ||
+		report.Target.Counts["conversations"] != int64(fixture.ConversationCount) ||
+		report.Target.Counts["messages"] != fixture.TotalMessages+3 ||
+		report.Target.Counts["outbox"] != 2 || report.Target.Counts["outbox_attachments"] != 1 {
+		t.Errorf("target counts = %+v", report.Target.Counts)
+	}
+	if report.Target.Counts["identities"] != 8 || report.Target.Counts["conversation_participants"] != 8 ||
+		report.Target.Counts["message_attachments"] != 2 {
+		t.Errorf("identity/participant/attachment target counts = %+v", report.Target.Counts)
+	}
+	if report.Media.LegacyAttachments != 2 || report.Media.PendingAttachments != 2 ||
+		report.Media.WhatsAppUnresolvable != 0 || report.Media.ScheduledBlobsVerified != 1 {
+		t.Errorf("media report = %+v", report.Media)
+	}
+	if report.Validation.QuickCheck != "ok" || len(report.Validation.ForeignKeyViolations) != 0 ||
+		!report.Validation.CountsMatched || !report.Validation.SampledHashesMatched ||
+		!report.Validation.BlobReferencesValid || !report.Validation.SourceUnchanged {
+		t.Errorf("validation report = %+v", report.Validation)
+	}
+	if len(report.SampledHashes) != int(fixture.TotalMessages) {
+		t.Errorf("sampled hashes = %d, want all %d fixture messages", len(report.SampledHashes), fixture.TotalMessages)
+	}
+	for _, sample := range report.SampledHashes {
+		if !sample.Matched || sample.ExpectedSHA256 != sample.ActualSHA256 {
+			t.Errorf("sampled hash mismatch: %+v", sample)
+		}
+	}
+}
+
+func assertR5ReadParity(t *testing.T, reads *v2read.Source, fixture r5LegacyFixture) {
+	t.Helper()
+	conversations, err := reads.ListConversations(50)
+	if err != nil {
+		t.Fatalf("list migrated conversations: %v", err)
+	}
+	if len(conversations) != fixture.ConversationCount {
+		t.Fatalf("migrated conversation count = %d, want %d", len(conversations), fixture.ConversationCount)
+	}
+	for index := 1; index < len(conversations); index++ {
+		previous, current := conversations[index-1], conversations[index]
+		if previous.LastMessageTS < current.LastMessageTS ||
+			(previous.LastMessageTS == current.LastMessageTS && previous.ConversationID > current.ConversationID) {
+			t.Errorf("conversation recency order at %d: %+v before %+v", index, previous, current)
+		}
+	}
+	whatsAppCount := 0
+	for _, conversation := range conversations {
+		if conversation.SourcePlatform == "whatsapp" {
+			whatsAppCount++
+		}
+	}
+	if whatsAppCount != 1 {
+		t.Fatalf("migrated @lid-merged WhatsApp conversations = %d, want one", whatsAppCount)
+	}
+
+	for _, expectedConversation := range fixture.Conversations {
+		gotConversation, err := reads.GetConversation(expectedConversation.V2ID())
+		if err != nil {
+			t.Fatalf("get migrated conversation %q: %v", expectedConversation.LegacyID, err)
+		}
+		if gotConversation.Name != expectedConversation.Name || gotConversation.SourcePlatform != expectedConversation.Platform {
+			t.Errorf("conversation %q = %+v", expectedConversation.LegacyID, gotConversation)
+		}
+		gotMessages, err := reads.GetMessagesByConversation(expectedConversation.V2ID(), 100)
+		if err != nil {
+			t.Fatalf("read migrated conversation %q: %v", expectedConversation.LegacyID, err)
+		}
+		// Pending schedules add optimistic messages to the Google and WhatsApp
+		// threads, and the ambiguous Signal sending row adds the report-only
+		// optimistic message. Pin those known additions per thread so a missing
+		// history row cannot hide behind the global reconciliation count.
+		extraOptimistic := map[string]int{
+			r5GoogleConversation:   1,
+			r5WhatsAppConversation: 1,
+			r5SignalConversation:   1,
+		}[expectedConversation.LegacyID]
+		if len(gotMessages) != len(expectedConversation.Messages)+extraOptimistic {
+			t.Errorf("conversation %q message count = %d, want %d history + %d known optimistic",
+				expectedConversation.LegacyID, len(gotMessages), len(expectedConversation.Messages), extraOptimistic)
+		}
+		byRemote := make(map[string]*db.Message, len(gotMessages))
+		for _, message := range gotMessages {
+			byRemote[message.SourceID] = message
+		}
+		for _, expected := range expectedConversation.Messages {
+			got := byRemote[expected.RemoteID]
+			if got == nil {
+				t.Errorf("conversation %q missing remote message %q; got %+v", expectedConversation.LegacyID, expected.RemoteID, sortedR5Keys(byRemote))
+				continue
+			}
+			if got.Body != expected.Body || got.IsFromMe != expected.FromMe ||
+				got.SourcePlatform != expectedConversation.Platform || got.SourceID != expected.RemoteID {
+				t.Errorf("message parity %q = body %q from_me=%v platform=%q source=%q; want %q/%v/%q/%q",
+					expected.LegacyID, got.Body, got.IsFromMe, got.SourcePlatform, got.SourceID,
+					expected.Body, expected.FromMe, expectedConversation.Platform, expected.RemoteID)
+			}
+			wantMessageID := v2keys.DeriveID(
+				"message",
+				expectedConversation.AccountID,
+				expectedConversation.LegacyID+"\x1f"+expected.RemoteID,
+			)
+			if got.MessageID != wantMessageID {
+				t.Errorf("message ID mapping %q = %q, want %q", expected.LegacyID, got.MessageID, wantMessageID)
+			}
+			if !expected.FromMe && (got.SenderNumber != expected.SenderValue || got.SenderName != expected.SenderName) {
+				t.Errorf("message sender parity %q = %q/%q, want %q/%q",
+					expected.LegacyID, got.SenderName, got.SenderNumber, expected.SenderName, expected.SenderValue)
+			}
+		}
+	}
+}
+
+func sortedR5Keys(values map[string]*db.Message) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func r5IngressRecords(t *testing.T, baseMS int64, bodies map[string]string) []bridge.RawIngressRecord {
+	t.Helper()
+
+	googleMessage := &gmproto.Message{
+		MessageID:      "google-r5-ingest-remote",
+		ConversationID: r5GoogleConversation,
+		Timestamp:      (baseMS + 30_000) * 1_000,
+		SenderParticipant: &gmproto.Participant{
+			FullName: "R5 Google Ingest Sender",
+			ID:       &gmproto.SmallInfo{Number: "+15550900001"},
+		},
+		MessageStatus: &gmproto.MessageStatus{Status: gmproto.MessageStatusType_INCOMING_COMPLETE},
+		MessageInfo: []*gmproto.MessageInfo{{
+			Data: &gmproto.MessageInfo_MessageContent{
+				MessageContent: &gmproto.MessageContent{Content: bodies["sms"]},
+			},
+		}},
+	}
+	googlePayload, googleProto, err := ingest.MarshalGoogleMessageFrame(&libgm.WrappedMessage{
+		Message: googleMessage,
+	})
+	if err != nil {
+		t.Fatalf("marshal Google ingress fixture: %v", err)
+	}
+	googleHash := sha256.Sum256(googleProto)
+
+	whatsAppProto, err := proto.Marshal(&waE2E.Message{Conversation: proto.String(bodies["whatsapp"])})
+	if err != nil {
+		t.Fatalf("marshal WhatsApp ingress protobuf: %v", err)
+	}
+	whatsAppPayload, err := json.Marshal(map[string]any{
+		"kind": "message", "chat_jid": "14155550100@s.whatsapp.net",
+		"sender_jid": "14155550200@s.whatsapp.net", "message_id": "wa-r5-ingest-remote",
+		"timestamp_ms": baseMS + 31_000, "is_from_me": false, "is_group": false,
+		"push_name": "R5 WhatsApp Ingest Sender", "proto_b64": whatsAppProto,
+	})
+	if err != nil {
+		t.Fatalf("marshal WhatsApp ingress envelope: %v", err)
+	}
+
+	signalTimestamp := baseMS + 32_000
+	signalLine := []byte(fmt.Sprintf(
+		`{"account":"+15550009999","envelope":{"sourceServiceId":%q,"sourceName":"R5 Signal Ingest Sender","timestamp":%d,"dataMessage":{"timestamp":%d,"message":%q}}}`,
+		r5SignalACI, signalTimestamp, signalTimestamp, bodies["signal"],
+	))
+	signalRecord, ephemeral, err := ingest.BuildSignalIngress(
+		r5SignalAccountID, 1, "+15550009999", signalLine, "", "", time.UnixMilli(signalTimestamp),
+	)
+	if err != nil || signalRecord == nil || ephemeral != nil {
+		t.Fatalf("build Signal ingress fixture = record %v ephemeral %v error %v", signalRecord, ephemeral, err)
+	}
+
+	return []bridge.RawIngressRecord{
+		{
+			AccountID: r5GoogleAccountID, Generation: 1,
+			DedupeKey: "msg:google-r5-ingest-remote:" + hex.EncodeToString(googleHash[:4]),
+			Codec:     ingest.GoogleCodec, CodecVersion: ingest.GoogleCodecVersion,
+			ReceivedAt: time.UnixMilli(baseMS + 30_000), Payload: googlePayload,
+		},
+		{
+			AccountID: r5WhatsAppAccountID, Generation: 1, DedupeKey: "msg:wa-r5-ingest-remote:r5",
+			Codec: ingest.WhatsAppCodec, CodecVersion: ingest.WhatsAppCodecVersion,
+			ReceivedAt: time.UnixMilli(baseMS + 31_000), Payload: whatsAppPayload,
+		},
+		*signalRecord,
+	}
+}
+
+func assertR5HTTPSurfaces(
+	t *testing.T,
+	handler http.Handler,
+	reads *v2read.Source,
+	fixture r5LegacyFixture,
+	downloadedMedia []byte,
+	google *scripted.Adapter,
+) {
+	t.Helper()
+	request := func(path string) *httptest.ResponseRecorder {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "http://127.0.0.1"+path, nil))
+		return recorder
+	}
+
+	conversations := request("/api/conversations?limit=50")
+	if conversations.Code != http.StatusOK {
+		t.Fatalf("HTTP list conversations = %d: %s", conversations.Code, conversations.Body.String())
+	}
+	var conversationPayload []*db.Conversation
+	if err := json.Unmarshal(conversations.Body.Bytes(), &conversationPayload); err != nil ||
+		len(conversationPayload) != fixture.ConversationCount {
+		t.Fatalf("HTTP conversation payload = %d, %v: %s", len(conversationPayload), err, conversations.Body.String())
+	}
+
+	googleFixture := fixture.Conversations[0]
+	messages := request("/api/conversations/" + googleFixture.V2ID() + "/messages?limit=100")
+	if messages.Code != http.StatusOK || !strings.Contains(messages.Body.String(), googleFixture.Messages[0].Body) {
+		t.Fatalf("HTTP conversation messages = %d: %s", messages.Code, messages.Body.String())
+	}
+	search := request("/api/search?q=" + r5SharedSearchToken + "&limit=50")
+	if search.Code != http.StatusOK || !strings.Contains(search.Body.String(), r5SharedSearchToken) {
+		t.Fatalf("HTTP search = %d: %s", search.Code, search.Body.String())
+	}
+
+	mediaMessages, err := reads.SearchMessagesFiltered(r5SharedSearchToken+" google incoming media", db.SearchFilter{Limit: 10})
+	if err != nil || len(mediaMessages) != 1 || mediaMessages[0].MediaID == "" {
+		t.Fatalf("locate migrated Google media message = %+v, %v", mediaMessages, err)
+	}
+	media := request("/api/media/" + mediaMessages[0].MessageID)
+	if media.Code != http.StatusOK || !bytes.Equal(media.Body.Bytes(), downloadedMedia) {
+		t.Fatalf("HTTP migrated media = %d %q, want %q", media.Code, media.Body.Bytes(), downloadedMedia)
+	}
+	if calls := google.DownloadRequests(); len(calls) != 1 || calls[0].Ref.RemoteID != "google-r5-media" {
+		t.Fatalf("scripted migrated media download calls = %+v", calls)
+	}
+	// The second read must be blob-local; the scripted queue is empty and a
+	// second transport call would fail this assertion or the response itself.
+	mediaFromBlob := request("/api/media/" + mediaMessages[0].MessageID)
+	if mediaFromBlob.Code != http.StatusOK || !bytes.Equal(mediaFromBlob.Body.Bytes(), downloadedMedia) ||
+		len(google.DownloadRequests()) != 1 {
+		t.Fatalf("HTTP persisted v2 blob = %d %q, downloads=%d", mediaFromBlob.Code, mediaFromBlob.Body.Bytes(), len(google.DownloadRequests()))
+	}
+
+	// The scheduled media blob is migrated into outbox_attachments rather than
+	// message_attachments; exercise its canonical v1 outbox download as well.
+	outboxID := v2keys.DeriveID("outbox", r5WhatsAppAccountID, "r5-pending-media")
+	scheduledMedia := request("/api/v1/outbox/" + outboxID + "/media")
+	if scheduledMedia.Code != http.StatusOK || !bytes.Equal(scheduledMedia.Body.Bytes(), fixture.ScheduledMedia) {
+		t.Fatalf("HTTP migrated scheduled outbox media = %d %q, want %q", scheduledMedia.Code, scheduledMedia.Body.Bytes(), fixture.ScheduledMedia)
+	}
+}
+
+func assertR5MCPReadSurfaces(
+	t *testing.T,
+	legacy *db.Store,
+	reads *v2read.Source,
+	fixture r5LegacyFixture,
+) {
+	t.Helper()
+	a := &app.App{Store: legacy, Logger: zerolog.Nop()}
+	server := mcpserver.NewMCPServer("r5-backend-it", "test")
+	omtools.RegisterWithOptions(server, a, omtools.Options{Reads: reads, V2Primary: true})
+
+	checks := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{name: "list_conversations", args: map[string]any{"limit": float64(50)}, want: fixture.Conversations[0].Name},
+		{name: "get_messages", args: map[string]any{"limit": float64(100)}, want: "r5 google ingest projected"},
+		{name: "search_messages", args: map[string]any{"query": r5SharedSearchToken, "limit": float64(50)}, want: r5SharedSearchToken},
+		{name: "get_status", args: map[string]any{}, want: "Serving store (v2)"},
+	}
+	for _, check := range checks {
+		registered := server.GetTool(check.name)
+		if registered == nil {
+			t.Fatalf("MCP tool %q was not registered", check.name)
+		}
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = check.args
+		result, err := registered.Handler(context.Background(), request)
+		if err != nil {
+			t.Fatalf("MCP %s: %v", check.name, err)
+		}
+		encoded, marshalErr := json.Marshal(result)
+		if marshalErr != nil || result.IsError || !strings.Contains(string(encoded), check.want) {
+			t.Fatalf("MCP %s result = %s, marshal=%v error=%v; want %q", check.name, encoded, marshalErr, result.IsError, check.want)
+		}
+	}
+}
+
+func waitR5(t *testing.T, description string, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", description)
+}

--- a/cmd/r5_cutover_rehearsal_test.go
+++ b/cmd/r5_cutover_rehearsal_test.go
@@ -1,0 +1,577 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/bridgeadapters/scripted"
+	"github.com/maxghenis/openmessage/internal/cutover"
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/migration"
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2read"
+	"github.com/maxghenis/openmessage/internal/v2wire"
+)
+
+var r5CutoverNow = time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+
+func TestCutoverRehearsal(t *testing.T) {
+	ctx := context.Background()
+	fixture := buildR5LegacyFixture(t)
+	googleConversation := fixture.Conversations[0]
+
+	// R8 preflight: allow the shadow dispatcher to settle a confirmed send and
+	// prove its projector made that send visible in the legacy cutover source.
+	legacy, err := db.New(fixture.StorePath)
+	if err != nil {
+		t.Fatalf("open legacy fixture for projector drain: %v", err)
+	}
+	legacyClosed := false
+	t.Cleanup(func() {
+		if !legacyClosed {
+			_ = legacy.Close()
+		}
+	})
+	oldStack, err := newV2Stack(v2StackDeps{DataDir: fixture.DataDir, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatalf("create pre-cutover shadow v2 stack: %v", err)
+	}
+	google := scripted.New(r5GoogleAccountID, bridge.PlatformGoogle)
+	if err := oldStack.RegisterAdapter(google); err != nil {
+		_ = oldStack.Store.Close()
+		t.Fatalf("register pre-cutover scripted Google adapter: %v", err)
+	}
+	google.EnqueueTextResult(bridge.SendResult{
+		RemoteMessageID: "r5-preflight-confirmed-remote",
+		AcceptedAt:      time.Now(),
+		EchoExpected:    true,
+	})
+	confirmed, err := v2wire.SubmitText(ctx, v2wire.Deps{
+		Legacy: legacy, V2: oldStack.Store, Service: oldStack.Service, Registry: oldStack.Registry,
+	}, v2wire.TextInput{
+		ConversationID: googleConversation.LegacyID,
+		Body:           "r5 projector drain sentinel",
+		IdempotencyKey: "r5-projector-drain",
+	})
+	if err != nil {
+		_ = oldStack.Store.Close()
+		t.Fatalf("submit pre-cutover v2 send: %v", err)
+	}
+	shadowCtx, cancelShadow := context.WithCancel(context.Background())
+	stopShadow := oldStack.Start(shadowCtx, legacy, nil, false)
+	shadowStopped := false
+	t.Cleanup(func() {
+		if !shadowStopped {
+			stopShadow()
+		}
+		cancelShadow()
+	})
+	waitR5(t, "pre-cutover send confirmation", func() bool {
+		delivery, getErr := oldStack.Service.Get(ctx, confirmed.OutboxID)
+		return getErr == nil && delivery.State == messaging.OutboxConfirmed
+	})
+	waitR5(t, "pre-cutover projector drain into legacy", func() bool {
+		messages, readErr := legacy.GetMessagesByConversation(googleConversation.LegacyID, 100)
+		if readErr != nil {
+			return false
+		}
+		for _, message := range messages {
+			if message.Body == "r5 projector drain sentinel" && message.IsFromMe {
+				return true
+			}
+		}
+		return false
+	})
+	oldOutbox, err := sqlite.NewOutboxRepository(oldStack.Store, time.Now)
+	if err != nil {
+		t.Fatalf("open pre-cutover outbox for drain watermark: %v", err)
+	}
+	confirmedRow, err := oldOutbox.FindByID(ctx, confirmed.OutboxID)
+	if err != nil {
+		t.Fatalf("read pre-cutover confirmed row: %v", err)
+	}
+	beyondDrain, err := oldOutbox.ListConfirmedSince(ctx, confirmedRow.UpdatedAtMS, 10)
+	if err != nil || len(beyondDrain) != 0 {
+		t.Fatalf("confirmed rows beyond projector drain watermark = %+v, %v", beyondDrain, err)
+	}
+
+	// This future v2-native intent is absent from legacy and is exactly the
+	// non-re-derivable work that store-aside + CarryPendingOutbox must retain.
+	futureScheduledMS := time.Now().UTC().Add(48 * time.Hour).Truncate(time.Millisecond).UnixMilli()
+	pending, err := v2wire.SubmitTextV2(ctx, v2wire.NativeDeps{
+		V2: oldStack.Store, Service: oldStack.Service, Registry: oldStack.Registry,
+	}, v2wire.TextInput{
+		ConversationID: googleConversation.LegacyID,
+		Body:           "r5 carry future scheduled sentinel",
+		IdempotencyKey: "r5-cutover-carry-future",
+		NotBefore:      time.UnixMilli(futureScheduledMS),
+	})
+	if err != nil {
+		t.Fatalf("submit future pre-cutover intent: %v", err)
+	}
+	if delivery, err := oldStack.Service.Get(ctx, pending.OutboxID); err != nil || delivery.State != messaging.OutboxQueued {
+		t.Fatalf("future pre-cutover delivery = %+v, %v, want queued", delivery, err)
+	}
+
+	stopShadow()
+	shadowStopped = true
+	cancelShadow()
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("close quiesced legacy source: %v", err)
+	}
+	legacyClosed = true
+	legacyHashAtQuiesce := fileSHA256(t, fixture.StorePath)
+
+	// Backup and a real --check are the go/no-go gates. The check uses a
+	// separate target because canonical v2 state is intentionally still present
+	// until the next store-aside step.
+	backup := runR5Backup(t, fixture.DataDir, r5CutoverNow)
+	manifestData, err := os.ReadFile(backup.ManifestPath)
+	if err != nil {
+		t.Fatalf("read cutover backup manifest: %v", err)
+	}
+	var manifest backupManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatalf("decode cutover backup manifest: %v", err)
+	}
+	if manifest.Source.QuickCheck != "ok" {
+		t.Fatalf("cutover backup quick_check = %q, want ok", manifest.Source.QuickCheck)
+	}
+	checkTarget := filepath.Join(fixture.DataDir, "v2-cutover-check")
+	checkReport := runR5Migrate(t, fixture.DataDir, checkTarget, true, r5CutoverNow.Add(time.Minute))
+	if !checkReport.OK || !checkReport.Validation.Passed || checkReport.Target.Published {
+		t.Fatalf("cutover migrate --check gate = ok=%v passed=%v published=%v",
+			checkReport.OK, checkReport.Validation.Passed, checkReport.Target.Published)
+	}
+
+	asideDir := moveR5CanonicalV2Aside(t, fixture.DataDir, r5CutoverNow)
+	v2Dir := filepath.Join(fixture.DataDir, "v2")
+	publishReport := runR5Migrate(t, fixture.DataDir, v2Dir, false, r5CutoverNow.Add(2*time.Minute))
+	if !publishReport.OK || !publishReport.Validation.Passed || !publishReport.Target.Published {
+		t.Fatalf("cutover migration publish = ok=%v passed=%v published=%v",
+			publishReport.OK, publishReport.Validation.Passed, publishReport.Target.Published)
+	}
+	if got := fileSHA256(t, fixture.StorePath); got != legacyHashAtQuiesce {
+		t.Fatalf("legacy source changed through backup/migration: got %s, want %s", got, legacyHashAtQuiesce)
+	}
+
+	oldStore, err := sqlite.Open(filepath.Join(asideDir, v2StoreName))
+	if err != nil {
+		t.Fatalf("open retained pre-cutover store: %v", err)
+	}
+	oldBlobs, err := blob.New(filepath.Join(asideDir, v2BlobName))
+	if err != nil {
+		_ = oldStore.Close()
+		t.Fatalf("open retained pre-cutover blobs: %v", err)
+	}
+	freshStore, err := sqlite.Open(filepath.Join(v2Dir, v2StoreName))
+	if err != nil {
+		_ = oldStore.Close()
+		t.Fatalf("open freshly migrated store for carry: %v", err)
+	}
+	freshBlobs, err := blob.New(filepath.Join(v2Dir, v2BlobName))
+	if err != nil {
+		_ = freshStore.Close()
+		_ = oldStore.Close()
+		t.Fatalf("open freshly migrated blobs for carry: %v", err)
+	}
+	oldEndpoint, err := cutover.NewEndpoint(oldStore, oldBlobs, time.Now)
+	if err != nil {
+		t.Fatalf("create old cutover endpoint: %v", err)
+	}
+	freshEndpoint, err := cutover.NewEndpoint(freshStore, freshBlobs, time.Now)
+	if err != nil {
+		t.Fatalf("create fresh cutover endpoint: %v", err)
+	}
+	carryReport, err := cutover.CarryPendingOutbox(ctx, oldEndpoint, freshEndpoint)
+	if err != nil {
+		t.Fatalf("carry pending pre-cutover outbox: %v", err)
+	}
+	if len(carryReport.Carried) != 1 || len(carryReport.Reported) != 0 || len(carryReport.Uncarryable) != 0 ||
+		carryReport.Carried[0].IdempotencyKey != "r5-cutover-carry-future" {
+		t.Fatalf("cutover carry report = %+v", carryReport)
+	}
+	freshCarryable, err := freshEndpoint.ListCarryable(ctx)
+	if err != nil {
+		t.Fatalf("list freshly carried outbox: %v", err)
+	}
+	carriedFound := false
+	for _, item := range freshCarryable {
+		if item.IdempotencyKey == "r5-cutover-carry-future" {
+			carriedFound = item.ScheduledForMS == futureScheduledMS &&
+				item.RemoteConversationID == googleConversation.RemoteID &&
+				item.Body == "r5 carry future scheduled sentinel"
+		}
+	}
+	if !carriedFound {
+		t.Fatalf("fresh outbox did not preserve carried schedule/natural key: %+v", freshCarryable)
+	}
+	secondCarry, err := cutover.CarryPendingOutbox(ctx, oldEndpoint, freshEndpoint)
+	if err != nil || len(secondCarry.Carried) != 0 {
+		t.Fatalf("second cutover carry = %+v, %v, want idempotent no-op", secondCarry, err)
+	}
+	if err := freshStore.Close(); err != nil {
+		t.Fatalf("close fresh carry store: %v", err)
+	}
+	if err := oldStore.Close(); err != nil {
+		t.Fatalf("close retained carry source: %v", err)
+	}
+
+	// Flip the explicit selector, boot v2-primary, smoke the migrated corpus,
+	// then reconstruct the stack over the same store to pin restart recovery.
+	t.Setenv("OPENMESSAGES_DATA_DIR", fixture.DataDir)
+	t.Setenv("OPENMESSAGES_DEMO", "0")
+	t.Setenv("OPENMESSAGES_V2_PRIMARY", "1")
+	t.Setenv("OPENMESSAGES_V2_SEND", "")
+	t.Setenv("OPENMESSAGES_V2_INGEST", "")
+	mode, err := resolveV2RuntimeMode(false, fixture.DataDir)
+	if err != nil || !mode.Primary || !mode.Send || !mode.Ingest {
+		t.Fatalf("resolve cutover selector = %+v, %v", mode, err)
+	}
+
+	firstBoot, err := newV2Stack(v2StackDeps{DataDir: fixture.DataDir, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatalf("first v2-primary boot: %v", err)
+	}
+	firstBootCtx, cancelFirstBoot := context.WithCancel(context.Background())
+	stopFirstBoot := firstBoot.Start(firstBootCtx, nil, nil, true)
+	firstBootStopped := false
+	t.Cleanup(func() {
+		if !firstBootStopped {
+			stopFirstBoot()
+		}
+		cancelFirstBoot()
+	})
+	firstReads := v2read.New(firstBoot.Store)
+	assertR5CutoverSmokeReads(t, firstReads, googleConversation)
+	if delivery, err := firstBoot.Service.Get(ctx, pending.OutboxID); err != nil || delivery.State != messaging.OutboxQueued {
+		t.Fatalf("carried delivery on first boot = %+v, %v", delivery, err)
+	}
+	stopFirstBoot()
+	firstBootStopped = true
+	cancelFirstBoot()
+
+	secondBoot, err := newV2Stack(v2StackDeps{DataDir: fixture.DataDir, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatalf("restart v2-primary stack: %v", err)
+	}
+	restartGoogle := scripted.New(r5GoogleAccountID, bridge.PlatformGoogle)
+	if err := secondBoot.RegisterAdapter(restartGoogle); err != nil {
+		_ = secondBoot.Store.Close()
+		t.Fatalf("register post-restart Google adapter: %v", err)
+	}
+	if delivery, err := secondBoot.Service.Get(ctx, pending.OutboxID); err != nil || delivery.State != messaging.OutboxQueued {
+		_ = secondBoot.Store.Close()
+		t.Fatalf("carried delivery after restart = %+v, %v", delivery, err)
+	}
+	restartGoogle.EnqueueTextResult(bridge.SendResult{
+		RemoteMessageID: "r5-cutover-smoke-remote", AcceptedAt: time.Now(), EchoExpected: true,
+	})
+	restartCtx, cancelRestart := context.WithCancel(context.Background())
+	stopRestart := secondBoot.Start(restartCtx, nil, nil, true)
+	restartStopped := false
+	t.Cleanup(func() {
+		if !restartStopped {
+			stopRestart()
+		}
+		cancelRestart()
+	})
+	smokeSubmission, err := v2wire.SubmitTextV2(ctx, v2wire.NativeDeps{
+		V2: secondBoot.Store, Service: secondBoot.Service, Registry: secondBoot.Registry,
+	}, v2wire.TextInput{
+		ConversationID: googleConversation.V2ID(),
+		Body:           "r5 post-cutover smoke send",
+		IdempotencyKey: "r5-post-cutover-smoke",
+	})
+	if err != nil {
+		t.Fatalf("submit post-cutover smoke send: %v", err)
+	}
+	waitR5(t, "post-cutover smoke confirmation", func() bool {
+		delivery, getErr := secondBoot.Service.Get(ctx, smokeSubmission.OutboxID)
+		return getErr == nil && delivery.State == messaging.OutboxConfirmed &&
+			delivery.RemoteMessageID == "r5-cutover-smoke-remote"
+	})
+	secondReads := v2read.New(secondBoot.Store)
+	waitR5(t, "post-cutover smoke visibility", func() bool {
+		messages, readErr := secondReads.SearchMessagesFiltered(
+			"r5 post-cutover smoke send", db.SearchFilter{Limit: 10},
+		)
+		return readErr == nil && len(messages) == 1 && messages[0].IsFromMe &&
+			messages[0].SourceID == "r5-cutover-smoke-remote"
+	})
+	stopRestart()
+	restartStopped = true
+	cancelRestart()
+
+	if got := fileSHA256(t, fixture.StorePath); got != legacyHashAtQuiesce {
+		t.Fatalf("legacy rollback source changed after v2 boot: got %s, want %s", got, legacyHashAtQuiesce)
+	}
+	for _, retained := range []string{v2StoreName, v2BlobName} {
+		if _, err := os.Stat(filepath.Join(asideDir, retained)); err != nil {
+			t.Fatalf("retained pre-cutover artifact %q missing: %v", retained, err)
+		}
+	}
+}
+
+func TestMigrateRefusesExistingV2Store(t *testing.T) {
+	fixture := buildR5LegacyFixture(t)
+
+	t.Run("published store", func(t *testing.T) {
+		targetDir := filepath.Join(t.TempDir(), "v2")
+		report := runR5Migrate(t, fixture.DataDir, targetDir, false, r5CutoverNow)
+		if !report.Target.Published {
+			t.Fatal("first migration did not publish the canonical v2 store")
+		}
+		storePath := filepath.Join(targetDir, v2StoreName)
+		before, err := os.ReadFile(storePath)
+		if err != nil {
+			t.Fatalf("read first published store: %v", err)
+		}
+
+		failure, commandErr := runR5MigrateExpectFailure(
+			t, fixture.DataDir, targetDir, false, r5CutoverNow.Add(time.Minute),
+		)
+		assertR5CanonicalStateRefusal(t, failure, commandErr, storePath)
+		after, err := os.ReadFile(storePath)
+		if err != nil {
+			t.Fatalf("read refused target store: %v", err)
+		}
+		if !bytes.Equal(after, before) {
+			t.Fatal("second migration changed the existing canonical v2 store")
+		}
+	})
+
+	for _, name := range []string{v2StoreName + "-wal", v2StoreName + "-shm", v2BlobName} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			targetDir := filepath.Join(t.TempDir(), "v2")
+			if err := os.MkdirAll(targetDir, 0o700); err != nil {
+				t.Fatalf("create target: %v", err)
+			}
+			canonicalPath := filepath.Join(targetDir, name)
+			sentinelPath := canonicalPath
+			if name == v2BlobName {
+				if err := os.Mkdir(canonicalPath, 0o700); err != nil {
+					t.Fatalf("create canonical blobs sentinel: %v", err)
+				}
+				sentinelPath = filepath.Join(canonicalPath, "retain-me")
+			}
+			if err := os.WriteFile(sentinelPath, []byte("canonical-state-must-survive"), 0o600); err != nil {
+				t.Fatalf("write canonical state sentinel: %v", err)
+			}
+
+			failure, commandErr := runR5MigrateExpectFailure(
+				t, fixture.DataDir, targetDir, false, r5CutoverNow.Add(2*time.Minute),
+			)
+			assertR5CanonicalStateRefusal(t, failure, commandErr, canonicalPath)
+			got, err := os.ReadFile(sentinelPath)
+			if err != nil {
+				t.Fatalf("read retained canonical state sentinel: %v", err)
+			}
+			if string(got) != "canonical-state-must-survive" {
+				t.Fatalf("canonical state sentinel = %q, want unchanged", got)
+			}
+		})
+	}
+}
+
+func TestMigrateCheckNoGoOnRemoteIDCollision(t *testing.T) {
+	fixture := buildR5LegacyFixture(t)
+	conversation := fixture.Conversations[0]
+	original := conversation.Messages[0]
+	legacy, err := db.New(fixture.StorePath)
+	if err != nil {
+		t.Fatalf("reopen legacy fixture for collision: %v", err)
+	}
+	if err := legacy.UpsertMessage(&db.Message{
+		MessageID:      "r5-deliberate-remote-id-collision",
+		ConversationID: conversation.LegacyID,
+		SenderName:     "Collision Sender",
+		SenderNumber:   "+15559990000",
+		Body:           "deliberately colliding migration row",
+		TimestampMS:    fixture.BaseMS + 13_000,
+		Status:         "delivered",
+		SourcePlatform: conversation.Platform,
+		SourceID:       original.RemoteID,
+	}); err != nil {
+		_ = legacy.Close()
+		t.Fatalf("seed deliberate remote-ID collision: %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("close colliding legacy fixture: %v", err)
+	}
+
+	targetDir := filepath.Join(fixture.DataDir, "v2-no-go")
+	var stdout, stderr bytes.Buffer
+	commandErr := runMigrateCommand(
+		context.Background(),
+		[]string{"--check", "--from", fixture.DataDir, "--to", targetDir},
+		r5MigrateDependencies(r5CutoverNow),
+		&stdout,
+		&stderr,
+	)
+	if commandErr == nil {
+		t.Fatalf("migrate --check accepted a remote-ID collision\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	if got := ExitCode(commandErr); got != migrateTransformExitCode {
+		t.Fatalf("migrate --check no-go exit code = %d, want %d: %v", got, migrateTransformExitCode, commandErr)
+	}
+	report := decodeR5MigrationReport(t, stdout.Bytes())
+	if report.OK || !report.Check || report.Validation.Passed || report.Target.Published {
+		t.Fatalf("migrate --check no-go report = ok=%v check=%v passed=%v published=%v",
+			report.OK, report.Check, report.Validation.Passed, report.Target.Published)
+	}
+	if len(report.MessageCollisions) != 1 {
+		t.Fatalf("migrate --check collisions = %+v, want exactly one", report.MessageCollisions)
+	}
+	collision := report.MessageCollisions[0]
+	if collision.AccountID != conversation.AccountID ||
+		collision.ConversationID != conversation.LegacyID ||
+		collision.RemoteMessageID != original.RemoteID ||
+		len(collision.LegacyMessageIDs) != 2 {
+		t.Fatalf("migrate --check collision evidence = %+v", collision)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, v2StoreName)); !os.IsNotExist(err) {
+		t.Fatalf("no-go check published a canonical store: %v", err)
+	}
+	for _, staged := range []string{v2TempStoreName, v2TempBlobName} {
+		if _, err := os.Stat(filepath.Join(targetDir, staged)); !os.IsNotExist(err) {
+			t.Fatalf("no-go check retained staged state %q: %v", staged, err)
+		}
+	}
+}
+
+func runR5MigrateExpectFailure(
+	t *testing.T,
+	sourceDir string,
+	targetDir string,
+	check bool,
+	now time.Time,
+) (migrateFailureOutput, error) {
+	t.Helper()
+	args := []string{"--from", sourceDir, "--to", targetDir}
+	if check {
+		args = append([]string{"--check"}, args...)
+	}
+	var stdout, stderr bytes.Buffer
+	err := runMigrateCommand(
+		context.Background(), args, r5MigrateDependencies(now), &stdout, &stderr,
+	)
+	if err == nil {
+		t.Fatalf("runMigrateCommand unexpectedly succeeded\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	var failure migrateFailureOutput
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &failure); decodeErr != nil {
+		t.Fatalf(
+			"decode migrate failure output: %v\nstdout:\n%s\nstderr:\n%s",
+			decodeErr,
+			stdout.String(),
+			stderr.String(),
+		)
+	}
+	return failure, err
+}
+
+func assertR5CanonicalStateRefusal(
+	t *testing.T,
+	failure migrateFailureOutput,
+	commandErr error,
+	canonicalPath string,
+) {
+	t.Helper()
+	canonicalParent, err := filepath.EvalSymlinks(filepath.Dir(canonicalPath))
+	if err != nil {
+		t.Fatalf("canonicalize refusal path: %v", err)
+	}
+	canonicalPath = filepath.Join(canonicalParent, filepath.Base(canonicalPath))
+	if got := ExitCode(commandErr); got != migrateSourceExitCode {
+		t.Fatalf("migrate refusal exit code = %d, want %d: %v", got, migrateSourceExitCode, commandErr)
+	}
+	if failure.OK || failure.ExitCode != migrateSourceExitCode {
+		t.Fatalf("migrate refusal JSON = %+v", failure)
+	}
+	for _, required := range []string{
+		"v2 target already contains canonical state at " + canonicalPath,
+		"existing stores and blobs are never overwritten",
+	} {
+		if !strings.Contains(commandErr.Error(), required) || !strings.Contains(failure.Error, required) {
+			t.Fatalf("migrate refusal did not contain %q: err=%v JSON=%+v", required, commandErr, failure)
+		}
+	}
+}
+
+func decodeR5MigrationReport(t *testing.T, stdout []byte) migration.Report {
+	t.Helper()
+	var report migration.Report
+	if err := json.Unmarshal(stdout, &report); err != nil {
+		t.Fatalf("decode migration report: %v\nstdout:\n%s", err, stdout)
+	}
+	return report
+}
+
+func moveR5CanonicalV2Aside(t *testing.T, dataDir string, now time.Time) string {
+	t.Helper()
+	v2Dir := filepath.Join(dataDir, "v2")
+	asideDir := filepath.Join(v2Dir, "pre-cutover-"+now.UTC().Format("20060102T150405Z"))
+	if err := os.MkdirAll(asideDir, 0o700); err != nil {
+		t.Fatalf("create retained pre-cutover directory: %v", err)
+	}
+	moved := make(map[string]bool)
+	for _, name := range []string{v2StoreName, v2StoreName + "-wal", v2StoreName + "-shm", v2BlobName} {
+		source := filepath.Join(v2Dir, name)
+		if _, err := os.Lstat(source); os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			t.Fatalf("inspect canonical v2 artifact %q: %v", name, err)
+		}
+		if err := os.Rename(source, filepath.Join(asideDir, name)); err != nil {
+			t.Fatalf("retain canonical v2 artifact %q: %v", name, err)
+		}
+		moved[name] = true
+	}
+	if !moved[v2StoreName] || !moved[v2BlobName] {
+		t.Fatalf("store-aside moved artifacts = %+v, want store and blobs", moved)
+	}
+	return asideDir
+}
+
+func assertR5CutoverSmokeReads(
+	t *testing.T,
+	reads *v2read.Source,
+	googleConversation r5FixtureConversation,
+) {
+	t.Helper()
+	conversations, err := reads.ListConversations(50)
+	if err != nil || len(conversations) == 0 {
+		t.Fatalf("cutover smoke list conversations = %d, %v", len(conversations), err)
+	}
+	messages, err := reads.GetMessagesByConversation(googleConversation.V2ID(), 100)
+	if err != nil {
+		t.Fatalf("cutover smoke read Google conversation: %v", err)
+	}
+	wantBody := googleConversation.Messages[0].Body
+	readFound := false
+	projectedFound := false
+	for _, message := range messages {
+		readFound = readFound || message.Body == wantBody
+		projectedFound = projectedFound || message.Body == "r5 projector drain sentinel"
+	}
+	if !readFound || !projectedFound {
+		t.Fatalf("cutover smoke thread omitted migrated fixture/projected send: %+v", messages)
+	}
+	search, err := reads.SearchMessagesFiltered(r5SharedSearchToken, db.SearchFilter{Limit: 50})
+	if err != nil || len(search) < 5 {
+		t.Fatalf("cutover smoke search = %d, %v, want all platforms", len(search), err)
+	}
+}

--- a/internal/bridgeadapters/scripted/adapter.go
+++ b/internal/bridgeadapters/scripted/adapter.go
@@ -1,0 +1,521 @@
+// Package scripted provides a deterministic, in-memory bridge adapter for
+// hermetic integration tests. It owns no real transport and performs no
+// network I/O.
+package scripted
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+// MediaCall is one captured MediaSender invocation. Data contains the bytes
+// read from the request's one-shot Reader; Request.Reader is always nil.
+type MediaCall struct {
+	Request bridge.MediaRequest
+	Data    []byte
+}
+
+// DownloadCall is one captured MediaDownloader invocation.
+type DownloadCall struct {
+	AccountID string
+	Ref       bridge.MediaRef
+}
+
+type sendStep struct {
+	result  bridge.SendResult
+	failure *bridge.OpError
+}
+
+type downloadStep struct {
+	data     []byte
+	filename string
+	mime     string
+	failure  *bridge.OpError
+}
+
+// Adapter is a FIFO-scripted bridge.Adapter. The concrete type deliberately
+// implements TextSender, MediaSender, and MediaDownloader so registering it
+// exposes all three capabilities through bridge.Registry.
+type Adapter struct {
+	accountID string
+	platform  bridge.Platform
+
+	mu sync.Mutex
+
+	sink          bridge.ConnectionSink
+	startRequests []bridge.StartRequest
+
+	textSteps    []sendStep
+	textRequests []bridge.TextRequest
+
+	mediaSteps    []sendStep
+	mediaRequests []MediaCall
+
+	downloadSteps    []downloadStep
+	downloadRequests []DownloadCall
+}
+
+// New constructs a deterministic adapter for one bridge account.
+func New(accountID string, platform bridge.Platform) *Adapter {
+	return &Adapter{accountID: accountID, platform: platform}
+}
+
+func (a *Adapter) AccountID() string {
+	if a == nil {
+		return ""
+	}
+	return a.accountID
+}
+
+func (a *Adapter) Platform() bridge.Platform {
+	if a == nil {
+		return ""
+	}
+	return a.platform
+}
+
+// Start captures the generation's ConnectionSink and returns an immediately
+// ready run. The run remains active until its parent context ends or Stop is
+// called.
+func (a *Adapter) Start(
+	ctx context.Context,
+	req bridge.StartRequest,
+	sink bridge.ConnectionSink,
+) (bridge.Run, error) {
+	if ctx == nil {
+		return nil, errors.New("scripted lifecycle: nil start context")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if a == nil {
+		return nil, bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "scripted_adapter_nil",
+			Cause:       errors.New("scripted adapter is nil"),
+		}
+	}
+	if req.AccountID != a.accountID {
+		return nil, bridge.OpError{
+			Class:       bridge.FailureMisconfigured,
+			Operation:   "connect",
+			Fingerprint: "scripted_account_mismatch",
+			Cause: fmt.Errorf(
+				"start account %q does not match adapter account %q",
+				req.AccountID,
+				a.accountID,
+			),
+		}
+	}
+
+	a.mu.Lock()
+	a.sink = sink
+	a.startRequests = append(a.startRequests, req)
+	a.mu.Unlock()
+
+	runCtx, cancel := context.WithCancel(ctx)
+	r := &run{
+		ctx:       runCtx,
+		cancel:    cancel,
+		ready:     make(chan struct{}),
+		done:      make(chan error, 1),
+		stopped:   make(chan struct{}),
+		finish:    make(chan error, 1),
+		startedAt: time.Now(),
+	}
+	close(r.ready)
+	go r.coordinate()
+	return r, nil
+}
+
+// Sink returns the ConnectionSink captured by the most recent successful
+// Start call.
+func (a *Adapter) Sink() bridge.ConnectionSink {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.sink
+}
+
+// StartRequests returns a race-safe snapshot of successful Start calls.
+func (a *Adapter) StartRequests() []bridge.StartRequest {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]bridge.StartRequest(nil), a.startRequests...)
+}
+
+// EnqueueTextResult appends one successful SendText outcome.
+func (a *Adapter) EnqueueTextResult(result bridge.SendResult) {
+	a.mu.Lock()
+	a.textSteps = append(a.textSteps, sendStep{result: result})
+	a.mu.Unlock()
+}
+
+// EnqueueTextError appends one classified SendText failure. The OpError is
+// returned unchanged when its step is consumed.
+func (a *Adapter) EnqueueTextError(failure bridge.OpError) {
+	step := sendStep{failure: copyOpError(failure)}
+	a.mu.Lock()
+	a.textSteps = append(a.textSteps, step)
+	a.mu.Unlock()
+}
+
+func (a *Adapter) SendText(
+	_ context.Context,
+	req bridge.TextRequest,
+) (bridge.SendResult, error) {
+	if a == nil {
+		return bridge.SendResult{}, nilAdapterFailure("send_text")
+	}
+
+	a.mu.Lock()
+	a.textRequests = append(a.textRequests, cloneTextRequest(req))
+	if len(a.textSteps) == 0 {
+		a.mu.Unlock()
+		return bridge.SendResult{}, queueEmptyFailure(
+			"send_text",
+			"scripted_text_queue_empty",
+			true,
+		)
+	}
+	step := a.textSteps[0]
+	a.textSteps = a.textSteps[1:]
+	a.mu.Unlock()
+
+	if step.failure != nil {
+		return bridge.SendResult{}, *step.failure
+	}
+	return step.result, nil
+}
+
+// TextRequests returns a race-safe, deep-copied snapshot of SendText calls.
+func (a *Adapter) TextRequests() []bridge.TextRequest {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	requests := make([]bridge.TextRequest, len(a.textRequests))
+	for i := range a.textRequests {
+		requests[i] = cloneTextRequest(a.textRequests[i])
+	}
+	return requests
+}
+
+// EnqueueMediaResult appends one successful SendMedia outcome.
+func (a *Adapter) EnqueueMediaResult(result bridge.SendResult) {
+	a.mu.Lock()
+	a.mediaSteps = append(a.mediaSteps, sendStep{result: result})
+	a.mu.Unlock()
+}
+
+// EnqueueMediaError appends one classified SendMedia failure. The OpError is
+// returned unchanged when its step is consumed.
+func (a *Adapter) EnqueueMediaError(failure bridge.OpError) {
+	step := sendStep{failure: copyOpError(failure)}
+	a.mu.Lock()
+	a.mediaSteps = append(a.mediaSteps, step)
+	a.mu.Unlock()
+}
+
+func (a *Adapter) SendMedia(
+	_ context.Context,
+	req bridge.MediaRequest,
+) (bridge.SendResult, error) {
+	if a == nil {
+		return bridge.SendResult{}, nilAdapterFailure("send_media")
+	}
+
+	var (
+		data    []byte
+		readErr error
+	)
+	if req.Reader == nil {
+		readErr = errors.New("scripted media request has a nil reader")
+	} else {
+		data, readErr = io.ReadAll(req.Reader)
+	}
+	captured := MediaCall{Request: cloneMediaRequest(req), Data: cloneBytes(data)}
+
+	a.mu.Lock()
+	a.mediaRequests = append(a.mediaRequests, captured)
+	if readErr != nil {
+		a.mu.Unlock()
+		return bridge.SendResult{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "send_media",
+			Fingerprint: "scripted_media_read_failed",
+			Dispatch:    bridge.DispatchNotCalled,
+			Cause:       fmt.Errorf("read scripted media request: %w", readErr),
+		}
+	}
+	if len(a.mediaSteps) == 0 {
+		a.mu.Unlock()
+		return bridge.SendResult{}, queueEmptyFailure(
+			"send_media",
+			"scripted_media_queue_empty",
+			true,
+		)
+	}
+	step := a.mediaSteps[0]
+	a.mediaSteps = a.mediaSteps[1:]
+	a.mu.Unlock()
+
+	if step.failure != nil {
+		return bridge.SendResult{}, *step.failure
+	}
+	return step.result, nil
+}
+
+// MediaRequests returns a race-safe, deep-copied snapshot of SendMedia calls.
+func (a *Adapter) MediaRequests() []MediaCall {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	requests := make([]MediaCall, len(a.mediaRequests))
+	for i := range a.mediaRequests {
+		requests[i] = cloneMediaCall(a.mediaRequests[i])
+	}
+	return requests
+}
+
+// EnqueueDownload appends one successful DownloadMedia outcome. Data is copied
+// at enqueue time and each call receives a fresh reader over another copy.
+func (a *Adapter) EnqueueDownload(data []byte, filename, mime string) {
+	a.mu.Lock()
+	a.downloadSteps = append(a.downloadSteps, downloadStep{
+		data:     cloneBytes(data),
+		filename: filename,
+		mime:     mime,
+	})
+	a.mu.Unlock()
+}
+
+// EnqueueDownloadError appends one classified DownloadMedia failure. The
+// OpError is returned unchanged when its step is consumed.
+func (a *Adapter) EnqueueDownloadError(failure bridge.OpError) {
+	step := downloadStep{failure: copyOpError(failure)}
+	a.mu.Lock()
+	a.downloadSteps = append(a.downloadSteps, step)
+	a.mu.Unlock()
+}
+
+func (a *Adapter) DownloadMedia(
+	_ context.Context,
+	accountID string,
+	ref bridge.MediaRef,
+) (bridge.MediaStream, error) {
+	if a == nil {
+		return bridge.MediaStream{}, nilAdapterFailure("download_media")
+	}
+
+	a.mu.Lock()
+	a.downloadRequests = append(a.downloadRequests, DownloadCall{
+		AccountID: accountID,
+		Ref:       cloneMediaRef(ref),
+	})
+	if len(a.downloadSteps) == 0 {
+		a.mu.Unlock()
+		return bridge.MediaStream{}, queueEmptyFailure(
+			"download_media",
+			"scripted_download_queue_empty",
+			false,
+		)
+	}
+	step := a.downloadSteps[0]
+	a.downloadSteps = a.downloadSteps[1:]
+	a.mu.Unlock()
+
+	if step.failure != nil {
+		return bridge.MediaStream{}, *step.failure
+	}
+	data := cloneBytes(step.data)
+	return bridge.MediaStream{
+		ReadCloser: io.NopCloser(bytes.NewReader(data)),
+		Size:       int64(len(data)),
+		Filename:   step.filename,
+		MIME:       step.mime,
+	}, nil
+}
+
+// DownloadRequests returns a race-safe, deep-copied snapshot of DownloadMedia
+// calls.
+func (a *Adapter) DownloadRequests() []DownloadCall {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	requests := make([]DownloadCall, len(a.downloadRequests))
+	for i := range a.downloadRequests {
+		requests[i] = DownloadCall{
+			AccountID: a.downloadRequests[i].AccountID,
+			Ref:       cloneMediaRef(a.downloadRequests[i].Ref),
+		}
+	}
+	return requests
+}
+
+func cloneTextRequest(req bridge.TextRequest) bridge.TextRequest {
+	cloned := req
+	cloned.ReplyTo = cloneMessageRef(req.ReplyTo)
+	return cloned
+}
+
+func cloneMediaRequest(req bridge.MediaRequest) bridge.MediaRequest {
+	cloned := req
+	cloned.Reader = nil
+	cloned.ReplyTo = cloneMessageRef(req.ReplyTo)
+	return cloned
+}
+
+func cloneMediaCall(call MediaCall) MediaCall {
+	return MediaCall{
+		Request: cloneMediaRequest(call.Request),
+		Data:    cloneBytes(call.Data),
+	}
+}
+
+func cloneMessageRef(ref *bridge.MessageRef) *bridge.MessageRef {
+	if ref == nil {
+		return nil
+	}
+	cloned := *ref
+	return &cloned
+}
+
+func cloneMediaRef(ref bridge.MediaRef) bridge.MediaRef {
+	cloned := ref
+	cloned.Opaque = cloneBytes(ref.Opaque)
+	return cloned
+}
+
+func cloneBytes(data []byte) []byte {
+	return append([]byte(nil), data...)
+}
+
+func copyOpError(failure bridge.OpError) *bridge.OpError {
+	if failure.Class == "" {
+		panic("scripted: bridge.OpError must have a failure class")
+	}
+	cloned := failure
+	return &cloned
+}
+
+func nilAdapterFailure(operation string) bridge.OpError {
+	return bridge.OpError{
+		Class:       bridge.FailureMisconfigured,
+		Operation:   operation,
+		Fingerprint: "scripted_adapter_nil",
+		Dispatch:    dispatchForOperation(operation),
+		Cause:       errors.New("scripted adapter is nil"),
+	}
+}
+
+func queueEmptyFailure(operation, fingerprint string, dispatchedOperation bool) bridge.OpError {
+	failure := bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   operation,
+		Fingerprint: fingerprint,
+		Cause:       errors.New("scripted outcome queue is empty"),
+	}
+	if dispatchedOperation {
+		failure.Dispatch = bridge.DispatchNotCalled
+	}
+	return failure
+}
+
+func dispatchForOperation(operation string) bridge.DispatchCertainty {
+	if operation == "send_text" || operation == "send_media" {
+		return bridge.DispatchNotCalled
+	}
+	return ""
+}
+
+type run struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	ready     chan struct{}
+	done      chan error
+	stopped   chan struct{}
+	finish    chan error
+	startedAt time.Time
+
+	finishOnce sync.Once
+}
+
+func (r *run) Ready() <-chan struct{} { return r.ready }
+
+func (r *run) Done() <-chan error { return r.done }
+
+func (r *run) Probe(ctx context.Context) (bridge.Liveness, error) {
+	if ctx == nil {
+		return bridge.Liveness{}, errors.New("scripted run: nil probe context")
+	}
+	if err := ctx.Err(); err != nil {
+		return bridge.Liveness{}, err
+	}
+	if err := r.ctx.Err(); err != nil {
+		return bridge.Liveness{}, bridge.OpError{
+			Class:       bridge.FailureTransient,
+			Operation:   "probe",
+			Fingerprint: "scripted_run_stopped",
+			Cause:       err,
+		}
+	}
+	return bridge.Liveness{AliveAt: r.startedAt, Detail: "scripted_ready"}, nil
+}
+
+func (r *run) Stop(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("scripted run: nil stop context")
+	}
+	select {
+	case <-r.stopped:
+		return nil
+	default:
+	}
+	r.finishOnce.Do(func() { r.finish <- nil })
+	select {
+	case <-r.stopped:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *run) coordinate() {
+	var terminal error
+	select {
+	case terminal = <-r.finish:
+	case <-r.ctx.Done():
+		terminal = r.ctx.Err()
+	}
+	r.cancel()
+	r.done <- terminal
+	close(r.done)
+	close(r.stopped)
+}
+
+var (
+	_ bridge.Adapter         = (*Adapter)(nil)
+	_ bridge.TextSender      = (*Adapter)(nil)
+	_ bridge.MediaSender     = (*Adapter)(nil)
+	_ bridge.MediaDownloader = (*Adapter)(nil)
+	_ bridge.Run             = (*run)(nil)
+)

--- a/internal/bridgeadapters/scripted/adapter_test.go
+++ b/internal/bridgeadapters/scripted/adapter_test.go
@@ -1,0 +1,304 @@
+package scripted
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+func TestAdapterStartIsReadyAndCapturesConnection(t *testing.T) {
+	t.Parallel()
+
+	adapter := New("google-account", bridge.PlatformGoogle)
+	sink := &recordingSink{}
+	req := bridge.StartRequest{
+		AccountID:       "google-account",
+		DeviceID:        "device-1",
+		RemoteAccountID: "remote-1",
+		Generation:      7,
+	}
+	run, err := adapter.Start(context.Background(), req, sink)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	select {
+	case <-run.Ready():
+	default:
+		t.Fatal("Ready() was not closed before Start returned")
+	}
+	if got := adapter.Sink(); got != sink {
+		t.Fatalf("Sink() = %T %p, want %T %p", got, got, sink, sink)
+	}
+	if got := adapter.StartRequests(); !reflect.DeepEqual(got, []bridge.StartRequest{req}) {
+		t.Fatalf("StartRequests() = %+v, want %+v", got, []bridge.StartRequest{req})
+	}
+
+	liveness, err := run.Probe(context.Background())
+	if err != nil {
+		t.Fatalf("Probe() error = %v", err)
+	}
+	if liveness.AliveAt.IsZero() || liveness.Detail != "scripted_ready" {
+		t.Fatalf("Probe() = %+v, want non-zero scripted_ready liveness", liveness)
+	}
+
+	if err := run.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if terminal, ok := <-run.Done(); !ok || terminal != nil {
+		t.Fatalf("first Done() receive = (%v, %v), want (nil, true)", terminal, ok)
+	}
+	if terminal, ok := <-run.Done(); ok || terminal != nil {
+		t.Fatalf("second Done() receive = (%v, %v), want (nil, false)", terminal, ok)
+	}
+}
+
+func TestAdapterScriptsTextCallsInFIFOOrder(t *testing.T) {
+	t.Parallel()
+
+	adapter := New("signal-account", bridge.PlatformSignal)
+	wantResult := bridge.SendResult{
+		RemoteMessageID: "signal-remote-1",
+		AcceptedAt:      time.Unix(1_700_000_000, 0),
+		EchoExpected:    true,
+	}
+	wantFailure := bridge.OpError{
+		Class:       bridge.FailureRateLimited,
+		Operation:   "send_text",
+		RetryAt:     time.Unix(1_700_000_060, 0),
+		Fingerprint: "scripted_rate_limit",
+		Dispatch:    bridge.DispatchNotCalled,
+		Cause:       errors.New("try later"),
+	}
+	adapter.EnqueueTextResult(wantResult)
+	adapter.EnqueueTextError(wantFailure)
+
+	req1 := bridge.TextRequest{
+		AccountID:    "signal-account",
+		Conversation: bridge.ConversationRef{RemoteID: "conversation-1"},
+		Body:         "first",
+		ReplyTo:      &bridge.MessageRef{RemoteID: "reply-1"},
+		RequestID:    "request-1",
+	}
+	result, err := adapter.SendText(context.Background(), req1)
+	if err != nil || !reflect.DeepEqual(result, wantResult) {
+		t.Fatalf("first SendText() = (%+v, %v), want (%+v, nil)", result, err, wantResult)
+	}
+	req1.ReplyTo.RemoteID = "mutated-after-call"
+
+	req2 := bridge.TextRequest{AccountID: "signal-account", Body: "second", RequestID: "request-2"}
+	result, err = adapter.SendText(context.Background(), req2)
+	if result != (bridge.SendResult{}) {
+		t.Fatalf("second SendText() result = %+v, want zero", result)
+	}
+	assertOpError(t, err, wantFailure)
+
+	_, err = adapter.SendText(context.Background(), bridge.TextRequest{RequestID: "request-3"})
+	var exhausted bridge.OpError
+	if !errors.As(err, &exhausted) {
+		t.Fatalf("empty-script SendText() error = %T %v, want bridge.OpError", err, err)
+	}
+	if exhausted.Class != bridge.FailureTransient ||
+		exhausted.Dispatch != bridge.DispatchNotCalled ||
+		exhausted.Operation != "send_text" ||
+		exhausted.Fingerprint != "scripted_text_queue_empty" {
+		t.Fatalf("empty-script SendText() error = %+v", exhausted)
+	}
+
+	wantRequests := []bridge.TextRequest{
+		{
+			AccountID:    "signal-account",
+			Conversation: bridge.ConversationRef{RemoteID: "conversation-1"},
+			Body:         "first",
+			ReplyTo:      &bridge.MessageRef{RemoteID: "reply-1"},
+			RequestID:    "request-1",
+		},
+		req2,
+		{RequestID: "request-3"},
+	}
+	if got := adapter.TextRequests(); !reflect.DeepEqual(got, wantRequests) {
+		t.Fatalf("TextRequests() = %+v, want %+v", got, wantRequests)
+	}
+	got := adapter.TextRequests()
+	got[0].ReplyTo.RemoteID = "mutated-snapshot"
+	if again := adapter.TextRequests(); again[0].ReplyTo.RemoteID != "reply-1" {
+		t.Fatalf("TextRequests() returned aliased reply: %+v", again[0].ReplyTo)
+	}
+}
+
+func TestAdapterScriptsMediaAndCapturesBytes(t *testing.T) {
+	t.Parallel()
+
+	adapter := New("whatsapp-account", bridge.PlatformWhatsApp)
+	wantResult := bridge.SendResult{RemoteMessageID: "wa-media-1", EchoExpected: true}
+	wantFailure := bridge.OpError{
+		Class:       bridge.FailureTransient,
+		Operation:   "send_media",
+		Fingerprint: "scripted_media_failure",
+		Dispatch:    bridge.DispatchUncertain,
+		Cause:       errors.New("connection reset"),
+	}
+	adapter.EnqueueMediaResult(wantResult)
+	adapter.EnqueueMediaError(wantFailure)
+
+	req1 := bridge.MediaRequest{
+		AccountID:    "whatsapp-account",
+		Conversation: bridge.ConversationRef{RemoteID: "wa-chat"},
+		Reader:       bytes.NewReader([]byte("first payload")),
+		Size:         int64(len("first payload")),
+		Filename:     "first.txt",
+		MIME:         "text/plain",
+		Caption:      "caption",
+		ReplyTo:      &bridge.MessageRef{RemoteID: "wa-reply"},
+		RequestID:    "media-request-1",
+	}
+	result, err := adapter.SendMedia(context.Background(), req1)
+	if err != nil || !reflect.DeepEqual(result, wantResult) {
+		t.Fatalf("first SendMedia() = (%+v, %v), want (%+v, nil)", result, err, wantResult)
+	}
+
+	req2 := bridge.MediaRequest{Reader: bytes.NewReader([]byte("second payload")), RequestID: "media-request-2"}
+	result, err = adapter.SendMedia(context.Background(), req2)
+	if result != (bridge.SendResult{}) {
+		t.Fatalf("second SendMedia() result = %+v, want zero", result)
+	}
+	assertOpError(t, err, wantFailure)
+
+	calls := adapter.MediaRequests()
+	if len(calls) != 2 {
+		t.Fatalf("len(MediaRequests()) = %d, want 2", len(calls))
+	}
+	if string(calls[0].Data) != "first payload" || string(calls[1].Data) != "second payload" {
+		t.Fatalf("MediaRequests() data = %q, %q", calls[0].Data, calls[1].Data)
+	}
+	if calls[0].Request.Reader != nil || calls[1].Request.Reader != nil {
+		t.Fatal("MediaRequests() retained a caller-owned Reader")
+	}
+	if calls[0].Request.ReplyTo == req1.ReplyTo {
+		t.Fatal("MediaRequests() retained a caller-owned ReplyTo pointer")
+	}
+
+	calls[0].Data[0] = 'X'
+	calls[0].Request.ReplyTo.RemoteID = "mutated"
+	again := adapter.MediaRequests()
+	if string(again[0].Data) != "first payload" || again[0].Request.ReplyTo.RemoteID != "wa-reply" {
+		t.Fatalf("MediaRequests() returned aliased state: %+v data=%q", again[0].Request, again[0].Data)
+	}
+}
+
+func TestAdapterScriptsDownloadsAndRegistryCapabilities(t *testing.T) {
+	t.Parallel()
+
+	adapter := New("google-account", bridge.PlatformGoogle)
+	adapter.EnqueueDownload([]byte("downloaded bytes"), "photo.jpg", "image/jpeg")
+	wantFailure := bridge.OpError{
+		Class:       bridge.FailureUnsupported,
+		Operation:   "download_media",
+		Fingerprint: "scripted_download_unsupported",
+		Cause:       errors.New("missing remote object"),
+	}
+	adapter.EnqueueDownloadError(wantFailure)
+
+	ref1 := bridge.MediaRef{RemoteID: "remote-media-1", Opaque: []byte("opaque-1"), Filename: "original.jpg"}
+	stream, err := adapter.DownloadMedia(context.Background(), "google-account", ref1)
+	if err != nil {
+		t.Fatalf("first DownloadMedia() error = %v", err)
+	}
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("read first DownloadMedia() stream: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("close first DownloadMedia() stream: %v", err)
+	}
+	if string(data) != "downloaded bytes" || stream.Size != int64(len(data)) ||
+		stream.Filename != "photo.jpg" || stream.MIME != "image/jpeg" {
+		t.Fatalf("first DownloadMedia() stream = data %q metadata %+v", data, stream)
+	}
+
+	ref1.Opaque[0] = 'X'
+	_, err = adapter.DownloadMedia(context.Background(), "google-account", bridge.MediaRef{RemoteID: "remote-media-2"})
+	assertOpError(t, err, wantFailure)
+	requests := adapter.DownloadRequests()
+	if len(requests) != 2 || string(requests[0].Ref.Opaque) != "opaque-1" {
+		t.Fatalf("DownloadRequests() = %+v", requests)
+	}
+
+	registry := bridge.NewRegistry()
+	if err := registry.Register(adapter); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	caps := registry.Capabilities("google-account")
+	if !caps.TextSend || !caps.MediaSend || !caps.MediaDownload {
+		t.Fatalf("Capabilities() = %+v, want text/media/download", caps)
+	}
+	for _, capability := range []bridge.Capability{
+		bridge.CapabilityTextSend,
+		bridge.CapabilityMediaSend,
+		bridge.CapabilityMediaDownload,
+	} {
+		lease, err := registry.Acquire(context.Background(), "google-account", capability)
+		if err != nil {
+			t.Fatalf("Acquire(%q) error = %v", capability, err)
+		}
+		if lease.Text == nil || lease.Media == nil || lease.Download == nil {
+			t.Fatalf("Acquire(%q) lease = %+v, want all scripted capabilities", capability, lease)
+		}
+		lease.Close()
+	}
+}
+
+func TestAdapterRejectsUnclassifiedScriptErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(*Adapter){
+		"text":     func(adapter *Adapter) { adapter.EnqueueTextError(bridge.OpError{}) },
+		"media":    func(adapter *Adapter) { adapter.EnqueueMediaError(bridge.OpError{}) },
+		"download": func(adapter *Adapter) { adapter.EnqueueDownloadError(bridge.OpError{}) },
+	}
+	for name, enqueue := range tests {
+		name, enqueue := name, enqueue
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				if recovered := recover(); recovered == nil {
+					t.Fatal("enqueueing an unclassified bridge.OpError did not panic")
+				}
+			}()
+			enqueue(New("account", bridge.PlatformGoogle))
+		})
+	}
+}
+
+func assertOpError(t *testing.T, got error, want bridge.OpError) {
+	t.Helper()
+	var failure bridge.OpError
+	if !errors.As(got, &failure) {
+		t.Fatalf("error = %T %v, want bridge.OpError %+v", got, got, want)
+	}
+	if !reflect.DeepEqual(failure, want) {
+		t.Fatalf("bridge.OpError = %+v, want %+v", failure, want)
+	}
+}
+
+type recordingSink struct{}
+
+func (*recordingSink) AppendIngress(context.Context, bridge.RawIngressRecord) error { return nil }
+
+func (*recordingSink) EmitEphemeral(context.Context, bridge.EphemeralEvent) error { return nil }
+
+func (*recordingSink) Beat(bridge.Generation, time.Time, string) {}
+
+var (
+	_ bridge.Adapter         = (*Adapter)(nil)
+	_ bridge.TextSender      = (*Adapter)(nil)
+	_ bridge.MediaSender     = (*Adapter)(nil)
+	_ bridge.MediaDownloader = (*Adapter)(nil)
+	_ bridge.ConnectionSink  = (*recordingSink)(nil)
+)

--- a/internal/cutover/carry.go
+++ b/internal/cutover/carry.go
@@ -1,0 +1,366 @@
+// Package cutover contains explicit, offline mechanisms used by the cutover
+// runbook. It does not rename or delete operator-owned stores.
+package cutover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+// CarrySource exposes the old-store reads needed to classify pending work and
+// stream any referenced attachment. ListCarryable must contain only queued and
+// not_dispatched rows; ListCarryReview contains uncertain, dispatching, and
+// store_failed rows for operator review.
+type CarrySource interface {
+	ListCarryable(context.Context) ([]sqlite.CarryableIntent, error)
+	ListCarryReview(context.Context) ([]sqlite.CarryReviewIntent, error)
+	Open(blob.BlobRef) (io.ReadCloser, error)
+}
+
+// CarryTarget exposes the fresh-store operations needed to recreate a safe
+// outbound intent. The UNIQUE(account_id, idempotency_key) constraint behind
+// the enqueue methods is the final idempotency boundary.
+type CarryTarget interface {
+	GetConversationByRemote(accountID, remoteConversationID string) (sqlite.Conversation, error)
+	Put(context.Context, io.Reader, string, int64) (blob.BlobRef, error)
+	EnqueueOutgoingMessage(
+		context.Context,
+		sqlite.NewOutboxItem,
+		sqlite.Message,
+	) (sqlite.OutboxItem, sqlite.EnqueueDisposition, error)
+	EnqueueOutgoingMediaMessage(
+		context.Context,
+		sqlite.NewOutboxItem,
+		sqlite.Message,
+		sqlite.OutboxAttachment,
+	) (sqlite.OutboxItem, sqlite.EnqueueDisposition, error)
+}
+
+// Endpoint combines a SQLite store, its outbox repository, and the adjacent
+// blob store into the CarrySource/CarryTarget seams. The embedded values
+// deliberately expose their existing methods without adapter-only variants.
+type Endpoint struct {
+	*sqlite.Store
+	*sqlite.OutboxRepository
+	*blob.BlobStore
+}
+
+// NewEndpoint wraps one v2 store directory for a cutover carry operation.
+func NewEndpoint(
+	store *sqlite.Store,
+	blobs *blob.BlobStore,
+	now func() time.Time,
+) (Endpoint, error) {
+	if store == nil {
+		return Endpoint{}, fmt.Errorf("create cutover endpoint: sqlite store is nil")
+	}
+	if blobs == nil {
+		return Endpoint{}, fmt.Errorf("create cutover endpoint: blob store is nil")
+	}
+	outbox, err := sqlite.NewOutboxRepository(store, now)
+	if err != nil {
+		return Endpoint{}, fmt.Errorf("create cutover endpoint: %w", err)
+	}
+	return Endpoint{
+		Store:            store,
+		OutboxRepository: outbox,
+		BlobStore:        blobs,
+	}, nil
+}
+
+// CarryEntry is one operator-visible cutover decision. Reason is populated
+// only for Uncarryable rows; Reported rows expose the old maybe-sent State that
+// prevents automatic retry.
+type CarryEntry struct {
+	OutboxID             string
+	AccountID            string
+	ConversationID       string
+	RemoteConversationID string
+	IdempotencyKey       string
+	Kind                 sqlite.OutboxKind
+	State                sqlite.OutboxState
+	Reason               string
+}
+
+// CarryReport is the complete evidence emitted by a carry pass. Carried lists
+// only newly inserted rows, so an idempotent second pass has zero Carried rows.
+// Reported is repeated on every pass because manual-review obligations remain.
+type CarryReport struct {
+	Carried     []CarryEntry
+	Reported    []CarryEntry
+	Uncarryable []CarryEntry
+}
+
+// CarryPendingOutbox copies only provably-unsent queued/not_dispatched intents
+// from old to fresh. It reports maybe-sent states without retrying them and
+// leaves terminal states untouched. Neither endpoint is renamed or deleted.
+//
+// PRECONDITION (the zero-double-send guarantee depends on it): the old store's
+// backend MUST be stopped before this runs. The cutover runbook (R8) enforces
+// this by ordering — stop the backend, move the store aside, then open it here
+// — and callers should open the old endpoint read-only, since carry never
+// writes it. A live dispatcher against the old store could transition a row
+// between ListCarryReview and ListCarryable, so this function assumes a
+// quiescent source and does not defend against a concurrent writer.
+func CarryPendingOutbox(
+	ctx context.Context,
+	old CarrySource,
+	fresh CarryTarget,
+) (CarryReport, error) {
+	report := CarryReport{
+		Carried:     make([]CarryEntry, 0),
+		Reported:    make([]CarryEntry, 0),
+		Uncarryable: make([]CarryEntry, 0),
+	}
+	if ctx == nil {
+		return report, fmt.Errorf("carry pending outbox: context is nil")
+	}
+	if old == nil {
+		return report, fmt.Errorf("carry pending outbox: old source is nil")
+	}
+	if fresh == nil {
+		return report, fmt.Errorf("carry pending outbox: fresh target is nil")
+	}
+
+	review, err := old.ListCarryReview(ctx)
+	if err != nil {
+		return report, fmt.Errorf("carry pending outbox: list manual-review rows: %w", err)
+	}
+	for _, item := range review {
+		report.Reported = append(report.Reported, carryEntryFromReview(item))
+	}
+
+	intents, err := old.ListCarryable(ctx)
+	if err != nil {
+		return report, fmt.Errorf("carry pending outbox: list carryable rows: %w", err)
+	}
+	for _, intent := range intents {
+		entry := carryEntryFromIntent(intent)
+		if intent.State != sqlite.OutboxQueued && intent.State != sqlite.OutboxNotDispatched {
+			return report, fmt.Errorf(
+				"carry pending outbox item %q: source returned non-carryable state %q",
+				intent.OutboxID,
+				intent.State,
+			)
+		}
+		if strings.TrimSpace(intent.RemoteConversationID) == "" {
+			entry.Reason = "old conversation has no remote conversation natural key"
+			report.Uncarryable = append(report.Uncarryable, entry)
+			continue
+		}
+
+		conversation, err := fresh.GetConversationByRemote(
+			intent.AccountID,
+			intent.RemoteConversationID,
+		)
+		if errors.Is(err, sqlite.ErrNotFound) {
+			entry.Reason = fmt.Sprintf(
+				"unresolved fresh conversation for account %q and remote ID %q",
+				intent.AccountID,
+				intent.RemoteConversationID,
+			)
+			report.Uncarryable = append(report.Uncarryable, entry)
+			continue
+		}
+		if err != nil {
+			return report, fmt.Errorf(
+				"carry pending outbox item %q: resolve fresh conversation: %w",
+				intent.OutboxID,
+				err,
+			)
+		}
+		if conversation.AccountID != intent.AccountID {
+			return report, fmt.Errorf(
+				"carry pending outbox item %q: fresh conversation %q belongs to account %q, want %q",
+				intent.OutboxID,
+				conversation.ConversationID,
+				conversation.AccountID,
+				intent.AccountID,
+			)
+		}
+		if !intent.MessagePresent || intent.LocalMessageID == nil ||
+			strings.TrimSpace(*intent.LocalMessageID) == "" || intent.MessageOccurredAtMS <= 0 {
+			entry.Reason = "optimistic outgoing message payload is missing"
+			report.Uncarryable = append(report.Uncarryable, entry)
+			continue
+		}
+
+		item := sqlite.NewOutboxItem{
+			OutboxID:           intent.OutboxID,
+			AccountID:          intent.AccountID,
+			ConversationID:     conversation.ConversationID,
+			Kind:               intent.Kind,
+			IdempotencyKey:     intent.IdempotencyKey,
+			PayloadHash:        intent.PayloadHash,
+			Operation:          intent.Operation,
+			LocalMessageID:     *intent.LocalMessageID,
+			TransportRequestID: intent.TransportRequestID,
+			ScheduledForMS:     intent.ScheduledForMS,
+		}
+		message := sqlite.Message{
+			MessageID:       *intent.LocalMessageID,
+			ConversationID:  conversation.ConversationID,
+			AccountID:       intent.AccountID,
+			RemoteMessageID: intent.TransportRequestID,
+			Direction:       sqlite.MessageDirectionOutgoing,
+			Body:            intent.Body,
+			ReplyToRemoteID: intent.ReplyToRemoteID,
+			State:           sqlite.MessageStateActive,
+			OccurredAtMS:    intent.MessageOccurredAtMS,
+		}
+
+		var (
+			carried     sqlite.OutboxItem
+			disposition sqlite.EnqueueDisposition
+		)
+		switch intent.Kind {
+		case sqlite.OutboxKindText:
+			carried, disposition, err = fresh.EnqueueOutgoingMessage(ctx, item, message)
+
+		case sqlite.OutboxKindMedia:
+			if strings.TrimSpace(intent.BlobHash) == "" || intent.BlobSizeBytes <= 0 ||
+				strings.TrimSpace(intent.MIME) == "" {
+				entry.Reason = "media blob metadata is missing"
+				report.Uncarryable = append(report.Uncarryable, entry)
+				continue
+			}
+			reader, openErr := old.Open(blob.BlobRef{Hash: intent.BlobHash})
+			if openErr != nil {
+				entry.Reason = fmt.Sprintf("media blob %q is unavailable: %v", intent.BlobHash, openErr)
+				report.Uncarryable = append(report.Uncarryable, entry)
+				continue
+			}
+			copied, putErr := fresh.Put(ctx, reader, intent.MIME, intent.BlobSizeBytes)
+			closeErr := reader.Close()
+			if putErr != nil {
+				return report, fmt.Errorf(
+					"carry pending outbox item %q: copy media blob %q: %w",
+					intent.OutboxID,
+					intent.BlobHash,
+					putErr,
+				)
+			}
+			if closeErr != nil {
+				return report, fmt.Errorf(
+					"carry pending outbox item %q: close media blob %q: %w",
+					intent.OutboxID,
+					intent.BlobHash,
+					closeErr,
+				)
+			}
+			if copied.Hash != intent.BlobHash || copied.Size != intent.BlobSizeBytes {
+				entry.Reason = fmt.Sprintf(
+					"media blob %q failed integrity check (copied hash %q, size %d; want size %d)",
+					intent.BlobHash,
+					copied.Hash,
+					copied.Size,
+					intent.BlobSizeBytes,
+				)
+				report.Uncarryable = append(report.Uncarryable, entry)
+				continue
+			}
+			carried, disposition, err = fresh.EnqueueOutgoingMediaMessage(
+				ctx,
+				item,
+				message,
+				sqlite.OutboxAttachment{
+					BlobHash:  intent.BlobHash,
+					SizeBytes: intent.BlobSizeBytes,
+					MIME:      intent.MIME,
+					Filename:  intent.Filename,
+				},
+			)
+
+		default:
+			entry.Reason = fmt.Sprintf("outbox kind %q has no cutover re-enqueue payload", intent.Kind)
+			report.Uncarryable = append(report.Uncarryable, entry)
+			continue
+		}
+		if err != nil {
+			// A foreign collision — the key already names a different fresh
+			// intent (migration- or ingest-created) — is an anomaly to surface,
+			// not a reason to abort every later row. Report it un-carryable
+			// (loud) and keep the batch moving; the pre-existing fresh row is
+			// untouched and this intent is neither carried nor dropped.
+			if errors.Is(err, sqlite.ErrIdempotencyConflict) {
+				entry.Reason = fmt.Sprintf("idempotency key %q already names a different fresh intent", intent.IdempotencyKey)
+				report.Uncarryable = append(report.Uncarryable, entry)
+				continue
+			}
+			return report, fmt.Errorf(
+				"carry pending outbox item %q into conversation %q: %w",
+				intent.OutboxID,
+				conversation.ConversationID,
+				err,
+			)
+		}
+		if err := validateExistingCarry(carried, intent, conversation.ConversationID); err != nil {
+			// DO NOTHING matched an existing row that differs from this intent:
+			// the same foreign-collision anomaly by another route. Report and
+			// continue rather than abort.
+			entry.Reason = err.Error()
+			report.Uncarryable = append(report.Uncarryable, entry)
+			continue
+		}
+		if disposition == sqlite.EnqueueInserted {
+			report.Carried = append(report.Carried, entry)
+		}
+	}
+
+	return report, nil
+}
+
+func validateExistingCarry(
+	carried sqlite.OutboxItem,
+	intent sqlite.CarryableIntent,
+	freshConversationID string,
+) error {
+	if carried.AccountID != intent.AccountID ||
+		carried.ConversationID != freshConversationID ||
+		carried.Kind != intent.Kind ||
+		carried.IdempotencyKey != intent.IdempotencyKey ||
+		carried.PayloadHash != intent.PayloadHash ||
+		carried.Operation != intent.Operation ||
+		carried.ScheduledForMS != intent.ScheduledForMS {
+		return fmt.Errorf(
+			"carry pending outbox item %q: idempotency key %q resolved to a different fresh intent",
+			intent.OutboxID,
+			intent.IdempotencyKey,
+		)
+	}
+	return nil
+}
+
+func carryEntryFromIntent(intent sqlite.CarryableIntent) CarryEntry {
+	return CarryEntry{
+		OutboxID:             intent.OutboxID,
+		AccountID:            intent.AccountID,
+		ConversationID:       intent.ConversationID,
+		RemoteConversationID: intent.RemoteConversationID,
+		IdempotencyKey:       intent.IdempotencyKey,
+		Kind:                 intent.Kind,
+		State:                intent.State,
+	}
+}
+
+func carryEntryFromReview(intent sqlite.CarryReviewIntent) CarryEntry {
+	return CarryEntry{
+		OutboxID:             intent.OutboxID,
+		AccountID:            intent.AccountID,
+		ConversationID:       intent.ConversationID,
+		RemoteConversationID: intent.RemoteConversationID,
+		IdempotencyKey:       intent.IdempotencyKey,
+		Kind:                 intent.Kind,
+		State:                intent.State,
+	}
+}
+
+var _ CarrySource = Endpoint{}
+var _ CarryTarget = Endpoint{}

--- a/internal/cutover/carry_test.go
+++ b/internal/cutover/carry_test.go
@@ -1,0 +1,542 @@
+package cutover
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+const carryTestNowMS int64 = 2_100_000_000_000
+
+func TestCutoverCarriesPendingOutbox(t *testing.T) {
+	ctx := context.Background()
+	now := time.UnixMilli(carryTestNowMS)
+	old := openCarryTestEndpoint(t, "old", now)
+	fresh := openCarryTestEndpoint(t, "fresh", now.Add(time.Second))
+	seedCarryAccount(t, old.Store, "account-a")
+	seedCarryAccount(t, fresh.Store, "account-a")
+	seedCarryConversation(t, old.Store, "old-conversation", "account-a", "remote-thread")
+	seedCarryConversation(t, fresh.Store, "fresh-conversation", "account-a", "remote-thread")
+
+	futureMS := now.Add(24 * time.Hour).UnixMilli()
+	queued := enqueueCarryText(t, ctx, old, "queued", "old-conversation", futureMS)
+
+	mediaBytes := []byte("pending attachment bytes")
+	mediaRef, err := old.BlobStore.Put(ctx, bytes.NewReader(mediaBytes), "image/png", int64(len(mediaBytes)))
+	if err != nil {
+		t.Fatalf("put old media blob: %v", err)
+	}
+	notDispatched := enqueueCarryMedia(
+		t,
+		ctx,
+		old,
+		"not-dispatched",
+		"old-conversation",
+		carryTestNowMS,
+		mediaRef,
+	)
+	notDispatchedLease := leaseCarryItem(t, ctx, old, now)
+	if notDispatchedLease.OutboxID != notDispatched.OutboxID {
+		t.Fatalf("leased outbox ID = %q, want %q", notDispatchedLease.OutboxID, notDispatched.OutboxID)
+	}
+	if err := old.OutboxRepository.MarkNotDispatched(
+		ctx,
+		notDispatched.OutboxID,
+		*notDispatchedLease.LeaseToken,
+		"transport",
+		"offline",
+		"scripted pre-call failure",
+		now.Add(time.Minute),
+	); err != nil {
+		t.Fatalf("mark not dispatched: %v", err)
+	}
+
+	confirmed := enqueueCarryText(t, ctx, old, "confirmed", "old-conversation", carryTestNowMS)
+	confirmedLease := leaseCarryItem(t, ctx, old, now)
+	markCarryTransportCalled(t, ctx, old, confirmedLease)
+	if err := old.OutboxRepository.Confirm(ctx, sqlite.Confirmation{
+		OutboxID:       confirmed.OutboxID,
+		LeaseToken:     *confirmedLease.LeaseToken,
+		ResultRemoteID: "confirmed-remote",
+	}); err != nil {
+		t.Fatalf("confirm outbox row: %v", err)
+	}
+
+	uncertain := enqueueCarryText(t, ctx, old, "uncertain", "old-conversation", carryTestNowMS)
+	uncertainLease := leaseCarryItem(t, ctx, old, now)
+	markCarryTransportCalled(t, ctx, old, uncertainLease)
+	if err := old.OutboxRepository.MarkUncertain(
+		ctx,
+		uncertain.OutboxID,
+		*uncertainLease.LeaseToken,
+		"transport",
+		"timeout",
+		"result unknown",
+	); err != nil {
+		t.Fatalf("mark uncertain: %v", err)
+	}
+
+	dispatching := enqueueCarryText(t, ctx, old, "dispatching", "old-conversation", carryTestNowMS)
+	dispatchingLease := leaseCarryItem(t, ctx, old, now)
+	if dispatchingLease.OutboxID != dispatching.OutboxID {
+		t.Fatalf("dispatching lease ID = %q, want %q", dispatchingLease.OutboxID, dispatching.OutboxID)
+	}
+
+	storeFailed := enqueueCarryText(t, ctx, old, "store-failed", "old-conversation", carryTestNowMS)
+	storeFailedLease := leaseCarryItem(t, ctx, old, now)
+	markCarryTransportCalled(t, ctx, old, storeFailedLease)
+	if err := old.OutboxRepository.MarkStoreFailed(
+		ctx,
+		storeFailed.OutboxID,
+		*storeFailedLease.LeaseToken,
+		"accepted-remote",
+		"projection failed",
+	); err != nil {
+		t.Fatalf("mark store failed: %v", err)
+	}
+
+	rejected := enqueueCarryText(t, ctx, old, "rejected", "old-conversation", carryTestNowMS)
+	rejectedLease := leaseCarryItem(t, ctx, old, now)
+	if err := old.OutboxRepository.Reject(
+		ctx,
+		rejected.OutboxID,
+		*rejectedLease.LeaseToken,
+		"remote",
+		"invalid",
+		"rejected",
+	); err != nil {
+		t.Fatalf("reject outbox row: %v", err)
+	}
+
+	canceled := enqueueCarryText(t, ctx, old, "canceled", "old-conversation", carryTestNowMS)
+	if err := old.OutboxRepository.Cancel(ctx, canceled.OutboxID); err != nil {
+		t.Fatalf("cancel outbox row: %v", err)
+	}
+
+	report, err := CarryPendingOutbox(ctx, old, fresh)
+	if err != nil {
+		t.Fatalf("CarryPendingOutbox(): %v", err)
+	}
+	assertCarryEntryIDs(t, "carried", report.Carried, []string{queued.OutboxID, notDispatched.OutboxID})
+	assertCarryEntryStates(t, "reported", report.Reported, []sqlite.OutboxState{
+		sqlite.OutboxUncertain,
+		sqlite.OutboxDispatching,
+		sqlite.OutboxStoreFailed,
+	})
+	if len(report.Uncarryable) != 0 {
+		t.Fatalf("uncarryable = %+v, want none", report.Uncarryable)
+	}
+
+	freshRows, err := fresh.OutboxRepository.ListCarryable(ctx)
+	if err != nil {
+		t.Fatalf("fresh ListCarryable(): %v", err)
+	}
+	if len(freshRows) != 2 {
+		t.Fatalf("fresh carryable rows = %+v, want exactly two", freshRows)
+	}
+	byID := make(map[string]sqlite.CarryableIntent, len(freshRows))
+	for _, row := range freshRows {
+		byID[row.OutboxID] = row
+		if row.ConversationID != "fresh-conversation" || row.RemoteConversationID != "remote-thread" {
+			t.Fatalf("carried conversation mapping = %+v", row)
+		}
+	}
+	if got := byID[queued.OutboxID]; got.IdempotencyKey != queued.IdempotencyKey ||
+		got.ScheduledForMS != futureMS || got.Body != "body-queued" ||
+		got.ReplyToRemoteID == nil || *got.ReplyToRemoteID != "reply-remote-queued" {
+		t.Fatalf("carried queued row = %+v", got)
+	}
+	if got := byID[notDispatched.OutboxID]; got.IdempotencyKey != notDispatched.IdempotencyKey ||
+		got.ScheduledForMS != carryTestNowMS || got.BlobHash != mediaRef.Hash ||
+		got.BlobSizeBytes != int64(len(mediaBytes)) || got.MIME != "image/png" ||
+		got.Filename != "pending.png" {
+		t.Fatalf("carried not-dispatched media row = %+v", got)
+	}
+	reader, err := fresh.BlobStore.Open(blob.BlobRef{Hash: mediaRef.Hash})
+	if err != nil {
+		t.Fatalf("open carried media blob: %v", err)
+	}
+	carriedMedia, readErr := io.ReadAll(reader)
+	closeErr := reader.Close()
+	if readErr != nil || closeErr != nil {
+		t.Fatalf("read carried media blob: read=%v close=%v", readErr, closeErr)
+	}
+	if !bytes.Equal(carriedMedia, mediaBytes) {
+		t.Fatalf("carried media bytes = %q, want %q", carriedMedia, mediaBytes)
+	}
+
+	second, err := CarryPendingOutbox(ctx, old, fresh)
+	if err != nil {
+		t.Fatalf("CarryPendingOutbox(second): %v", err)
+	}
+	if len(second.Carried) != 0 {
+		t.Fatalf("second carried = %+v, want no double-enqueue", second.Carried)
+	}
+	assertCarryEntryStates(t, "second reported", second.Reported, []sqlite.OutboxState{
+		sqlite.OutboxUncertain,
+		sqlite.OutboxDispatching,
+		sqlite.OutboxStoreFailed,
+	})
+	secondRows, err := fresh.OutboxRepository.ListCarryable(ctx)
+	if err != nil {
+		t.Fatalf("fresh ListCarryable(second): %v", err)
+	}
+	if len(secondRows) != 2 {
+		t.Fatalf("fresh rows after second carry = %d, want 2", len(secondRows))
+	}
+}
+
+func TestCarryPendingOutboxReportsUncarryableRows(t *testing.T) {
+	ctx := context.Background()
+	now := time.UnixMilli(carryTestNowMS)
+	old := openCarryTestEndpoint(t, "old", now)
+	fresh := openCarryTestEndpoint(t, "fresh", now)
+	seedCarryAccount(t, old.Store, "account-a")
+	seedCarryAccount(t, fresh.Store, "account-a")
+	seedCarryConversation(t, old.Store, "old-with-fresh-match", "account-a", "remote-with-match")
+	seedCarryConversation(t, fresh.Store, "fresh-match", "account-a", "remote-with-match")
+	seedCarryConversation(t, old.Store, "old-without-fresh-match", "account-a", "remote-without-match")
+
+	missingRef := blob.BlobRef{
+		Hash: "abababababababababababababababababababababababababababababababab",
+		Size: 25,
+		MIME: "image/png",
+	}
+	missingBlob := enqueueCarryMedia(
+		t,
+		ctx,
+		old,
+		"missing-blob",
+		"old-with-fresh-match",
+		carryTestNowMS,
+		missingRef,
+	)
+	unresolved := enqueueCarryText(
+		t,
+		ctx,
+		old,
+		"unresolved-conversation",
+		"old-without-fresh-match",
+		carryTestNowMS,
+	)
+
+	report, err := CarryPendingOutbox(ctx, old, fresh)
+	if err != nil {
+		t.Fatalf("CarryPendingOutbox(): %v", err)
+	}
+	if len(report.Carried) != 0 || len(report.Reported) != 0 || len(report.Uncarryable) != 2 {
+		t.Fatalf("report = %+v, want two uncarryable rows only", report)
+	}
+	reasons := map[string]string{}
+	for _, entry := range report.Uncarryable {
+		reasons[entry.OutboxID] = entry.Reason
+	}
+	if !strings.Contains(reasons[missingBlob.OutboxID], "blob") ||
+		!strings.Contains(reasons[unresolved.OutboxID], "conversation") {
+		t.Fatalf("uncarryable reasons = %+v", reasons)
+	}
+	rows, err := fresh.OutboxRepository.ListCarryable(ctx)
+	if err != nil {
+		t.Fatalf("fresh ListCarryable(): %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("fresh carryable rows = %+v, want none", rows)
+	}
+}
+
+func openCarryTestEndpoint(t *testing.T, name string, now time.Time) Endpoint {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("create %s store root: %v", name, err)
+	}
+	store, err := sqlite.Open(filepath.Join(root, "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("open %s sqlite store: %v", name, err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close %s sqlite store: %v", name, err)
+		}
+	})
+	blobs, err := blob.New(filepath.Join(root, "blobs"))
+	if err != nil {
+		t.Fatalf("open %s blob store: %v", name, err)
+	}
+	endpoint, err := NewEndpoint(store, blobs, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("NewEndpoint(%s): %v", name, err)
+	}
+	return endpoint
+}
+
+func seedCarryAccount(t *testing.T, store *sqlite.Store, accountID string) {
+	t.Helper()
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID:   accountID,
+		BridgeKey:   "scripted",
+		DisplayName: "Scripted",
+		Mode:        sqlite.AccountModeLive,
+		Enabled:     true,
+		ConfigJSON:  `{}`,
+		CreatedAtMS: carryTestNowMS,
+		UpdatedAtMS: carryTestNowMS,
+	}); err != nil {
+		t.Fatalf("seed account %q: %v", accountID, err)
+	}
+}
+
+func seedCarryConversation(
+	t *testing.T,
+	store *sqlite.Store,
+	conversationID, accountID, remoteConversationID string,
+) {
+	t.Helper()
+	if err := store.UpsertConversation(sqlite.Conversation{
+		ConversationID:       conversationID,
+		AccountID:            accountID,
+		RemoteConversationID: remoteConversationID,
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                remoteConversationID,
+		NotificationMode:     sqlite.NotificationModeAll,
+		MetadataJSON:         `{}`,
+		CreatedAtMS:          carryTestNowMS,
+		UpdatedAtMS:          carryTestNowMS,
+	}); err != nil {
+		t.Fatalf("seed conversation %q: %v", conversationID, err)
+	}
+}
+
+func enqueueCarryText(
+	t *testing.T,
+	ctx context.Context,
+	endpoint Endpoint,
+	id, conversationID string,
+	scheduledForMS int64,
+) sqlite.OutboxItem {
+	t.Helper()
+	item := carryTestItem(id, conversationID, sqlite.OutboxKindText, scheduledForMS)
+	reply := "reply-remote-" + id
+	row, disposition, err := endpoint.OutboxRepository.EnqueueOutgoingMessage(ctx, item, sqlite.Message{
+		MessageID:       item.LocalMessageID,
+		ConversationID:  conversationID,
+		AccountID:       item.AccountID,
+		RemoteMessageID: item.TransportRequestID,
+		Direction:       sqlite.MessageDirectionOutgoing,
+		Body:            "body-" + id,
+		ReplyToRemoteID: &reply,
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    carryTestNowMS,
+	})
+	if err != nil {
+		t.Fatalf("enqueue text %q: %v", id, err)
+	}
+	if disposition != sqlite.EnqueueInserted {
+		t.Fatalf("enqueue text %q disposition = %q", id, disposition)
+	}
+	return row
+}
+
+func enqueueCarryMedia(
+	t *testing.T,
+	ctx context.Context,
+	endpoint Endpoint,
+	id, conversationID string,
+	scheduledForMS int64,
+	ref blob.BlobRef,
+) sqlite.OutboxItem {
+	t.Helper()
+	item := carryTestItem(id, conversationID, sqlite.OutboxKindMedia, scheduledForMS)
+	row, disposition, err := endpoint.OutboxRepository.EnqueueOutgoingMediaMessage(ctx, item, sqlite.Message{
+		MessageID:       item.LocalMessageID,
+		ConversationID:  conversationID,
+		AccountID:       item.AccountID,
+		RemoteMessageID: item.TransportRequestID,
+		Direction:       sqlite.MessageDirectionOutgoing,
+		Body:            "caption-" + id,
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    carryTestNowMS,
+	}, sqlite.OutboxAttachment{
+		BlobHash:  ref.Hash,
+		SizeBytes: ref.Size,
+		MIME:      ref.MIME,
+		Filename:  "pending.png",
+	})
+	if err != nil {
+		t.Fatalf("enqueue media %q: %v", id, err)
+	}
+	if disposition != sqlite.EnqueueInserted {
+		t.Fatalf("enqueue media %q disposition = %q", id, disposition)
+	}
+	return row
+}
+
+func carryTestItem(
+	id, conversationID string,
+	kind sqlite.OutboxKind,
+	scheduledForMS int64,
+) sqlite.NewOutboxItem {
+	operation := "send_text"
+	if kind == sqlite.OutboxKindMedia {
+		operation = "send_media"
+	}
+	return sqlite.NewOutboxItem{
+		OutboxID:           "outbox-" + id,
+		AccountID:          "account-a",
+		ConversationID:     conversationID,
+		Kind:               kind,
+		IdempotencyKey:     "idempotency-" + id,
+		PayloadHash:        "payload-" + id,
+		Operation:          operation,
+		LocalMessageID:     "message-" + id,
+		TransportRequestID: "request-" + id,
+		ScheduledForMS:     scheduledForMS,
+	}
+}
+
+func leaseCarryItem(
+	t *testing.T,
+	ctx context.Context,
+	endpoint Endpoint,
+	now time.Time,
+) sqlite.Lease {
+	t.Helper()
+	leases, err := endpoint.OutboxRepository.LeaseDue(ctx, sqlite.LeaseRequest{
+		Owner:    "cutover-test",
+		Now:      now,
+		Duration: time.Minute,
+		Limit:    1,
+	})
+	if err != nil {
+		t.Fatalf("LeaseDue(): %v", err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("LeaseDue() rows = %+v, want one", leases)
+	}
+	return leases[0]
+}
+
+func markCarryTransportCalled(
+	t *testing.T,
+	ctx context.Context,
+	endpoint Endpoint,
+	lease sqlite.Lease,
+) {
+	t.Helper()
+	if err := endpoint.OutboxRepository.MarkTransportCalled(ctx, sqlite.Attempt{
+		OutboxID:   lease.OutboxID,
+		LeaseToken: *lease.LeaseToken,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(%q): %v", lease.OutboxID, err)
+	}
+}
+
+func assertCarryEntryIDs(t *testing.T, label string, entries []CarryEntry, want []string) {
+	t.Helper()
+	got := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		got = append(got, entry.OutboxID)
+	}
+	slices.Sort(got)
+	want = slices.Clone(want)
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Fatalf("%s IDs = %v, want %v", label, got, want)
+	}
+}
+
+func assertCarryEntryStates(
+	t *testing.T,
+	label string,
+	entries []CarryEntry,
+	want []sqlite.OutboxState,
+) {
+	t.Helper()
+	got := make([]sqlite.OutboxState, 0, len(entries))
+	for _, entry := range entries {
+		got = append(got, entry.State)
+	}
+	slices.Sort(got)
+	want = slices.Clone(want)
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Fatalf("%s states = %v, want %v", label, got, want)
+	}
+}
+
+// A foreign idempotency collision (the fresh store already holds a different
+// intent under the key) must report that one row un-carryable and keep the
+// batch moving, never abort every later row or corrupt the pre-existing row.
+func TestCarryPendingOutboxForeignCollisionReportsAndContinues(t *testing.T) {
+	ctx := context.Background()
+	now := time.UnixMilli(carryTestNowMS)
+	old := openCarryTestEndpoint(t, "old", now)
+	fresh := openCarryTestEndpoint(t, "fresh", now)
+	seedCarryAccount(t, old.Store, "account-a")
+	seedCarryConversation(t, old.Store, "conv-a", "account-a", "remote-conv-a")
+	seedCarryAccount(t, fresh.Store, "account-a")
+	seedCarryConversation(t, fresh.Store, "fresh-conv-a", "account-a", "remote-conv-a")
+
+	// Old store: a colliding row (shares the fresh row's key) and a clean row.
+	enqueueCarryText(t, ctx, old, "collides", "conv-a", carryTestNowMS)
+	enqueueCarryText(t, ctx, old, "clean", "conv-a", carryTestNowMS)
+
+	// Fresh store: pre-seed a DIFFERENT intent under the colliding row's key.
+	foreign := carryTestItem("collides", "fresh-conv-a", sqlite.OutboxKindText, carryTestNowMS)
+	foreign.OutboxID = "fresh-foreign"
+	foreign.LocalMessageID = "fresh-foreign-msg"
+	foreign.TransportRequestID = "fresh-foreign-req"
+	foreign.PayloadHash = "different-payload"
+	freshReply := "fresh-reply"
+	if _, disp, err := fresh.OutboxRepository.EnqueueOutgoingMessage(ctx, foreign, sqlite.Message{
+		MessageID:       foreign.LocalMessageID,
+		ConversationID:  "fresh-conv-a",
+		AccountID:       "account-a",
+		RemoteMessageID: foreign.TransportRequestID,
+		Direction:       sqlite.MessageDirectionOutgoing,
+		Body:            "a different message under the same key",
+		ReplyToRemoteID: &freshReply,
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    carryTestNowMS,
+	}); err != nil || disp != sqlite.EnqueueInserted {
+		t.Fatalf("seed foreign fresh intent: disp=%q err=%v", disp, err)
+	}
+
+	report, err := CarryPendingOutbox(ctx, old, fresh)
+	if err != nil {
+		t.Fatalf("CarryPendingOutbox() aborted the batch on a foreign collision: %v", err)
+	}
+	// The clean row carried; the colliding row is reported un-carryable.
+	if len(report.Carried) != 1 || report.Carried[0].OutboxID != "outbox-clean" {
+		t.Fatalf("carried = %+v, want exactly the clean row", report.Carried)
+	}
+	var collided *CarryEntry
+	for i := range report.Uncarryable {
+		if report.Uncarryable[i].OutboxID == "outbox-collides" {
+			collided = &report.Uncarryable[i]
+		}
+	}
+	if collided == nil {
+		t.Fatalf("colliding row not reported un-carryable: %+v", report.Uncarryable)
+	}
+	if !strings.Contains(collided.Reason, "idempotency") {
+		t.Fatalf("un-carryable reason = %q, want it to name the idempotency collision", collided.Reason)
+	}
+	// The pre-existing foreign fresh row is byte-unchanged.
+	got, err := fresh.OutboxRepository.FindByID(ctx, "fresh-foreign")
+	if err != nil {
+		t.Fatalf("fresh foreign row lookup: %v", err)
+	}
+	if got.PayloadHash != "different-payload" {
+		t.Fatalf("foreign fresh row mutated: payload_hash = %q", got.PayloadHash)
+	}
+}

--- a/internal/storage/sqlite/outbox.go
+++ b/internal/storage/sqlite/outbox.go
@@ -112,6 +112,37 @@ type PendingRow struct {
 	Emoji     *string
 }
 
+// CarryableIntent is the complete, self-contained payload needed to recreate
+// one provably-unsent outgoing message in a freshly migrated store. The
+// account-scoped remote conversation ID is the cross-store natural key; the
+// old conversation primary key is retained only for operator-facing reports.
+// MessagePresent distinguishes a missing optimistic row from a legitimate
+// empty body, while empty blob fields identify a missing media carrier.
+type CarryableIntent struct {
+	OutboxItem
+	RemoteConversationID string
+	Body                 string
+	ReplyToRemoteID      *string
+	MessageOccurredAtMS  int64
+	MessagePresent       bool
+	BlobHash             string
+	BlobSizeBytes        int64
+	MIME                 string
+	Filename             string
+}
+
+// CarryReviewIntent identifies a maybe-sent row that cutover must report and
+// must never enqueue automatically.
+type CarryReviewIntent struct {
+	OutboxID             string
+	AccountID            string
+	ConversationID       string
+	RemoteConversationID string
+	Kind                 OutboxKind
+	State                OutboxState
+	IdempotencyKey       string
+}
+
 // OutboxAttachment is the persisted blob metadata for one media outbox intent.
 // M2 stores exactly one attachment at ordinal zero. Enqueue stamps OutboxID,
 // Ordinal, and CreatedAtMS; GetOutboxAttachment populates every field.
@@ -938,6 +969,86 @@ func (r *OutboxRepository) EarliestDue(ctx context.Context) (time.Time, bool, er
 		return time.Time{}, false, nil
 	}
 	return time.UnixMilli(earliestMS.Int64), true, nil
+}
+
+// ListCarryable returns every provably-unsent outgoing intent with the full
+// message/media payload required to enqueue it in another store. It is
+// intentionally unbounded: cutover is an offline, all-or-reported operation,
+// so silently truncating the carry set would lose durable work.
+func (r *OutboxRepository) ListCarryable(ctx context.Context) ([]CarryableIntent, error) {
+	rows, err := r.store.db.QueryContext(ctx, `
+		SELECT `+prefixedOutboxColumns("o")+`,
+			c.remote_conversation_id,
+			m.message_id,
+			m.body,
+			m.reply_to_remote_id,
+			m.occurred_at_ms,
+			oa.blob_hash,
+			oa.size_bytes,
+			oa.mime,
+			oa.filename
+		FROM outbox o
+		LEFT JOIN conversations c
+			ON c.account_id = o.account_id AND c.conversation_id = o.conversation_id
+		LEFT JOIN messages m
+			ON m.message_id = o.local_message_id
+			AND m.account_id = o.account_id
+			AND m.conversation_id = o.conversation_id
+		LEFT JOIN outbox_attachments oa
+			ON oa.outbox_id = o.outbox_id AND oa.ordinal = 0
+		WHERE o.state IN ('queued', 'not_dispatched')
+		ORDER BY o.created_at_ms, o.outbox_id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list carryable outbox items: query: %w", err)
+	}
+	items, err := collectRows(rows, scanCarryableIntent)
+	if err != nil {
+		return nil, fmt.Errorf("list carryable outbox items: scan: %w", err)
+	}
+	return items, nil
+}
+
+// ListCarryReview returns the nonterminal states whose transport outcome may
+// be known or unknown but is never provably unsent. This separate enumerator
+// keeps ListCarryable's safety contract exact while giving cutover complete
+// operator-facing evidence for uncertain, in-flight, and store-failed rows.
+func (r *OutboxRepository) ListCarryReview(ctx context.Context) ([]CarryReviewIntent, error) {
+	rows, err := r.store.db.QueryContext(ctx, `
+		SELECT
+			o.outbox_id,
+			o.account_id,
+			o.conversation_id,
+			COALESCE(c.remote_conversation_id, ''),
+			o.kind,
+			o.state,
+			o.idempotency_key
+		FROM outbox o
+		LEFT JOIN conversations c
+			ON c.account_id = o.account_id AND c.conversation_id = o.conversation_id
+		WHERE o.state IN ('uncertain', 'dispatching', 'store_failed')
+		ORDER BY o.created_at_ms, o.outbox_id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list carry-review outbox items: query: %w", err)
+	}
+	items, err := collectRows(rows, func(row rowScanner) (CarryReviewIntent, error) {
+		var item CarryReviewIntent
+		err := row.Scan(
+			&item.OutboxID,
+			&item.AccountID,
+			&item.ConversationID,
+			&item.RemoteConversationID,
+			&item.Kind,
+			&item.State,
+			&item.IdempotencyKey,
+		)
+		return item, err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list carry-review outbox items: scan: %w", err)
+	}
+	return items, nil
 }
 
 // ListPending returns exactly the cancelable outbox set, ordered by the same
@@ -1995,6 +2106,71 @@ func scanPendingRow(row rowScanner) (PendingRow, error) {
 		&pending.Emoji,
 	)
 	return pending, err
+}
+
+func scanCarryableIntent(row rowScanner) (CarryableIntent, error) {
+	var (
+		intent               CarryableIntent
+		remoteConversationID sql.NullString
+		messageID            sql.NullString
+		body                 sql.NullString
+		replyToRemoteID      sql.NullString
+		messageOccurredAtMS  sql.NullInt64
+		blobHash             sql.NullString
+		blobSizeBytes        sql.NullInt64
+		mime                 sql.NullString
+		filename             sql.NullString
+	)
+	err := row.Scan(
+		&intent.OutboxID,
+		&intent.AccountID,
+		&intent.ConversationID,
+		&intent.Kind,
+		&intent.IdempotencyKey,
+		&intent.PayloadHash,
+		&intent.Operation,
+		&intent.State,
+		&intent.LocalMessageID,
+		&intent.TransportRequestID,
+		&intent.SendAgainOfOutboxID,
+		&intent.ResultRemoteID,
+		&intent.ErrorClass,
+		&intent.ErrorCode,
+		&intent.ErrorDetail,
+		&intent.AttemptCount,
+		&intent.LeaseOwner,
+		&intent.LeaseToken,
+		&intent.LeaseExpiresAtMS,
+		&intent.TransportCalledAtMS,
+		&intent.ScheduledForMS,
+		&intent.NextAttemptAtMS,
+		&intent.CreatedAtMS,
+		&intent.UpdatedAtMS,
+		&remoteConversationID,
+		&messageID,
+		&body,
+		&replyToRemoteID,
+		&messageOccurredAtMS,
+		&blobHash,
+		&blobSizeBytes,
+		&mime,
+		&filename,
+	)
+	if err != nil {
+		return CarryableIntent{}, err
+	}
+	intent.RemoteConversationID = remoteConversationID.String
+	intent.MessagePresent = messageID.Valid
+	intent.Body = body.String
+	if replyToRemoteID.Valid {
+		intent.ReplyToRemoteID = &replyToRemoteID.String
+	}
+	intent.MessageOccurredAtMS = messageOccurredAtMS.Int64
+	intent.BlobHash = blobHash.String
+	intent.BlobSizeBytes = blobSizeBytes.Int64
+	intent.MIME = mime.String
+	intent.Filename = filename.String
+	return intent, nil
 }
 
 func scanOutboxItem(row rowScanner) (OutboxItem, error) {


### PR DESCRIPTION
## What

The proof the R8 data cutover is safe, per `r5-selector-it-spec-2026-07-17.md` §6–§8. Second and final R5 PR.

- **Drain-or-carry** (`internal/cutover`): `CarryPendingOutbox` moves only provably-unsent `queued`/`not_dispatched` outbox intents from the pre-cutover v2 store into the freshly-migrated store, re-enqueued **by idempotency key** so a second run is a no-op (zero double-enqueue). It **reports** the maybe-sent states (`uncertain`/`dispatching`/`store_failed`) for operator review without ever retrying them, **ignores** terminal states, resolves conversations by `remote_conversation_id` natural key, copies media blobs with an integrity check before enqueue (missing/corrupt blob → reported un-carryable, never a dangling ref), and preserves future `scheduled_for_ms`. New `OutboxRepository.ListCarryable` returns the full re-enqueue payload. **The old store is never renamed or deleted** — R8 owns store-aside.
- **Backend IT** (`cmd/r5_backend_it_test.go`): a legacy fixture across all three platforms + the named edge cases (@lid-merged WhatsApp thread, signal:local: outgoing, reactions-as-messages, scheduled rows, media); real backup + real migrate in-process; integrity report asserted against known counts (12/12 body-hash matches, 0 remote-id collisions); boots v2-primary over the migrated store with scripted transports and exercises **every serving surface** with parity assertions — reads are served against an **inert in-memory legacy store**, so any accidental legacy read fails the assertion.
- **Cutover rehearsal** (`cmd/r5_cutover_rehearsal_test.go`): walks the full runbook — projector-drain → backup → `migrate --check` go/no-go → store-aside → migrate → carry → flip selector → boot → restart — and asserts the moved-aside store + untouched legacy source are retained for rollback. Real exit-code negatives (refuse-existing-v2 = 3, no-go = 5).

## Adversarial-review outcome (verdict: SHIP, no BLOCKING)

The reviewer proved — with repro tests the suite lacked — that the §8 killer scenario (an `uncertain` row carried and re-sent to a real person) is **impossible** (three independent barriers: SQL filter, defensive guard, separate review query), that a foreign idempotency collision aborts loud with no loss/corruption, and that the IT genuinely discriminates (would catch a dropped conversation, a mis-mapped remote id, or served legacy data).

Fixes folded in:
- **N1 — batch liveness**: a foreign idempotency collision (the fresh store already holds a different intent under the key) now reports that one row un-carryable and **continues** the batch, instead of aborting every later legitimate carry. Regression-tested (`TestCarryPendingOutboxForeignCollisionReportsAndContinues`) against a pre-seeded conflicting fresh intent, asserting the clean row still carries, the collision is reported with a loud reason, and the pre-existing fresh row is byte-unchanged.

On the reviewer's **S1** (code-enforce old-store quiescence): the suggested mechanism — refuse the carry when any row is `dispatching` — directly contradicts the spec's `dispatching → REPORT` contract and the happy-path test, so shipping it would be a wrong fix. The read-only-old-store open the reviewer also suggested is R8-runbook wiring (scope-fenced out of R5-2 per §9). I documented the quiescence precondition prominently on `CarryPendingOutbox` as the caller's obligation instead. Tracked for R8.

## Verification

Full `go test -race ./...`: 31 packages green (`internal/cutover` + `internal/bridgeadapters/scripted` added), independently verified outside the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
