### PR TITLE
v2-primary SSE notifier: bridge outbox + ingest changes to refetch events (rebuild W3 PR-B)

### DIFF
--- a/cmd/v2stack.go
+++ b/cmd/v2stack.go
@@ -332,6 +332,9 @@ func (s *v2Stack) Start(
 	if !v2Primary {
 		runnerCount++
 	}
+	if v2Primary {
+		runnerCount++
+	}
 	runWG.Add(runnerCount)
 	go func() {
 		defer runWG.Done()
@@ -359,6 +362,22 @@ func (s *v2Stack) Start(
 			defer runWG.Done()
 			if err := projector.Run(runCtx); err != nil && !errors.Is(err, context.Canceled) {
 				s.logger.Error().Err(err).Msg("V2 legacy projector stopped")
+			}
+		}()
+	}
+	if v2Primary {
+		notifier := &v2wire.PrimaryNotifier{
+			Sources: []func() <-chan struct{}{
+				s.Service.Changes,
+				s.worker.Changes,
+			},
+			Events: events,
+			Logger: s.logger,
+		}
+		go func() {
+			defer runWG.Done()
+			if err := notifier.Run(runCtx); err != nil && !errors.Is(err, context.Canceled) {
+				s.logger.Error().Err(err).Msg("V2 primary notifier stopped")
 			}
 		}()
 	}

--- a/cmd/v2stack_test.go
+++ b/cmd/v2stack_test.go
@@ -558,6 +558,37 @@ func TestV2PrimaryStackDoesNotStartLegacyProjector(t *testing.T) {
 	}
 }
 
