### PR TITLE
Add the inbound reactions read model: schema 0010 + two-mode worker apply (rebuild RR-1)

### DIFF
--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -364,7 +364,7 @@ func successfulTestTransform(
 			},
 			Target: migration.TargetReport{
 				Path: options.TargetPath, DatabasePath: options.TargetStorePath,
-				SchemaVersion: 9,
+				SchemaVersion: 10,
 			},
 			TableCounts: map[string]migration.TableReconciliation{
 				"messages": {

--- a/cmd/v2stack.go
+++ b/cmd/v2stack.go
@@ -268,10 +268,15 @@ func newV2Stack(deps v2StackDeps) (_ *v2Stack, resultErr error) {
 	if err != nil {
 		return nil, fmt.Errorf("configure v2 stack: create ingest message repository: %w", err)
 	}
+	reactions, err := sqlite.NewReactionRepository(store, clock.Now)
+	if err != nil {
+		return nil, fmt.Errorf("configure v2 stack: create ingest reaction repository: %w", err)
+	}
 	counters := &ingest.Counters{}
 	worker, err := ingest.NewWorker(ingest.WorkerConfig{
 		Store:        store,
 		Messages:     messages,
+		Reactions:    reactions,
 		EchoObserver: service,
 		Counters:     counters,
 		Logger:       deps.Logger,

--- a/internal/bridgeadapters/google/google_test.go
+++ b/internal/bridgeadapters/google/google_test.go
@@ -503,12 +503,17 @@ func TestIngressTeeThroughRealSinkDedupesExactFrames(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewMessageRepository(): %v", err)
 	}
+	reactions, err := sqlite.NewReactionRepository(store, now)
+	if err != nil {
+		t.Fatalf("NewReactionRepository(): %v", err)
+	}
 	counters := &ingest.Counters{}
 	worker, err := ingest.NewWorker(ingest.WorkerConfig{
-		Store:    store,
-		Messages: messages,
-		Counters: counters,
-		Logger:   zerolog.Nop(),
+		Store:     store,
+		Messages:  messages,
+		Reactions: reactions,
+		Counters:  counters,
+		Logger:    zerolog.Nop(),
 		Decoders: []ingest.DecoderRegistration{{
 			Codec:    ingest.GoogleCodec,
 			Platform: bridge.PlatformGoogle,

--- a/internal/ingest/counters.go
+++ b/internal/ingest/counters.go
@@ -16,7 +16,9 @@ type CounterSnapshot struct {
 	Projected         uint64 `json:"projected"`
 	Imported          uint64 `json:"imported"`
 	Mutations         uint64 `json:"mutations"`
-	ReactionsDropped  uint64 `json:"reactions_dropped"`
+	ReactionsApplied  uint64 `json:"reactions_applied"`
+	ReactionsRemoved  uint64 `json:"reactions_removed"`
+	ReactionsOrphaned uint64 `json:"reactions_orphaned"`
 	TapbackMessages   uint64 `json:"tapback_messages"`
 	EmptyStubsSkipped uint64 `json:"empty_stubs_skipped"`
 	ReceiptsSelf      uint64 `json:"receipts_self"`
@@ -39,7 +41,9 @@ type accountCounters struct {
 	projected         atomic.Uint64
 	imported          atomic.Uint64
 	mutations         atomic.Uint64
-	reactionsDropped  atomic.Uint64
+	reactionsApplied  atomic.Uint64
+	reactionsRemoved  atomic.Uint64
+	reactionsOrphaned atomic.Uint64
 	tapbackMessages   atomic.Uint64
 	emptyStubsSkipped atomic.Uint64
 	receiptsSelf      atomic.Uint64
@@ -119,12 +123,14 @@ func snapshotCounters(c *accountCounters) CounterSnapshot {
 		Projected:         c.projected.Load(),
 		Imported:          c.imported.Load(),
 		Mutations:         c.mutations.Load(),
-		ReactionsDropped:  c.reactionsDropped.Load(),
+		ReactionsApplied:  c.reactionsApplied.Load(),
+		ReactionsRemoved:  c.reactionsRemoved.Load(),
+		ReactionsOrphaned: c.reactionsOrphaned.Load(),
 		TapbackMessages:   c.tapbackMessages.Load(),
 		EmptyStubsSkipped: c.emptyStubsSkipped.Load(),
 		ReceiptsSelf:      c.receiptsSelf.Load(),
 		ReceiptsDropped:   c.receiptsDropped.Load(),
-		AppendErrors:     c.appendErrors.Load(),
+		AppendErrors:      c.appendErrors.Load(),
 		Quarantined:       c.quarantined.Load(),
 		StaleReplays:      c.staleReplays.Load(),
 		EchoReconciled:    c.echoReconciled.Load(),

--- a/internal/ingest/counters_test.go
+++ b/internal/ingest/counters_test.go
@@ -26,9 +26,13 @@ func TestCountersAreAtomicAndAccountScoped(t *testing.T) {
 		}()
 	}
 	wait.Wait()
-	counters.account("account-b").ephemeral.Add(1)
-	counters.account("account-b").tapbackMessages.Add(2)
-	counters.account("account-b").emptyStubsSkipped.Add(3)
+	accountBInternal := counters.account("account-b")
+	accountBInternal.ephemeral.Add(1)
+	accountBInternal.tapbackMessages.Add(2)
+	accountBInternal.emptyStubsSkipped.Add(3)
+	accountBInternal.reactionsApplied.Add(4)
+	accountBInternal.reactionsRemoved.Add(5)
+	accountBInternal.reactionsOrphaned.Add(6)
 
 	want := uint64(workers * increments)
 	accountA := counters.Snapshot("account-a")
@@ -37,6 +41,7 @@ func TestCountersAreAtomicAndAccountScoped(t *testing.T) {
 	}
 	accountB := counters.Snapshot("account-b")
 	if accountB.Ephemeral != 1 || accountB.TapbackMessages != 2 || accountB.EmptyStubsSkipped != 3 ||
+		accountB.ReactionsApplied != 4 || accountB.ReactionsRemoved != 5 || accountB.ReactionsOrphaned != 6 ||
 		accountB.Appended != 0 {
 		t.Fatalf("account-b snapshot = %+v, want additive ingest counters", accountB)
 	}

--- a/internal/ingest/google_echo_e2e_test.go
+++ b/internal/ingest/google_echo_e2e_test.go
@@ -143,6 +143,204 @@ func TestGoogleEchoUnknownTmpIDsAreSuccessfulNoops(t *testing.T) {
 	}
 }
 
+func TestGoogleEmbeddedReactionSnapshotsReconcileAbsenceAndStaleReplay(t *testing.T) {
+	const (
+		remoteMessageID  = "google-reaction-target"
+		alice            = "+15550000001"
+		bob              = "+15550000002"
+		localParticipant = "+15550000003"
+	)
+	harness := newGoogleEchoHarness(t, nil)
+	withReactions := func(
+		occurredAt time.Time,
+		reactions ...*gmproto.ReactionEntry,
+	) *gmproto.Message {
+		message := googleEchoMessage(
+			remoteMessageID,
+			"",
+			"Google reaction target",
+			false,
+			occurredAt,
+		)
+		message.Reactions = reactions
+		return message
+	}
+	fullSnapshot := func(occurredAt time.Time) *gmproto.Message {
+		return withReactions(
+			occurredAt,
+			&gmproto.ReactionEntry{
+				Data:           &gmproto.ReactionData{Unicode: "👍"},
+				ParticipantIDs: []string{alice, bob},
+			},
+			&gmproto.ReactionEntry{
+				Data:           &gmproto.ReactionData{Unicode: "❤️"},
+				ParticipantIDs: []string{localParticipant},
+			},
+		)
+	}
+
+	harness.appendMessage(t, fullSnapshot(googleEchoNow))
+	harness.waitFor(t, "initial Google reaction snapshot", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 1 && snapshot.ReactionsApplied == 3
+	})
+	target, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		googleEchoAccountID,
+		googleEchoConversationID,
+		remoteMessageID,
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(Google reaction target): %v", err)
+	}
+	rows := activeReactionRows(t, harness.reactions, target.MessageID)
+	if len(rows) != 3 {
+		t.Fatalf("initial Google reaction rows = %+v, want three", rows)
+	}
+	assertReactionByCanonical(t, rows, map[string]string{
+		alice: "👍", bob: "👍", localParticipant: "❤️",
+	})
+	if got := countSQLiteRows(t, harness.storePath, `
+		SELECT COUNT(*)
+		FROM reactions
+		WHERE message_id = ?
+		  AND reactor_key = 'self'
+	`, target.MessageID); got != 0 {
+		t.Fatalf("Google self-key reaction rows = %d, want participant identity key", got)
+	}
+
+	// Google identifies the local reactor by participant number, not "self";
+	// a re-delivery must still converge to one row for that participant.
+	harness.clock.Set(googleEchoNow.Add(time.Minute))
+	harness.appendMessage(t, fullSnapshot(googleEchoNow.Add(time.Minute)))
+	harness.waitFor(t, "idempotent Google own-reaction re-delivery", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 2 && snapshot.ReactionsApplied == 3 && snapshot.ReactionsRemoved == 0
+	})
+	rows = activeReactionRows(t, harness.reactions, target.MessageID)
+	assertReactionByCanonical(t, rows, map[string]string{
+		alice: "👍", bob: "👍", localParticipant: "❤️",
+	})
+
+	harness.clock.Set(googleEchoNow.Add(2 * time.Minute))
+	harness.appendMessage(t, withReactions(
+		googleEchoNow.Add(2*time.Minute),
+		&gmproto.ReactionEntry{
+			Data:           &gmproto.ReactionData{Unicode: "👍"},
+			ParticipantIDs: []string{alice},
+		},
+	))
+	harness.waitFor(t, "Google reaction removal by absence", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 3 && snapshot.ReactionsApplied == 3 && snapshot.ReactionsRemoved == 2
+	})
+	assertSingleActiveReaction(t, harness.reactions, target.MessageID, "👍", alice, false)
+	if got := countSQLiteRows(t, harness.storePath, `
+		SELECT COUNT(*)
+		FROM reactions
+		WHERE message_id = ? AND state = 'removed'
+	`, target.MessageID); got != 2 {
+		t.Fatalf("Google reaction tombstones = %d, want two removals by absence", got)
+	}
+
+	harness.clock.Set(googleEchoNow.Add(3 * time.Minute))
+	harness.appendMessage(t, withReactions(
+		googleEchoNow.Add(3*time.Minute),
+		&gmproto.ReactionEntry{
+			Data:           &gmproto.ReactionData{Unicode: "😂"},
+			ParticipantIDs: []string{alice},
+		},
+	))
+	harness.waitFor(t, "Google reaction emoji switch", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 4 && snapshot.ReactionsApplied == 4 && snapshot.ReactionsRemoved == 2
+	})
+	assertSingleActiveReaction(t, harness.reactions, target.MessageID, "😂", alice, false)
+
+	// The inbox stores receipt order from the injected clock. A later-drained
+	// frame with an older receipt sequence must not overwrite the current set.
+	harness.clock.Set(googleEchoNow.Add(150 * time.Second))
+	harness.appendMessage(t, withReactions(
+		googleEchoNow.Add(3*time.Minute),
+		&gmproto.ReactionEntry{
+			Data:           &gmproto.ReactionData{Unicode: "😂"},
+			ParticipantIDs: []string{bob},
+		},
+	))
+	harness.waitFor(t, "stale Google reaction snapshot processing", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 5
+	})
+	assertSingleActiveReaction(t, harness.reactions, target.MessageID, "😂", alice, false)
+	if snapshot := harness.counters.Snapshot(googleEchoAccountID); snapshot.ReactionsApplied != 4 || snapshot.ReactionsRemoved != 2 || snapshot.Quarantined != 0 {
+		t.Fatalf("Google stale snapshot counters = %+v", snapshot)
+	}
+}
+
+func TestGoogleTapbackReactionIsCountedOrphanNotQuarantined(t *testing.T) {
+	harness := newGoogleEchoHarness(t, nil)
+	message := googleEchoMessage(
+		"google-tapback-message",
+		"",
+		`Liked "a quoted message"`,
+		false,
+		googleEchoNow,
+	)
+	harness.appendMessage(t, message)
+	harness.waitFor(t, "Google tapback orphan", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 1 && snapshot.ReactionsOrphaned == 1
+	})
+	snapshot := harness.counters.Snapshot(googleEchoAccountID)
+	if snapshot.TapbackMessages != 1 || snapshot.Quarantined != 0 ||
+		snapshot.ReactionsApplied != 0 || snapshot.ReactionsRemoved != 0 {
+		t.Fatalf("Google tapback counters = %+v", snapshot)
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
+func TestGoogleReactionSnapshotBindsToRepointedOutgoingMessage(t *testing.T) {
+	harness := newGoogleEchoHarness(t, nil)
+	submission, requestID := harness.enqueueAndConfirm(
+		t,
+		"reaction-repoint",
+		"outgoing Google reaction target",
+	)
+	message := googleEchoMessage(
+		"google-reaction-repointed",
+		requestID,
+		"outgoing Google reaction target",
+		true,
+		googleEchoNow.Add(time.Minute),
+	)
+	message.Reactions = []*gmproto.ReactionEntry{{
+		Data:           &gmproto.ReactionData{Unicode: "👍"},
+		ParticipantIDs: []string{"+15550000005"},
+	}}
+	harness.appendMessage(t, message)
+	harness.waitFor(t, "Google reaction on repointed outgoing message", func(snapshot CounterSnapshot) bool {
+		return snapshot.Projected == 1 && snapshot.ReactionsApplied == 1
+	})
+
+	target, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		googleEchoAccountID,
+		googleEchoConversationID,
+		"google-reaction-repointed",
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(repointed reaction target): %v", err)
+	}
+	if target.MessageID != submission.LocalMessageID {
+		t.Fatalf("repointed target ID = %q, want local ID %q", target.MessageID, submission.LocalMessageID)
+	}
+	assertSingleActiveReaction(
+		t,
+		harness.reactions,
+		submission.LocalMessageID,
+		"👍",
+		"+15550000005",
+		false,
+	)
+	if snapshot := harness.counters.Snapshot(googleEchoAccountID); snapshot.Quarantined != 0 {
+		t.Fatalf("Google reaction repoint counters = %+v", snapshot)
+	}
+}
+
 func TestGoogleIngestDoesNotFeedLegacyProjector(t *testing.T) {
 	harness := newGoogleEchoHarness(t, nil)
 	legacy, err := db.New(filepath.Join(t.TempDir(), "legacy.sqlite3"))
@@ -151,15 +349,20 @@ func TestGoogleIngestDoesNotFeedLegacyProjector(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = legacy.Close() })
 
-	harness.appendMessage(t, googleEchoMessage(
+	message := googleEchoMessage(
 		"google-inbound-no-feedback",
 		"",
 		"inbound must stay v2-only",
 		false,
 		googleEchoNow.Add(4*time.Minute),
-	))
+	)
+	message.Reactions = []*gmproto.ReactionEntry{{
+		Data:           &gmproto.ReactionData{Unicode: "👍"},
+		ParticipantIDs: []string{"+15550000004"},
+	}}
+	harness.appendMessage(t, message)
 	harness.waitFor(t, "inbound projection", func(snapshot CounterSnapshot) bool {
-		return snapshot.Projected == 1
+		return snapshot.Projected == 1 && snapshot.ReactionsApplied == 1
 	})
 	if got := harness.countOutboxRows(t); got != 0 {
 		t.Fatalf("outbox rows after inbound ingest = %d, want zero", got)
@@ -293,6 +496,7 @@ type googleEchoHarness struct {
 	store     *sqlite.Store
 	storePath string
 	messages  *sqlite.MessageRepository
+	reactions *sqlite.ReactionRepository
 	service   *messaging.MessageService
 	sink      *Sink
 	worker    *Worker
@@ -331,6 +535,10 @@ func newGoogleEchoHarness(t *testing.T, decoder bridge.Decoder) *googleEchoHarne
 	if err != nil {
 		t.Fatalf("NewMessageRepository(): %v", err)
 	}
+	reactions, err := sqlite.NewReactionRepository(store, clock.Now)
+	if err != nil {
+		t.Fatalf("NewReactionRepository(): %v", err)
+	}
 	counters := &Counters{}
 	if decoder == nil {
 		decoder = NewGoogleDecoder(counters)
@@ -338,6 +546,7 @@ func newGoogleEchoHarness(t *testing.T, decoder bridge.Decoder) *googleEchoHarne
 	worker, err := NewWorker(WorkerConfig{
 		Store:        store,
 		Messages:     messages,
+		Reactions:    reactions,
 		EchoObserver: service,
 		Counters:     counters,
 		Logger:       zerolog.Nop(),
@@ -368,6 +577,7 @@ func newGoogleEchoHarness(t *testing.T, decoder bridge.Decoder) *googleEchoHarne
 		store:     store,
 		storePath: storePath,
 		messages:  messages,
+		reactions: reactions,
 		service:   service,
 		sink:      sink,
 		worker:    worker,
@@ -707,6 +917,12 @@ func (c *googleEchoClock) Now() time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.now
+}
+
+func (c *googleEchoClock) Set(now time.Time) {
+	c.mu.Lock()
+	c.now = now
+	c.mu.Unlock()
 }
 
 func (c *googleEchoClock) NewTimer(delay time.Duration) messaging.Timer {

--- a/internal/ingest/reaction_worker_test.go
+++ b/internal/ingest/reaction_worker_test.go
@@ -1,0 +1,84 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func activeReactionRows(
+	t *testing.T,
+	repository *sqlite.ReactionRepository,
+	messageID string,
+) []sqlite.ReactionRow {
+	t.Helper()
+	byMessage, err := repository.ReactionsForMessages(
+		context.Background(),
+		[]string{messageID},
+	)
+	if err != nil {
+		t.Fatalf("ReactionsForMessages(%q): %v", messageID, err)
+	}
+	return byMessage[messageID]
+}
+
+func assertSingleActiveReaction(
+	t *testing.T,
+	repository *sqlite.ReactionRepository,
+	messageID string,
+	emoji string,
+	canonical string,
+	isSelf bool,
+) {
+	t.Helper()
+	rows := activeReactionRows(t, repository, messageID)
+	if len(rows) != 1 {
+		t.Fatalf("active reactions for %q = %+v, want one", messageID, rows)
+	}
+	row := rows[0]
+	if row.Emoji != emoji || row.ReactorCanonical != canonical || row.ReactorIsSelf != isSelf {
+		t.Fatalf(
+			"active reaction for %q = %+v, want emoji=%q canonical=%q self=%v",
+			messageID,
+			row,
+			emoji,
+			canonical,
+			isSelf,
+		)
+	}
+}
+
+func assertNoActiveReactions(
+	t *testing.T,
+	repository *sqlite.ReactionRepository,
+	messageID string,
+) {
+	t.Helper()
+	if rows := activeReactionRows(t, repository, messageID); len(rows) != 0 {
+		t.Fatalf("active reactions for %q = %+v, want none", messageID, rows)
+	}
+}
+
+func assertReactionByCanonical(
+	t *testing.T,
+	rows []sqlite.ReactionRow,
+	want map[string]string,
+) {
+	t.Helper()
+	got := make(map[string]string, len(rows))
+	for _, row := range rows {
+		if row.ReactorIsSelf {
+			t.Fatalf("unexpected self-key row in canonical reaction set: %+v", row)
+		}
+		got[row.ReactorCanonical] = row.Emoji
+	}
+	if len(got) != len(want) {
+		t.Fatalf("reaction canonical map = %+v, want %+v", got, want)
+	}
+	for canonical, emoji := range want {
+		if got[canonical] != emoji {
+			t.Fatalf("reaction canonical map = %+v, want %+v", got, want)
+		}
+	}
+}

--- a/internal/ingest/signaldecoder.go
+++ b/internal/ingest/signaldecoder.go
@@ -415,6 +415,12 @@ func decodeSignalReaction(
 	if reaction.IsRemove {
 		action = bridge.ReactionRemove
 	}
+	emoji := strings.TrimSpace(reaction.Emoji)
+	if !reaction.IsRemove && emoji == "" {
+		// Out-of-contract signal-cli frame: removals are explicit via isRemove.
+		// WhatsApp's empty-emoji=remove convention does not apply here.
+		return nil
+	}
 	return &bridge.Event{
 		Kind: bridge.EventReaction,
 		Reaction: &bridge.ReactionEvent{
@@ -425,7 +431,7 @@ func decodeSignalReaction(
 				Name:   strings.TrimSpace(actorName),
 				IsSelf: actorIsSelf,
 			},
-			Emoji:      strings.TrimSpace(reaction.Emoji),
+			Emoji:      emoji,
 			Action:     action,
 			OccurredAt: time.UnixMilli(timestamp),
 		},

--- a/internal/ingest/signaldecoder_test.go
+++ b/internal/ingest/signaldecoder_test.go
@@ -369,6 +369,10 @@ func TestSignalDecoderSkipsNonProjectingEnvelopes(t *testing.T) {
 			line: `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","timestamp":1700000000123}}`,
 		},
 		{
+			name: "empty emoji non-remove reaction",
+			line: `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","timestamp":1700000000123,"dataMessage":{"reaction":{"emoji":"","targetSentTimestamp":1700000000999,"targetAuthorNumber":"+15551230000"}}}}`,
+		},
+		{
 			name: "missing inbound source",
 			line: `{"account":"+15551230000","envelope":{"timestamp":1700000000123,"dataMessage":{"timestamp":1700000000123,"message":"quarantined by legacy"}}}`,
 		},
@@ -408,6 +412,23 @@ func TestSignalDecoderSkipsNonProjectingEnvelopes(t *testing.T) {
 				t.Fatalf("Decode() = %+v, want %d events", events, test.wantEvents)
 			}
 		})
+	}
+}
+
+func TestSignalWorkerDoesNotQuarantineEmptyEmojiNonRemoveReaction(t *testing.T) {
+	harness := newSignalWorkerHarness(t, "empty-reaction.sqlite3")
+	harness.start(t)
+	record := mustBuildSignalRecord(t, []byte(`{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","timestamp":1700000000123,"dataMessage":{"reaction":{"emoji":"   ","targetSentTimestamp":1700000000999,"targetAuthorNumber":"+15551230000"}}}}`))
+	if err := harness.sink.AppendIngress(context.Background(), record); err != nil {
+		t.Fatalf("AppendIngress(): %v", err)
+	}
+	waitSignalCondition(t, "Signal empty-emoji reaction processed", func() bool {
+		pending, err := harness.messages.Unprocessed(context.Background())
+		return err == nil && len(pending) == 0
+	})
+	snapshot := harness.counters.Snapshot(signalDecoderAccountID)
+	if snapshot.Quarantined != 0 || snapshot.ReactionsApplied != 0 || snapshot.ReactionsRemoved != 0 {
+		t.Fatalf("Signal empty-emoji reaction counters = %+v, want no quarantine or reaction changes", snapshot)
 	}
 }
 
@@ -650,6 +671,78 @@ func TestSignalOutgoingAliasConvergesThroughRealDecoderAndWorker(t *testing.T) {
 	}
 }
 
+func TestSignalReactionDeltasResolveLocalAliasAndSelfEchoIdempotently(t *testing.T) {
+	const (
+		remoteConversationID = "signal:+15551234567"
+		conversationID       = "signal-reaction-conversation"
+		targetTimestamp      = int64(1_700_000_000_999)
+		targetMessageID      = "signal-reaction-target"
+	)
+	harness := newSignalWorkerHarness(t, "reaction-alias.sqlite3")
+	seedSignalConversation(t, harness.store, conversationID, remoteConversationID)
+	alias := v2keys.SignalLocalAlias(remoteConversationID, targetTimestamp)
+	seedSignalMessage(
+		t,
+		harness.messages,
+		targetMessageID,
+		conversationID,
+		alias,
+		"migrated local target",
+		targetTimestamp,
+	)
+	harness.start(t)
+
+	appendLine := func(label, line string) bridge.RawIngressRecord {
+		t.Helper()
+		record := mustBuildSignalRecord(t, []byte(line))
+		if err := harness.sink.AppendIngress(context.Background(), record); err != nil {
+			t.Fatalf("AppendIngress(%s): %v", label, err)
+		}
+		return record
+	}
+
+	appendLine("inbound add", `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","sourceName":"Taylor","timestamp":1700000003123,"dataMessage":{"timestamp":1700000003123,"reaction":{"emoji":"👍","target":{"timestamp":1700000000999,"authorNumber":"+15551230000"}}}}}`)
+	waitSignalCondition(t, "Signal inbound reaction add through local alias", func() bool {
+		return harness.counters.Snapshot(signalDecoderAccountID).ReactionsApplied == 1
+	})
+	assertSingleActiveReaction(t, harness.reactions, targetMessageID, "👍", "+15551234567", false)
+
+	appendLine("inbound remove", `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","sourceName":"Taylor","timestamp":1700000004123,"dataMessage":{"timestamp":1700000004123,"reaction":{"emoji":"👍","target":{"timestamp":1700000000999,"authorNumber":"+15551230000"},"isRemove":true}}}}`)
+	waitSignalCondition(t, "Signal inbound reaction remove", func() bool {
+		return harness.counters.Snapshot(signalDecoderAccountID).ReactionsRemoved == 1
+	})
+	assertNoActiveReactions(t, harness.reactions, targetMessageID)
+
+	selfRecord := appendLine("sent self add", `{"account":"+15551230000","envelope":{"sourceNumber":"+15551230000","timestamp":1700000005123,"syncMessage":{"sentMessage":{"timestamp":1700000005123,"destinationNumber":"+15551234567","reaction":{"emoji":"🔥","targetSentTimestamp":1700000000999,"targetAuthorNumber":"+15551230000"}}}}}`)
+	waitSignalCondition(t, "Signal sent self-reaction echo", func() bool {
+		return harness.counters.Snapshot(signalDecoderAccountID).ReactionsApplied == 2
+	})
+	assertSingleActiveReaction(t, harness.reactions, targetMessageID, "🔥", "", true)
+
+	// Replaying the same durable echo must converge on the same self row.
+	if err := harness.sink.AppendIngress(context.Background(), selfRecord); err != nil {
+		t.Fatalf("AppendIngress(sent self replay): %v", err)
+	}
+	waitSignalCondition(t, "Signal sent self-reaction replay", func() bool {
+		snapshot := harness.counters.Snapshot(signalDecoderAccountID)
+		return snapshot.Deduped == 1 && snapshot.DecodedEvents == 4
+	})
+	assertSingleActiveReaction(t, harness.reactions, targetMessageID, "🔥", "", true)
+
+	appendLine("orphan", `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","sourceName":"Taylor","timestamp":1700000006123,"dataMessage":{"timestamp":1700000006123,"reaction":{"emoji":"😂","target":{"timestamp":1700000000888,"authorNumber":"+15551230000"}}}}}`)
+	waitSignalCondition(t, "Signal orphan reaction", func() bool {
+		return harness.counters.Snapshot(signalDecoderAccountID).ReactionsOrphaned == 1
+	})
+	snapshot := harness.counters.Snapshot(signalDecoderAccountID)
+	if snapshot.ReactionsApplied != 2 || snapshot.ReactionsRemoved != 1 ||
+		snapshot.ReactionsOrphaned != 1 || snapshot.Quarantined != 0 {
+		t.Fatalf("Signal reaction counters = %+v", snapshot)
+	}
+	if got := countSignalReactionRows(t, harness.path, targetMessageID); got != 2 {
+		t.Fatalf("Signal reaction rows = %d, want one actor tombstone plus one self row", got)
+	}
+}
+
 func TestSignalMigrationOutputConvergesWithLiveDecoder(t *testing.T) {
 	const (
 		remoteConversationID = "signal:+16505550100"
@@ -772,13 +865,14 @@ func TestSignalMigrationOutputConvergesWithLiveDecoder(t *testing.T) {
 }
 
 type signalWorkerHarness struct {
-	path     string
-	store    *sqlite.Store
-	messages *sqlite.MessageRepository
-	counters *Counters
-	worker   *Worker
-	sink     *Sink
-	started  bool
+	path      string
+	store     *sqlite.Store
+	messages  *sqlite.MessageRepository
+	reactions *sqlite.ReactionRepository
+	counters  *Counters
+	worker    *Worker
+	sink      *Sink
+	started   bool
 }
 
 func newSignalWorkerHarness(t *testing.T, filename string) *signalWorkerHarness {
@@ -820,12 +914,20 @@ func newSignalWorkerHarnessForStore(
 ) *signalWorkerHarness {
 	t.Helper()
 	counters := &Counters{}
+	reactions, err := sqlite.NewReactionRepository(
+		store,
+		func() time.Time { return signalDecoderReceivedAt },
+	)
+	if err != nil {
+		t.Fatalf("NewReactionRepository(): %v", err)
+	}
 	worker, err := NewWorker(WorkerConfig{
-		Store:    store,
-		Messages: messages,
-		Counters: counters,
-		Logger:   zerolog.Nop(),
-		Now:      func() time.Time { return signalDecoderReceivedAt },
+		Store:     store,
+		Messages:  messages,
+		Reactions: reactions,
+		Counters:  counters,
+		Logger:    zerolog.Nop(),
+		Now:       func() time.Time { return signalDecoderReceivedAt },
 		Decoders: []DecoderRegistration{{
 			Codec:    SignalJSONRPCCodec,
 			Platform: bridge.PlatformSignal,
@@ -849,7 +951,8 @@ func newSignalWorkerHarnessForStore(
 	}
 	return &signalWorkerHarness{
 		path: path, store: store, messages: messages,
-		counters: counters, worker: worker, sink: sink,
+		reactions: reactions,
+		counters:  counters, worker: worker, sink: sink,
 	}
 }
 
@@ -988,6 +1091,24 @@ func countSignalRows(t *testing.T, path, table string) int {
 	query := "SELECT COUNT(*) FROM " + table + " WHERE account_id = ?"
 	if err := database.QueryRow(query, signalDecoderAccountID).Scan(&count); err != nil {
 		t.Fatalf("count %s: %v", table, err)
+	}
+	return count
+}
+
+func countSignalReactionRows(t *testing.T, path, messageID string) int {
+	t.Helper()
+	database, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open(reactions): %v", err)
+	}
+	defer database.Close()
+	var count int
+	if err := database.QueryRow(`
+		SELECT COUNT(*)
+		FROM reactions
+		WHERE message_id = ?
+	`, messageID).Scan(&count); err != nil {
+		t.Fatalf("count reactions: %v", err)
 	}
 	return count
 }

--- a/internal/ingest/sink_worker_test.go
+++ b/internal/ingest/sink_worker_test.go
@@ -397,9 +397,17 @@ func i01NewWorker(
 	echoes EchoObserver,
 ) *Worker {
 	t.Helper()
+	reactions, err := sqlite.NewReactionRepository(
+		store,
+		func() time.Time { return i01TestTime },
+	)
+	if err != nil {
+		t.Fatalf("sqlite.NewReactionRepository(): %v", err)
+	}
 	worker, err := NewWorker(WorkerConfig{
 		Store:        store,
 		Messages:     messages,
+		Reactions:    reactions,
 		EchoObserver: echoes,
 		Counters:     counters,
 		Logger:       zerolog.Nop(),

--- a/internal/ingest/whatsappdecoder_test.go
+++ b/internal/ingest/whatsappdecoder_test.go
@@ -492,6 +492,133 @@ func TestWhatsAppHistorySyncWorkerProjectsFirstAndImportsSecond(t *testing.T) {
 	i01AssertNoPending(t, harness.messages)
 }
 
+func TestWhatsAppReactionDeltasApplySwitchRemoveAndOrphanThroughWorker(t *testing.T) {
+	harness := newWhatsAppWorkerHarness(t)
+	appendFrame := func(
+		label string,
+		envelope whatsAppFrameEnvelope,
+		message *waE2E.Message,
+	) bridge.RawIngressRecord {
+		t.Helper()
+		record, protoBytes := waMessageRecord(t, envelope, message)
+		record.AccountID = waWorkerAccountID
+		record.DedupeKey = "reaction:" + label + ":" + waHash8(protoBytes)
+		record.ReceivedAt = waWorkerNow.Add(time.Duration(envelope.TimestampMS-waTimestampMS) * time.Millisecond)
+		if err := harness.sink.AppendIngress(context.Background(), record); err != nil {
+			t.Fatalf("AppendIngress(%s): %v", label, err)
+		}
+		return record
+	}
+
+	targetEnvelope := waBaseMessageEnvelope()
+	targetEnvelope.MessageID = "reaction-target"
+	appendFrame(
+		"target",
+		targetEnvelope,
+		&waE2E.Message{Conversation: proto.String("react to this")},
+	)
+	i01WaitFor(t, "WhatsApp reaction target projection", func() bool {
+		return harness.counters.Snapshot(waWorkerAccountID).Projected == 1
+	})
+	conversation, err := harness.store.GetConversationByRemote(
+		waWorkerAccountID,
+		"whatsapp:"+waCanonicalChatJID,
+	)
+	if err != nil {
+		t.Fatalf("GetConversationByRemote(): %v", err)
+	}
+	target, err := harness.messages.GetMessageByRemote(
+		context.Background(),
+		waWorkerAccountID,
+		conversation.ConversationID,
+		"reaction-target",
+	)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(reaction target): %v", err)
+	}
+
+	reactionFrame := func(
+		label string,
+		targetID string,
+		emoji string,
+		occurredAtMS int64,
+		fromMe bool,
+	) bridge.RawIngressRecord {
+		envelope := waBaseMessageEnvelope()
+		envelope.MessageID = "reaction-envelope-" + label
+		envelope.TimestampMS = occurredAtMS
+		envelope.IsFromMe = fromMe
+		return appendFrame(label, envelope, &waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{
+			Key:  &waCommon.MessageKey{ID: proto.String(targetID)},
+			Text: proto.String(emoji),
+		}})
+	}
+
+	changes := harness.worker.Changes()
+	reactionFrame("add", "reaction-target", "👍", waTimestampMS+100, false)
+	i01WaitFor(t, "WhatsApp reaction add", func() bool {
+		return harness.counters.Snapshot(waWorkerAccountID).ReactionsApplied == 1
+	})
+	assertWorkerChangeClosed(t, changes, "WhatsApp reaction add")
+	assertSingleActiveReaction(t, harness.reactions, target.MessageID, "👍", "+14155550200", false)
+
+	// WhatsApp represents a switch as another add delta by the same reactor.
+	reactionFrame("switch", "reaction-target", "❤️", waTimestampMS+200, false)
+	i01WaitFor(t, "WhatsApp reaction switch", func() bool {
+		return harness.counters.Snapshot(waWorkerAccountID).ReactionsApplied == 2
+	})
+	assertSingleActiveReaction(t, harness.reactions, target.MessageID, "❤️", "+14155550200", false)
+
+	reactionFrame("remove", "reaction-target", "", waTimestampMS+300, false)
+	i01WaitFor(t, "WhatsApp reaction removal", func() bool {
+		return harness.counters.Snapshot(waWorkerAccountID).ReactionsRemoved == 1
+	})
+	assertNoActiveReactions(t, harness.reactions, target.MessageID)
+	if got := i01QueryInt64(t, harness.path, `
+		SELECT COUNT(*)
+		FROM reactions
+		WHERE message_id = ? AND state = 'removed' AND emoji = '❤️'
+	`, target.MessageID); got != 1 {
+		t.Fatalf("retained WhatsApp tombstones = %d, want 1", got)
+	}
+
+	// A late WAL-drain add that predates the removal must not resurrect it.
+	reactionFrame("stale-add", "reaction-target", "😂", waTimestampMS+250, false)
+	i01WaitFor(t, "WhatsApp stale reaction frame processing", func() bool {
+		pending, err := harness.messages.Unprocessed(context.Background())
+		return err == nil && len(pending) == 0
+	})
+	assertNoActiveReactions(t, harness.reactions, target.MessageID)
+	snapshot := harness.counters.Snapshot(waWorkerAccountID)
+	if snapshot.ReactionsApplied != 2 || snapshot.ReactionsRemoved != 1 {
+		t.Fatalf("counters after stale reaction = %+v, want applied=2 removed=1", snapshot)
+	}
+
+	selfRecord := reactionFrame("self", "reaction-target", "🔥", waTimestampMS+400, true)
+	i01WaitFor(t, "WhatsApp self-reaction echo", func() bool {
+		return harness.counters.Snapshot(waWorkerAccountID).ReactionsApplied == 3
+	})
+	assertSingleActiveReaction(t, harness.reactions, target.MessageID, "🔥", "", true)
+	if err := harness.sink.AppendIngress(context.Background(), selfRecord); err != nil {
+		t.Fatalf("AppendIngress(self reaction replay): %v", err)
+	}
+	i01WaitFor(t, "WhatsApp self-reaction replay", func() bool {
+		snapshot := harness.counters.Snapshot(waWorkerAccountID)
+		return snapshot.Deduped == 1 && snapshot.DecodedEvents == 7
+	})
+	assertSingleActiveReaction(t, harness.reactions, target.MessageID, "🔥", "", true)
+
+	reactionFrame("orphan", "missing-reaction-target", "👍", waTimestampMS+500, false)
+	i01WaitFor(t, "WhatsApp orphan reaction", func() bool {
+		return harness.counters.Snapshot(waWorkerAccountID).ReactionsOrphaned == 1
+	})
+	snapshot = harness.counters.Snapshot(waWorkerAccountID)
+	if snapshot.Quarantined != 0 {
+		t.Fatalf("orphan reaction counters = %+v, want no quarantine", snapshot)
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
 func TestWhatsAppIngressDedupeUsesMessageIDAndProtoHash(t *testing.T) {
 	harness := newWhatsAppWorkerHarness(t)
 	envelope := waBaseMessageEnvelope()
@@ -615,12 +742,13 @@ func TestWhatsAppDecoderRejectsMalformedBoundaries(t *testing.T) {
 }
 
 type whatsAppWorkerHarness struct {
-	path     string
-	store    *sqlite.Store
-	messages *sqlite.MessageRepository
-	counters *Counters
-	worker   *Worker
-	sink     *Sink
+	path      string
+	store     *sqlite.Store
+	messages  *sqlite.MessageRepository
+	reactions *sqlite.ReactionRepository
+	counters  *Counters
+	worker    *Worker
+	sink      *Sink
 }
 
 func newWhatsAppWorkerHarness(t *testing.T) *whatsAppWorkerHarness {
@@ -652,14 +780,19 @@ func newWhatsAppWorkerHarness(t *testing.T) *whatsAppWorkerHarness {
 	if err != nil {
 		t.Fatalf("NewMessageRepository(): %v", err)
 	}
+	reactions, err := sqlite.NewReactionRepository(store, now)
+	if err != nil {
+		t.Fatalf("NewReactionRepository(): %v", err)
+	}
 	counters := &Counters{}
 	worker, err := NewWorker(WorkerConfig{
-		Store:    store,
-		Messages: messages,
-		Counters: counters,
-		Logger:   zerolog.Nop(),
-		Now:      now,
-		Decoders: []DecoderRegistration{NewWhatsAppDecoderRegistration()},
+		Store:     store,
+		Messages:  messages,
+		Reactions: reactions,
+		Counters:  counters,
+		Logger:    zerolog.Nop(),
+		Now:       now,
+		Decoders:  []DecoderRegistration{NewWhatsAppDecoderRegistration()},
 	})
 	if err != nil {
 		t.Fatalf("NewWorker(): %v", err)
@@ -667,12 +800,13 @@ func newWhatsAppWorkerHarness(t *testing.T) *whatsAppWorkerHarness {
 	sink := i01NewSink(t, messages, worker, counters, "whatsapp-inbox")
 	i01StartWorker(t, worker)
 	return &whatsAppWorkerHarness{
-		path:     path,
-		store:    store,
-		messages: messages,
-		counters: counters,
-		worker:   worker,
-		sink:     sink,
+		path:      path,
+		store:     store,
+		messages:  messages,
+		reactions: reactions,
+		counters:  counters,
+		worker:    worker,
+		sink:      sink,
 	}
 }
 

--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -36,6 +36,7 @@ type DecoderRegistration struct {
 type WorkerConfig struct {
 	Store         *sqlite.Store
 	Messages      *sqlite.MessageRepository
+	Reactions     *sqlite.ReactionRepository
 	EchoObserver  EchoObserver
 	Counters      *Counters
 	Logger        zerolog.Logger
@@ -56,18 +57,26 @@ type workItem struct {
 	replay  bool
 }
 
+type googleReactionSnapshot struct {
+	accountID      string
+	conversationID string
+	messageID      string
+	entries        []sqlite.ReactionSnapshotEntry
+}
+
 // Worker drains durable inbox records and applies normalized events without
 // touching the legacy store.
 type Worker struct {
-	store    *sqlite.Store
-	messages *sqlite.MessageRepository
-	echoes   EchoObserver
-	counters *Counters
-	logger   zerolog.Logger
-	now      func() time.Time
-	decoders map[string]registeredDecoder
-	work     chan workItem
-	running  atomic.Bool
+	store     *sqlite.Store
+	messages  *sqlite.MessageRepository
+	reactions *sqlite.ReactionRepository
+	echoes    EchoObserver
+	counters  *Counters
+	logger    zerolog.Logger
+	now       func() time.Time
+	decoders  map[string]registeredDecoder
+	work      chan workItem
+	running   atomic.Bool
 
 	changeMu sync.Mutex
 	changed  chan struct{}
@@ -81,6 +90,9 @@ func NewWorker(config WorkerConfig) (*Worker, error) {
 	}
 	if config.Messages == nil {
 		return nil, fmt.Errorf("create ingest worker: message repository is nil")
+	}
+	if config.Reactions == nil {
+		return nil, fmt.Errorf("create ingest worker: reaction repository is nil")
 	}
 	if config.Counters == nil {
 		config.Counters = &Counters{}
@@ -120,15 +132,16 @@ func NewWorker(config WorkerConfig) (*Worker, error) {
 	}
 
 	return &Worker{
-		store:    config.Store,
-		messages: config.Messages,
-		echoes:   config.EchoObserver,
-		counters: config.Counters,
-		logger:   config.Logger,
-		now:      config.Now,
-		decoders: decoders,
-		work:     make(chan workItem, config.QueueCapacity),
-		changed:  make(chan struct{}),
+		store:     config.Store,
+		messages:  config.Messages,
+		reactions: config.Reactions,
+		echoes:    config.EchoObserver,
+		counters:  config.Counters,
+		logger:    config.Logger,
+		now:       config.Now,
+		decoders:  decoders,
+		work:      make(chan workItem, config.QueueCapacity),
+		changed:   make(chan struct{}),
 	}, nil
 }
 
@@ -252,6 +265,7 @@ func (w *Worker) handleRecord(
 	if err == nil || ctx.Err() != nil {
 		return changed
 	}
+	partialChanged := changed
 	changed = false
 
 	var stale staleReplayError
@@ -269,7 +283,7 @@ func (w *Worker) handleRecord(
 	var deterministic quarantineError
 	if errors.As(err, &deterministic) {
 		w.markQuarantined(ctx, inboxID, record, deterministic.cause)
-		return false
+		return partialChanged
 	}
 
 	var exhausted transientExhaustedError
@@ -280,11 +294,11 @@ func (w *Worker) handleRecord(
 			Str("inbox_id", inboxID).
 			Str("codec", record.Codec).
 			Msg("Ingest projection exhausted transient retries; leaving frame unprocessed")
-		return false
+		return partialChanged
 	}
 
 	w.markQuarantined(ctx, inboxID, record, err)
-	return false
+	return partialChanged
 }
 
 func (w *Worker) markQuarantined(
@@ -420,6 +434,8 @@ func (w *Worker) applyEvents(
 ) (bool, error) {
 	accountID := record.AccountID
 	changed := false
+	googleSnapshots := make(map[string]*googleReactionSnapshot)
+	googleSnapshotOrder := make([]string, 0)
 	for _, event := range events {
 		if event.Kind != bridge.EventConversation {
 			continue
@@ -459,6 +475,22 @@ func (w *Worker) applyEvents(
 			}
 			w.counters.account(accountID).imported.Add(1)
 		}
+		if platform == bridge.PlatformGoogle {
+			// Message upserts preserve the first local primary key on a remote-key
+			// conflict (including an optimistic outgoing row repointed by the echo
+			// observer). Recover that effective parent before binding the embedded
+			// snapshot; projection.MessageID is only the would-be derived key.
+			effective, err := w.messages.GetMessageByRemote(
+				ctx,
+				projection.Message.AccountID,
+				projection.Message.ConversationID,
+				projection.Message.RemoteMessageID,
+			)
+			if err != nil {
+				return false, err
+			}
+			projection.Message.MessageID = effective.MessageID
+		}
 		changed = true
 		// Conversation rows are never re-upserted from message frames, so
 		// recency advances through this targeted monotone bump instead.
@@ -467,6 +499,21 @@ func (w *Worker) applyEvents(
 			projection.Message.OccurredAtMS,
 		); err != nil {
 			return false, err
+		}
+		if platform == bridge.PlatformGoogle {
+			key := reactionRemoteTargetKey(
+				platform,
+				event.Message.RemoteConversationID,
+				event.Message.RemoteMessageID,
+			)
+			if _, exists := googleSnapshots[key]; !exists {
+				googleSnapshotOrder = append(googleSnapshotOrder, key)
+			}
+			googleSnapshots[key] = &googleReactionSnapshot{
+				accountID:      projection.Message.AccountID,
+				conversationID: projection.Message.ConversationID,
+				messageID:      projection.Message.MessageID,
+			}
 		}
 		messageCount++
 	}
@@ -517,9 +564,102 @@ func (w *Worker) applyEvents(
 		}
 	}
 
-	for _, event := range events {
-		if event.Kind == bridge.EventReaction {
-			w.counters.account(accountID).reactionsDropped.Add(1)
+	if platform == bridge.PlatformGoogle {
+		for _, event := range events {
+			if event.Kind != bridge.EventReaction {
+				continue
+			}
+			reaction := *event.Reaction
+			key := reactionRemoteTargetKey(
+				platform,
+				reaction.RemoteConversationID,
+				reaction.TargetRemoteMessageID,
+			)
+			snapshot, exists := googleSnapshots[key]
+			if strings.TrimSpace(reaction.TargetRemoteMessageID) == "" || !exists {
+				w.countOrphanReaction(accountID, inboxID, reaction)
+				continue
+			}
+			entry, ok, err := w.prepareReactionSnapshotEntry(accountID, platform, reaction)
+			if err != nil {
+				return changed, err
+			}
+			if !ok {
+				continue
+			}
+			snapshot.entries = append(snapshot.entries, entry)
+		}
+
+		sourceSeqMS := record.ReceivedAt.UnixMilli()
+		if sourceSeqMS <= 0 {
+			return changed, fmt.Errorf("reaction snapshot source sequence is not positive")
+		}
+		for _, key := range googleSnapshotOrder {
+			snapshot := googleSnapshots[key]
+			changes, err := w.reactions.ReplaceEmbeddedReactions(
+				ctx,
+				snapshot.messageID,
+				snapshot.accountID,
+				snapshot.conversationID,
+				snapshot.entries,
+				sourceSeqMS,
+			)
+			if err != nil {
+				return changed, err
+			}
+			if changes.Applied > 0 {
+				w.counters.account(accountID).reactionsApplied.Add(uint64(changes.Applied))
+			}
+			if changes.Removed > 0 {
+				w.counters.account(accountID).reactionsRemoved.Add(uint64(changes.Removed))
+			}
+			if changes.Applied > 0 || changes.Removed > 0 {
+				changed = true
+			}
+		}
+	} else {
+		for _, event := range events {
+			if event.Kind != bridge.EventReaction {
+				continue
+			}
+			reaction := *event.Reaction
+			target, found, err := w.resolveReactionTarget(
+				ctx,
+				accountID,
+				platform,
+				reaction,
+			)
+			if err != nil {
+				return changed, err
+			}
+			if !found {
+				w.countOrphanReaction(accountID, inboxID, reaction)
+				continue
+			}
+			apply, err := w.prepareReactionApply(
+				accountID,
+				platform,
+				target,
+				reaction,
+				record.ReceivedAt.UnixMilli(),
+			)
+			if err != nil {
+				return changed, err
+			}
+			applied, err := w.reactions.ApplyReaction(ctx, apply)
+			if err != nil {
+				return changed, err
+			}
+			if !applied {
+				continue
+			}
+			switch reaction.Action {
+			case bridge.ReactionRemove:
+				w.counters.account(accountID).reactionsRemoved.Add(1)
+			default:
+				w.counters.account(accountID).reactionsApplied.Add(1)
+			}
+			changed = true
 		}
 	}
 
@@ -763,6 +903,175 @@ func identityRaw(reference bridge.IdentityRef) string {
 		raw = strings.TrimSpace(reference.Canonical)
 	}
 	return raw
+}
+
+type preparedReactionActor struct {
+	key        string
+	identityID *string
+	isSelf     bool
+	label      string
+}
+
+func (w *Worker) prepareReactionActor(
+	accountID string,
+	platform bridge.Platform,
+	reference bridge.IdentityRef,
+	emoji string,
+) (preparedReactionActor, error) {
+	if reference.IsSelf {
+		return preparedReactionActor{
+			key:    "self",
+			isSelf: true,
+			label:  "me",
+		}, nil
+	}
+	if identityRaw(reference) == "" {
+		// On the delta path, an anonymous remove with an empty emoji derives
+		// "anon:" and cannot correlate with an earlier "anon:<emoji>" add. This
+		// is acceptable: well-formed WhatsApp/Signal frames carry an actor, while
+		// Google snapshots remove absent reactors without using this key.
+		return preparedReactionActor{key: "anon:" + emoji}, nil
+	}
+	identity, err := w.resolveIdentity(accountID, platform, reference)
+	if err != nil {
+		return preparedReactionActor{}, err
+	}
+	identityID := identity.IdentityID
+	return preparedReactionActor{
+		key:        identityID,
+		identityID: &identityID,
+	}, nil
+}
+
+func (w *Worker) prepareReactionSnapshotEntry(
+	accountID string,
+	platform bridge.Platform,
+	reaction bridge.ReactionEvent,
+) (sqlite.ReactionSnapshotEntry, bool, error) {
+	emoji := strings.TrimSpace(reaction.Emoji)
+	if emoji == "" {
+		return sqlite.ReactionSnapshotEntry{}, false, nil
+	}
+	actor, err := w.prepareReactionActor(accountID, platform, reaction.Actor, emoji)
+	if err != nil {
+		return sqlite.ReactionSnapshotEntry{}, false, err
+	}
+	return sqlite.ReactionSnapshotEntry{
+		ReactorKey:        actor.key,
+		ReactorIdentityID: actor.identityID,
+		ReactorIsSelf:     actor.isSelf,
+		ReactorLabel:      actor.label,
+		Emoji:             emoji,
+	}, true, nil
+}
+
+func (w *Worker) prepareReactionApply(
+	accountID string,
+	platform bridge.Platform,
+	target sqlite.Message,
+	reaction bridge.ReactionEvent,
+	sourceSeqMS int64,
+) (sqlite.ReactionApply, error) {
+	actor, err := w.prepareReactionActor(accountID, platform, reaction.Actor, reaction.Emoji)
+	if err != nil {
+		return sqlite.ReactionApply{}, err
+	}
+	occurredAtMS := reaction.OccurredAt.UnixMilli()
+	if occurredAtMS <= 0 {
+		return sqlite.ReactionApply{}, fmt.Errorf("reaction occurrence time is not positive")
+	}
+	if sourceSeqMS <= 0 {
+		return sqlite.ReactionApply{}, fmt.Errorf("reaction source sequence is not positive")
+	}
+	return sqlite.ReactionApply{
+		AccountID:         accountID,
+		ConversationID:    target.ConversationID,
+		MessageID:         target.MessageID,
+		ReactorKey:        actor.key,
+		ReactorIdentityID: actor.identityID,
+		ReactorIsSelf:     actor.isSelf,
+		ReactorLabel:      actor.label,
+		Emoji:             reaction.Emoji,
+		Action:            reaction.Action,
+		OccurredAtMS:      occurredAtMS,
+		SourceSeqMS:       sourceSeqMS,
+	}, nil
+}
+
+func (w *Worker) resolveReactionTarget(
+	ctx context.Context,
+	accountID string,
+	platform bridge.Platform,
+	reaction bridge.ReactionEvent,
+) (sqlite.Message, bool, error) {
+	conversation, remoteConversationID, err := w.existingConversation(
+		accountID,
+		platform,
+		reaction.RemoteConversationID,
+	)
+	if errors.Is(err, sqlite.ErrNotFound) {
+		return sqlite.Message{}, false, nil
+	}
+	if err != nil {
+		return sqlite.Message{}, false, err
+	}
+	targetRemoteID := strings.TrimSpace(reaction.TargetRemoteMessageID)
+	target, err := w.messages.GetMessageByRemote(
+		ctx,
+		accountID,
+		conversation.ConversationID,
+		targetRemoteID,
+	)
+	if err == nil {
+		return target, true, nil
+	}
+	if !errors.Is(err, sqlite.ErrNotFound) {
+		return sqlite.Message{}, false, err
+	}
+	if platform != bridge.PlatformSignal {
+		return sqlite.Message{}, false, nil
+	}
+
+	timestamp, err := strconv.ParseInt(targetRemoteID, 10, 64)
+	if err != nil {
+		return sqlite.Message{}, false, nil
+	}
+	alias := v2keys.SignalLocalAlias(remoteConversationID, timestamp)
+	target, err = w.messages.GetMessageByRemote(
+		ctx,
+		accountID,
+		conversation.ConversationID,
+		alias,
+	)
+	if errors.Is(err, sqlite.ErrNotFound) {
+		return sqlite.Message{}, false, nil
+	}
+	if err != nil {
+		return sqlite.Message{}, false, err
+	}
+	return target, true, nil
+}
+
+func (w *Worker) countOrphanReaction(
+	accountID string,
+	inboxID string,
+	reaction bridge.ReactionEvent,
+) {
+	w.counters.account(accountID).reactionsOrphaned.Add(1)
+	w.logger.Debug().
+		Str("account_id", accountID).
+		Str("inbox_id", inboxID).
+		Str("remote_message_id", reaction.TargetRemoteMessageID).
+		Msg("Ignored reaction for missing message")
+}
+
+func reactionRemoteTargetKey(
+	platform bridge.Platform,
+	remoteConversationID string,
+	remoteMessageID string,
+) string {
+	return v2keys.NormalizeRemoteConversationID(string(platform), remoteConversationID) +
+		"\x1f" + strings.TrimSpace(remoteMessageID)
 }
 
 func (w *Worker) messageProjection(

--- a/internal/ingest/worker_contract_test.go
+++ b/internal/ingest/worker_contract_test.go
@@ -26,15 +26,44 @@ func TestNewWorkerUsesOnlyConfiguredDecoders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewMessageRepository(): %v", err)
 	}
+	reactions, err := sqlite.NewReactionRepository(store, time.Now)
+	if err != nil {
+		t.Fatalf("NewReactionRepository(): %v", err)
+	}
+	if _, err := NewWorker(WorkerConfig{
+		Store: store, Messages: messages,
+	}); err == nil {
+		t.Fatal("NewWorker() without reaction repository succeeded")
+	}
 	worker, err := NewWorker(WorkerConfig{
-		Store:    store,
-		Messages: messages,
+		Store:     store,
+		Messages:  messages,
+		Reactions: reactions,
 	})
 	if err != nil {
 		t.Fatalf("NewWorker(): %v", err)
 	}
 	if got := len(worker.decoders); got != 0 {
 		t.Fatalf("NewWorker() registered %d implicit decoders, want none", got)
+	}
+}
+
+func TestPrepareReactionSnapshotEntryTrimsAndSkipsEmptyEmoji(t *testing.T) {
+	worker := &Worker{}
+	entry, ok, err := worker.prepareReactionSnapshotEntry(
+		"account", bridge.PlatformGoogle, bridge.ReactionEvent{Emoji: "  👍  "},
+	)
+	if err != nil || !ok {
+		t.Fatalf("prepare padded snapshot reaction = (%+v, %v, %v), want stored entry", entry, ok, err)
+	}
+	if entry.Emoji != "👍" || entry.ReactorKey != "anon:👍" {
+		t.Fatalf("prepared padded snapshot reaction = %+v, want trimmed emoji and key", entry)
+	}
+	entry, ok, err = worker.prepareReactionSnapshotEntry(
+		"account", bridge.PlatformGoogle, bridge.ReactionEvent{Emoji: " \t "},
+	)
+	if err != nil || ok || entry != (sqlite.ReactionSnapshotEntry{}) {
+		t.Fatalf("prepare whitespace-only snapshot reaction = (%+v, %v, %v), want skipped", entry, ok, err)
 	}
 }
 
@@ -136,6 +165,54 @@ func TestWorkerContainsApplyPanicAndContinues(t *testing.T) {
 	})
 	if _, err := i01GetMessage(harness.messages, "panic-message"); !errors.Is(err, sqlite.ErrNotFound) {
 		t.Fatalf("panicking message lookup error = %v, want ErrNotFound", err)
+	}
+	i01AssertNoPending(t, harness.messages)
+}
+
+func TestWorkerWhitespaceSnapshotReactionIsSkippedWithoutQuarantine(t *testing.T) {
+	const remoteMessageID = "reaction-error-message"
+	decoder := i01DecoderFunc(func(
+		_ context.Context,
+		_ bridge.RawIngressRecord,
+	) ([]bridge.Event, error) {
+		events := i01OutgoingMessageEvents(remoteMessageID, "message survives reaction error", "")
+		events = append(events, bridge.Event{
+			Kind: bridge.EventReaction,
+			Reaction: &bridge.ReactionEvent{
+				RemoteConversationID:  i01RemoteConversationID,
+				TargetRemoteMessageID: remoteMessageID,
+				Actor:                 bridge.IdentityRef{IsSelf: true},
+				Emoji:                 "",
+				Action:                bridge.ReactionAdd,
+				OccurredAt:            i01TestTime,
+			},
+		})
+		return events, nil
+	})
+	harness := i01NewHarness(t, decoder, nil)
+	i01StartWorker(t, harness.worker)
+	i01MustAppend(t, harness.sink, i01IngressRecord(
+		"reaction-error:message",
+		[]byte("reaction-error"),
+	))
+
+	i01WaitFor(t, "whitespace reaction skipped after message projection", func() bool {
+		pending, err := harness.messages.Unprocessed(context.Background())
+		return err == nil && len(pending) == 0
+	})
+	message, err := i01GetMessage(harness.messages, remoteMessageID)
+	if err != nil {
+		t.Fatalf("GetMessageByRemote(projected before reaction error): %v", err)
+	}
+	if message.Body != "message survives reaction error" {
+		t.Fatalf("projected message body = %q", message.Body)
+	}
+	if rows := activeReactionRows(t, harness.worker.reactions, message.MessageID); len(rows) != 0 {
+		t.Fatalf("active reactions after failed apply = %+v, want none", rows)
+	}
+	snapshot := harness.counters.Snapshot(i01AccountID)
+	if snapshot.Projected != 1 || snapshot.Quarantined != 0 || snapshot.ReactionsApplied != 0 || snapshot.ReactionsRemoved != 0 {
+		t.Fatalf("whitespace snapshot reaction counters = %+v", snapshot)
 	}
 	i01AssertNoPending(t, harness.messages)
 }

--- a/internal/ingest/worker_paths_test.go
+++ b/internal/ingest/worker_paths_test.go
@@ -36,10 +36,11 @@ func (d *workerPathDecoder) Decode(
 }
 
 type workerPathHarness struct {
-	store    *sqlite.Store
-	messages *sqlite.MessageRepository
-	worker   *Worker
-	nextID   int
+	store     *sqlite.Store
+	messages  *sqlite.MessageRepository
+	reactions *sqlite.ReactionRepository
+	worker    *Worker
+	nextID    int
 }
 
 func newWorkerPathHarness(
@@ -73,11 +74,16 @@ func newWorkerPathHarness(
 	if err != nil {
 		t.Fatalf("NewMessageRepository(): %v", err)
 	}
+	reactions, err := sqlite.NewReactionRepository(store, now)
+	if err != nil {
+		t.Fatalf("NewReactionRepository(): %v", err)
+	}
 	worker, err := NewWorker(WorkerConfig{
-		Store:    store,
-		Messages: messages,
-		Counters: &Counters{},
-		Now:      now,
+		Store:     store,
+		Messages:  messages,
+		Reactions: reactions,
+		Counters:  &Counters{},
+		Now:       now,
 		Decoders: []DecoderRegistration{{
 			Codec:    workerPathCodec,
 			Platform: platform,
@@ -90,9 +96,10 @@ func newWorkerPathHarness(
 		t.Fatalf("NewWorker(): %v", err)
 	}
 	return &workerPathHarness{
-		store:    store,
-		messages: messages,
-		worker:   worker,
+		store:     store,
+		messages:  messages,
+		reactions: reactions,
+		worker:    worker,
 	}
 }
 

--- a/internal/livetransport/live_test.go
+++ b/internal/livetransport/live_test.go
@@ -233,10 +233,15 @@ func TestLiveIngestVerification(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewMessageRepository(): %v", err)
 	}
+	reactions, err := sqlite.NewReactionRepository(store, time.Now)
+	if err != nil {
+		t.Fatalf("NewReactionRepository(): %v", err)
+	}
 	counters := &ingest.Counters{}
 	worker, err := ingest.NewWorker(ingest.WorkerConfig{
 		Store:        store,
 		Messages:     messages,
+		Reactions:    reactions,
 		EchoObserver: service,
 		Counters:     counters,
 		Logger:       logger,

--- a/internal/migration/transform_test.go
+++ b/internal/migration/transform_test.go
@@ -419,14 +419,14 @@ func assertFixtureReport(t *testing.T, report Report, sourceHash string) {
 			t.Errorf("source file evidence did not reconcile: %+v", file)
 		}
 	}
-	if report.Target.SchemaVersion != 9 || len(report.Target.MigrationChecksums) != 9 {
-		t.Fatalf("target schema = version %d with %d checksums, want version 9 with 9 checksums", report.Target.SchemaVersion, len(report.Target.MigrationChecksums))
+	if report.Target.SchemaVersion != 10 || len(report.Target.MigrationChecksums) != 10 {
+		t.Fatalf("target schema = version %d with %d checksums, want version 10 with 10 checksums", report.Target.SchemaVersion, len(report.Target.MigrationChecksums))
 	}
 	wantTargetCounts := map[string]int64{
 		"accounts": 5, "devices": 5, "people": 1, "person_identities": 2,
 		"conversations": 6, "inbox": 0, "messages": 14,
 		"message_attachments": 3, "outbox": 2, "outbox_attachments": 1,
-		"read_cursors": 6,
+		"read_cursors": 6, "reactions": 0, "reaction_snapshot_fences": 0,
 	}
 	for table, want := range wantTargetCounts {
 		if got := report.Target.Counts[table]; got != want {

--- a/internal/migration/validate.go
+++ b/internal/migration/validate.go
@@ -19,8 +19,11 @@ import (
 var targetCountTables = []string{
 	"accounts", "devices", "identities", "people", "person_identities",
 	"conversations", "conversation_participants", "inbox", "messages",
-	"message_attachments", "outbox", "outbox_attachments", "read_cursors",
+	"message_attachments", "outbox", "outbox_attachments", "reactions", "reaction_snapshot_fences",
+	"read_cursors",
 }
+
+const migration0010Checksum = "dfab4551335d92045cb895e5b2c781f4f57216bbc428a705fc26bbdd474db0b1"
 
 func checkpointAndSyncSQLite(ctx context.Context, path string) error {
 	database, err := sql.Open("sqlite", path)
@@ -148,7 +151,8 @@ func validateTarget(
 	countsMatched := countsMatch(dataset, state, report, actualHistory, actualScheduled, actualHistoryByPlatform)
 	report.Validation.CountsMatched = countsMatched
 	report.Validation.Passed = quick == "ok" &&
-		report.Target.SchemaVersion == 9 && len(report.Target.MigrationChecksums) == 9 &&
+		report.Target.SchemaVersion == 10 && len(report.Target.MigrationChecksums) == 10 &&
+		report.Target.MigrationChecksums[9] == migration0010Checksum &&
 		len(fkViolations) == 0 && orphanTotal(orphans) == 0 &&
 		countsMatched && report.Validation.SampledHashesMatched &&
 		report.Validation.BlobReferencesValid && report.Validation.SourceUnchanged &&
@@ -194,6 +198,7 @@ func fillTableReconciliations(
 		name  string
 		count int64
 	}{
+		// RR-2 flips the reactions V2 value to the seeded count.
 		{"reactions", dataset.dropped.ReactionsBearingMessages},
 		{"transcripts", dataset.dropped.TranscriptBearingMessages},
 		{"contact_avatars", dataset.dropped.ContactAvatars},
@@ -329,6 +334,9 @@ func countsMatch(
 		report.Target.Counts["outbox"] != dataset.scheduleByStatus["pending"] ||
 		report.Target.Counts["outbox_attachments"] != state.expectedPendingMedia ||
 		report.Target.Counts["read_cursors"] != state.expectedCursors ||
+		// RR-2 flips reactions to the seeded count.
+		report.Target.Counts["reactions"] != 0 ||
+		report.Target.Counts["reaction_snapshot_fences"] != 0 ||
 		report.Target.Counts["inbox"] != 0 {
 		return false
 	}

--- a/internal/migration/validate_reactions_test.go
+++ b/internal/migration/validate_reactions_test.go
@@ -1,0 +1,19 @@
+package migration
+
+import "testing"
+
+func TestCountsMatchRejectsStrayMigratedReaction(t *testing.T) {
+	dataset := legacyDataset{}
+	state := &transformState{
+		accounts:                  map[string]accountSpec{},
+		identities:                map[identityKey]*identityCandidate{},
+		conversations:             map[string]*conversationPlan{},
+		contactIdentityKeys:       map[identityKey]struct{}{},
+		expectedHistoryByPlatform: map[string]map[string]struct{}{},
+		scheduledMessages:         map[string]struct{}{},
+	}
+	report := &Report{Target: TargetReport{Counts: map[string]int64{"reactions": 1}}}
+	if countsMatch(dataset, state, report, 0, 0, map[string]int64{}) {
+		t.Fatal("countsMatch accepted a migrated store with one stray reactions row")
+	}
+}

--- a/internal/signallive/aci_convergence_external_test.go
+++ b/internal/signallive/aci_convergence_external_test.go
@@ -131,11 +131,16 @@ func TestSignalCaptureReplayDedupeSurvivesContactResolutionDrift(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewMessageRepository(): %v", err)
 	}
+	reactions, err := sqlite.NewReactionRepository(v2Store, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("NewReactionRepository(): %v", err)
+	}
 	counters := &ingest.Counters{}
 	worker, err := ingest.NewWorker(ingest.WorkerConfig{
-		Store:    v2Store,
-		Messages: messages,
-		Counters: counters,
+		Store:     v2Store,
+		Messages:  messages,
+		Reactions: reactions,
+		Counters:  counters,
 	})
 	if err != nil {
 		t.Fatalf("NewWorker(): %v", err)

--- a/internal/storage/sqlite/attachments_test.go
+++ b/internal/storage/sqlite/attachments_test.go
@@ -322,8 +322,8 @@ func openAttachmentTestRepository(t *testing.T) (*Store, *AttachmentRepository) 
 		}
 	})
 
-	if len(embeddedMigrations) != 9 {
-		t.Fatalf("embedded migrations = %d, want 9", len(embeddedMigrations))
+	if len(embeddedMigrations) != 10 {
+		t.Fatalf("embedded migrations = %d, want 10", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 3)

--- a/internal/storage/sqlite/identity_graph_test.go
+++ b/internal/storage/sqlite/identity_graph_test.go
@@ -162,8 +162,8 @@ func openIdentityGraphTestStore(t *testing.T) *Store {
 		}
 	})
 
-	if len(embeddedMigrations) != 9 {
-		t.Fatalf("embedded migrations = %d, want 9", len(embeddedMigrations))
+	if len(embeddedMigrations) != 10 {
+		t.Fatalf("embedded migrations = %d, want 10", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 2)

--- a/internal/storage/sqlite/message_attachments_test.go
+++ b/internal/storage/sqlite/message_attachments_test.go
@@ -83,8 +83,8 @@ func TestMessageAttachmentsMigrationAppliesToBlankAndExistingV7AndReopens(t *tes
 			}
 		})
 		after := readLedgerRows(t, store.db)
-		if len(after) != 9 {
-			t.Fatalf("migrated ledger rows = %d, want 9", len(after))
+		if len(after) != 10 {
+			t.Fatalf("migrated ledger rows = %d, want 10", len(after))
 		}
 		if !slices.Equal(after[:7], before) {
 			t.Fatalf("migrations 0001-0007 changed:\nbefore: %+v\nafter:  %+v", before, after[:7])
@@ -252,10 +252,10 @@ func TestMessageAttachmentRowsCascadeWithMessageDeletion(t *testing.T) {
 
 func assertMessageAttachmentsMigration(t *testing.T, store *Store) {
 	t.Helper()
-	if len(embeddedMigrations) != 9 {
-		t.Fatalf("embedded migrations = %d, want 9", len(embeddedMigrations))
+	if len(embeddedMigrations) != 10 {
+		t.Fatalf("embedded migrations = %d, want 10", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 9)
+	assertPragmaInt(t, store.db, "user_version", 10)
 	ledger := readLedgerRow(t, store.db, 8)
 	if ledger.name != "message_attachments" {
 		t.Fatalf("migration 0008 name = %q, want message_attachments", ledger.name)

--- a/internal/storage/sqlite/messages_test.go
+++ b/internal/storage/sqlite/messages_test.go
@@ -1178,8 +1178,8 @@ func TestMessagesInboxMigrationIsChecksummedAndStrict(t *testing.T) {
 		t,
 		func() time.Time { return time.UnixMilli(messageTestTimeMS) },
 	)
-	if len(embeddedMigrations) != 9 {
-		t.Fatalf("embedded migrations = %d, want 9", len(embeddedMigrations))
+	if len(embeddedMigrations) != 10 {
+		t.Fatalf("embedded migrations = %d, want 10", len(embeddedMigrations))
 	}
 	assertPragmaInt(t, store.db, "user_version", len(embeddedMigrations))
 	ledger := readLedgerRow(t, store.db, 4)

--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -63,6 +63,9 @@ var migration0008SQL string
 //go:embed migrations/0009_outbox_send_again.sql
 var migration0009SQL string
 
+//go:embed migrations/0010_reactions.sql
+var migration0010SQL string
+
 var embeddedMigrations = []migration{
 	newMigration(1, "storage_shell", migration0001SQL, newStorageShellArguments),
 	newMigration(2, "identity_graph", migration0002SQL, nil),
@@ -73,6 +76,7 @@ var embeddedMigrations = []migration{
 	newMigration(7, "reactions_read", migration0007SQL, nil),
 	newMigration(8, "message_attachments", migration0008SQL, nil),
 	newMigration(9, "outbox_send_again", migration0009SQL, nil),
+	newMigration(10, "reactions", migration0010SQL, nil),
 }
 
 func newMigration(

--- a/internal/storage/sqlite/migrations/0010_reactions.sql
+++ b/internal/storage/sqlite/migrations/0010_reactions.sql
@@ -1,0 +1,43 @@
+-- Inbound reaction read model (M3/D2). One row per person per message; emoji is a
+-- mutable attribute. Removals are tombstones (state='removed'), never deletes, so
+-- replayed/out-of-order frames converge by last-writer-wins. Distinct from the
+-- send-side outbox_reactions table in 0007.
+CREATE TABLE reactions (
+    message_id           TEXT NOT NULL,
+    reactor_key          TEXT NOT NULL CHECK (trim(reactor_key) <> ''),
+    account_id           TEXT NOT NULL,
+    conversation_id      TEXT NOT NULL,
+    reactor_identity_id  TEXT,                       -- FK identities; NULL for self / unattributed
+    reactor_is_self      INTEGER NOT NULL DEFAULT 0 CHECK (reactor_is_self IN (0, 1)),
+    reactor_label        TEXT NOT NULL DEFAULT '',   -- raw actor token for display when identity is NULL and not self
+    emoji                TEXT NOT NULL CHECK (
+        (state = 'removed' OR trim(emoji) != '') AND length(emoji) <= 64
+    ),
+    state                TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active', 'removed')),
+    occurred_at_ms       INTEGER NOT NULL CHECK (occurred_at_ms > 0),
+    source_seq_ms        INTEGER NOT NULL DEFAULT 0, -- frame ReceivedAt; monotone guard for snapshot reconcile
+    created_at_ms        INTEGER NOT NULL CHECK (created_at_ms > 0),
+    updated_at_ms        INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    PRIMARY KEY (message_id, reactor_key),
+    FOREIGN KEY (message_id)
+        REFERENCES messages(message_id) ON DELETE CASCADE,
+    FOREIGN KEY (account_id, conversation_id)
+        REFERENCES conversations(account_id, conversation_id) ON DELETE CASCADE,
+    FOREIGN KEY (reactor_identity_id)
+        REFERENCES identities(identity_id)
+) STRICT;
+
+-- Read-path: active reactions for a batch of messages (v2read DTO aggregation).
+CREATE INDEX reactions_message_state_idx ON reactions(message_id, state);
+-- Conversation-scoped maintenance / CASCADE support.
+CREATE INDEX reactions_conversation_idx ON reactions(conversation_id);
+
+-- Per-message monotone fence for Google embedded-snapshot reconcile. This is
+-- separate because an empty snapshot writes no reaction rows yet must still
+-- advance the fence. Delta-mode platforms never touch it.
+CREATE TABLE reaction_snapshot_fences (
+    message_id     TEXT NOT NULL PRIMARY KEY
+        REFERENCES messages(message_id) ON DELETE CASCADE,
+    source_seq_ms  INTEGER NOT NULL CHECK (source_seq_ms >= 0),
+    updated_at_ms  INTEGER NOT NULL CHECK (updated_at_ms > 0)
+) STRICT;

--- a/internal/storage/sqlite/outbox_test.go
+++ b/internal/storage/sqlite/outbox_test.go
@@ -2473,10 +2473,10 @@ func TestOutboxMigrationIsChecksummedAndStrict(t *testing.T) {
 	store, _ := openOutboxTestRepository(t, func() time.Time {
 		return time.UnixMilli(outboxTestTimeMS)
 	})
-	if len(embeddedMigrations) != 9 {
-		t.Fatalf("embedded migrations = %d, want 9", len(embeddedMigrations))
+	if len(embeddedMigrations) != 10 {
+		t.Fatalf("embedded migrations = %d, want 10", len(embeddedMigrations))
 	}
-	assertPragmaInt(t, store.db, "user_version", 9)
+	assertPragmaInt(t, store.db, "user_version", 10)
 	ledger := readLedgerRow(t, store.db, 5)
 	if ledger.name != "outbox" {
 		t.Fatalf("migration 0005 name = %q, want outbox", ledger.name)
@@ -2583,8 +2583,8 @@ func TestOutboxSendAgainMigrationAppliesToBlankAndExistingV8DatabaseWithRows(t *
 			}
 		})
 		after := readLedgerRows(t, store.db)
-		if len(after) != 9 {
-			t.Fatalf("migrated ledger rows = %d, want 9", len(after))
+		if len(after) != 10 {
+			t.Fatalf("migrated ledger rows = %d, want 10", len(after))
 		}
 		if !slices.Equal(after[:8], before) {
 			t.Fatalf("migrations 0001-0008 changed:\nbefore: %+v\nafter:  %+v", before, after[:8])
@@ -2613,7 +2613,7 @@ func TestOutboxSendAgainMigrationAppliesToBlankAndExistingV8DatabaseWithRows(t *
 
 func assertOutboxSendAgainMigration(t *testing.T, store *Store) {
 	t.Helper()
-	assertPragmaInt(t, store.db, "user_version", 9)
+	assertPragmaInt(t, store.db, "user_version", 10)
 	ledger := readLedgerRow(t, store.db, 9)
 	if ledger.name != "outbox_send_again" {
 		t.Fatalf("migration 0009 name = %q, want outbox_send_again", ledger.name)
@@ -2715,8 +2715,8 @@ func TestOutboxAttachmentsMigrationAppliesToBlankAndExistingV5Database(t *testin
 			}
 		})
 		after := readLedgerRows(t, store.db)
-		if len(after) != 9 {
-			t.Fatalf("migrated ledger rows = %d, want 9", len(after))
+		if len(after) != 10 {
+			t.Fatalf("migrated ledger rows = %d, want 10", len(after))
 		}
 		if !slices.Equal(after[:5], before) {
 			t.Fatalf("migrations 0001-0005 changed:\nbefore: %+v\nafter:  %+v", before, after[:5])
@@ -2727,7 +2727,7 @@ func TestOutboxAttachmentsMigrationAppliesToBlankAndExistingV5Database(t *testin
 
 func assertOutboxAttachmentsMigration(t *testing.T, store *Store) {
 	t.Helper()
-	assertPragmaInt(t, store.db, "user_version", 9)
+	assertPragmaInt(t, store.db, "user_version", 10)
 	ledger := readLedgerRow(t, store.db, 6)
 	if ledger.name != "outbox_attachments" {
 		t.Fatalf("migration 0006 name = %q, want outbox_attachments", ledger.name)
@@ -2782,7 +2782,7 @@ func TestReactionsReadMigrationAppliesToBlankAndReopens(t *testing.T) {
 
 func assertReactionsReadMigration(t *testing.T, store *Store) {
 	t.Helper()
-	assertPragmaInt(t, store.db, "user_version", 9)
+	assertPragmaInt(t, store.db, "user_version", 10)
 	ledger := readLedgerRow(t, store.db, 7)
 	if ledger.name != "reactions_read" {
 		t.Fatalf("migration 0007 name = %q, want reactions_read", ledger.name)

--- a/internal/storage/sqlite/reactions.go
+++ b/internal/storage/sqlite/reactions.go
@@ -1,0 +1,546 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+const reactionMessageQueryBatchSize = 500
+
+// ReactionApply is one per-reactor reaction mutation for a resolved message.
+// OccurredAtMS orders delta mutations; SourceSeqMS carries the enclosing source
+// frame's ordering value when one is available.
+type ReactionApply struct {
+	AccountID      string
+	ConversationID string
+	MessageID      string
+
+	ReactorKey        string
+	ReactorIdentityID *string
+	ReactorIsSelf     bool
+	ReactorLabel      string
+	Emoji             string
+	Action            bridge.ReactionAction
+	OccurredAtMS      int64
+	SourceSeqMS       int64
+}
+
+// ReactionSnapshotEntry is one active reactor in a full embedded reaction
+// snapshot. Reactors absent from a newer snapshot are tombstoned.
+type ReactionSnapshotEntry struct {
+	ReactorKey        string
+	ReactorIdentityID *string
+	ReactorIsSelf     bool
+	ReactorLabel      string
+	Emoji             string
+}
+
+// ReactionRow is the active read shape consumed by the v2 DTO mapper.
+type ReactionRow struct {
+	MessageID        string
+	Emoji            string
+	ReactorIsSelf    bool
+	ReactorCanonical string
+	ReactorLabel     string
+	OccurredAtMS     int64
+}
+
+// ReactionRepository owns the inbound reaction read model.
+type ReactionRepository struct {
+	store *Store
+	now   func() time.Time
+}
+
+// NewReactionRepository creates a reaction repository. The clock is required
+// so storage-owned creation and update timestamps are deterministic in tests.
+func NewReactionRepository(
+	store *Store,
+	now func() time.Time,
+) (*ReactionRepository, error) {
+	if store == nil || store.db == nil {
+		return nil, fmt.Errorf("create reaction repository: store is nil")
+	}
+	if now == nil {
+		return nil, fmt.Errorf("create reaction repository: now function is nil")
+	}
+	return &ReactionRepository{store: store, now: now}, nil
+}
+
+// ApplyReaction applies one WhatsApp, Signal, or tapback delta. A newer
+// removal preserves the previous emoji for audit; a removal received before
+// any add inserts an empty-emoji tombstone that fences stale adds. Delta
+// application neither reads nor writes the embedded-snapshot fence table.
+func (r *ReactionRepository) ApplyReaction(
+	ctx context.Context,
+	reaction ReactionApply,
+) (bool, error) {
+	state := "active"
+	emoji := reaction.Emoji
+	switch reaction.Action {
+	case bridge.ReactionAdd, bridge.ReactionSwitch:
+	case bridge.ReactionRemove:
+		state = "removed"
+		// A remove with no prior row inserts an empty tombstone. The conflict
+		// branch below deliberately retains reactions.emoji instead.
+		emoji = ""
+	default:
+		return false, fmt.Errorf(
+			"apply reaction (%q, %q): unsupported action %q",
+			reaction.MessageID,
+			reaction.ReactorKey,
+			reaction.Action,
+		)
+	}
+
+	nowMS, err := r.nowMS("apply reaction")
+	if err != nil {
+		return false, err
+	}
+	result, err := r.store.db.ExecContext(ctx, `
+		INSERT INTO reactions (
+			message_id,
+			reactor_key,
+			account_id,
+			conversation_id,
+			reactor_identity_id,
+			reactor_is_self,
+			reactor_label,
+			emoji,
+			state,
+			occurred_at_ms,
+			source_seq_ms,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(message_id, reactor_key) DO UPDATE SET
+			reactor_identity_id = excluded.reactor_identity_id,
+			reactor_is_self = excluded.reactor_is_self,
+			reactor_label = excluded.reactor_label,
+			emoji = CASE
+				WHEN excluded.state = 'removed' THEN reactions.emoji
+				ELSE excluded.emoji
+			END,
+			state = excluded.state,
+			occurred_at_ms = excluded.occurred_at_ms,
+			source_seq_ms = excluded.source_seq_ms,
+			updated_at_ms = excluded.updated_at_ms
+		WHERE excluded.occurred_at_ms > reactions.occurred_at_ms
+		   OR (
+			excluded.occurred_at_ms = reactions.occurred_at_ms
+			AND (
+				reactions.reactor_identity_id IS NOT excluded.reactor_identity_id
+				OR reactions.reactor_is_self IS NOT excluded.reactor_is_self
+				OR reactions.reactor_label IS NOT excluded.reactor_label
+				OR reactions.state IS NOT excluded.state
+				OR (
+					excluded.state = 'active'
+					AND reactions.emoji IS NOT excluded.emoji
+				)
+				OR reactions.source_seq_ms IS NOT excluded.source_seq_ms
+			)
+		   )
+	`,
+		reaction.MessageID,
+		reaction.ReactorKey,
+		reaction.AccountID,
+		reaction.ConversationID,
+		reaction.ReactorIdentityID,
+		reaction.ReactorIsSelf,
+		reaction.ReactorLabel,
+		emoji,
+		state,
+		reaction.OccurredAtMS,
+		reaction.SourceSeqMS,
+		nowMS,
+		nowMS,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"apply reaction (%q, %q): %w",
+			reaction.MessageID,
+			reaction.ReactorKey,
+			mapConstraintError(err),
+		)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf(
+			"apply reaction (%q, %q): read rows affected: %w",
+			reaction.MessageID,
+			reaction.ReactorKey,
+			err,
+		)
+	}
+	if affected != 0 && affected != 1 {
+		return false, fmt.Errorf(
+			"apply reaction (%q, %q): affected %d rows, want at most 1",
+			reaction.MessageID,
+			reaction.ReactorKey,
+			affected,
+		)
+	}
+	return affected == 1, nil
+}
+
+// ReactionSnapshotResult counts semantic changes made by a full snapshot.
+type ReactionSnapshotResult struct {
+	Applied int
+	Removed int
+}
+
+// ReplaceEmbeddedReactions reconciles a Google embedded full snapshot in one
+// transaction. Snapshot ordering is fenced by sourceSeqMS rather than the
+// per-reaction occurrence timestamp used by ApplyReaction.
+func (r *ReactionRepository) ReplaceEmbeddedReactions(
+	ctx context.Context,
+	messageID string,
+	accountID string,
+	conversationID string,
+	entries []ReactionSnapshotEntry,
+	sourceSeqMS int64,
+) (ReactionSnapshotResult, error) {
+	var changes ReactionSnapshotResult
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return changes, fmt.Errorf(
+			"replace embedded reactions for message %q: begin transaction: %w",
+			messageID,
+			err,
+		)
+	}
+	defer tx.Rollback()
+
+	var storedSourceSeqMS sql.NullInt64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT source_seq_ms
+		FROM reaction_snapshot_fences
+		WHERE message_id = ?
+	`, messageID).Scan(&storedSourceSeqMS); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return changes, fmt.Errorf(
+			"replace embedded reactions for message %q: read source fence: %w",
+			messageID,
+			err,
+		)
+	}
+	if storedSourceSeqMS.Valid && sourceSeqMS < storedSourceSeqMS.Int64 {
+		return changes, nil
+	}
+
+	nowMS, err := r.nowMS("replace embedded reactions")
+	if err != nil {
+		return changes, err
+	}
+	present := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		present[entry.ReactorKey] = struct{}{}
+		var storedIdentity sql.NullString
+		var storedIsSelf bool
+		var storedLabel, storedEmoji, storedState string
+		rowErr := tx.QueryRowContext(ctx, `
+			SELECT reactor_identity_id, reactor_is_self, reactor_label, emoji, state
+			FROM reactions
+			WHERE message_id = ? AND reactor_key = ?
+		`, messageID, entry.ReactorKey).Scan(
+			&storedIdentity, &storedIsSelf, &storedLabel, &storedEmoji, &storedState,
+		)
+		if rowErr != nil && !errors.Is(rowErr, sql.ErrNoRows) {
+			return changes, fmt.Errorf(
+				"replace embedded reactions for message %q reactor %q: read semantic state: %w",
+				messageID, entry.ReactorKey, rowErr,
+			)
+		}
+		semanticChange := errors.Is(rowErr, sql.ErrNoRows) ||
+			storedIdentity.Valid != (entry.ReactorIdentityID != nil) ||
+			(storedIdentity.Valid && storedIdentity.String != *entry.ReactorIdentityID) ||
+			storedIsSelf != entry.ReactorIsSelf || storedLabel != entry.ReactorLabel ||
+			storedEmoji != entry.Emoji || storedState != "active"
+		result, err := tx.ExecContext(ctx, `
+			INSERT INTO reactions (
+				message_id,
+				reactor_key,
+				account_id,
+				conversation_id,
+				reactor_identity_id,
+				reactor_is_self,
+				reactor_label,
+				emoji,
+				state,
+				occurred_at_ms,
+				source_seq_ms,
+				created_at_ms,
+				updated_at_ms
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?)
+			ON CONFLICT(message_id, reactor_key) DO UPDATE SET
+				reactor_identity_id = excluded.reactor_identity_id,
+				reactor_is_self = excluded.reactor_is_self,
+				reactor_label = excluded.reactor_label,
+				emoji = excluded.emoji,
+				state = 'active',
+				occurred_at_ms = excluded.occurred_at_ms,
+				source_seq_ms = excluded.source_seq_ms,
+				updated_at_ms = excluded.updated_at_ms
+			WHERE excluded.source_seq_ms > reactions.source_seq_ms
+			   OR (
+				excluded.source_seq_ms = reactions.source_seq_ms
+				AND (
+					reactions.reactor_identity_id IS NOT excluded.reactor_identity_id
+					OR reactions.reactor_is_self IS NOT excluded.reactor_is_self
+					OR reactions.reactor_label IS NOT excluded.reactor_label
+					OR reactions.emoji IS NOT excluded.emoji
+					OR reactions.state IS NOT 'active'
+				)
+			   )
+		`,
+			messageID,
+			entry.ReactorKey,
+			accountID,
+			conversationID,
+			entry.ReactorIdentityID,
+			entry.ReactorIsSelf,
+			entry.ReactorLabel,
+			entry.Emoji,
+			nowMS,
+			sourceSeqMS,
+			nowMS,
+			nowMS,
+		)
+		if err != nil {
+			return changes, fmt.Errorf(
+				"replace embedded reactions for message %q reactor %q: %w",
+				messageID,
+				entry.ReactorKey,
+				mapConstraintError(err),
+			)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return changes, fmt.Errorf(
+				"replace embedded reactions for message %q reactor %q: read rows affected: %w",
+				messageID,
+				entry.ReactorKey,
+				err,
+			)
+		}
+		if affected != 0 && affected != 1 {
+			return changes, fmt.Errorf(
+				"replace embedded reactions for message %q reactor %q: affected %d rows, want at most 1",
+				messageID,
+				entry.ReactorKey,
+				affected,
+			)
+		}
+		if affected == 1 && semanticChange {
+			changes.Applied++
+		}
+	}
+
+	conditions := []string{"message_id = ?", "state = 'active'"}
+	arguments := []any{nowMS, sourceSeqMS, nowMS, messageID}
+	if len(present) > 0 {
+		keys := make([]string, 0, len(present))
+		for key := range present {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(keys)), ",")
+		conditions = append(conditions, "reactor_key NOT IN ("+placeholders+")")
+		for _, key := range keys {
+			arguments = append(arguments, key)
+		}
+	}
+	result, err := tx.ExecContext(ctx, `
+		UPDATE reactions
+		SET
+			state = 'removed',
+			occurred_at_ms = ?,
+			source_seq_ms = ?,
+			updated_at_ms = ?
+		WHERE `+strings.Join(conditions, " AND "), arguments...)
+	if err != nil {
+		return changes, fmt.Errorf(
+			"replace embedded reactions for message %q: tombstone absent reactors: %w",
+			messageID,
+			mapConstraintError(err),
+		)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return changes, fmt.Errorf(
+			"replace embedded reactions for message %q: read tombstoned rows affected: %w",
+			messageID,
+			err,
+		)
+	}
+	changes.Removed = int(affected)
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO reaction_snapshot_fences (message_id, source_seq_ms, updated_at_ms)
+		VALUES (?, ?, ?)
+		ON CONFLICT(message_id) DO UPDATE SET
+			source_seq_ms = excluded.source_seq_ms,
+			updated_at_ms = excluded.updated_at_ms
+	`, messageID, sourceSeqMS, nowMS); err != nil {
+		return changes, fmt.Errorf(
+			"replace embedded reactions for message %q: write source fence: %w",
+			messageID,
+			mapConstraintError(err),
+		)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return changes, fmt.Errorf(
+			"replace embedded reactions for message %q: commit: %w",
+			messageID,
+			mapConstraintError(err),
+		)
+	}
+	return changes, nil
+}
+
+// SeedReaction inserts one active migration row inside the caller's write
+// transaction. The first row for a (message, reactor) pair wins, normalizing
+// legacy multi-emoji duplicates to the one-reaction-per-person model. Seeds
+// neither read nor write the embedded-snapshot fence table.
+func (r *ReactionRepository) SeedReaction(
+	ctx context.Context,
+	tx *sql.Tx,
+	reaction ReactionApply,
+) error {
+	if tx == nil {
+		return fmt.Errorf(
+			"seed reaction (%q, %q): transaction is nil",
+			reaction.MessageID,
+			reaction.ReactorKey,
+		)
+	}
+	nowMS, err := r.nowMS("seed reaction")
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO reactions (
+			message_id,
+			reactor_key,
+			account_id,
+			conversation_id,
+			reactor_identity_id,
+			reactor_is_self,
+			reactor_label,
+			emoji,
+			state,
+			occurred_at_ms,
+			source_seq_ms,
+			created_at_ms,
+			updated_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, 0, ?, ?)
+		ON CONFLICT(message_id, reactor_key) DO NOTHING
+	`,
+		reaction.MessageID,
+		reaction.ReactorKey,
+		reaction.AccountID,
+		reaction.ConversationID,
+		reaction.ReactorIdentityID,
+		reaction.ReactorIsSelf,
+		reaction.ReactorLabel,
+		reaction.Emoji,
+		reaction.OccurredAtMS,
+		nowMS,
+		nowMS,
+	); err != nil {
+		return fmt.Errorf(
+			"seed reaction (%q, %q): %w",
+			reaction.MessageID,
+			reaction.ReactorKey,
+			mapConstraintError(err),
+		)
+	}
+	return nil
+}
+
+// ReactionsForMessages loads active reactions for a batch of messages in a
+// stable order suitable for deterministic legacy-shape aggregation.
+func (r *ReactionRepository) ReactionsForMessages(
+	ctx context.Context,
+	messageIDs []string,
+) (map[string][]ReactionRow, error) {
+	result := make(map[string][]ReactionRow)
+	if len(messageIDs) == 0 {
+		return result, nil
+	}
+
+	unique := make([]string, 0, len(messageIDs))
+	seen := make(map[string]struct{}, len(messageIDs))
+	for _, messageID := range messageIDs {
+		if _, exists := seen[messageID]; exists {
+			continue
+		}
+		seen[messageID] = struct{}{}
+		unique = append(unique, messageID)
+	}
+	for start := 0; start < len(unique); start += reactionMessageQueryBatchSize {
+		end := min(start+reactionMessageQueryBatchSize, len(unique))
+		batch := unique[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
+		arguments := make([]any, len(batch))
+		for index, messageID := range batch {
+			arguments[index] = messageID
+		}
+
+		rows, err := r.store.db.QueryContext(ctx, `
+			SELECT
+				r.message_id,
+				r.emoji,
+				r.reactor_is_self,
+				COALESCE(i.canonical_value, ''),
+				r.reactor_label,
+				r.occurred_at_ms
+			FROM reactions AS r
+			LEFT JOIN identities AS i
+			  ON i.identity_id = r.reactor_identity_id
+			WHERE r.message_id IN (`+placeholders+`)
+			  AND r.state = 'active'
+			ORDER BY r.message_id, r.occurred_at_ms, r.reactor_key
+		`, arguments...)
+		if err != nil {
+			return nil, fmt.Errorf("list reactions for messages: %w", err)
+		}
+		for rows.Next() {
+			var row ReactionRow
+			if err := rows.Scan(
+				&row.MessageID,
+				&row.Emoji,
+				&row.ReactorIsSelf,
+				&row.ReactorCanonical,
+				&row.ReactorLabel,
+				&row.OccurredAtMS,
+			); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scan reaction for messages: %w", err)
+			}
+			result[row.MessageID] = append(result[row.MessageID], row)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("iterate reactions for messages: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("close reactions for messages: %w", err)
+		}
+	}
+	return result, nil
+}
+
+func (r *ReactionRepository) nowMS(operation string) (int64, error) {
+	nowMS := r.now().UnixMilli()
+	if nowMS <= 0 {
+		return 0, fmt.Errorf("%s: current Unix time is not positive", operation)
+	}
+	return nowMS, nil
+}

--- a/internal/storage/sqlite/reactions_migration_test.go
+++ b/internal/storage/sqlite/reactions_migration_test.go
@@ -1,0 +1,232 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestReactionsMigrationAppliesToBlankAndExistingV9Database(t *testing.T) {
+	t.Run("blank", func(t *testing.T) {
+		store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+		if err != nil {
+			t.Fatalf("Open(): %v", err)
+		}
+		t.Cleanup(func() {
+			if err := store.Close(); err != nil {
+				t.Errorf("Close(): %v", err)
+			}
+		})
+
+		assertReactionsMigration(t, store)
+	})
+
+	t.Run("existing v9", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "store.sqlite3")
+		database, err := sql.Open("sqlite", storeDSN(path))
+		if err != nil {
+			t.Fatalf("sql.Open(): %v", err)
+		}
+		if err := database.Ping(); err != nil {
+			_ = database.Close()
+			t.Fatalf("Ping(): %v", err)
+		}
+		if err := enableWAL(context.Background(), database); err != nil {
+			_ = database.Close()
+			t.Fatalf("enableWAL(): %v", err)
+		}
+		if err := verifyConnectionPragmas(context.Background(), database); err != nil {
+			_ = database.Close()
+			t.Fatalf("verifyConnectionPragmas(): %v", err)
+		}
+		if err := runMigrations(context.Background(), database, embeddedMigrations[:9]); err != nil {
+			_ = database.Close()
+			t.Fatalf("runMigrations(v9): %v", err)
+		}
+		before := readLedgerRows(t, database)
+		if len(before) != 9 {
+			_ = database.Close()
+			t.Fatalf("v9 ledger rows = %d, want 9", len(before))
+		}
+		if err := database.Close(); err != nil {
+			t.Fatalf("close v9 database: %v", err)
+		}
+
+		store, err := Open(path)
+		if err != nil {
+			t.Fatalf("Open(v9): %v", err)
+		}
+		t.Cleanup(func() {
+			if err := store.Close(); err != nil {
+				t.Errorf("Close(): %v", err)
+			}
+		})
+		after := readLedgerRows(t, store.db)
+		if len(after) != 10 {
+			t.Fatalf("migrated ledger rows = %d, want 10", len(after))
+		}
+		if !slices.Equal(after[:9], before) {
+			t.Fatalf("migrations 0001-0009 changed:\nbefore: %+v\nafter:  %+v", before, after[:9])
+		}
+		assertReactionsMigration(t, store)
+	})
+}
+
+func assertReactionsMigration(t *testing.T, store *Store) {
+	t.Helper()
+	if len(embeddedMigrations) != 10 {
+		t.Fatalf("embedded migrations = %d, want 10", len(embeddedMigrations))
+	}
+	assertPragmaInt(t, store.db, "user_version", 10)
+	ledger := readLedgerRow(t, store.db, 10)
+	if ledger.name != "reactions" {
+		t.Fatalf("migration 0010 name = %q, want reactions", ledger.name)
+	}
+	if ledger.checksum != embeddedMigrations[9].checksumSHA256 {
+		t.Fatalf(
+			"migration 0010 checksum = %q, want %q",
+			ledger.checksum,
+			embeddedMigrations[9].checksumSHA256,
+		)
+	}
+	const wantChecksum = "dfab4551335d92045cb895e5b2c781f4f57216bbc428a705fc26bbdd474db0b1"
+	if ledger.checksum != wantChecksum {
+		t.Fatalf("migration 0010 checksum = %q, want pinned %q", ledger.checksum, wantChecksum)
+	}
+
+	for _, table := range []string{"reactions", "reaction_snapshot_fences"} {
+		var strict int
+		if err := store.db.QueryRow(`
+			SELECT strict
+			FROM pragma_table_list
+			WHERE schema = 'main' AND name = ?
+		`, table).Scan(&strict); err != nil {
+			t.Fatalf("read %s STRICT flag: %v", table, err)
+		}
+		if strict != 1 {
+			t.Fatalf("%s strict = %d, want 1", table, strict)
+		}
+	}
+	for _, index := range []string{"reactions_message_state_idx", "reactions_conversation_idx"} {
+		var exists bool
+		if err := store.db.QueryRow(`
+			SELECT EXISTS (
+				SELECT 1 FROM sqlite_schema
+				WHERE type = 'index' AND name = ?
+			)
+		`, index).Scan(&exists); err != nil {
+			t.Fatalf("inspect migration index %q: %v", index, err)
+		}
+		if !exists {
+			t.Fatalf("migration index %q is missing", index)
+		}
+	}
+}
+
+func TestReactionsMigrationEnforcesTombstoneEmojiAndForeignKeys(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+
+	const nowMS = int64(2_000_000_000_000)
+	mustExec(t, store.db, `
+		INSERT INTO accounts (account_id, bridge_key, created_at_ms, updated_at_ms)
+		VALUES ('account-reactions', 'test', ?, ?)
+	`, nowMS, nowMS)
+	mustExec(t, store.db, `
+		INSERT INTO conversations (
+			conversation_id, account_id, remote_conversation_id, kind,
+			created_at_ms, updated_at_ms
+		) VALUES ('conversation-reactions', 'account-reactions', 'remote-conversation', 'direct', ?, ?)
+	`, nowMS, nowMS)
+	mustExec(t, store.db, `
+		INSERT INTO identities (
+			identity_id, account_id, kind, canonical_value, raw_value,
+			created_at_ms, updated_at_ms
+		) VALUES ('identity-reactor', 'account-reactions', 'phone', '+15550100001', '+15550100001', ?, ?)
+	`, nowMS, nowMS)
+	mustExec(t, store.db, `
+		INSERT INTO messages (
+			message_id, conversation_id, account_id, remote_message_id,
+			direction, occurred_at_ms, created_at_ms, updated_at_ms
+		) VALUES (
+			'message-reactions', 'conversation-reactions', 'account-reactions',
+			'remote-message', 'incoming', ?, ?, ?
+		)
+	`, nowMS, nowMS, nowMS)
+
+	insert := func(reactorKey, identityID, emoji, state string) error {
+		_, err := store.db.Exec(`
+			INSERT INTO reactions (
+				message_id, reactor_key, account_id, conversation_id,
+				reactor_identity_id, emoji, state, occurred_at_ms,
+				created_at_ms, updated_at_ms
+			) VALUES (
+				'message-reactions', ?, 'account-reactions', 'conversation-reactions',
+				NULLIF(?, ''), ?, ?, ?, ?, ?
+			)
+		`, reactorKey, identityID, emoji, state, nowMS, nowMS, nowMS)
+		return err
+	}
+	if err := insert("identity-reactor", "identity-reactor", "👍", "active"); err != nil {
+		t.Fatalf("insert active reaction: %v", err)
+	}
+	if err := insert("remove-before-add", "", "", "removed"); err != nil {
+		t.Fatalf("insert empty-emoji tombstone: %v", err)
+	}
+	if err := insert("non-empty-whitespace", "", "   ", "active"); err == nil {
+		t.Fatal("insert whitespace-only active reaction succeeded, want CHECK constraint error")
+	}
+	for _, test := range []struct {
+		name, emoji, state string
+	}{
+		{name: "active empty", emoji: "", state: "active"},
+		{name: "active over limit", emoji: strings.Repeat("a", 65), state: "active"},
+		{name: "tombstone over limit", emoji: strings.Repeat("a", 65), state: "removed"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := insert("invalid-"+test.name, "", test.emoji, test.state); err == nil {
+				t.Fatal("reaction insert succeeded, want CHECK constraint error")
+			}
+		})
+	}
+	if err := insert("missing-identity", "identity-missing", "👍", "active"); err == nil {
+		t.Fatal("reaction with missing identity succeeded, want foreign-key error")
+	}
+	if _, err := store.db.Exec(`
+		INSERT INTO reactions (
+			message_id, reactor_key, account_id, conversation_id, emoji, state,
+			occurred_at_ms, created_at_ms, updated_at_ms
+		) VALUES (
+			'message-missing', 'missing-message', 'account-reactions',
+			'conversation-reactions', '👍', 'active', ?, ?, ?
+		)
+	`, nowMS, nowMS, nowMS); err == nil {
+		t.Fatal("reaction with missing message succeeded, want foreign-key error")
+	}
+	if _, err := store.db.Exec(`
+		INSERT INTO reactions (
+			message_id, reactor_key, account_id, conversation_id, emoji, state,
+			occurred_at_ms, created_at_ms, updated_at_ms
+		) VALUES (
+			'message-reactions', 'missing-conversation', 'account-reactions',
+			'conversation-missing', '👍', 'active', ?, ?, ?
+		)
+	`, nowMS, nowMS, nowMS); err == nil {
+		t.Fatal("reaction with missing conversation succeeded, want foreign-key error")
+	}
+
+	if _, err := store.db.Exec(`DELETE FROM messages WHERE message_id = 'message-reactions'`); err != nil {
+		t.Fatalf("delete reaction parent message: %v", err)
+	}
+	assertRowCount(t, store.db, "reactions", 0)
+}

--- a/internal/storage/sqlite/reactions_test.go
+++ b/internal/storage/sqlite/reactions_test.go
@@ -1,0 +1,796 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+)
+
+const reactionTestTimeMS int64 = 1_910_000_000_000
+
+func TestNewReactionRepositoryRequiresStoreAndClock(t *testing.T) {
+	if _, err := NewReactionRepository(nil, time.Now); err == nil {
+		t.Fatal("NewReactionRepository(nil store) succeeded")
+	}
+
+	store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+	if _, err := NewReactionRepository(store, nil); err == nil {
+		t.Fatal("NewReactionRepository(nil clock) succeeded")
+	}
+}
+
+func TestApplyReactionAddSwitchRemoveIsIdempotentAndLastWriterWins(t *testing.T) {
+	clock := newMessageTestClock(reactionTestTimeMS)
+	store, repository := openReactionTestRepository(t, clock.Now)
+	seedReactionGraph(t, store, "message-a")
+	seedReactionIdentity(t, store, "identity-alice", "+15550000001")
+
+	apply := ReactionApply{
+		AccountID:         "account-a",
+		ConversationID:    "conversation-a",
+		MessageID:         "message-a",
+		ReactorKey:        "identity-alice",
+		ReactorIdentityID: pointer("identity-alice"),
+		ReactorLabel:      "raw-alice",
+		Emoji:             "👍",
+		Action:            bridge.ReactionAdd,
+		OccurredAtMS:      100,
+		SourceSeqMS:       11,
+	}
+	applied, err := repository.ApplyReaction(context.Background(), apply)
+	if err != nil {
+		t.Fatalf("ApplyReaction(add): %v", err)
+	}
+	if !applied {
+		t.Fatal("ApplyReaction(add) applied = false, want true")
+	}
+	row := readStoredReaction(t, store, apply.MessageID, apply.ReactorKey)
+	if row.Emoji != "👍" || row.State != "active" || row.OccurredAtMS != 100 ||
+		row.SourceSeqMS != 11 || row.CreatedAtMS != reactionTestTimeMS ||
+		row.UpdatedAtMS != reactionTestTimeMS {
+		t.Fatalf("stored add = %+v", row)
+	}
+
+	clock.Set(reactionTestTimeMS + 100)
+	applied, err = repository.ApplyReaction(context.Background(), apply)
+	if err != nil {
+		t.Fatalf("ApplyReaction(duplicate add): %v", err)
+	}
+	if applied {
+		t.Fatal("ApplyReaction(duplicate add) applied = true, want false")
+	}
+	row = readStoredReaction(t, store, apply.MessageID, apply.ReactorKey)
+	if row.UpdatedAtMS != reactionTestTimeMS {
+		t.Fatalf("duplicate add updated_at_ms = %d, want %d", row.UpdatedAtMS, reactionTestTimeMS)
+	}
+
+	clock.Set(reactionTestTimeMS + 200)
+	switchReaction := apply
+	switchReaction.Emoji = "❤️"
+	switchReaction.Action = bridge.ReactionSwitch
+	switchReaction.OccurredAtMS = 200
+	switchReaction.SourceSeqMS = 12
+	applied, err = repository.ApplyReaction(context.Background(), switchReaction)
+	if err != nil {
+		t.Fatalf("ApplyReaction(switch): %v", err)
+	}
+	if !applied {
+		t.Fatal("ApplyReaction(switch) applied = false, want true")
+	}
+	row = readStoredReaction(t, store, apply.MessageID, apply.ReactorKey)
+	if row.Emoji != "❤️" || row.State != "active" || row.OccurredAtMS != 200 ||
+		row.UpdatedAtMS != reactionTestTimeMS+200 {
+		t.Fatalf("stored switch = %+v", row)
+	}
+
+	clock.Set(reactionTestTimeMS + 300)
+	remove := switchReaction
+	remove.Action = bridge.ReactionRemove
+	remove.Emoji = ""
+	remove.OccurredAtMS = 300
+	remove.SourceSeqMS = 13
+	applied, err = repository.ApplyReaction(context.Background(), remove)
+	if err != nil {
+		t.Fatalf("ApplyReaction(remove): %v", err)
+	}
+	if !applied {
+		t.Fatal("ApplyReaction(remove) applied = false, want true")
+	}
+	row = readStoredReaction(t, store, apply.MessageID, apply.ReactorKey)
+	if row.State != "removed" || row.Emoji != "❤️" {
+		t.Fatalf("stored removal state/emoji = (%q, %q), want removed with retained heart", row.State, row.Emoji)
+	}
+	if row.OccurredAtMS != 300 || row.UpdatedAtMS != reactionTestTimeMS+300 {
+		t.Fatalf("stored removal = %+v", row)
+	}
+
+	clock.Set(reactionTestTimeMS + 400)
+	staleAdd := apply
+	staleAdd.Emoji = "😂"
+	staleAdd.OccurredAtMS = 250
+	staleAdd.SourceSeqMS = 99
+	applied, err = repository.ApplyReaction(context.Background(), staleAdd)
+	if err != nil {
+		t.Fatalf("ApplyReaction(stale add): %v", err)
+	}
+	if applied {
+		t.Fatal("ApplyReaction(stale add) applied = true, want false")
+	}
+	row = readStoredReaction(t, store, apply.MessageID, apply.ReactorKey)
+	if row.State != "removed" || row.Emoji != "❤️" || row.OccurredAtMS != 300 {
+		t.Fatalf("row after stale add = %+v, want retained tombstone", row)
+	}
+}
+
+func TestApplyReactionRemoveBeforeAddCreatesEmptyTombstone(t *testing.T) {
+	store, repository := openReactionTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(reactionTestTimeMS) },
+	)
+	seedReactionGraph(t, store, "message-a")
+
+	remove := ReactionApply{
+		AccountID:      "account-a",
+		ConversationID: "conversation-a",
+		MessageID:      "message-a",
+		ReactorKey:     "raw:unknown",
+		ReactorLabel:   "unknown",
+		Action:         bridge.ReactionRemove,
+		OccurredAtMS:   100,
+	}
+	applied, err := repository.ApplyReaction(context.Background(), remove)
+	if err != nil {
+		t.Fatalf("ApplyReaction(remove before add): %v", err)
+	}
+	if !applied {
+		t.Fatal("ApplyReaction(remove before add) applied = false, want true")
+	}
+	row := readStoredReaction(t, store, remove.MessageID, remove.ReactorKey)
+	if row.State != "removed" || row.Emoji != "" {
+		t.Fatalf("remove-before-add row state/emoji = (%q, %q), want (removed, empty)", row.State, row.Emoji)
+	}
+
+	lateAdd := remove
+	lateAdd.Action = bridge.ReactionAdd
+	lateAdd.Emoji = "👍"
+	lateAdd.OccurredAtMS = 50
+	applied, err = repository.ApplyReaction(context.Background(), lateAdd)
+	if err != nil {
+		t.Fatalf("ApplyReaction(late earlier add): %v", err)
+	}
+	if applied {
+		t.Fatal("ApplyReaction(late earlier add) applied = true, want false")
+	}
+	row = readStoredReaction(t, store, remove.MessageID, remove.ReactorKey)
+	if row.State != "removed" || row.Emoji != "" || row.OccurredAtMS != 100 {
+		t.Fatalf("row after late earlier add = %+v, want empty tombstone", row)
+	}
+
+	newAdd := lateAdd
+	newAdd.OccurredAtMS = 101
+	applied, err = repository.ApplyReaction(context.Background(), newAdd)
+	if err != nil {
+		t.Fatalf("ApplyReaction(newer add): %v", err)
+	}
+	if !applied {
+		t.Fatal("ApplyReaction(newer add) applied = false, want true")
+	}
+	row = readStoredReaction(t, store, remove.MessageID, remove.ReactorKey)
+	if row.State != "active" || row.Emoji != "👍" {
+		t.Fatalf("row after newer add = %+v, want active thumbs-up", row)
+	}
+}
+
+func TestApplyReactionRejectsUnsupportedActionAndMapsConstraints(t *testing.T) {
+	store, repository := openReactionTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(reactionTestTimeMS) },
+	)
+	seedReactionGraph(t, store, "message-a")
+
+	base := ReactionApply{
+		AccountID:      "account-a",
+		ConversationID: "conversation-a",
+		MessageID:      "message-a",
+		ReactorKey:     "self",
+		ReactorIsSelf:  true,
+		Emoji:          "👍",
+		OccurredAtMS:   100,
+	}
+	invalid := base
+	invalid.Action = bridge.ReactionAction("toggle")
+	if _, err := repository.ApplyReaction(context.Background(), invalid); err == nil {
+		t.Fatal("ApplyReaction(unsupported action) succeeded")
+	}
+
+	emptyEmoji := base
+	emptyEmoji.Action = bridge.ReactionAdd
+	emptyEmoji.Emoji = ""
+	_, err := repository.ApplyReaction(context.Background(), emptyEmoji)
+	if !errors.Is(err, ErrConstraintViolation) {
+		t.Fatalf("ApplyReaction(empty active emoji) error = %v, want ErrConstraintViolation", err)
+	}
+
+	orphan := base
+	orphan.Action = bridge.ReactionAdd
+	orphan.MessageID = "message-missing"
+	_, err = repository.ApplyReaction(context.Background(), orphan)
+	if !errors.Is(err, ErrConstraintViolation) {
+		t.Fatalf("ApplyReaction(orphan message) error = %v, want ErrConstraintViolation", err)
+	}
+	assertRowCount(t, store.db, "reactions", 0)
+}
+
+func TestReplaceEmbeddedReactionsReconcilesAbsenceAndRejectsStaleSnapshots(t *testing.T) {
+	clock := newMessageTestClock(reactionTestTimeMS)
+	store, repository := openReactionTestRepository(t, clock.Now)
+	seedReactionGraph(t, store, "message-a")
+	seedReactionIdentity(t, store, "identity-alice", "+15550000001")
+	seedReactionIdentity(t, store, "identity-bob", "+15550000002")
+
+	initial := []ReactionSnapshotEntry{
+		{
+			ReactorKey:        "identity-alice",
+			ReactorIdentityID: pointer("identity-alice"),
+			ReactorLabel:      "alice",
+			Emoji:             "👍",
+		},
+		{
+			ReactorKey:        "identity-bob",
+			ReactorIdentityID: pointer("identity-bob"),
+			ReactorLabel:      "bob",
+			Emoji:             "👍",
+		},
+		{
+			ReactorKey:    "self",
+			ReactorIsSelf: true,
+			ReactorLabel:  "me",
+			Emoji:         "❤️",
+		},
+	}
+	changes, err := repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", initial, 1_000,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(initial): %v", err)
+	}
+	if changes.Applied != 3 || changes.Removed != 0 {
+		t.Fatalf("ReplaceEmbeddedReactions(initial) changes = %+v, want applied 3", changes)
+	}
+	assertReactionStates(t, store, "message-a", map[string]storedReaction{
+		"identity-alice": {Emoji: "👍", State: "active", SourceSeqMS: 1_000},
+		"identity-bob":   {Emoji: "👍", State: "active", SourceSeqMS: 1_000},
+		"self":           {Emoji: "❤️", State: "active", SourceSeqMS: 1_000},
+	})
+
+	changes, err = repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", initial, 1_100,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(idempotent replay): %v", err)
+	}
+	if changes != (ReactionSnapshotResult{}) {
+		t.Fatalf("ReplaceEmbeddedReactions(higher-seq identical replay) changes = %+v, want zero", changes)
+	}
+
+	clock.Set(reactionTestTimeMS + 100)
+	current := initial[:1]
+	changes, err = repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", current, 2_000,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(removal by absence): %v", err)
+	}
+	if changes.Applied != 0 || changes.Removed != 2 {
+		t.Fatalf("ReplaceEmbeddedReactions(removal by absence) changes = %+v, want removed 2", changes)
+	}
+	assertReactionStates(t, store, "message-a", map[string]storedReaction{
+		"identity-alice": {Emoji: "👍", State: "active", SourceSeqMS: 2_000},
+		// R1: snapshot tombstones retain the stored emoji for audit.
+		"identity-bob": {Emoji: "👍", State: "removed", SourceSeqMS: 2_000},
+		"self":         {Emoji: "❤️", State: "removed", SourceSeqMS: 2_000},
+	})
+
+	stale := []ReactionSnapshotEntry{
+		{
+			ReactorKey:        "identity-bob",
+			ReactorIdentityID: pointer("identity-bob"),
+			Emoji:             "😂",
+		},
+	}
+	changes, err = repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", stale, 1_500,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(stale): %v", err)
+	}
+	if changes != (ReactionSnapshotResult{}) {
+		t.Fatalf("ReplaceEmbeddedReactions(stale) changes = %+v, want zero", changes)
+	}
+	assertReactionStates(t, store, "message-a", map[string]storedReaction{
+		"identity-alice": {Emoji: "👍", State: "active", SourceSeqMS: 2_000},
+		"identity-bob":   {Emoji: "👍", State: "removed", SourceSeqMS: 2_000},
+		"self":           {Emoji: "❤️", State: "removed", SourceSeqMS: 2_000},
+	})
+}
+
+func TestReplaceEmbeddedReactionsEmptyFirstSnapshotFencesOlderNonEmptySnapshot(t *testing.T) {
+	store, repository := openReactionTestRepository(
+		t, func() time.Time { return time.UnixMilli(reactionTestTimeMS) },
+	)
+	seedReactionGraph(t, store, "message-a")
+
+	changes, err := repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", nil, 200,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(empty seq 200): %v", err)
+	}
+	if changes != (ReactionSnapshotResult{}) {
+		t.Fatalf("ReplaceEmbeddedReactions(empty seq 200) changes = %+v, want zero", changes)
+	}
+
+	changes, err = repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a",
+		[]ReactionSnapshotEntry{{ReactorKey: "self", ReactorIsSelf: true, Emoji: "👍"}}, 100,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(non-empty seq 100): %v", err)
+	}
+	if changes != (ReactionSnapshotResult{}) {
+		t.Fatalf("ReplaceEmbeddedReactions(non-empty seq 100) changes = %+v, want zero", changes)
+	}
+	assertRowCount(t, store.db, "reactions", 0)
+	assertReactionSnapshotFence(t, store, "message-a", 200)
+}
+
+func TestReplaceEmbeddedReactionsNewerEmptySnapshotRejectsOlderReplay(t *testing.T) {
+	store, repository := openReactionTestRepository(
+		t, func() time.Time { return time.UnixMilli(reactionTestTimeMS) },
+	)
+	seedReactionGraph(t, store, "message-a")
+	entries := []ReactionSnapshotEntry{{ReactorKey: "self", ReactorIsSelf: true, Emoji: "👍"}}
+	if _, err := repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", entries, 100,
+	); err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(non-empty seq 100): %v", err)
+	}
+	if _, err := repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", nil, 200,
+	); err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(empty seq 200): %v", err)
+	}
+	row := readStoredReaction(t, store, "message-a", "self")
+	if row.State != "removed" || row.SourceSeqMS != 200 {
+		t.Fatalf("row after empty snapshot = %+v, want removed at seq 200", row)
+	}
+	assertReactionSnapshotFence(t, store, "message-a", 200)
+
+	changes, err := repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", entries, 100,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(older replay): %v", err)
+	}
+	if changes != (ReactionSnapshotResult{}) {
+		t.Fatalf("ReplaceEmbeddedReactions(older replay) changes = %+v, want zero", changes)
+	}
+	row = readStoredReaction(t, store, "message-a", "self")
+	if row.State != "removed" || row.SourceSeqMS != 200 {
+		t.Fatalf("row after older replay = %+v, want retained seq-200 tombstone", row)
+	}
+}
+
+func TestReplaceEmbeddedReactionsRollsBackAtomically(t *testing.T) {
+	store, repository := openReactionTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(reactionTestTimeMS) },
+	)
+	seedReactionGraph(t, store, "message-a")
+	if _, err := repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", nil, 500,
+	); err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(initial fence): %v", err)
+	}
+
+	entries := []ReactionSnapshotEntry{
+		{ReactorKey: "self", ReactorIsSelf: true, Emoji: "👍"},
+		{ReactorKey: "invalid", Emoji: ""},
+	}
+	_, err := repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", entries, 1_000,
+	)
+	if !errors.Is(err, ErrConstraintViolation) {
+		t.Fatalf("ReplaceEmbeddedReactions(invalid entry) error = %v, want ErrConstraintViolation", err)
+	}
+	assertRowCount(t, store.db, "reactions", 0)
+	assertReactionSnapshotFence(t, store, "message-a", 500)
+}
+
+func TestSeedReactionUsesExplicitTransactionAndKeepsFirstRow(t *testing.T) {
+	clock := newMessageTestClock(reactionTestTimeMS)
+	store, repository := openReactionTestRepository(t, clock.Now)
+	seedReactionGraph(t, store, "message-a")
+
+	seed := ReactionApply{
+		AccountID:      "account-a",
+		ConversationID: "conversation-a",
+		MessageID:      "message-a",
+		ReactorKey:     "self",
+		ReactorIsSelf:  true,
+		ReactorLabel:   "me",
+		Emoji:          "👍",
+		// SeedReaction deliberately ignores Action and SourceSeqMS: migration
+		// rows are always active with source_seq_ms=0.
+		Action:       bridge.ReactionRemove,
+		OccurredAtMS: 123,
+		SourceSeqMS:  999,
+	}
+	if err := repository.SeedReaction(context.Background(), nil, seed); err == nil {
+		t.Fatal("SeedReaction(nil transaction) succeeded")
+	}
+
+	tx, err := store.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx(): %v", err)
+	}
+	if err := repository.SeedReaction(context.Background(), tx, seed); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("SeedReaction(first): %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit(): %v", err)
+	}
+
+	clock.Set(reactionTestTimeMS + 100)
+	duplicate := seed
+	duplicate.Emoji = "❤️"
+	duplicate.OccurredAtMS = 456
+	tx, err = store.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx(duplicate): %v", err)
+	}
+	if err := repository.SeedReaction(context.Background(), tx, duplicate); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("SeedReaction(duplicate): %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit(duplicate): %v", err)
+	}
+
+	row := readStoredReaction(t, store, seed.MessageID, seed.ReactorKey)
+	if row.State != "active" || row.Emoji != "👍" || row.OccurredAtMS != 123 ||
+		row.SourceSeqMS != 0 || row.CreatedAtMS != reactionTestTimeMS ||
+		row.UpdatedAtMS != reactionTestTimeMS {
+		t.Fatalf("seeded row = %+v", row)
+	}
+}
+
+func TestReactionsForMessagesReturnsStableActiveRowsForLegacyAggregation(t *testing.T) {
+	store, repository := openReactionTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(reactionTestTimeMS) },
+	)
+	seedReactionGraph(t, store, "message-a")
+	seedReactionMessage(t, store, "message-b")
+	seedReactionIdentity(t, store, "identity-alice", "+15550000001")
+	seedReactionIdentity(t, store, "identity-bob", "+15550000002")
+
+	for _, reaction := range []ReactionApply{
+		{
+			AccountID: "account-a", ConversationID: "conversation-a", MessageID: "message-a",
+			ReactorKey: "identity-bob", ReactorIdentityID: pointer("identity-bob"),
+			ReactorLabel: "bob raw", Emoji: "👍", Action: bridge.ReactionAdd, OccurredAtMS: 100,
+		},
+		{
+			AccountID: "account-a", ConversationID: "conversation-a", MessageID: "message-a",
+			ReactorKey: "identity-alice", ReactorIdentityID: pointer("identity-alice"),
+			ReactorLabel: "alice raw", Emoji: "👍", Action: bridge.ReactionAdd, OccurredAtMS: 100,
+		},
+		{
+			AccountID: "account-a", ConversationID: "conversation-a", MessageID: "message-b",
+			ReactorKey: "self", ReactorIsSelf: true, ReactorLabel: "me",
+			Emoji: "❤️", Action: bridge.ReactionAdd, OccurredAtMS: 200,
+		},
+		{
+			AccountID: "account-a", ConversationID: "conversation-a", MessageID: "message-b",
+			ReactorKey: "raw:mystery", ReactorLabel: "Mystery",
+			Emoji: "❤️", Action: bridge.ReactionAdd, OccurredAtMS: 201,
+		},
+		{
+			AccountID: "account-a", ConversationID: "conversation-a", MessageID: "message-b",
+			ReactorKey: "raw:removed", ReactorLabel: "Removed",
+			Action: bridge.ReactionRemove, OccurredAtMS: 202,
+		},
+	} {
+		if _, err := repository.ApplyReaction(context.Background(), reaction); err != nil {
+			t.Fatalf("ApplyReaction(%s/%s): %v", reaction.MessageID, reaction.ReactorKey, err)
+		}
+	}
+
+	messageIDs := make([]string, 0, reactionMessageQueryBatchSize+4)
+	messageIDs = append(messageIDs, "message-b")
+	for index := 0; index < reactionMessageQueryBatchSize+1; index++ {
+		messageIDs = append(messageIDs, fmt.Sprintf("missing-%04d", index))
+	}
+	messageIDs = append(messageIDs, "message-a", "message-b")
+
+	got, err := repository.ReactionsForMessages(context.Background(), messageIDs)
+	if err != nil {
+		t.Fatalf("ReactionsForMessages(): %v", err)
+	}
+	want := map[string][]ReactionRow{
+		"message-a": {
+			{
+				MessageID: "message-a", Emoji: "👍", ReactorCanonical: "+15550000001",
+				ReactorLabel: "alice raw", OccurredAtMS: 100,
+			},
+			{
+				MessageID: "message-a", Emoji: "👍", ReactorCanonical: "+15550000002",
+				ReactorLabel: "bob raw", OccurredAtMS: 100,
+			},
+		},
+		"message-b": {
+			{
+				MessageID: "message-b", Emoji: "❤️", ReactorIsSelf: true,
+				ReactorLabel: "me", OccurredAtMS: 200,
+			},
+			{
+				MessageID: "message-b", Emoji: "❤️", ReactorLabel: "Mystery",
+				OccurredAtMS: 201,
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ReactionsForMessages() = %#v, want %#v", got, want)
+	}
+
+	again, err := repository.ReactionsForMessages(context.Background(), messageIDs)
+	if err != nil {
+		t.Fatalf("ReactionsForMessages(second call): %v", err)
+	}
+	if !reflect.DeepEqual(again, got) {
+		t.Fatalf("second ReactionsForMessages() = %#v, first %#v", again, got)
+	}
+
+	assertLegacyReactionJSON(t, got["message-a"], `[{"emoji":"👍","count":2,"actors":["+15550000001","+15550000002"]}]`)
+	assertLegacyReactionJSON(t, got["message-b"], `[{"emoji":"❤️","count":2,"actors":["me","Mystery"]}]`)
+
+	empty, err := repository.ReactionsForMessages(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ReactionsForMessages(nil): %v", err)
+	}
+	if empty == nil || len(empty) != 0 {
+		t.Fatalf("ReactionsForMessages(nil) = %#v, want non-nil empty map", empty)
+	}
+}
+
+func TestReactionRowsCascadeWithMessage(t *testing.T) {
+	store, repository := openReactionTestRepository(
+		t,
+		func() time.Time { return time.UnixMilli(reactionTestTimeMS) },
+	)
+	seedReactionGraph(t, store, "message-a")
+	if _, err := repository.ApplyReaction(context.Background(), ReactionApply{
+		AccountID: "account-a", ConversationID: "conversation-a", MessageID: "message-a",
+		ReactorKey: "self", ReactorIsSelf: true, Emoji: "👍",
+		Action: bridge.ReactionAdd, OccurredAtMS: 100,
+	}); err != nil {
+		t.Fatalf("ApplyReaction(): %v", err)
+	}
+	if _, err := repository.ReplaceEmbeddedReactions(
+		context.Background(), "message-a", "account-a", "conversation-a", nil, 200,
+	); err != nil {
+		t.Fatalf("ReplaceEmbeddedReactions(): %v", err)
+	}
+	assertReactionSnapshotFence(t, store, "message-a", 200)
+	if _, err := store.db.Exec(`DELETE FROM messages WHERE message_id = ?`, "message-a"); err != nil {
+		t.Fatalf("delete message: %v", err)
+	}
+	assertRowCount(t, store.db, "reactions", 0)
+	assertRowCount(t, store.db, "reaction_snapshot_fences", 0)
+}
+
+type storedReaction struct {
+	MessageID         string
+	ReactorKey        string
+	ReactorIdentityID *string
+	ReactorIsSelf     bool
+	ReactorLabel      string
+	Emoji             string
+	State             string
+	OccurredAtMS      int64
+	SourceSeqMS       int64
+	CreatedAtMS       int64
+	UpdatedAtMS       int64
+}
+
+func assertReactionSnapshotFence(t *testing.T, store *Store, messageID string, want int64) {
+	t.Helper()
+	var got int64
+	if err := store.db.QueryRow(`
+		SELECT source_seq_ms FROM reaction_snapshot_fences WHERE message_id = ?
+	`, messageID).Scan(&got); err != nil {
+		t.Fatalf("read reaction snapshot fence for %q: %v", messageID, err)
+	}
+	if got != want {
+		t.Fatalf("reaction snapshot fence for %q = %d, want %d", messageID, got, want)
+	}
+}
+
+func openReactionTestRepository(
+	t *testing.T,
+	now func() time.Time,
+) (*Store, *ReactionRepository) {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "store.sqlite3"))
+	if err != nil {
+		t.Fatalf("Open(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close(): %v", err)
+		}
+	})
+	repository, err := NewReactionRepository(store, now)
+	if err != nil {
+		t.Fatalf("NewReactionRepository(): %v", err)
+	}
+	return store, repository
+}
+
+func seedReactionGraph(t *testing.T, store *Store, messageID string) {
+	t.Helper()
+	seedMessageAccount(t, store, "account-a", "signal")
+	seedMessageConversation(t, store, "conversation-a", "account-a")
+	seedReactionMessage(t, store, messageID)
+}
+
+func seedReactionMessage(t *testing.T, store *Store, messageID string) {
+	t.Helper()
+	repository := mustMessageRepository(t, store, reactionTestTimeMS)
+	message := messageTestMessage(
+		messageID,
+		"conversation-a",
+		"account-a",
+		"remote-"+messageID,
+		nil,
+	)
+	if err := repository.ImportMessage(context.Background(), MessageProjection{Message: message}); err != nil {
+		t.Fatalf("seed ImportMessage(%q): %v", messageID, err)
+	}
+}
+
+func seedReactionIdentity(t *testing.T, store *Store, identityID, canonical string) {
+	t.Helper()
+	identity := repositoryTestIdentity(identityID, "account-a", canonical)
+	identity.Kind = IdentityKind("e164")
+	identity.RawValue = canonical
+	mustRepositoryWrite(t, "seed reaction identity", store.UpsertIdentity(identity))
+}
+
+func readStoredReaction(
+	t *testing.T,
+	store *Store,
+	messageID string,
+	reactorKey string,
+) storedReaction {
+	t.Helper()
+	var (
+		row        storedReaction
+		identityID sql.NullString
+	)
+	err := store.db.QueryRow(`
+		SELECT
+			message_id,
+			reactor_key,
+			reactor_identity_id,
+			reactor_is_self,
+			reactor_label,
+			emoji,
+			state,
+			occurred_at_ms,
+			source_seq_ms,
+			created_at_ms,
+			updated_at_ms
+		FROM reactions
+		WHERE message_id = ? AND reactor_key = ?
+	`, messageID, reactorKey).Scan(
+		&row.MessageID,
+		&row.ReactorKey,
+		&identityID,
+		&row.ReactorIsSelf,
+		&row.ReactorLabel,
+		&row.Emoji,
+		&row.State,
+		&row.OccurredAtMS,
+		&row.SourceSeqMS,
+		&row.CreatedAtMS,
+		&row.UpdatedAtMS,
+	)
+	if err != nil {
+		t.Fatalf("read reaction (%q, %q): %v", messageID, reactorKey, err)
+	}
+	if identityID.Valid {
+		row.ReactorIdentityID = pointer(identityID.String)
+	}
+	return row
+}
+
+func assertReactionStates(
+	t *testing.T,
+	store *Store,
+	messageID string,
+	want map[string]storedReaction,
+) {
+	t.Helper()
+	for reactorKey, expected := range want {
+		got := readStoredReaction(t, store, messageID, reactorKey)
+		if got.Emoji != expected.Emoji || got.State != expected.State ||
+			got.SourceSeqMS != expected.SourceSeqMS {
+			t.Fatalf(
+				"reaction %q = {emoji:%q state:%q source_seq:%d}, want {emoji:%q state:%q source_seq:%d}",
+				reactorKey,
+				got.Emoji,
+				got.State,
+				got.SourceSeqMS,
+				expected.Emoji,
+				expected.State,
+				expected.SourceSeqMS,
+			)
+		}
+	}
+	assertRowCount(t, store.db, "reactions", len(want))
+}
+
+type legacyReactionShape struct {
+	Emoji  string   `json:"emoji"`
+	Count  int      `json:"count"`
+	Actors []string `json:"actors,omitempty"`
+}
+
+func assertLegacyReactionJSON(t *testing.T, rows []ReactionRow, want string) {
+	t.Helper()
+	grouped := make([]legacyReactionShape, 0)
+	byEmoji := make(map[string]int)
+	for _, row := range rows {
+		index, exists := byEmoji[row.Emoji]
+		if !exists {
+			index = len(grouped)
+			byEmoji[row.Emoji] = index
+			grouped = append(grouped, legacyReactionShape{Emoji: row.Emoji})
+		}
+		actor := row.ReactorLabel
+		if row.ReactorCanonical != "" {
+			actor = row.ReactorCanonical
+		}
+		if row.ReactorIsSelf {
+			actor = "me"
+		}
+		grouped[index].Count++
+		grouped[index].Actors = append(grouped[index].Actors, actor)
+	}
+	encoded, err := json.Marshal(grouped)
+	if err != nil {
+		t.Fatalf("json.Marshal(legacy reactions): %v", err)
+	}
+	if string(encoded) != want {
+		t.Fatalf("legacy reaction JSON = %s, want %s", encoded, want)
+	}
+}

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -87,6 +87,8 @@ func TestOpenInitializesBlankDatabase(t *testing.T) {
 		"outbox_read_receipts",
 		"people",
 		"person_identities",
+		"reaction_snapshot_fences",
+		"reactions",
 		"read_cursors",
 		"schema_migrations",
 		"store_metadata",

--- a/internal/web/apiv1_test.go
+++ b/internal/web/apiv1_test.go
@@ -107,20 +107,26 @@ func TestStatusReportsV2IngestCounters(t *testing.T) {
 			provider: func() map[string]ingest.CounterSnapshot {
 				return map[string]ingest.CounterSnapshot{
 					"google:primary": {
-						Appended:      7,
-						DecodedEvents: 6,
-						Projected:     5,
-						Quarantined:   1,
+						Appended:          7,
+						DecodedEvents:     6,
+						Projected:         5,
+						ReactionsApplied:  4,
+						ReactionsRemoved:  3,
+						ReactionsOrphaned: 2,
+						Quarantined:       1,
 					},
 				}
 			},
 			wantEnabled: true,
 			wantPerAccount: map[string]ingest.CounterSnapshot{
 				"google:primary": {
-					Appended:      7,
-					DecodedEvents: 6,
-					Projected:     5,
-					Quarantined:   1,
+					Appended:          7,
+					DecodedEvents:     6,
+					Projected:         5,
+					ReactionsApplied:  4,
+					ReactionsRemoved:  3,
+					ReactionsOrphaned: 2,
+					Quarantined:       1,
 				},
 			},
 		},
@@ -131,6 +137,10 @@ func TestStatusReportsV2IngestCounters(t *testing.T) {
 			ts := newV1RecorderHarness(t, APIOptions{V2IngestCounters: test.provider})
 			resp := ts.do(t, httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/status", nil))
 			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			var payload struct {
 				V2Ingest struct {
@@ -138,7 +148,7 @@ func TestStatusReportsV2IngestCounters(t *testing.T) {
 					PerAccount map[string]ingest.CounterSnapshot `json:"per_account"`
 				} `json:"v2_ingest"`
 			}
-			if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			if err := json.Unmarshal(body, &payload); err != nil {
 				t.Fatal(err)
 			}
 			if payload.V2Ingest.Enabled != test.wantEnabled {
@@ -147,7 +157,34 @@ func TestStatusReportsV2IngestCounters(t *testing.T) {
 			if !reflect.DeepEqual(payload.V2Ingest.PerAccount, test.wantPerAccount) {
 				t.Fatalf("v2_ingest.per_account = %#v, want %#v", payload.V2Ingest.PerAccount, test.wantPerAccount)
 			}
+			if test.wantEnabled {
+				assertReactionCounterJSONNames(t, body, "google:primary")
+			}
 		})
+	}
+}
+
+func assertReactionCounterJSONNames(t *testing.T, body []byte, accountID string) {
+	t.Helper()
+	var payload struct {
+		V2Ingest struct {
+			PerAccount map[string]map[string]json.RawMessage `json:"per_account"`
+		} `json:"v2_ingest"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatal(err)
+	}
+	counters, ok := payload.V2Ingest.PerAccount[accountID]
+	if !ok {
+		t.Fatalf("v2_ingest.per_account missing %q", accountID)
+	}
+	for _, key := range []string{"reactions_applied", "reactions_removed", "reactions_orphaned"} {
+		if _, ok := counters[key]; !ok {
+			t.Errorf("v2_ingest.per_account[%q] missing JSON counter %q", accountID, key)
+		}
+	}
+	if _, ok := counters["reactions_dropped"]; ok {
+		t.Errorf("v2_ingest.per_account[%q] retained retired JSON counter %q", accountID, "reactions_dropped")
 	}
 }
 


### PR DESCRIPTION
## Rebuild RR-1 — inbound reactions read model (schema 0010 + two-mode worker apply)

Closes the top behavioral gap at cutover: **5,455 reactions on the real store would vanish** because the ingest worker drops the ReactionEvents the decoders already emit. After RR-1, live reactions accrue durably in the v2 store. Read-model only — send side (0007 outbox_reactions) untouched; migration seeding + DTO serving follow in RR-2.

### Design
- **`reactions`**: one row per (message_id, reactor_key); removals are LWW tombstones, never deletes; removal-with-no-prior inserts an empty-emoji tombstone so it still beats a late-arriving add (resolution R1).
- **`reaction_snapshot_fences`**: per-message monotone fence for Google full-snapshot reconcile (resolution R3). Sol's build correctly stopped on this: deriving the fence from `MAX(source_seq_ms)` over rows means a **first-ever empty snapshot writes no rows**, so a later-arriving *older* snapshot would be accepted and resurrect a removed reaction. Fence upsert + reconcile are one transaction; equal-seq replay stays idempotent; deltas and RR-2 seeds never touch fences.
- **Two apply modes**: WhatsApp/Signal per-reactor deltas (occurred_at_ms LWW) vs Google embedded snapshots (removal-by-absence behind the fence).
- **Signal target fallback**: raw-timestamp miss retries via `v2keys.SignalLocalAlias`, byte-matching how outgoing Signal rows are stored.
- **Google PK repoint**: reactions bind after a post-projection `GetMessageByRemote` lookup because ProjectMessage preserves an optimistic local PK without returning it (pinned by an outgoing-repoint test).
- **Honest counters**: `reactions_applied/removed/orphaned` count *semantic* changes — identical snapshot re-deliveries (every Google status transition) move nothing; removal-by-absence counts as removed. Orphans are counted, never quarantined; out-of-contract frames degrade to skips.

### Review
Opus adversarial review: **SHIP, zero blocking**. All five findings (2 should-fix, 3 nit) fixed with per-fix discriminators: snapshot counters flipped from re-delivery-noise to semantic counts (pre-fix assertions 1→2 / removed=0 now provably fail), Signal empty-emoji non-remove skips instead of quarantining the frame, anon-key correlation limit documented, migration gate now holds `reactions == 0` symmetric with fences (RR-2 flips it to the seeded count), emoji CHECK tightened to `trim()` with worker-side trimming so no writer can trip it.

### Verification
- Independent full `GOWORK=off go test -race ./...` outside the sandbox: **31/31 packages, exit 0** (twice: post-build and post-fixes).
- 0010 checksum `dfab4551335d92045cb895e5b2c781f4f57216bbc428a705fc26bbdd474db0b1` pinned across migration validation, ledger regression, and store table assertions; no stale 9-pins (grepped).
- Scope fence held: no RR-2 seeding/DTO changes, dispatch/outbox untouched, live test passive-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
