### PR TITLE
Surface v2 outbox send state on read-DTO message status (rebuild W3 PR-C0)

### DIFF
--- a/internal/storage/sqlite/outbox.go
+++ b/internal/storage/sqlite/outbox.go
@@ -2017,6 +2017,37 @@ func (r *OutboxRepository) FindStoreFailedDue(
 	return items, nil
 }
 
+// LatestStateForLocalMessage returns the delivery state of the most recent
+// outbox row for an optimistic outgoing message, so a read surface can show
+// its send lifecycle. ok is false when the message has no outbox row (a
+// received message, or one whose send predates the outbox). When SendAgain has
+// linked several attempts to one local message, the newest row wins.
+func (r *OutboxRepository) LatestStateForLocalMessage(
+	ctx context.Context,
+	accountID, localMessageID string,
+) (state OutboxState, ok bool, err error) {
+	var value string
+	scanErr := r.store.db.QueryRowContext(ctx, `
+		SELECT state
+		FROM outbox
+		WHERE account_id = ? AND local_message_id = ?
+		ORDER BY created_at_ms DESC, outbox_id DESC
+		LIMIT 1
+	`, accountID, localMessageID).Scan(&value)
+	if errors.Is(scanErr, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if scanErr != nil {
+		return "", false, fmt.Errorf(
+			"outbox state for message %q (account %q): %w",
+			localMessageID,
+			accountID,
+			scanErr,
+		)
+	}
+	return OutboxState(value), true, nil
+}
+
 // FindByTransportRequestID returns the account-scoped row carrying the stable
 // request ID supplied to the transport.
 func (r *OutboxRepository) FindByTransportRequestID(

--- a/internal/v2read/map.go
+++ b/internal/v2read/map.go
@@ -161,6 +161,13 @@ func (s *Source) mapMessage(
 	if message.ReplyToRemoteID != nil {
 		dto.ReplyToID = *message.ReplyToRemoteID
 	}
+	if dto.IsFromMe {
+		status, err := s.sendStatusForMessage(message)
+		if err != nil {
+			return nil, err
+		}
+		dto.Status = status
+	}
 	attachment, ok, err := s.messageAttachment(context.Background(), message.MessageID)
 	if err != nil {
 		return nil, err
@@ -190,4 +197,40 @@ func (s *Source) messageAttachment(
 		)
 	}
 	return attachment, true, nil
+}
+
+// sendStatusForMessage maps an outgoing message's most recent outbox delivery
+// state onto the legacy status vocabulary the web UI already renders
+// (sending/sent/failed). It is deliberately honest per the durable-send
+// contract: queued/dispatching/not_dispatched/uncertain all read as "sending"
+// — never "failed" — because none of them is a settled failure and an
+// ambiguous send must not be shown as failed. store_failed reads "sent"
+// (the transport delivered; only the local record needs repair). Terminal
+// rejected/canceled read "failed". A message with no outbox row (received, or
+// pre-outbox) carries no status.
+func (s *Source) sendStatusForMessage(message sqlite.Message) (string, error) {
+	if strings.TrimSpace(message.MessageID) == "" {
+		return "", nil
+	}
+	state, ok, err := s.outbox.LatestStateForLocalMessage(
+		context.Background(),
+		message.AccountID,
+		message.MessageID,
+	)
+	if err != nil {
+		return "", fmt.Errorf("map message %q send status: %w", message.MessageID, err)
+	}
+	if !ok {
+		return "", nil
+	}
+	switch state {
+	case sqlite.OutboxQueued, sqlite.OutboxDispatching, sqlite.OutboxNotDispatched, sqlite.OutboxUncertain:
+		return db.OutgoingSendStatusSending, nil
+	case sqlite.OutboxConfirmed, sqlite.OutboxStoreFailed:
+		return db.OutgoingSendStatusSent, nil
+	case sqlite.OutboxRejected, sqlite.OutboxCanceled:
+		return db.OutgoingSendStatusFailed, nil
+	default:
+		return "", nil
+	}
 }

--- a/internal/v2read/sendstatus_test.go
+++ b/internal/v2read/sendstatus_test.go
@@ -1,0 +1,164 @@
+package v2read
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+// An outgoing v2 message must carry its durable send state on the read DTO, so
+// the composer can render it honestly after a refetch. queued/uncertain read as
+// "sending" (never "failed"), confirmed as "sent", rejected as "failed", and a
+// message with no outbox row carries no status.
+func TestV2ReadOutgoingMessageStatusReflectsOutbox(t *testing.T) {
+	store, messages, source := openSourceTestStore(t)
+	seedSourceAccount(t, store, "acct", "google_messages")
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conv",
+		AccountID:            "acct",
+		RemoteConversationID: "remote-conv",
+		Kind:                 sqlite.ConversationKindDirect,
+		Title:                "Thread",
+		NotificationMode:     sqlite.NotificationModeAll,
+	})
+	outbox, err := sqlite.NewOutboxRepository(store, func() time.Time { return time.UnixMilli(sourceTestTimeMS) })
+	if err != nil {
+		t.Fatalf("NewOutboxRepository(): %v", err)
+	}
+	ctx := context.Background()
+
+	// enqueue creates the optimistic outgoing message + a queued outbox row.
+	enqueue := func(t *testing.T, id string) sqlite.OutboxItem {
+		t.Helper()
+		item, disp, err := outbox.EnqueueOutgoingMessage(ctx, sqlite.NewOutboxItem{
+			OutboxID:           "outbox-" + id,
+			AccountID:          "acct",
+			ConversationID:     "conv",
+			Kind:               sqlite.OutboxKindText,
+			IdempotencyKey:     "key-" + id,
+			PayloadHash:        "hash-" + id,
+			Operation:          "send_text",
+			LocalMessageID:     id,
+			TransportRequestID: "req-" + id,
+		}, sqlite.Message{
+			MessageID:       id,
+			ConversationID:  "conv",
+			AccountID:       "acct",
+			RemoteMessageID: "req-" + id,
+			Direction:       sqlite.MessageDirectionOutgoing,
+			Body:            "body-" + id,
+			State:           sqlite.MessageStateActive,
+			OccurredAtMS:    sourceTestTimeMS,
+		})
+		if err != nil || disp != sqlite.EnqueueInserted {
+			t.Fatalf("enqueue %q: disp=%q err=%v", id, disp, err)
+		}
+		return item
+	}
+	lease := func(t *testing.T, id string) sqlite.Lease {
+		t.Helper()
+		leases, err := outbox.LeaseDue(ctx, sqlite.LeaseRequest{
+			Owner:    "test",
+			Now:      time.UnixMilli(sourceTestTimeMS),
+			Duration: time.Minute,
+			Limit:    10,
+		})
+		if err != nil {
+			t.Fatalf("LeaseDue(): %v", err)
+		}
+		for _, l := range leases {
+			if l.OutboxID == "outbox-"+id {
+				return l
+			}
+		}
+		t.Fatalf("no lease for %q", id)
+		return sqlite.Lease{}
+	}
+	statusFor := func(t *testing.T, id string) string {
+		t.Helper()
+		msgs, err := source.GetMessagesByConversation("conv", 100)
+		if err != nil {
+			t.Fatalf("GetMessagesByConversation(): %v", err)
+		}
+		for _, m := range msgs {
+			if m.MessageID == id {
+				return m.Status
+			}
+		}
+		t.Fatalf("message %q not found", id)
+		return ""
+	}
+
+	// queued → sending
+	enqueue(t, "queued-msg")
+	if got := statusFor(t, "queued-msg"); got != db.OutgoingSendStatusSending {
+		t.Fatalf("queued status = %q, want sending", got)
+	}
+
+	// confirmed → sent
+	enqueue(t, "confirmed-msg")
+	cl := lease(t, "confirmed-msg")
+	if cl.LeaseToken == nil {
+		t.Fatal("confirmed lease has no token")
+	}
+	if err := outbox.MarkTransportCalled(ctx, sqlite.Attempt{
+		OutboxID:   "outbox-confirmed-msg",
+		LeaseToken: *cl.LeaseToken,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(): %v", err)
+	}
+	if err := outbox.Confirm(ctx, sqlite.Confirmation{
+		OutboxID:       "outbox-confirmed-msg",
+		LeaseToken:     *cl.LeaseToken,
+		ResultRemoteID: "permanent-confirmed",
+	}); err != nil {
+		t.Fatalf("Confirm(): %v", err)
+	}
+	if got := statusFor(t, "confirmed-msg"); got != db.OutgoingSendStatusSent {
+		t.Fatalf("confirmed status = %q, want sent", got)
+	}
+
+	// rejected → failed
+	enqueue(t, "rejected-msg")
+	rl := lease(t, "rejected-msg")
+	if err := outbox.Reject(ctx, "outbox-rejected-msg", *rl.LeaseToken, "unsupported", "no_route", "nope"); err != nil {
+		t.Fatalf("Reject(): %v", err)
+	}
+	if got := statusFor(t, "rejected-msg"); got != db.OutgoingSendStatusFailed {
+		t.Fatalf("rejected status = %q, want failed", got)
+	}
+
+	// uncertain → sending (never failed: an ambiguous send is not a failure)
+	enqueue(t, "uncertain-msg")
+	ul := lease(t, "uncertain-msg")
+	if err := outbox.MarkTransportCalled(ctx, sqlite.Attempt{
+		OutboxID:   "outbox-uncertain-msg",
+		LeaseToken: *ul.LeaseToken,
+	}); err != nil {
+		t.Fatalf("MarkTransportCalled(uncertain): %v", err)
+	}
+	if err := outbox.MarkUncertain(ctx, "outbox-uncertain-msg", *ul.LeaseToken, "transient", "timeout", "unknown"); err != nil {
+		t.Fatalf("MarkUncertain(): %v", err)
+	}
+	if got := statusFor(t, "uncertain-msg"); got != db.OutgoingSendStatusSending {
+		t.Fatalf("uncertain status = %q, want sending (never failed)", got)
+	}
+
+	// A received message (no outbox row) carries no status.
+	importSourceMessage(t, messages, sqlite.Message{
+		MessageID:       "incoming-msg",
+		ConversationID:  "conv",
+		AccountID:       "acct",
+		RemoteMessageID: "remote-incoming",
+		Direction:       sqlite.MessageDirectionIncoming,
+		Body:            "hi",
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    sourceTestTimeMS,
+	})
+	if got := statusFor(t, "incoming-msg"); got != "" {
+		t.Fatalf("incoming status = %q, want empty", got)
+	}
+}

--- a/internal/v2read/source.go
+++ b/internal/v2read/source.go
@@ -17,6 +17,7 @@ type Source struct {
 	store       *sqlite.Store
 	messages    *sqlite.MessageRepository
 	attachments *sqlite.MessageAttachmentRepository
+	outbox      *sqlite.OutboxRepository
 }
 
 // New constructs a v2 canonical read source. A nil store is retained as an
@@ -29,11 +30,12 @@ func New(store *sqlite.Store) *Source {
 	}
 	source.messages, _ = sqlite.NewMessageRepository(store, time.Now)
 	source.attachments, _ = sqlite.NewMessageAttachmentRepository(store, time.Now)
+	source.outbox, _ = sqlite.NewOutboxRepository(store, time.Now)
 	return source
 }
 
 func (s *Source) ready() error {
-	if s == nil || s.store == nil || s.messages == nil || s.attachments == nil {
+	if s == nil || s.store == nil || s.messages == nil || s.attachments == nil || s.outbox == nil {
 		return fmt.Errorf("v2 read source: store is nil")
 	}
 	return nil


### PR DESCRIPTION
## What

A backend prerequisite for the composer flip (PR-C), surfaced when the composer build hit a real design gap: the spec assumed a refetched v2 message carries its durable send-state, but it doesn't.

The v2 `messages.state` column is **content**-lifecycle only (`active/edited/deleted`); a message's **send** lifecycle (queued → dispatching → confirmed / uncertain / …) lives in the `outbox` table. So a refetched v2 thread row had an empty `Status`, and the composer couldn't render "sending / sent / failed" honestly after its refetch.

- **`OutboxRepository.LatestStateForLocalMessage`** — the newest outbox row for an outgoing message (newest wins across `SendAgain`-linked attempts); `ok=false` for a message with no outbox row.
- **`v2read` maps it onto the status vocabulary the UI already renders** (`sending/sent/failed`), honestly per the durable-send contract:
  - `queued` / `dispatching` / `not_dispatched` / `uncertain` → **`sending`** — never `failed`; an ambiguous or auto-retrying send is not a settled failure (INV-3).
  - `confirmed` / `store_failed` → **`sent`** — the transport delivered (store_failed only needs local repair).
  - `rejected` / `canceled` → **`failed`**.
  - received message, or no outbox row → no status.

No new UI vocabulary is invented; the precise `uncertain`/`not_dispatched` affordances (with do-not-resend guidance and actions) remain PR-D's outbox tray, which reads `/api/v1/outbox` directly.

## Why separate

Sol correctly stopped the composer build here rather than hacking it (caching the submit response would freeze the bubble; JS-polling the outbox would fork the source of truth). This is pure backend data-mapping — not reactable UI — so it merges normally and unblocks PR-C.

## Verification

`TestV2ReadOutgoingMessageStatusReflectsOutbox` drives an outgoing message through queued/confirmed/rejected/uncertain via the real state machine and asserts the DTO status for each, plus the no-outbox-row (incoming) empty case. Full `go test -race ./...`: 31 packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