+func TestV2PrimaryStackStartsPrimaryNotifier(t *testing.T) {
+	stack, err := newV2Stack(v2StackDeps{
+		Logger:  zerolog.Nop(),
+		DataDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("newV2Stack(): %v", err)
+	}
+
+	events := web.NewEventBroker()
+	subscriptionID, published := events.Subscribe()
+	defer events.Unsubscribe(subscriptionID)
+
+	stop := stack.Start(context.Background(), nil, events, true)
+	defer stop()
+
+	for _, want := range []web.StreamEvent{
+		{Type: web.EventTypeMessages},
+		{Type: web.EventTypeConversations},
+	} {
+		select {
+		case got := <-published:
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("primary notifier event = %+v, want %+v", got, want)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out waiting for primary notifier event %+v", want)
+		}
+	}
+}
+
 func TestLegacyPrimaryStackStillStartsLegacyProjector(t *testing.T) {
 	var logs bytes.Buffer
 	stack, err := newV2Stack(v2StackDeps{

--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -7,6 +7,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -67,6 +68,9 @@ type Worker struct {
 	decoders map[string]registeredDecoder
 	work     chan workItem
 	running  atomic.Bool
+
+	changeMu sync.Mutex
+	changed  chan struct{}
 }
 
 // NewWorker validates and copies its explicitly configured decoder
@@ -124,6 +128,7 @@ func NewWorker(config WorkerConfig) (*Worker, error) {
 		now:      config.Now,
 		decoders: decoders,
 		work:     make(chan workItem, config.QueueCapacity),
+		changed:  make(chan struct{}),
 	}, nil
 }
 
@@ -165,6 +170,25 @@ func (w *Worker) enqueue(item workItem) {
 	}
 }
 
+func (w *Worker) signalChange() {
+	w.changeMu.Lock()
+	close(w.changed)
+	w.changed = make(chan struct{})
+	w.changeMu.Unlock()
+}
+
+func (w *Worker) changeChannel() <-chan struct{} {
+	w.changeMu.Lock()
+	defer w.changeMu.Unlock()
+	return w.changed
+}
+
+// Changes returns the current ingest-change broadcast channel. The channel
+// closes on the next change; callers must call Changes again after it closes.
+func (w *Worker) Changes() <-chan struct{} {
+	return w.changeChannel()
+}
+
 func (w *Worker) drain(ctx context.Context) {
 	var records []sqlite.InboxRecord
 	err := retryTransient(ctx, func() error {
@@ -178,11 +202,17 @@ func (w *Worker) drain(ctx context.Context) {
 		}
 		return
 	}
+	changed := false
 	for _, record := range records {
 		if ctx.Err() != nil {
 			return
 		}
-		w.handleRecord(ctx, record.InboxID, rawIngressRecord(record))
+		if w.handleRecord(ctx, record.InboxID, rawIngressRecord(record)) {
+			changed = true
+		}
+	}
+	if changed {
+		w.signalChange()
 	}
 }
 
@@ -202,9 +232,10 @@ func (w *Worker) handleRecord(
 	ctx context.Context,
 	inboxID string,
 	record bridge.RawIngressRecord,
-) {
+) (changed bool) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
+			changed = false
 			w.markQuarantined(ctx, inboxID, record, fmt.Errorf(
 				"ingest frame panic: %v\n%s",
 				recovered,
@@ -214,11 +245,14 @@ func (w *Worker) handleRecord(
 	}()
 
 	err := retryTransient(ctx, func() error {
-		return w.processRecord(ctx, inboxID, record)
+		var err error
+		changed, err = w.processRecordResult(ctx, inboxID, record)
+		return err
 	})
 	if err == nil || ctx.Err() != nil {
-		return
+		return changed
 	}
+	changed = false
 
 	var stale staleReplayError
 	if errors.As(err, &stale) {
@@ -229,13 +263,13 @@ func (w *Worker) handleRecord(
 			Str("inbox_id", inboxID).
 			Str("codec", record.Codec).
 			Msg("Ignored stale ingest replay")
-		return
+		return false
 	}
 
 	var deterministic quarantineError
 	if errors.As(err, &deterministic) {
 		w.markQuarantined(ctx, inboxID, record, deterministic.cause)
-		return
+		return false
 	}
 
 	var exhausted transientExhaustedError
@@ -246,10 +280,11 @@ func (w *Worker) handleRecord(
 			Str("inbox_id", inboxID).
 			Str("codec", record.Codec).
 			Msg("Ingest projection exhausted transient retries; leaving frame unprocessed")
-		return
+		return false
 	}
 
 	w.markQuarantined(ctx, inboxID, record, err)
+	return false
 }
 
 func (w *Worker) markQuarantined(
@@ -286,23 +321,33 @@ func (w *Worker) processRecord(
 	inboxID string,
 	record bridge.RawIngressRecord,
 ) error {
+	_, err := w.processRecordResult(ctx, inboxID, record)
+	return err
+}
+
+func (w *Worker) processRecordResult(
+	ctx context.Context,
+	inboxID string,
+	record bridge.RawIngressRecord,
+) (bool, error) {
 	registration, exists := w.decoders[record.Codec]
 	if !exists {
-		return quarantine(fmt.Errorf("unknown ingress codec %q", record.Codec))
+		return false, quarantine(fmt.Errorf("unknown ingress codec %q", record.Codec))
 	}
 	events, err := decodeSafely(ctx, registration.decoder, record)
 	if err != nil {
-		return quarantine(err)
+		return false, quarantine(err)
 	}
 	for index := range events {
 		events[index].AccountID = record.AccountID
 		events[index].SourceInboxID = inboxID
 		if err := validateDecodedEvent(events[index]); err != nil {
-			return quarantine(fmt.Errorf("decoded event %d: %w", index, err))
+			return false, quarantine(fmt.Errorf("decoded event %d: %w", index, err))
 		}
 	}
 	w.counters.account(record.AccountID).decodedEvents.Add(uint64(len(events)))
-	return classifyApplyError(w.applyEvents(ctx, registration.platform, record, inboxID, events))
+	changed, err := w.applyEvents(ctx, registration.platform, record, inboxID, events)
+	return changed, classifyApplyError(err)
 }
 
 func decodeSafely(
@@ -372,15 +417,17 @@ func (w *Worker) applyEvents(
 	record bridge.RawIngressRecord,
 	inboxID string,
 	events []bridge.Event,
-) error {
+) (bool, error) {
 	accountID := record.AccountID
+	changed := false
 	for _, event := range events {
 		if event.Kind != bridge.EventConversation {
 			continue
 		}
 		if _, err := w.refreshConversation(accountID, platform, *event.Conversation); err != nil {
-			return err
+			return false, err
 		}
+		changed = true
 	}
 
 	messageCount := 0
@@ -398,27 +445,28 @@ func (w *Worker) applyEvents(
 			messageCount == 0,
 		)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if messageCount == 0 {
 			if err := w.messages.ProjectMessage(ctx, projection); err != nil {
-				return err
+				return false, err
 			}
 			projected = true
 			w.counters.account(accountID).projected.Add(1)
 		} else {
 			if err := w.messages.ImportMessage(ctx, projection); err != nil {
-				return err
+				return false, err
 			}
 			w.counters.account(accountID).imported.Add(1)
 		}
+		changed = true
 		// Conversation rows are never re-upserted from message frames, so
 		// recency advances through this targeted monotone bump instead.
 		if err := w.store.BumpConversationRecency(
 			projection.Message.ConversationID,
 			projection.Message.OccurredAtMS,
 		); err != nil {
-			return err
+			return false, err
 		}
 		messageCount++
 	}
@@ -429,7 +477,7 @@ func (w *Worker) applyEvents(
 		}
 		mutation := *event.MessageMutation
 		if strings.TrimSpace(mutation.RemoteMessageID) == "" {
-			return fmt.Errorf("message mutation remote ID is empty")
+			return false, fmt.Errorf("message mutation remote ID is empty")
 		}
 		conversation, remoteConversationID, err := w.existingConversation(
 			accountID,
@@ -443,7 +491,7 @@ func (w *Worker) applyEvents(
 			// canonical would-be PK without creating a conversation row.
 			conversationID = v2keys.DeriveID("conversation", accountID, remoteConversationID)
 		} else if err != nil {
-			return err
+			return false, err
 		}
 		updated, err := w.messages.ApplyMessageMutation(
 			ctx,
@@ -455,10 +503,11 @@ func (w *Worker) applyEvents(
 			inboxID,
 		)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if updated {
 			w.counters.account(accountID).mutations.Add(1)
+			changed = true
 		} else {
 			w.logger.Debug().
 				Str("account_id", accountID).
@@ -491,10 +540,11 @@ func (w *Worker) applyEvents(
 		}
 		applied, err := w.advanceReadCursor(ctx, accountID, platform, *event.Receipt)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if applied {
 			w.counters.account(accountID).receiptsSelf.Add(1)
+			changed = true
 		} else {
 			// The conversation or local device is not known yet. That is an
 			// ordering gap, not a defect: drop the cursor advance benignly
@@ -505,10 +555,10 @@ func (w *Worker) applyEvents(
 
 	if !projected {
 		if err := w.messages.MarkInboxProcessed(ctx, inboxID, accountID); err != nil {
-			return err
+			return false, err
 		}
 	}
-	return nil
+	return changed, nil
 }
 
 func (w *Worker) refreshConversation(

--- a/internal/ingest/worker_test.go
+++ b/internal/ingest/worker_test.go
@@ -1,0 +1,103 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+func TestWorkerChangesBroadcastAfterProjectedDrain(t *testing.T) {
+	decoder := i01DecoderFunc(func(
+		_ context.Context,
+		_ bridge.RawIngressRecord,
+	) ([]bridge.Event, error) {
+		return i01OutgoingMessageEvents("changes-projected", "projected body", ""), nil
+	})
+	harness := i01NewHarness(t, decoder, nil)
+	changes := harness.worker.Changes()
+
+	i01MustAppend(t, harness.sink, i01IngressRecord(
+		"changes:projected",
+		[]byte("projected"),
+	))
+	harness.worker.drain(context.Background())
+
+	message, err := i01GetMessage(harness.messages, "changes-projected")
+	if err != nil {
+		t.Fatalf("GetMessageByRemote() after drain: %v", err)
+	}
+	if message.Body != "projected body" {
+		t.Fatalf("projected message body = %q, want projected body", message.Body)
+	}
+	assertWorkerChangeClosed(t, changes, "projected drain")
+
+	next := harness.worker.Changes()
+	if next == changes {
+		t.Fatal("Changes() did not replace the closed broadcast channel")
+	}
+	assertWorkerChangeOpen(t, next, "replacement channel")
+}
+
+func TestWorkerChangesDoesNotBroadcastForQuarantinedOrNoopDrain(t *testing.T) {
+	tests := []struct {
+		name   string
+		record bridge.RawIngressRecord
+	}{
+		{
+			name: "quarantined",
+			record: func() bridge.RawIngressRecord {
+				record := i01IngressRecord(
+					"changes:quarantined",
+					[]byte("quarantined"),
+				)
+				record.Codec = "changes.unknown"
+				return record
+			}(),
+		},
+		{
+			name: "no events",
+			record: i01IngressRecord(
+				"changes:no-events",
+				[]byte("no-events"),
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decoder := i01DecoderFunc(func(
+				_ context.Context,
+				_ bridge.RawIngressRecord,
+			) ([]bridge.Event, error) {
+				return nil, nil
+			})
+			harness := i01NewHarness(t, decoder, nil)
+			changes := harness.worker.Changes()
+
+			i01MustAppend(t, harness.sink, test.record)
+			harness.worker.drain(context.Background())
+
+			i01AssertNoPending(t, harness.messages)
+			assertWorkerChangeOpen(t, changes, test.name+" drain")
+		})
+	}
+}
+
+func assertWorkerChangeClosed(t *testing.T, changes <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-changes:
+	default:
+		t.Fatalf("Changes() channel remained open after %s", description)
+	}
+}
+
+func assertWorkerChangeOpen(t *testing.T, changes <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-changes:
+		t.Fatalf("Changes() channel closed after %s", description)
+	default:
+	}
+}

--- a/internal/v2wire/notifier.go
+++ b/internal/v2wire/notifier.go
@@ -1,0 +1,131 @@
+package v2wire
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+const (
+	primaryNotifierFallbackInterval  = 5 * time.Second
+	primaryNotifierClockPollInterval = time.Millisecond
+)
+
+// PrimaryNotifier turns coarse v2 state changes into the SSE events that ask
+// the web client to refetch its message and conversation views.
+type PrimaryNotifier struct {
+	Sources []func() <-chan struct{}
+	Events  EventPublisher
+	Logger  zerolog.Logger
+	Now     func() time.Time
+}
+
+// Run publishes once immediately, then again after any source change or the
+// fallback interval. Each loop snapshots all broadcast channels before
+// publishing so changes concurrent with publication remain observable.
+func (n *PrimaryNotifier) Run(ctx context.Context) error {
+	if n == nil {
+		return errors.New("run v2 primary notifier: notifier is nil")
+	}
+	if ctx == nil {
+		return errors.New("run v2 primary notifier: context is nil")
+	}
+	if n.Events == nil {
+		return errors.New("run v2 primary notifier: event publisher is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	fallback := newPrimaryNotifierFallback(n.Now)
+	defer fallback.stop()
+
+	for {
+		sourceChannels := snapshotPrimaryNotifierSources(n.Sources)
+		n.Events.PublishMessages("")
+		n.Events.PublishConversations()
+
+		cases := make([]reflect.SelectCase, 0, len(sourceChannels)+2)
+		cases = append(cases,
+			reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ctx.Done())},
+			reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(fallback.ticks)},
+		)
+		for _, sourceChannel := range sourceChannels {
+			cases = append(cases, reflect.SelectCase{
+				Dir:  reflect.SelectRecv,
+				Chan: reflect.ValueOf(sourceChannel),
+			})
+		}
+
+		chosen, _, _ := reflect.Select(cases)
+		if chosen == 0 {
+			return ctx.Err()
+		}
+	}
+}
+
+func snapshotPrimaryNotifierSources(sources []func() <-chan struct{}) []<-chan struct{} {
+	channels := make([]<-chan struct{}, 0, len(sources))
+	for _, source := range sources {
+		if source != nil {
+			channels = append(channels, source())
+		}
+	}
+	return channels
+}
+
+type primaryNotifierFallback struct {
+	ticks <-chan time.Time
+	stop  func()
+}
+
+func newPrimaryNotifierFallback(now func() time.Time) primaryNotifierFallback {
+	if now == nil {
+		ticker := time.NewTicker(primaryNotifierFallbackInterval)
+		return primaryNotifierFallback{ticks: ticker.C, stop: ticker.Stop}
+	}
+
+	// A time-reading function cannot directly wake a select. In tests, poll
+	// the supplied logical clock on a short real ticker and emit at most one
+	// wake for any forward jump. Production leaves Now nil and uses the exact
+	// five-second ticker path above.
+	ticks := make(chan time.Time, 1)
+	stop := make(chan struct{})
+	stopped := make(chan struct{})
+	lastTick := now()
+	go func() {
+		defer close(stopped)
+		poller := time.NewTicker(primaryNotifierClockPollInterval)
+		defer poller.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-poller.C:
+				current := now()
+				if current.Before(lastTick) {
+					lastTick = current
+					continue
+				}
+				if current.Sub(lastTick) < primaryNotifierFallbackInterval {
+					continue
+				}
+				lastTick = current
+				select {
+				case ticks <- current:
+				default:
+				}
+			}
+		}
+	}()
+	return primaryNotifierFallback{
+		ticks: ticks,
+		stop: func() {
+			close(stop)
+			<-stopped
+		},
+	}
+}

--- a/internal/v2wire/notifier_test.go
+++ b/internal/v2wire/notifier_test.go
@@ -1,0 +1,271 @@
+package v2wire
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func TestPrimaryNotifierPublishesForEitherSource(t *testing.T) {
+	sourceA := newNotifierTestSource()
+	sourceB := newNotifierTestSource()
+	events := newNotifierTestEvents()
+	notifier := &PrimaryNotifier{
+		Sources: []func() <-chan struct{}{sourceA.Changes, sourceB.Changes},
+		Events:  events,
+		Logger:  zerolog.Nop(),
+	}
+
+	cancel, done := runNotifierTest(t, notifier)
+	events.waitForPairs(t, 1) // The notifier publishes once before its first wait.
+
+	sourceA.Fire()
+	events.waitForPairs(t, 2)
+	events.requireStablePairs(t, 2)
+
+	sourceB.Fire()
+	events.waitForPairs(t, 3)
+	events.requireStablePairs(t, 3)
+
+	cancel()
+	requireNotifierStopped(t, done, context.Canceled)
+	events.requireEmptyConversationIDs(t)
+}
+
+func TestPrimaryNotifierCoalescesSimultaneousSources(t *testing.T) {
+	sourceA := newNotifierTestSource()
+	sourceB := newNotifierTestSource()
+	events := newNotifierTestEvents()
+	notifier := &PrimaryNotifier{
+		Sources: []func() <-chan struct{}{sourceA.Changes, sourceB.Changes},
+		Events:  events,
+		Logger:  zerolog.Nop(),
+	}
+
+	cancel, done := runNotifierTest(t, notifier)
+	events.waitForPairs(t, 1)
+
+	// Close both snapshotted channels while holding both source locks. Even if
+	// the notifier wakes after the first close, it cannot take a new snapshot
+	// until both channels have been closed and replaced.
+	fireNotifierTestSourcesTogether(sourceA, sourceB)
+	events.waitForPairs(t, 2)
+	events.requireStablePairs(t, 2)
+
+	cancel()
+	requireNotifierStopped(t, done, context.Canceled)
+}
+
+func TestPrimaryNotifierFallbackUsesClock(t *testing.T) {
+	clock := newNotifierTestClock(time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC))
+	events := newNotifierTestEvents()
+	notifier := &PrimaryNotifier{
+		Events: events,
+		Logger: zerolog.Nop(),
+		Now:    clock.Now,
+	}
+
+	cancel, done := runNotifierTest(t, notifier)
+	events.waitForPairs(t, 1)
+
+	clock.Advance(primaryNotifierFallbackInterval - time.Nanosecond)
+	events.requireStablePairs(t, 1)
+	clock.Advance(time.Nanosecond)
+	events.waitForPairs(t, 2)
+
+	// A large clock jump is one fallback wake, not one publish per skipped
+	// interval.
+	clock.Advance(5 * primaryNotifierFallbackInterval)
+	events.waitForPairs(t, 3)
+	events.requireStablePairs(t, 3)
+
+	cancel()
+	requireNotifierStopped(t, done, context.Canceled)
+}
+
+func TestPrimaryNotifierContextCancellationReturnsPromptly(t *testing.T) {
+	clock := newNotifierTestClock(time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC))
+	events := newNotifierTestEvents()
+	notifier := &PrimaryNotifier{
+		Sources: []func() <-chan struct{}{newNotifierTestSource().Changes},
+		Events:  events,
+		Logger:  zerolog.Nop(),
+		Now:     clock.Now,
+	}
+
+	cancel, done := runNotifierTest(t, notifier)
+	events.waitForPairs(t, 1)
+	cancel()
+	requireNotifierStopped(t, done, context.Canceled)
+}
+
+func runNotifierTest(t *testing.T, notifier *PrimaryNotifier) (context.CancelFunc, <-chan error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- notifier.Run(ctx)
+	}()
+	return cancel, done
+}
+
+func requireNotifierStopped(t *testing.T, done <-chan error, want error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		if !errors.Is(err, want) {
+			t.Fatalf("Run() error = %v, want %v", err, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run() did not return promptly")
+	}
+}
+
+type notifierTestSource struct {
+	mu      sync.Mutex
+	changed chan struct{}
+}
+
+func newNotifierTestSource() *notifierTestSource {
+	return &notifierTestSource{changed: make(chan struct{})}
+}
+
+func (s *notifierTestSource) Changes() <-chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.changed
+}
+
+func (s *notifierTestSource) Fire() {
+	s.mu.Lock()
+	close(s.changed)
+	s.changed = make(chan struct{})
+	s.mu.Unlock()
+}
+
+func fireNotifierTestSourcesTogether(a, b *notifierTestSource) {
+	a.mu.Lock()
+	b.mu.Lock()
+	close(a.changed)
+	close(b.changed)
+	a.changed = make(chan struct{})
+	b.changed = make(chan struct{})
+	b.mu.Unlock()
+	a.mu.Unlock()
+}
+
+type notifierTestEvents struct {
+	mu                sync.Mutex
+	messages          int
+	conversations     int
+	conversationIDs   []string
+	completedPairWake chan struct{}
+}
+
+func newNotifierTestEvents() *notifierTestEvents {
+	return &notifierTestEvents{completedPairWake: make(chan struct{})}
+}
+
+func (e *notifierTestEvents) PublishMessages(conversationID string) {
+	e.mu.Lock()
+	e.messages++
+	e.conversationIDs = append(e.conversationIDs, conversationID)
+	e.mu.Unlock()
+}
+
+func (e *notifierTestEvents) PublishConversations() {
+	e.mu.Lock()
+	e.conversations++
+	close(e.completedPairWake)
+	e.completedPairWake = make(chan struct{})
+	e.mu.Unlock()
+}
+
+func (e *notifierTestEvents) waitForPairs(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	for {
+		messages, conversations, wake := e.snapshot()
+		// PublishMessages and PublishConversations are two interface calls, so
+		// observing one in-progress pair here is valid. Completed pairs must
+		// remain balanced.
+		if messages < conversations || messages > conversations+1 {
+			t.Fatalf("invalid publish counts = messages %d, conversations %d", messages, conversations)
+		}
+		if conversations >= want {
+			if conversations != want || messages != want {
+				t.Fatalf("publish counts = messages %d, conversations %d; want %d each", messages, conversations, want)
+			}
+			return
+		}
+		select {
+		case <-wake:
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for %d publish pairs; got %d", want, conversations)
+		}
+	}
+}
+
+func (e *notifierTestEvents) requireStablePairs(t *testing.T, want int) {
+	t.Helper()
+	messages, conversations, wake := e.snapshot()
+	if messages != want || conversations != want {
+		t.Fatalf("publish counts = messages %d, conversations %d; want %d each", messages, conversations, want)
+	}
+	timer := time.NewTimer(25 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-wake:
+		messages, conversations, _ = e.snapshot()
+		t.Fatalf("unexpected extra publish: messages %d, conversations %d", messages, conversations)
+	case <-timer.C:
+		messages, conversations, _ = e.snapshot()
+		if messages != want || conversations != want {
+			t.Fatalf("publish counts became messages %d, conversations %d; want %d each", messages, conversations, want)
+		}
+	}
+}
+
+func (e *notifierTestEvents) requireEmptyConversationIDs(t *testing.T) {
+	t.Helper()
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for i, conversationID := range e.conversationIDs {
+		if conversationID != "" {
+			t.Fatalf("PublishMessages call %d conversation ID = %q, want empty", i, conversationID)
+		}
+	}
+}
+
+func (e *notifierTestEvents) snapshot() (int, int, <-chan struct{}) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.messages, e.conversations, e.completedPairWake
+}
+
+type notifierTestClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newNotifierTestClock(now time.Time) *notifierTestClock {
+	return &notifierTestClock{now: now}
+}
+
+func (c *notifierTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *notifierTestClock) Advance(delta time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(delta)
+	c.mu.Unlock()
+}


### PR DESCRIPTION
## What

The v2→SSE bridge that makes the web UI live in v2-primary (per `wave3-remaining-surfacing-spec-2026-07-17.md` PR-B). Pure wiring, no UI opinion. Without it, PR-C's composer flip would send into a visually dead thread.

- **`ingest.Worker.Changes()`** — a coalesced broadcast channel (the same closed-and-replaced idiom as `MessageService.Changes()`), signalled **once per drained batch after projection commits** — never per row, so an ingest backfill can't storm SSE. Guarded by the worker mutex.
- **`v2wire.PrimaryNotifier`** — fans the outbox (`Service.Changes`) and ingest (`worker.Changes`) change channels into `PublishMessages("")` + `PublishConversations()` coarse refetch events, publishing once per wake with a 5s fallback ticker, returning promptly on ctx cancel. Takes `func() <-chan struct{}` closures, not the concrete worker, so `v2wire` keeps no import of `internal/ingest` (cycle-free).
- **`cmd/v2stack.go`** — launches exactly one notifier **in place of the projector** when v2-primary (the projector still owns non-primary visibility, unchanged), joined via the existing `runWG`.

## Verification

Full `go test -race ./...`: 31 packages green (the race detector is the load-bearing check for a notifier). Discriminating tests: `Changes()` fires after a projected drain and **not** on a quarantined/no-op drain; the notifier publishes exactly one pair per source fire; **coalesces** two simultaneous sources; fallback fires on a controllable clock; ctx cancel returns promptly (no goroutine leak).

**Fence:** does not change what the UI does on an SSE event (still refetch); no per-conversation targeting; does not touch the projector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
