### PR TITLE
Fail loud on legacy scheduling in v2-primary + expose v2_primary (rebuild W3 PR-A)

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -288,7 +288,8 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		}
 		payload := map[string]any{
 			"connected": connected,
-			"v2_send":   opts.V2 != nil,
+			"v2_send":    opts.V2 != nil,
+			"v2_primary": opts.V2Primary,
 			"v2_ingest": map[string]any{
 				"enabled":     opts.V2IngestCounters != nil,
 				"per_account": v2IngestPerAccount,
@@ -1288,6 +1289,13 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	mux.HandleFunc("/api/schedule", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
+			// Post-migration the legacy scheduled_messages table is meaningless
+			// (v2 scheduling lives in the outbox), so return empty rather than
+			// erroring — the pre-PR-D scheduled panel shows nothing.
+			if opts.V2Primary {
+				writeJSON(w, []*db.ScheduledMessage{})
+				return
+			}
 			convID := strings.TrimSpace(r.URL.Query().Get("conversation_id"))
 			if convID == "" {
 				httpError(w, "conversation_id is required", 400)
@@ -1303,6 +1311,13 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			}
 			writeJSON(w, list)
 		case http.MethodPost:
+			// The legacy scheduler does not run in v2-primary, so a legacy
+			// scheduled row would never be drained. Fail loud instead of
+			// silently losing the send; v2 scheduling goes through the outbox.
+			if opts.V2Primary {
+				httpError(w, "v2 primary: use /api/v1/outbox", http.StatusConflict)
+				return
+			}
 			var req struct {
 				ConversationID string `json:"conversation_id"`
 				Body           string `json:"body"`
@@ -1352,6 +1367,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "method not allowed", 405)
 			return
 		}
+		if opts.V2Primary {
+			httpError(w, "v2 primary: use /api/v1/outbox", http.StatusConflict)
+			return
+		}
 		id := strings.TrimPrefix(r.URL.Path, "/api/schedule/")
 		if id == "" {
 			httpError(w, "scheduled message id required", 400)
@@ -1381,6 +1400,10 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	mux.HandleFunc("/api/schedule-media", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			httpError(w, "method not allowed", 405)
+			return
+		}
+		if opts.V2Primary {
+			httpError(w, "v2 primary: use /api/v1/outbox", http.StatusConflict)
 			return
 		}
 		if !parseBoundedMultipartForm(w, r) {

--- a/internal/web/r5_routing_test.go
+++ b/internal/web/r5_routing_test.go
@@ -431,3 +431,58 @@ func TestR5StatsAndStoryUnavailableInV2Primary(t *testing.T) {
 		}
 	}
 }
+
+func TestPRAScheduleAndStatusInV2Primary(t *testing.T) {
+	legacy, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+	handler := APIHandlerWithOptions(legacy, nil, zerolog.Nop(), nil, APIOptions{
+		Reads:     newRoutingReadSource(),
+		V2Primary: true,
+	})
+
+	// /api/status exposes the flip signal the composer keys on.
+	statusRec := httptest.NewRecorder()
+	handler.ServeHTTP(statusRec, httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/status", nil))
+	var status map[string]any
+	if err := json.NewDecoder(statusRec.Result().Body).Decode(&status); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if status["v2_primary"] != true {
+		t.Fatalf("status v2_primary = %#v, want true", status["v2_primary"])
+	}
+
+	// The scheduled-send black hole is closed: writing routes must 409 in
+	// v2-primary rather than silently persist a legacy row nothing drains.
+	for _, tc := range []struct {
+		method, path, body, ctype string
+	}{
+		{http.MethodPost, "http://127.0.0.1/api/schedule", `{"conversation_id":"c","body":"b","send_at":9999999999999}`, "application/json"},
+		{http.MethodDelete, "http://127.0.0.1/api/schedule/some-id", "", ""},
+	} {
+		req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+		if tc.ctype != "" {
+			req.Header.Set("Content-Type", tc.ctype)
+		}
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if got := rec.Result().StatusCode; got != http.StatusConflict {
+			t.Fatalf("%s %s = %d, want 409 in v2-primary", tc.method, tc.path, got)
+		}
+	}
+	// No legacy scheduled row was written by the refused POST.
+	if list, err := legacy.ListScheduledMessages("c"); err != nil {
+		t.Fatalf("ListScheduledMessages: %v", err)
+	} else if len(list) != 0 {
+		t.Fatalf("legacy scheduled rows = %d, want 0 (nothing persisted in v2-primary)", len(list))
+	}
+
+	// GET returns empty (not an error) so the pre-tray UI shows nothing.
+	getRec := httptest.NewRecorder()
+	handler.ServeHTTP(getRec, httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/schedule?conversation_id=c", nil))
+	if got := getRec.Result().StatusCode; got != http.StatusOK {
+		t.Fatalf("GET /api/schedule = %d, want 200 (empty list) in v2-primary", got)
+	}
+}


### PR DESCRIPTION
## What

First of the remaining Wave-3 surfacing PRs (per `wave3-remaining-surfacing-spec-2026-07-17.md`). Pure wiring, ships independently — and it closes a **real latent data-loss bug** on current main.

- **`/api/status` exposes `v2_primary`** — the one authoritative signal the app keys its send-routing on (the composer flip, PR-C, reads this, not `v2_send`).
- **Closes the scheduled-send black hole**: `/api/schedule` (POST + DELETE) and `/api/schedule-media` had **no v2-primary gate**, so in v2-primary they wrote a legacy `scheduled_messages` row — but the legacy scheduler doesn't run in v2-primary, so that row was **never drained and the send silently vanished**. They now return 409 (matching the already-gated `/api/send*`). The GET returns an empty list rather than erroring (post-migration the legacy scheduled table is meaningless), so the pre-tray scheduled panel shows nothing instead of breaking.

v2 scheduling routes through the outbox (`/api/v1/outbox` with `not_before`), surfaced by the tray PR (PR-D).

## Why now

This is fail-*silent* on main today: anyone running v2-primary who schedules a send loses it with no error. PR-A makes it fail-*loud* immediately, independent of the UI work.

## Verification

`TestPRAScheduleAndStatusInV2Primary` pins: `v2_primary:true` in status; POST/DELETE schedule → 409; no legacy row persisted by the refused POST; GET → 200 empty. Full `go test -race ./...`: 31 packages green.

**Fence:** does not touch `/api/send*` (already gated), does not add v2 scheduling (PR-D), does not delete `scheduler.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
