### PR TITLE
Migration hardening: drop degenerate legacy rows with counts instead of aborting (R2)

### DIFF
--- a/internal/migration/degenerate_rows_test.go
+++ b/internal/migration/degenerate_rows_test.go
@@ -1,0 +1,102 @@
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A real legacy store carries rows the clean-slate schema cannot represent:
+// NULL message ids, messages whose conversation was deleted, placeholder rows
+// with no timestamp, platform-inconsistent rows, empty or malformed
+// participants JSON, and unified contacts whose identifiers are not the
+// expected array (all observed in a production store during a cutover
+// rehearsal). A single such row previously aborted the entire migration; each
+// class must instead drop with an exact count while everything representable
+// migrates and every integrity gate still passes.
+func TestTransformDropsDegenerateLegacyRowsWithCounts(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fixture := buildMigrationFixture(t, root)
+
+	writer, err := sql.Open("sqlite", fixture.sourcePath)
+	mustNoError(t, err)
+	writer.SetMaxOpenConns(1)
+	exec := func(query string, args ...any) {
+		t.Helper()
+		_, execErr := writer.Exec(query, args...)
+		mustNoError(t, execErr)
+	}
+
+	// Message with a NULL primary key (empty-body placeholder).
+	exec(`INSERT INTO messages (message_id, conversation_id, body, timestamp_ms, source_platform)
+	      VALUES (NULL, 'sms-conversation', '', 0, 'sms')`)
+	// Message referencing a conversation that no longer exists.
+	exec(`INSERT INTO messages (message_id, conversation_id, body, timestamp_ms, source_platform)
+	      VALUES ('degenerate-orphan', 'deleted-conversation', 'orphan body', ?, 'sms')`, fixtureBaseMS+50_000)
+	// Message whose platform disagrees with its conversation's platform.
+	exec(`INSERT INTO messages (message_id, conversation_id, body, timestamp_ms, source_platform)
+	      VALUES ('degenerate-mismatch', 'sms-conversation', 'mismatch body', ?, 'signal')`, fixtureBaseMS+51_000)
+	// Message with a valid id but a non-positive timestamp.
+	exec(`INSERT INTO messages (message_id, conversation_id, body, timestamp_ms, source_platform)
+	      VALUES ('degenerate-zero-ts', 'sms-conversation', 'no time', 0, 'sms')`)
+	// Conversation with empty-string participants (must migrate, no roster,
+	// silently) and one with malformed participants JSON (must migrate,
+	// counted).
+	exec(`INSERT INTO conversations (conversation_id, name, participants, last_message_ts, source_platform)
+	      VALUES ('degenerate-empty-participants', 'Empty roster', '', ?, 'sms')`, fixtureBaseMS+52_000)
+	exec(`INSERT INTO conversations (conversation_id, name, participants, last_message_ts, source_platform)
+	      VALUES ('degenerate-bad-participants', 'Bad roster', '{"truncated', ?, 'sms')`, fixtureBaseMS+53_000)
+	// Unified contact whose identifiers column is a bare number, not an array.
+	exec(`INSERT INTO unified_contacts (unified_id, display_name, identifiers)
+	      VALUES ('degenerate-unified', 'Bare Number Person', '36040')`)
+	mustNoError(t, writer.Close())
+
+	report, err := Transform(context.Background(), Options{
+		SourcePath:      fixture.sourcePath,
+		TempStorePath:   filepath.Join(root, "store.sqlite3.tmp"),
+		TempBlobPath:    filepath.Join(root, "blobs.tmp"),
+		TargetPath:      filepath.Join(root, "canonical"),
+		TargetStorePath: filepath.Join(root, "canonical", "store.sqlite3"),
+		Check:           true,
+	})
+	mustNoError(t, err)
+
+	if !report.Validation.Passed || !report.Validation.CountsMatched {
+		t.Fatalf("validation = %+v, want passed with matched counts", report.Validation)
+	}
+	dropped := report.Dropped
+	if dropped.MalformedMessages != 1 || dropped.OrphanedMessages != 1 ||
+		dropped.PlatformMismatchMessages != 1 || dropped.NonPositiveTimestampMessages != 1 ||
+		dropped.MalformedParticipants != 1 || dropped.UnmappableUnifiedContacts != 1 {
+		t.Fatalf("dropped dimensions = %+v, want exactly one of each degenerate class", dropped)
+	}
+
+	// Both degenerate conversations still migrated (empty roster is fine).
+	conversations := report.TableCounts["conversations"]
+	if conversations.Legacy != conversations.V2 {
+		t.Fatalf("conversations legacy=%d v2=%d, want the degenerate-roster rows migrated", conversations.Legacy, conversations.V2)
+	}
+	// No degenerate message reached the v2 store.
+	messages := report.TableCounts["messages"]
+	if messages.Legacy != messages.V2 {
+		t.Fatalf("messages legacy=%d v2=%d, want dropped rows excluded from both sides of the reconciliation", messages.Legacy, messages.V2)
+	}
+
+	warned := strings.Join(report.Warnings, "\n")
+	for _, fragment := range []string{
+		"malformed legacy messages",
+		"referencing a missing conversation",
+		"platform disagreed",
+		"non-positive timestamp",
+		"unparseable participants",
+		"unmappable identifiers",
+	} {
+		if !strings.Contains(warned, fragment) {
+			t.Fatalf("warnings missing %q:\n%s", fragment, warned)
+		}
+	}
+}

--- a/internal/migration/report.go
+++ b/internal/migration/report.go
@@ -132,6 +132,27 @@ type DroppedDimensions struct {
 	ContactMetaCRM            int64 `json:"contact_meta_crm"`
 	OutgoingSendKeys          int64 `json:"outgoing_send_keys"`
 	Tabs                      int64 `json:"tabs"`
+	// MalformedMessages counts legacy message rows with no message_id — no
+	// stable identity or content to migrate, dropped rather than aborting.
+	MalformedMessages int64 `json:"malformed_messages"`
+	// OrphanedMessages counts messages whose conversation row no longer exists
+	// (already unreachable in the legacy app); dropped with a count.
+	OrphanedMessages int64 `json:"orphaned_messages"`
+	// PlatformMismatchMessages counts messages whose platform disagrees with
+	// their conversation's platform; dropped with a count.
+	PlatformMismatchMessages int64 `json:"platform_mismatch_messages"`
+	// NonPositiveTimestampMessages counts messages with a non-positive
+	// timestamp_ms (placeholder rows with no usable time); dropped with a count.
+	NonPositiveTimestampMessages int64 `json:"non_positive_timestamp_messages"`
+	// UnmappableMessages counts messages that map to an empty remote id;
+	// dropped with a count.
+	UnmappableMessages int64 `json:"unmappable_messages"`
+	// MalformedParticipants counts conversations whose participants JSON could
+	// not be parsed; the conversation migrated with no participant roster.
+	MalformedParticipants int64 `json:"malformed_participants"`
+	// UnmappableUnifiedContacts counts unified contacts whose identifiers were
+	// empty or not the expected JSON array; dropped with a count.
+	UnmappableUnifiedContacts int64 `json:"unmappable_unified_contacts"`
 }
 
 type MediaReport struct {

--- a/internal/migration/source.go
+++ b/internal/migration/source.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -196,7 +197,7 @@ func loadLegacySource(
 	if err := loadLegacyRows(ctx, database, &dataset); err != nil {
 		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: %v", ErrSource, err)
 	}
-	if err := validateLegacyRelationships(dataset); err != nil {
+	if err := validateLegacyRelationships(&dataset); err != nil {
 		return legacyDataset{}, SourceReport{}, fmt.Errorf("%w: %v", ErrSource, err)
 	}
 
@@ -242,11 +243,19 @@ func loadLegacyRows(ctx context.Context, database *sql.DB, dataset *legacyDatase
 		return fmt.Errorf("read conversations: %w", err)
 	}
 
+	// COALESCE every scanned column: a real legacy store can carry NULLs in
+	// columns the clean-slate schema treats as non-null (observed: SMS rows with
+	// a NULL message_id), and scanning NULL into a Go string/int fails outright.
+	// Coalescing lets the scan succeed so the row can be classified rather than
+	// aborting the entire migration.
 	rows, err = database.QueryContext(ctx, `
-		SELECT message_id, conversation_id, sender_name, sender_number, body,
-		       timestamp_ms, status, is_from_me, mentions_me, media_id, mime_type,
-		       decryption_key, reactions, reply_to_id, source_platform, source_id,
-		       transcript, transcribed_at, transcript_model
+		SELECT COALESCE(message_id, ''), COALESCE(conversation_id, ''),
+		       COALESCE(sender_name, ''), COALESCE(sender_number, ''), COALESCE(body, ''),
+		       COALESCE(timestamp_ms, 0), COALESCE(status, ''), COALESCE(is_from_me, 0),
+		       COALESCE(mentions_me, 0), COALESCE(media_id, ''), COALESCE(mime_type, ''),
+		       COALESCE(decryption_key, ''), COALESCE(reactions, ''), COALESCE(reply_to_id, ''),
+		       COALESCE(source_platform, ''), COALESCE(source_id, ''),
+		       COALESCE(transcript, ''), COALESCE(transcribed_at, 0), COALESCE(transcript_model, '')
 		FROM messages
 		ORDER BY source_platform, conversation_id, timestamp_ms, message_id
 	`)
@@ -264,6 +273,13 @@ func loadLegacyRows(ctx context.Context, database *sql.DB, dataset *legacyDatase
 		); err != nil {
 			rows.Close()
 			return fmt.Errorf("scan message: %w", err)
+		}
+		// A row with no message_id has no stable identity or content to migrate
+		// (observed: empty-body, zero-timestamp SMS placeholder rows). Drop it
+		// with a count rather than minting a bogus id or failing the migration.
+		if strings.TrimSpace(row.ID) == "" {
+			dataset.dropped.MalformedMessages++
+			continue
 		}
 		dataset.messages = append(dataset.messages, row)
 		platform := normalizeLegacyPlatform(row.Platform)
@@ -319,6 +335,17 @@ func loadLegacyRows(ctx context.Context, database *sql.DB, dataset *legacyDatase
 			rows.Close()
 			return fmt.Errorf("scan unified contact: %w", err)
 		}
+		// A real legacy store can carry unified_contacts whose identifiers
+		// column is not the expected JSON array (observed: a bare number under
+		// an older schema). Such a person cannot be mapped to any identity, so
+		// drop it with a count rather than aborting; messages and conversations
+		// migrate independently of the person-unification graph.
+		var identifiers []unifiedIdentifier
+		if trimmed := strings.TrimSpace(row.IdentifiersJSON); trimmed == "" ||
+			json.Unmarshal([]byte(trimmed), &identifiers) != nil || len(identifiers) == 0 {
+			dataset.dropped.UnmappableUnifiedContacts++
+			continue
+		}
 		dataset.unified = append(dataset.unified, row)
 	}
 	if err := closeRows(rows); err != nil {
@@ -371,7 +398,7 @@ func loadLegacyRows(ctx context.Context, database *sql.DB, dataset *legacyDatase
 	return nil
 }
 
-func validateLegacyRelationships(dataset legacyDataset) error {
+func validateLegacyRelationships(dataset *legacyDataset) error {
 	conversations := make(map[string]string, len(dataset.conversations))
 	for _, conversation := range dataset.conversations {
 		if strings.TrimSpace(conversation.ID) == "" {
@@ -383,31 +410,53 @@ func validateLegacyRelationships(dataset legacyDataset) error {
 		}
 		conversations[conversation.ID] = platform
 	}
-	for _, message := range dataset.messages {
-		if strings.TrimSpace(message.ID) == "" {
-			return fmt.Errorf("message has an empty primary key")
+	// A real legacy store accumulates messages the app can no longer surface —
+	// rows whose conversation was deleted, placeholder rows with no timestamp,
+	// platform-inconsistent rows. Migrating one is impossible, but a single bad
+	// row must not abort the whole cutover, so they are filtered here and
+	// counted for the operator rather than raised as a fatal error. The retained
+	// slice is what everything downstream (transform, count reconciliation)
+	// sees, so the accounting stays exact: legacy total = migrated + dropped.
+	// dropMessage removes a message's contribution to the scan-time aggregates
+	// so the per-platform and attachment reconciliations count only kept rows
+	// (legacy raw = kept + dropped, with the drop reported separately).
+	dropMessage := func(message legacyMessage, counter *int64) {
+		*counter++
+		dataset.platformMessages[normalizeLegacyPlatform(message.Platform)]--
+		if strings.TrimSpace(message.MediaID) != "" {
+			dataset.mediaRows--
 		}
+	}
+	kept := dataset.messages[:0:0]
+	for _, message := range dataset.messages {
 		platform := normalizeLegacyPlatform(message.Platform)
 		if _, err := accountForPlatform(platform); err != nil {
 			return err
 		}
+		if strings.TrimSpace(message.ID) == "" {
+			dropMessage(message, &dataset.dropped.MalformedMessages)
+			continue
+		}
 		conversationPlatform, ok := conversations[message.ConversationID]
 		if !ok {
-			return fmt.Errorf("message %q references missing conversation %q", message.ID, message.ConversationID)
+			dropMessage(message, &dataset.dropped.OrphanedMessages)
+			continue
 		}
 		if platform != conversationPlatform {
-			return fmt.Errorf(
-				"message %q platform %q does not match conversation %q platform %q",
-				message.ID, platform, message.ConversationID, conversationPlatform,
-			)
+			dropMessage(message, &dataset.dropped.PlatformMismatchMessages)
+			continue
 		}
 		if message.TimestampMS <= 0 {
-			return fmt.Errorf("message %q has non-positive timestamp_ms %d", message.ID, message.TimestampMS)
+			dropMessage(message, &dataset.dropped.NonPositiveTimestampMessages)
+			continue
 		}
 		if strings.TrimSpace(deriveRemoteMessageID(message)) == "" {
-			return fmt.Errorf("message %q maps to an empty remote_message_id", message.ID)
+			dropMessage(message, &dataset.dropped.UnmappableMessages)
+			continue
 		}
+		kept = append(kept, message)
 	}
+	dataset.messages = kept
 	for _, scheduled := range dataset.scheduled {
 		if strings.TrimSpace(scheduled.ID) == "" {
 			return fmt.Errorf("scheduled message has an empty primary key")

--- a/internal/migration/transform.go
+++ b/internal/migration/transform.go
@@ -202,12 +202,15 @@ func Transform(ctx context.Context, options Options) (report Report, returnErr e
 	}
 	report.Schedule = scheduleReport(dataset)
 	report.Media.LegacyAttachments = dataset.mediaRows
-	appendRequiredWarnings(&report)
 
 	state, err := buildTransformState(dataset, &report)
 	if err != nil {
 		return report, fmt.Errorf("%w: plan transform: %v", ErrSource, err)
 	}
+	// Warnings render after planning: buildTransformState contributes dropped
+	// dimensions of its own (for example unparseable participant rosters), and
+	// a warning pass before it would silently omit them.
+	appendRequiredWarnings(&report)
 
 	target, err := sqlite.Open(options.TempStorePath)
 	if err != nil {
@@ -302,9 +305,17 @@ func buildTransformState(dataset legacyDataset, report *Report) (*transformState
 			Legacy: legacy, Account: account,
 			V2ID: v2keys.DeriveID("conversation", account.AccountID, legacy.ID),
 		}
+		// A real legacy store carries conversations with an empty-string or
+		// malformed participants column. Those are unparseable JSON, but the
+		// conversation itself (and its messages) is fine — migrate it with no
+		// participants rather than aborting the whole cutover on a degraded
+		// roster. Empty is silent; malformed is counted for the operator.
 		var participants []legacyParticipant
-		if err := json.Unmarshal([]byte(legacy.ParticipantsJSON), &participants); err != nil {
-			return nil, fmt.Errorf("conversation %q participants JSON: %w", legacy.ID, err)
+		if trimmed := strings.TrimSpace(legacy.ParticipantsJSON); trimmed != "" {
+			if err := json.Unmarshal([]byte(trimmed), &participants); err != nil {
+				participants = nil
+				report.Dropped.MalformedParticipants++
+			}
 		}
 		seen := map[identityKey]bool{}
 		for index, participant := range participants {
@@ -1037,6 +1048,27 @@ func appendRequiredWarnings(report *Report) {
 	}
 	if count := report.Dropped.Tabs; count > 0 {
 		report.Warnings = append(report.Warnings, fmt.Sprintf("%d custom tabs were counted and dropped", count))
+	}
+	if count := report.Dropped.MalformedMessages; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d malformed legacy messages (no message_id) were counted and dropped", count))
+	}
+	if count := report.Dropped.OrphanedMessages; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d messages referencing a missing conversation (already unreachable in the legacy app) were counted and dropped", count))
+	}
+	if count := report.Dropped.PlatformMismatchMessages; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d messages whose platform disagreed with their conversation were counted and dropped", count))
+	}
+	if count := report.Dropped.NonPositiveTimestampMessages; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d messages with a non-positive timestamp were counted and dropped", count))
+	}
+	if count := report.Dropped.UnmappableMessages; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d messages that map to an empty remote id were counted and dropped", count))
+	}
+	if count := report.Dropped.MalformedParticipants; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d conversations had unparseable participants and migrated with no roster", count))
+	}
+	if count := report.Dropped.UnmappableUnifiedContacts; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d unified contacts had unmappable identifiers and were counted and dropped", count))
 	}
 	if count := report.Schedule.AmbiguousSending; count > 0 {
 		report.Warnings = append(report.Warnings, fmt.Sprintf("%d ambiguous in-flight scheduled sends were not auto-resent; optimistic messages were preserved for verify/SendAgain", count))

--- a/internal/migration/validate.go
+++ b/internal/migration/validate.go
@@ -201,6 +201,13 @@ func fillTableReconciliations(
 		{"contact_meta", dataset.dropped.ContactMetaCRM},
 		{"outgoing_send_keys", dataset.dropped.OutgoingSendKeys},
 		{"tabs", dataset.dropped.Tabs},
+		{"malformed_messages", dataset.dropped.MalformedMessages},
+		{"orphaned_messages", dataset.dropped.OrphanedMessages},
+		{"platform_mismatch_messages", dataset.dropped.PlatformMismatchMessages},
+		{"non_positive_timestamp_messages", dataset.dropped.NonPositiveTimestampMessages},
+		{"unmappable_messages", dataset.dropped.UnmappableMessages},
+		{"malformed_participants", dataset.dropped.MalformedParticipants},
+		{"unmappable_unified_contacts", dataset.dropped.UnmappableUnifiedContacts},
 	} {
 		add(dropped.name, dropped.count, 0, dropped.count, "dropped_with_count")
 	}


### PR DESCRIPTION
## What

A cutover rehearsal against the real production store (588 MB, 64,826 messages) surfaced six classes of degenerate legacy rows that each **aborted the entire migration** — fixtures never contained them:

| Class | Real-store count | Handling now |
|---|---|---|
| NULL `message_id` (empty placeholder rows) | 137 | dropped, counted |
| Conversation deleted (already unreachable in the app) | 2,180 | dropped, counted |
| Non-positive timestamp | 5 | dropped, counted |
| Platform disagrees with conversation | 3 | dropped, counted |
| Empty / malformed participants JSON | 10 | conversation migrates, roster empty; malformed counted |
| `unified_contacts.identifiers` = bare number (old schema) | 19 | dropped, counted |

Mechanics: the source scan COALESCEs every nullable column; relationship validation filters unmigratable messages into per-class `dropped_dimensions` (decrementing the scan-time platform/attachment aggregates so reconciliation stays exact — legacy total = migrated + dropped); warnings render after planning so plan-time drops are reported. Every class gets an operator-facing warning.

## Proof

- **Real store**: migration now completes with **all integrity gates passing** — 62,501 messages, 1,101 conversations, counts matched, 15/15 sampled hashes, source byte-unchanged, 0 FK violations/orphans/collisions.
- **Regression test** (`TestTransformDropsDegenerateLegacyRowsWithCounts`): injects one row of each class into the standard fixture, asserts exact drop counts, matched reconciliation, and per-class warnings. Fails on pre-fix code (which aborted on the first degenerate row).
- Full `go test -race ./...`: 31 packages green.

## Why this is cutover-blocking

Without it, R8 on the real store fails on the first degenerate row. With it, the rehearsal has been run end-to-end on the actual data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
