### PR TITLE
Seed legacy reactions in migration and serve them from the v2 read path (rebuild RR-2)

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -596,8 +596,11 @@ func writeHumanMigrationReport(writer io.Writer, report migration.Report) {
 		report.Schedule.PendingToOutbox, report.Schedule.PendingMedia,
 		report.Schedule.AmbiguousSending, report.Schedule.SkippedSent,
 		report.Schedule.SkippedCanceled, report.Schedule.SkippedFailed)
-	fmt.Fprintf(writer, "Dropped (counted): reactions=%d transcripts=%d avatars=%d drafts=%d contact_meta(CRM)=%d outgoing_send_keys=%d tabs=%d\n",
-		report.Dropped.ReactionsBearingMessages,
+	fmt.Fprintf(writer, "Reactions: messages=%d seeded_messages=%d seeded_rows=%d malformed=%d unmappable=%d\n",
+		report.Reactions.MessagesWithReactions, report.Reactions.MessagesSeeded,
+		report.Reactions.RowsSeeded, report.Dropped.MalformedReactions,
+		report.Dropped.UnmappableReactions)
+	fmt.Fprintf(writer, "Dropped (counted): transcripts=%d avatars=%d drafts=%d contact_meta(CRM)=%d outgoing_send_keys=%d tabs=%d\n",
 		report.Dropped.TranscriptBearingMessages,
 		report.Dropped.ContactAvatars,
 		report.Dropped.Drafts,

--- a/cmd/r5_backend_it_test.go
+++ b/cmd/r5_backend_it_test.go
@@ -688,8 +688,8 @@ func assertR5IntegrityReport(
 		report.Schedule.SkippedFailed != 0 || report.Schedule.OptimisticOnlyRows != 1 {
 		t.Errorf("schedule report = %+v", report.Schedule)
 	}
-	if report.Dropped.ReactionsBearingMessages != 1 {
-		t.Errorf("reactions-bearing messages = %d, want 1", report.Dropped.ReactionsBearingMessages)
+	if report.Reactions.MessagesWithReactions != 1 || report.Reactions.MessagesSeeded != 1 || report.Reactions.RowsSeeded != 1 {
+		t.Errorf("reaction report = %+v, want one seeded reaction", report.Reactions)
 	}
 	if report.ReadState.ConversationsWithUnreadCount != 1 || report.ReadState.LossyWarning == "" {
 		t.Errorf("read-state report = %+v", report.ReadState)
@@ -800,6 +800,9 @@ func assertR5ReadParity(t *testing.T, reads *v2read.Source, fixture r5LegacyFixt
 			)
 			if got.MessageID != wantMessageID {
 				t.Errorf("message ID mapping %q = %q, want %q", expected.LegacyID, got.MessageID, wantMessageID)
+			}
+			if expected.LegacyID == "google-r5-empty-source" && got.Reactions != `[{"emoji":"👍","count":1}]` {
+				t.Errorf("message reaction parity %q = %q", expected.LegacyID, got.Reactions)
 			}
 			if !expected.FromMe && (got.SenderNumber != expected.SenderValue || got.SenderName != expected.SenderName) {
 				t.Errorf("message sender parity %q = %q/%q, want %q/%q",

--- a/internal/ingest/signaldecoder_test.go
+++ b/internal/ingest/signaldecoder_test.go
@@ -743,6 +743,84 @@ func TestSignalReactionDeltasResolveLocalAliasAndSelfEchoIdempotently(t *testing
 	}
 }
 
+func TestSignalMigratedReactionsConvergeWithLiveDecoderAndWorker(t *testing.T) {
+	const (
+		e164Actor  = "+15551234567"
+		aciActor   = "11111111-2222-3333-4444-555555555555"
+		e164Target = "1700000000999"
+		aciTarget  = "1700000001999"
+	)
+	root := t.TempDir()
+	legacyPath := filepath.Join(root, "legacy.sqlite3")
+	legacy, err := legacydb.New(legacyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, conversation := range []*legacydb.Conversation{
+		{ConversationID: "signal:" + e164Actor, Name: "E164", Participants: `[]`, LastMessageTS: 1_700_000_001_999, SourcePlatform: "signal"},
+		{ConversationID: "signal:" + aciActor, Name: "ACI", Participants: `[]`, LastMessageTS: 1_700_000_002_999, SourcePlatform: "signal"},
+	} {
+		if err := legacy.UpsertConversation(conversation); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, message := range []*legacydb.Message{
+		{MessageID: "signal:" + e164Target, ConversationID: "signal:" + e164Actor, SenderName: "Me", SenderNumber: signalSelf, Body: "E164 target", TimestampMS: 1_700_000_000_999, IsFromMe: true, SourcePlatform: "signal", Reactions: `[{"emoji":"👍","count":1,"actors":["` + e164Actor + `"]}]`},
+		{MessageID: "signal:" + aciTarget, ConversationID: "signal:" + aciActor, SenderName: "Me", SenderNumber: signalSelf, Body: "ACI target", TimestampMS: 1_700_000_001_999, IsFromMe: true, SourcePlatform: "signal", Reactions: `[{"emoji":"🔥","count":1,"actors":["` + aciActor + `"]}]`},
+	} {
+		if err := legacy.UpsertMessage(message); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	staged := filepath.Join(root, "staged.sqlite3")
+	report, err := migration.Transform(context.Background(), migration.Options{SourcePath: legacyPath, TempStorePath: staged, TempBlobPath: filepath.Join(root, "blobs"), TargetPath: filepath.Join(root, "target"), TargetStorePath: filepath.Join(root, "target", "store.sqlite3"), Check: true})
+	if err != nil {
+		t.Fatalf("migration.Transform(): %v (report=%+v)", err, report)
+	}
+	store, err := sqlite.Open(staged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close store: %v", err)
+		}
+	})
+	messages, err := sqlite.NewMessageRepository(store, func() time.Time { return signalDecoderReceivedAt })
+	if err != nil {
+		t.Fatal(err)
+	}
+	harness := newSignalWorkerHarnessForStore(t, staged, store, messages)
+	harness.start(t)
+
+	keyFor := func(kind, canonical string) string {
+		return v2keys.DeriveID("identity", signalDecoderAccountID, kind+"\x1f"+canonical)
+	}
+	e164Key, aciKey := keyFor("e164", e164Actor), keyFor("signal_aci", aciActor)
+	messageID := func(conversation, remote string) string {
+		return v2keys.DeriveID("message", signalDecoderAccountID, conversation+"\x1f"+remote)
+	}
+	aciMessageID := messageID("signal:"+aciActor, aciTarget)
+	assertReactionDBRow(t, staged, messageID("signal:"+e164Actor, e164Target), e164Key, 0, "", "👍", 1)
+	assertReactionDBRow(t, staged, aciMessageID, aciKey, 0, "", "🔥", 1)
+
+	for label, line := range map[string]string{
+		"e164": `{"account":"+15551230000","envelope":{"sourceNumber":"+15551234567","sourceName":"Taylor","timestamp":1700000003123,"dataMessage":{"timestamp":1700000003123,"reaction":{"emoji":"❤️","target":{"timestamp":1700000000999,"authorNumber":"+15551230000"}}}}}`,
+		"aci":  `{"account":"+15551230000","envelope":{"sourceServiceId":"11111111-2222-3333-4444-555555555555","sourceName":"ACI Taylor","timestamp":1700000004123,"dataMessage":{"timestamp":1700000004123,"reaction":{"emoji":"😂","target":{"timestamp":1700000001999,"authorNumber":"+15551230000"}}}}}`,
+	} {
+		if err := harness.sink.AppendIngress(context.Background(), mustBuildSignalRecord(t, []byte(line))); err != nil {
+			t.Fatalf("AppendIngress(%s): %v", label, err)
+		}
+	}
+	waitSignalCondition(t, "migrated Signal reactions applied", func() bool { return harness.counters.Snapshot(signalDecoderAccountID).ReactionsApplied == 2 })
+	assertReactionDBRow(t, staged, messageID("signal:"+e164Actor, e164Target), e164Key, 0, "", "❤️", 1)
+	assertReactionDBRow(t, staged, aciMessageID, aciKey, 0, "", "😂", 1)
+}
+
 func TestSignalMigrationOutputConvergesWithLiveDecoder(t *testing.T) {
 	const (
 		remoteConversationID = "signal:+16505550100"

--- a/internal/ingest/whatsappdecoder_test.go
+++ b/internal/ingest/whatsappdecoder_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"path/filepath"
@@ -20,7 +21,10 @@ import (
 
 	"github.com/maxghenis/openmessage/internal/bridge"
 	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
+	legacydb "github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/migration"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2keys"
 )
 
 const (
@@ -619,6 +623,116 @@ func TestWhatsAppReactionDeltasApplySwitchRemoveAndOrphanThroughWorker(t *testin
 	i01AssertNoPending(t, harness.messages)
 }
 
+func TestWhatsAppMigratedReactionsConvergeWithLiveDecoderAndWorker(t *testing.T) {
+	const (
+		accountID          = "whatsapp-primary"
+		conversationRemote = "whatsapp:" + waCanonicalChatJID
+		contactTarget      = "wa-contact-target"
+		selfTarget         = "wa-self-target"
+		ownJID             = "14155550300@s.whatsapp.net"
+	)
+	root := t.TempDir()
+	legacyPath := filepath.Join(root, "legacy.sqlite3")
+	legacy, err := legacydb.New(legacyPath)
+	if err != nil {
+		t.Fatalf("legacydb.New(): %v", err)
+	}
+	if err := legacy.UpsertConversation(&legacydb.Conversation{ConversationID: conversationRemote, Name: "WA convergence", Participants: `[]`, LastMessageTS: waTimestampMS, SourcePlatform: "whatsapp"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, message := range []*legacydb.Message{
+		{MessageID: "whatsapp:" + contactTarget, ConversationID: conversationRemote, SenderName: "Grace", SenderNumber: waSenderJID, Body: "contact target", TimestampMS: waTimestampMS, SourcePlatform: "whatsapp", Reactions: `[{"emoji":"👍","count":1,"actors":["` + waSenderJID + `"]}]`},
+		{MessageID: "whatsapp:" + selfTarget, ConversationID: conversationRemote, SenderName: "Grace", SenderNumber: waSenderJID, Body: "self target", TimestampMS: waTimestampMS + 1, SourcePlatform: "whatsapp", Reactions: `[{"emoji":"🔥","count":1,"actors":["` + ownJID + `"]}]`},
+		{MessageID: "whatsapp:own-number-evidence", ConversationID: conversationRemote, SenderName: "Me", SenderNumber: "+14155550300", Body: "own number evidence", TimestampMS: waTimestampMS - 1, IsFromMe: true, SourcePlatform: "whatsapp"},
+	} {
+		if err := legacy.UpsertMessage(message); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	staged := filepath.Join(root, "staged.sqlite3")
+	report, err := migration.Transform(context.Background(), migration.Options{SourcePath: legacyPath, TempStorePath: staged, TempBlobPath: filepath.Join(root, "blobs"), TargetPath: filepath.Join(root, "target"), TargetStorePath: filepath.Join(root, "target", "store.sqlite3"), Check: true})
+	if err != nil {
+		t.Fatalf("migration.Transform(): %v (report=%+v)", err, report)
+	}
+	store, err := sqlite.Open(staged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close store: %v", err)
+		}
+	})
+	messages, err := sqlite.NewMessageRepository(store, func() time.Time { return waWorkerNow })
+	if err != nil {
+		t.Fatal(err)
+	}
+	harness := newWhatsAppWorkerHarnessForStore(t, staged, store, messages)
+
+	conversation, err := store.GetConversationByRemote(accountID, conversationRemote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	messageID := func(remote string) string {
+		return v2keys.DeriveID("message", accountID, conversationRemote+"\x1f"+remote)
+	}
+	contactKey := v2keys.DeriveID("identity", accountID, "e164\x1f+14155550200")
+	assertReactionDBRow(t, staged, messageID(contactTarget), contactKey, 0, "", "👍", 1)
+	assertReactionDBRow(t, staged, messageID(selfTarget), "self", 1, "me", "🔥", 1)
+
+	appendReaction := func(label, target, emoji, sender string, fromMe bool, at int64) {
+		envelope := waBaseMessageEnvelope()
+		envelope.ChatJID, envelope.SenderJID, envelope.MessageID = waCanonicalChatJID, sender, "migration-reaction-"+label
+		envelope.TimestampMS, envelope.IsFromMe = at, fromMe
+		record, bytes := waMessageRecord(t, envelope, &waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{Key: &waCommon.MessageKey{ID: proto.String(target)}, Text: proto.String(emoji)}})
+		record.AccountID, record.DedupeKey, record.ReceivedAt = accountID, "migration-reaction:"+label+":"+waHash8(bytes), waWorkerNow
+		if err := harness.sink.AppendIngress(context.Background(), record); err != nil {
+			t.Fatal(err)
+		}
+	}
+	appendReaction("contact", contactTarget, "❤️", waSenderJID, false, waTimestampMS+100)
+	appendReaction("self", selfTarget, "😂", ownJID, true, waTimestampMS+101)
+	i01WaitFor(t, "migrated WhatsApp reactions applied", func() bool { return harness.counters.Snapshot(accountID).ReactionsApplied == 2 })
+	assertReactionDBRow(t, staged, messageID(contactTarget), contactKey, 0, "", "❤️", 1)
+	assertReactionDBRow(t, staged, messageID(selfTarget), "self", 1, "me", "😂", 1)
+	_ = conversation
+}
+
+func assertReactionDBRow(t *testing.T, path, messageID, key string, isSelf int, label, emoji string, count int) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var gotCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM reactions WHERE message_id = ? AND reactor_key = ?`, messageID, key).Scan(&gotCount); err != nil {
+		t.Fatal(err)
+	}
+	if gotCount != count {
+		t.Fatalf("reaction (%s, %s) rows = %d, want %d", messageID, key, gotCount, count)
+	}
+	var total int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM reactions WHERE message_id = ?`, messageID).Scan(&total); err != nil {
+		t.Fatal(err)
+	}
+	if total != count {
+		t.Fatalf("all reaction rows for message %s = %d, want exactly %d converged row", messageID, total, count)
+	}
+	var gotSelf int
+	var gotLabel, gotEmoji string
+	if err := db.QueryRow(`SELECT reactor_is_self, reactor_label, emoji FROM reactions WHERE message_id = ? AND reactor_key = ?`, messageID, key).Scan(&gotSelf, &gotLabel, &gotEmoji); err != nil {
+		t.Fatal(err)
+	}
+	if gotSelf != isSelf || gotLabel != label || gotEmoji != emoji {
+		t.Fatalf("reaction row = self=%d label=%q emoji=%q, want %d/%q/%q", gotSelf, gotLabel, gotEmoji, isSelf, label, emoji)
+	}
+}
+
 func TestWhatsAppIngressDedupeUsesMessageIDAndProtoHash(t *testing.T) {
 	harness := newWhatsAppWorkerHarness(t)
 	envelope := waBaseMessageEnvelope()
@@ -780,6 +894,12 @@ func newWhatsAppWorkerHarness(t *testing.T) *whatsAppWorkerHarness {
 	if err != nil {
 		t.Fatalf("NewMessageRepository(): %v", err)
 	}
+	return newWhatsAppWorkerHarnessForStore(t, path, store, messages)
+}
+
+func newWhatsAppWorkerHarnessForStore(t *testing.T, path string, store *sqlite.Store, messages *sqlite.MessageRepository) *whatsAppWorkerHarness {
+	t.Helper()
+	now := func() time.Time { return waWorkerNow }
 	reactions, err := sqlite.NewReactionRepository(store, now)
 	if err != nil {
 		t.Fatalf("NewReactionRepository(): %v", err)

--- a/internal/migration/degenerate_rows_test.go
+++ b/internal/migration/degenerate_rows_test.go
@@ -43,6 +43,9 @@ func TestTransformDropsDegenerateLegacyRowsWithCounts(t *testing.T) {
 	// Message with a valid id but a non-positive timestamp.
 	exec(`INSERT INTO messages (message_id, conversation_id, body, timestamp_ms, source_platform)
 	      VALUES ('degenerate-zero-ts', 'sms-conversation', 'no time', 0, 'sms')`)
+	// A malformed reactions payload degrades only reactions; its message moves.
+	exec(`INSERT INTO messages (message_id, conversation_id, body, timestamp_ms, source_platform, reactions)
+	      VALUES ('degenerate-bad-reactions', 'sms-conversation', 'valid message', ?, 'sms', '{oops')`, fixtureBaseMS+51_500)
 	// Conversation with empty-string participants (must migrate, no roster,
 	// silently) and one with malformed participants JSON (must migrate,
 	// counted).
@@ -71,7 +74,8 @@ func TestTransformDropsDegenerateLegacyRowsWithCounts(t *testing.T) {
 	dropped := report.Dropped
 	if dropped.MalformedMessages != 1 || dropped.OrphanedMessages != 1 ||
 		dropped.PlatformMismatchMessages != 1 || dropped.NonPositiveTimestampMessages != 1 ||
-		dropped.MalformedParticipants != 1 || dropped.UnmappableUnifiedContacts != 1 {
+		dropped.MalformedParticipants != 1 || dropped.UnmappableUnifiedContacts != 1 ||
+		dropped.MalformedReactions != 1 {
 		t.Fatalf("dropped dimensions = %+v, want exactly one of each degenerate class", dropped)
 	}
 
@@ -94,6 +98,7 @@ func TestTransformDropsDegenerateLegacyRowsWithCounts(t *testing.T) {
 		"non-positive timestamp",
 		"unparseable participants",
 		"unmappable identifiers",
+		"malformed reactions JSON",
 	} {
 		if !strings.Contains(warned, fragment) {
 			t.Fatalf("warnings missing %q:\n%s", fragment, warned)

--- a/internal/migration/reaction_planner_test.go
+++ b/internal/migration/reaction_planner_test.go
@@ -1,0 +1,79 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/v2keys"
+)
+
+func TestPlanLegacyReactionsNormalizesPlatformActorsAndSelf(t *testing.T) {
+	wa := platformAccounts["whatsapp"]
+	signal := platformAccounts["signal"]
+	state := reactionPlannerState(map[string]accountSpec{"wa": wa, "signal": signal})
+	dataset := legacyDataset{messages: []legacyMessage{
+		{ID: "own-wa", ConversationID: "wa", Platform: "whatsapp", SenderNumber: "+16506303657", IsFromMe: true, TimestampMS: 100},
+		{ID: "wa-contact", ConversationID: "wa", Platform: "whatsapp", Reactions: `[{"emoji":"👍","count":1,"actors":["14155550200@s.whatsapp.net"]}]`, TimestampMS: 200},
+		{ID: "wa-self", ConversationID: "wa", Platform: "whatsapp", Reactions: `[{"emoji":"🔥","count":1,"actors":["16506303657@s.whatsapp.net"]}]`, TimestampMS: 300},
+		{ID: "signal-aci", ConversationID: "signal", Platform: "signal", Reactions: `[{"emoji":"❤️","count":1,"actors":["AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"]}]`, TimestampMS: 400},
+		{ID: "signal-e164", ConversationID: "signal", Platform: "signal", Reactions: `[{"emoji":"😂","count":1,"actors":["+15551234567"]}]`, TimestampMS: 500},
+	}}
+	report := &Report{}
+	planLegacyReactions(dataset, state, report)
+	if len(state.reactions) != 4 {
+		t.Fatalf("rows = %d, want 4", len(state.reactions))
+	}
+	waID := v2keys.DeriveID("identity", wa.AccountID, "e164\x1f+14155550200")
+	aciID := v2keys.DeriveID("identity", signal.AccountID, "signal_aci\x1faaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	signalID := v2keys.DeriveID("identity", signal.AccountID, "e164\x1f+15551234567")
+	want := []struct {
+		key, label string
+		self       bool
+	}{{waID, "", false}, {"self", "me", true}, {aciID, "", false}, {signalID, "", false}}
+	for index, expected := range want {
+		row := state.reactions[index].Row
+		if row.ReactorKey != expected.key || row.ReactorLabel != expected.label || row.ReactorIsSelf != expected.self {
+			t.Errorf("row %d = key %q label %q self %v, want %+v", index, row.ReactorKey, row.ReactorLabel, row.ReactorIsSelf, expected)
+		}
+	}
+}
+
+func TestPlanLegacyReactionDegradationsAndOrdering(t *testing.T) {
+	state := reactionPlannerState(map[string]accountSpec{"sms": platformAccounts["sms"]})
+	dataset := legacyDataset{messages: []legacyMessage{{ID: "m", ConversationID: "sms", Platform: "sms", TimestampMS: 100,
+		Reactions: `[{"emoji":"🔥","count":3},{"emoji":"👍","count":3,"actors":["+1","+2"]},{"emoji":"❤️","count":1,"actors":["+3"]}]`}}}
+	report := &Report{}
+	planLegacyReactions(dataset, state, report)
+	if report.Reactions.ActorlessCountCollapsed != 2 || report.Reactions.ActorCountSurplusDropped != 1 || report.Reactions.RowsPlannable != 4 {
+		t.Fatalf("reaction accounting = %+v", report.Reactions)
+	}
+	if len(state.reactions) != 4 {
+		t.Fatalf("rows = %d, want 4", len(state.reactions))
+	}
+	wantTimes := []int64{100, 101, 101, 102}
+	for i, want := range wantTimes {
+		if state.reactions[i].Row.OccurredAtMS != want {
+			t.Errorf("row %d time = %d, want %d", i, state.reactions[i].Row.OccurredAtMS, want)
+		}
+	}
+}
+
+func TestPlanLegacyReactionMalformedAndUnmappableBranches(t *testing.T) {
+	state := reactionPlannerState(map[string]accountSpec{"sms": platformAccounts["sms"]})
+	dataset := legacyDataset{messages: []legacyMessage{
+		{ID: "empty", ConversationID: "sms", Platform: "sms", TimestampMS: 100, Reactions: `[{"emoji":" ","count":1}]`},
+		{ID: "bad-identity", ConversationID: "sms", Platform: "sms", TimestampMS: 101, Reactions: `[{"emoji":"🔥","count":1,"actors":["+"]}]`},
+	}}
+	report := &Report{}
+	planLegacyReactions(dataset, state, report)
+	if report.Dropped.MalformedReactions != 1 || report.Dropped.UnmappableReactions != 1 || len(state.reactions) != 0 {
+		t.Fatalf("report/state = %+v / %d rows", report.Dropped, len(state.reactions))
+	}
+}
+
+func reactionPlannerState(conversations map[string]accountSpec) *transformState {
+	plans := map[string]*conversationPlan{}
+	for id, account := range conversations {
+		plans[id] = &conversationPlan{Account: account, V2ID: "v2-" + id}
+	}
+	return &transformState{accounts: map[string]accountSpec{}, identities: map[identityKey]*identityCandidate{}, conversations: plans}
+}

--- a/internal/migration/report.go
+++ b/internal/migration/report.go
@@ -34,6 +34,7 @@ type Report struct {
 	Identities        IdentityReport                    `json:"identities"`
 	Schedule          ScheduleReport                    `json:"schedule"`
 	ReadState         ReadStateReport                   `json:"read_state"`
+	Reactions         ReactionReport                    `json:"reactions"`
 	Dropped           DroppedDimensions                 `json:"dropped_dimensions"`
 	SignalLocalRows   int64                             `json:"signal_local_rows"`
 	Media             MediaReport                       `json:"media"`
@@ -41,6 +42,18 @@ type Report struct {
 	SampledHashes     []SampledHash                     `json:"sampled_hashes"`
 	Validation        ValidationReport                  `json:"validation"`
 	Warnings          []string                          `json:"warnings"`
+}
+
+type ReactionReport struct {
+	MessagesWithReactions     int64 `json:"messages_with_reactions"`
+	MessagesSeeded            int64 `json:"messages_seeded"`
+	MessagesFullyDeduplicated int64 `json:"messages_fully_deduplicated"`
+	RowsPlannable             int64 `json:"rows_plannable"`
+	RowsSeeded                int64 `json:"rows_seeded"`
+	ActorlessCountCollapsed   int64 `json:"actorless_count_collapsed"`
+	ActorCountSurplusDropped  int64 `json:"actor_count_surplus_dropped"`
+	DuplicateRowsDropped      int64 `json:"duplicate_rows_dropped"`
+	SeedConflicts             int64 `json:"seed_conflicts"`
 }
 
 type SourceReport struct {
@@ -153,6 +166,13 @@ type DroppedDimensions struct {
 	// UnmappableUnifiedContacts counts unified contacts whose identifiers were
 	// empty or not the expected JSON array; dropped with a count.
 	UnmappableUnifiedContacts int64 `json:"unmappable_unified_contacts"`
+	// MalformedReactions counts reaction-bearing messages whose JSON could not
+	// be decoded or contained no usable emoji entries. The message still moves.
+	MalformedReactions int64 `json:"malformed_reactions"`
+	// UnmappableReactions counts reaction-bearing messages with reactor tokens
+	// that cannot be converted to the platform's live-ingest identity key.
+	UnmappableReactions               int64 `json:"unmappable_reactions"`
+	ReactionMessagesDroppedWithParent int64 `json:"reaction_messages_dropped_with_parent"`
 }
 
 type MediaReport struct {

--- a/internal/migration/source.go
+++ b/internal/migration/source.go
@@ -89,13 +89,14 @@ type legacyDataset struct {
 	unified       []legacyUnifiedContact
 	scheduled     []legacyScheduledMessage
 
-	tableCounts      map[string]int64
-	scheduleByStatus map[string]int64
-	platformMessages map[string]int64
-	dropped          DroppedDimensions
-	signalLocalRows  int64
-	unreadRows       int64
-	mediaRows        int64
+	tableCounts              map[string]int64
+	scheduleByStatus         map[string]int64
+	platformMessages         map[string]int64
+	dropped                  DroppedDimensions
+	signalLocalRows          int64
+	unreadRows               int64
+	mediaRows                int64
+	reactionsBearingMessages int64
 }
 
 var requiredLegacyColumns = map[string][]string{
@@ -290,7 +291,7 @@ func loadLegacyRows(ctx context.Context, database *sql.DB, dataset *legacyDatase
 		if strings.TrimSpace(row.Reactions) != "" &&
 			strings.TrimSpace(row.Reactions) != "null" &&
 			strings.TrimSpace(row.Reactions) != "[]" {
-			dataset.dropped.ReactionsBearingMessages++
+			dataset.reactionsBearingMessages++
 		}
 		if strings.TrimSpace(row.Transcript) != "" || row.TranscribedAtMS != 0 ||
 			strings.TrimSpace(row.TranscriptModel) != "" {
@@ -422,6 +423,10 @@ func validateLegacyRelationships(dataset *legacyDataset) error {
 	// (legacy raw = kept + dropped, with the drop reported separately).
 	dropMessage := func(message legacyMessage, counter *int64) {
 		*counter++
+		rawReactions := strings.TrimSpace(message.Reactions)
+		if rawReactions != "" && rawReactions != "null" && rawReactions != "[]" {
+			dataset.dropped.ReactionMessagesDroppedWithParent++
+		}
 		dataset.platformMessages[normalizeLegacyPlatform(message.Platform)]--
 		if strings.TrimSpace(message.MediaID) != "" {
 			dataset.mediaRows--

--- a/internal/migration/transform.go
+++ b/internal/migration/transform.go
@@ -119,6 +119,10 @@ type expectedMessage struct {
 	MediaID  string
 }
 
+type reactionPlan struct {
+	Row sqlite.ReactionApply
+}
+
 type scheduledBlob struct {
 	OutboxID string
 	Ref      blob.BlobRef
@@ -141,6 +145,7 @@ type transformState struct {
 	expectedCursors           int64
 	expectedPendingMedia      int64
 	scheduledBlobs            []scheduledBlob
+	reactions                 []reactionPlan
 }
 
 // Transform creates and validates a complete staged v2 store using only
@@ -195,6 +200,7 @@ func Transform(ctx context.Context, options Options) (report Report, returnErr e
 		return report, err
 	}
 	report.Dropped = dataset.dropped
+	report.Reactions.MessagesWithReactions = dataset.reactionsBearingMessages
 	report.SignalLocalRows = dataset.signalLocalRows
 	report.ReadState = ReadStateReport{
 		LossyWarning:                 "legacy read state was lossy",
@@ -207,11 +213,6 @@ func Transform(ctx context.Context, options Options) (report Report, returnErr e
 	if err != nil {
 		return report, fmt.Errorf("%w: plan transform: %v", ErrSource, err)
 	}
-	// Warnings render after planning: buildTransformState contributes dropped
-	// dimensions of its own (for example unparseable participant rosters), and
-	// a warning pass before it would silently omit them.
-	appendRequiredWarnings(&report)
-
 	target, err := sqlite.Open(options.TempStorePath)
 	if err != nil {
 		return report, fmt.Errorf("%w: initialize merged v2 schema: %v", ErrTransform, err)
@@ -235,6 +236,10 @@ func Transform(ctx context.Context, options Options) (report Report, returnErr e
 	if err != nil {
 		return report, fmt.Errorf("%w: initialize message importer: %v", ErrTransform, err)
 	}
+	reactionRepository, err := sqlite.NewReactionRepository(target, now)
+	if err != nil {
+		return report, fmt.Errorf("%w: initialize reaction importer: %v", ErrTransform, err)
+	}
 	outboxRepository, err := sqlite.NewOutboxRepository(target, now)
 	if err != nil {
 		return report, fmt.Errorf("%w: initialize outbox importer: %v", ErrTransform, err)
@@ -255,6 +260,12 @@ func Transform(ctx context.Context, options Options) (report Report, returnErr e
 	if err := writeHistory(ctx, messageRepository, dataset, state, &clockMS, &report); err != nil {
 		return report, fmt.Errorf("%w: %v", ErrTransform, err)
 	}
+	if err := writeReactions(ctx, reactionRepository, state, &report); err != nil {
+		return report, fmt.Errorf("%w: %v", ErrTransform, err)
+	}
+	// Warnings render after reaction planning and writing, which contribute
+	// degradation counters just like participant planning does.
+	appendRequiredWarnings(&report)
 	if err := writeScheduled(
 		ctx, messageRepository, outboxRepository, blobs, dataset, state, &clockMS, &report,
 	); err != nil {
@@ -360,6 +371,8 @@ func buildTransformState(dataset legacyDataset, report *Report) (*transformState
 		}
 	}
 
+	planLegacyReactions(dataset, state, report)
+
 	if len(dataset.contacts) > 0 {
 		account, _ := accountForPlatform("sms")
 		state.accounts[account.Platform] = account
@@ -422,6 +435,173 @@ func buildTransformState(dataset legacyDataset, report *Report) (*transformState
 		state.unified = append(state.unified, plan)
 	}
 	return state, nil
+}
+
+type legacyReaction struct {
+	Emoji  string   `json:"emoji"`
+	Count  int      `json:"count"`
+	Actors []string `json:"actors,omitempty"`
+}
+
+func planLegacyReactions(dataset legacyDataset, state *transformState, report *Report) {
+	ownNumbers := map[string]map[string]struct{}{}
+	for _, message := range dataset.messages {
+		platform, number := normalizeLegacyPlatform(message.Platform), strings.TrimSpace(message.SenderNumber)
+		if message.IsFromMe && isE164(number) {
+			if ownNumbers[platform] == nil {
+				ownNumbers[platform] = map[string]struct{}{}
+			}
+			ownNumbers[platform][number] = struct{}{}
+		}
+	}
+	for _, message := range dataset.messages {
+		raw := strings.TrimSpace(message.Reactions)
+		if raw == "" || raw == "null" || raw == "[]" {
+			continue
+		}
+		var entries []legacyReaction
+		if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+			report.Dropped.MalformedReactions++
+			continue
+		}
+		conversation := state.conversations[message.ConversationID]
+		if conversation == nil {
+			continue
+		}
+		messageID := v2keys.DeriveID("message", conversation.Account.AccountID,
+			message.ConversationID+"\x1f"+deriveRemoteMessageID(message))
+		seen := map[string]struct{}{}
+		messageMalformed, messageUnmappable := false, false
+		before := len(state.reactions)
+		for entryIndex, entry := range entries {
+			emoji := strings.TrimSpace(entry.Emoji)
+			if emoji == "" {
+				messageMalformed = true
+				continue
+			}
+			actors := entry.Actors
+			if len(actors) == 0 && entry.Count > 0 {
+				actors = []string{""}
+				report.Reactions.ActorlessCountCollapsed += int64(max(entry.Count-1, 0))
+			}
+			report.Reactions.RowsPlannable += int64(len(actors))
+			if len(entry.Actors) > 0 && entry.Count > len(entry.Actors) {
+				report.Reactions.ActorCountSurplusDropped += int64(entry.Count - len(entry.Actors))
+			}
+			for _, actor := range actors {
+				actor = strings.TrimSpace(actor)
+				row := sqlite.ReactionApply{
+					AccountID: conversation.Account.AccountID, ConversationID: conversation.V2ID,
+					MessageID: messageID, Emoji: emoji, OccurredAtMS: message.TimestampMS + int64(entryIndex),
+				}
+				platform := conversation.Account.Platform
+				normalizedActor := normalizeLegacyReactionActor(platform, actor)
+				switch {
+				case strings.EqualFold(actor, "me") || isOwnReactionActor(platform, actor, normalizedActor, ownNumbers[platform]):
+					row.ReactorKey, row.ReactorIsSelf, row.ReactorLabel = "self", true, "me"
+				case actor == "":
+					row.ReactorKey = "anon:" + emoji
+				default:
+					// Live ingest resolves non-self Google participant numbers and
+					// WhatsApp/Signal actor tokens through this exact IdentityKey path;
+					// using it here makes a post-cutover frame hit the seeded PK.
+					key, err := addIdentity(state, conversation.Account, normalizedActor, "", false, 5)
+					if err != nil {
+						messageUnmappable = true
+						continue
+					}
+					id := identityID(key)
+					row.ReactorKey, row.ReactorIdentityID, row.ReactorLabel = id, &id, ""
+				}
+				if _, exists := seen[row.ReactorKey]; exists {
+					report.Reactions.DuplicateRowsDropped++
+					continue
+				}
+				seen[row.ReactorKey] = struct{}{}
+				state.reactions = append(state.reactions, reactionPlan{Row: row})
+			}
+		}
+		if messageMalformed {
+			report.Dropped.MalformedReactions++
+		}
+		if messageUnmappable {
+			report.Dropped.UnmappableReactions++
+		}
+		if len(state.reactions) > before {
+			report.Reactions.MessagesSeeded++
+			report.Reactions.RowsSeeded += int64(len(state.reactions) - before)
+		} else if !messageMalformed && !messageUnmappable {
+			report.Reactions.MessagesFullyDeduplicated++
+		}
+	}
+}
+
+func isE164(value string) bool {
+	if len(value) < 2 || value[0] != '+' {
+		return false
+	}
+	for _, char := range value[1:] {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeLegacyReactionActor(platform, actor string) string {
+	actor = strings.TrimSpace(actor)
+	// Cross-reference whatsAppIdentity in whatsappdecoder.go: canonical user
+	// JIDs become E.164 before IdentityKey on live ingest.
+	if platform == "whatsapp" {
+		const suffix = "@s.whatsapp.net"
+		if strings.HasSuffix(strings.ToLower(actor), suffix) {
+			user := actor[:len(actor)-len(suffix)]
+			allDigits := user != ""
+			for _, char := range user {
+				if char < '0' || char > '9' {
+					allDigits = false
+					break
+				}
+			}
+			if allDigits {
+				return "+" + user
+			}
+		}
+	}
+	return actor
+}
+
+func isOwnReactionActor(platform, raw, normalized string, own map[string]struct{}) bool {
+	if _, ok := own[normalized]; ok {
+		return true
+	}
+	if platform == "whatsapp" {
+		user := strings.SplitN(strings.TrimSpace(raw), "@", 2)[0]
+		_, ok := own["+"+user]
+		return ok
+	}
+	return false
+}
+
+func writeReactions(
+	ctx context.Context,
+	repository *sqlite.ReactionRepository,
+	state *transformState,
+	report *Report,
+) error {
+	rows := make([]sqlite.ReactionApply, 0, len(state.reactions))
+	for _, planned := range state.reactions {
+		rows = append(rows, planned.Row)
+	}
+	seeded, err := repository.SeedReactions(ctx, rows)
+	if err != nil {
+		return fmt.Errorf("seed legacy reactions: %w", err)
+	}
+	if seeded != report.Reactions.RowsSeeded {
+		report.Reactions.SeedConflicts += report.Reactions.RowsSeeded - seeded
+		report.Warnings = append(report.Warnings, fmt.Sprintf("reaction seeding inserted %d of %d planned rows; validation will diagnose message-key collisions", seeded, report.Reactions.RowsSeeded))
+	}
+	return nil
 }
 
 func writeAccounts(target *sqlite.Store, state *transformState) error {
@@ -1028,8 +1208,11 @@ func scheduleReport(dataset legacyDataset) ScheduleReport {
 
 func appendRequiredWarnings(report *Report) {
 	report.Warnings = append(report.Warnings, report.ReadState.LossyWarning)
-	if count := report.Dropped.ReactionsBearingMessages; count > 0 {
-		report.Warnings = append(report.Warnings, fmt.Sprintf("%d messages with reactions were counted and dropped: merged v2 has no reaction read model", count))
+	if count := report.Dropped.MalformedReactions; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d messages had malformed reactions JSON and migrated without all reactions", count))
+	}
+	if count := report.Dropped.UnmappableReactions; count > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%d messages had unmappable reaction entries and migrated without all reactions", count))
 	}
 	if count := report.Dropped.TranscriptBearingMessages; count > 0 {
 		report.Warnings = append(report.Warnings, fmt.Sprintf("%d messages with transcripts were counted and dropped: merged v2 has no transcript columns", count))

--- a/internal/migration/transform_test.go
+++ b/internal/migration/transform_test.go
@@ -13,13 +13,16 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	googleadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/google"
 	signaladapter "github.com/maxghenis/openmessage/internal/bridgeadapters/signal"
 	whatsappadapter "github.com/maxghenis/openmessage/internal/bridgeadapters/whatsapp"
 	legacydb "github.com/maxghenis/openmessage/internal/db"
 	"github.com/maxghenis/openmessage/internal/storage/blob"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 	"github.com/maxghenis/openmessage/internal/v2keys"
+	"github.com/maxghenis/openmessage/internal/v2read"
 	"github.com/maxghenis/openmessage/internal/whatsappmedia"
 )
 
@@ -136,6 +139,106 @@ func TestTransformReadsHotWALWithoutMutatingSourceFamily(t *testing.T) {
 	}
 	if _, err := os.Lstat(stagedStore + legacySnapshotSuffix); !os.IsNotExist(err) {
 		t.Fatalf("migration left private source snapshot behind: %v", err)
+	}
+}
+
+func TestMigratedGoogleSelfReactionConvergesWithLiveSnapshot(t *testing.T) {
+	root := t.TempDir()
+	fixture := buildMigrationFixture(t, root)
+	legacy, err := sql.Open("sqlite", fixture.sourcePath)
+	mustNoError(t, err)
+	_, err = legacy.Exec(`UPDATE messages SET reactions = ? WHERE message_id = 'google-server-2'`,
+		`[{"emoji":"🔥","count":1,"actors":["+15550009999"]}]`)
+	mustNoError(t, err)
+	mustNoError(t, legacy.Close())
+	staged := filepath.Join(root, "convergence.sqlite3")
+	report, err := Transform(context.Background(), Options{
+		SourcePath: fixture.sourcePath, TempStorePath: staged,
+		TempBlobPath: filepath.Join(root, "convergence-blobs"),
+		TargetPath:   filepath.Join(root, "target"), TargetStorePath: filepath.Join(root, "target", "store.sqlite3"),
+		Check: true,
+	})
+	mustNoError(t, err)
+	if report.Reactions.RowsSeeded != 2 {
+		t.Fatalf("seeded rows = %d, want fixture reaction plus Google self reaction", report.Reactions.RowsSeeded)
+	}
+	store, err := sqlite.Open(staged)
+	mustNoError(t, err)
+	defer store.Close()
+	repository, err := sqlite.NewReactionRepository(store, func() time.Time { return time.UnixMilli(fixtureBaseMS + 20_000) })
+	mustNoError(t, err)
+	messageID := v2keys.DeriveID("message", "google-primary", "sms-conversation\x1fgoogle-server-2")
+	changes, err := repository.ReplaceEmbeddedReactions(context.Background(), messageID, "google-primary",
+		v2keys.DeriveID("conversation", "google-primary", "sms-conversation"),
+		[]sqlite.ReactionSnapshotEntry{{ReactorKey: "self", ReactorIsSelf: true, ReactorLabel: "me", Emoji: "🔥"}},
+		fixtureBaseMS+20_000)
+	mustNoError(t, err)
+	if changes.Removed != 0 {
+		t.Fatalf("first live snapshot changes = %+v, want no removal", changes)
+	}
+	changes, err = repository.ReplaceEmbeddedReactions(context.Background(), messageID, "google-primary",
+		v2keys.DeriveID("conversation", "google-primary", "sms-conversation"),
+		[]sqlite.ReactionSnapshotEntry{{ReactorKey: "self", ReactorIsSelf: true, ReactorLabel: "me", Emoji: "🔥"}},
+		fixtureBaseMS+20_001)
+	mustNoError(t, err)
+	if changes.Applied != 0 || changes.Removed != 0 {
+		t.Fatalf("second live snapshot changes = %+v, want semantic no-op", changes)
+	}
+	rows, err := repository.ReactionsForMessages(context.Background(), []string{messageID})
+	mustNoError(t, err)
+	if len(rows[messageID]) != 1 {
+		t.Fatalf("active rows after live snapshot = %+v, want one converged row", rows[messageID])
+	}
+}
+
+func TestMigratedReactionServeParityPreservesOrderAndPinsCountDegradation(t *testing.T) {
+	const conversationID = "serve-reaction-parity"
+	root := t.TempDir()
+	legacyPath := filepath.Join(root, "legacy.sqlite3")
+	legacy, err := legacydb.New(legacyPath)
+	mustNoError(t, err)
+	mustNoError(t, legacy.UpsertConversation(&legacydb.Conversation{ConversationID: conversationID, Name: "Serve parity", Participants: `[]`, LastMessageTS: fixtureBaseMS + 3, SourcePlatform: "sms"}))
+	wants := map[string]string{
+		"multi":    `[{"emoji":"🔥","count":1,"actors":["+15550000001"]},{"emoji":"👍","count":1,"actors":["+15550000002"]},{"emoji":"😂","count":1,"actors":["+15550000003"]}]`,
+		"collapse": `[{"emoji":"👍","count":3}]`,
+		"surplus":  `[{"emoji":"❤️","count":4,"actors":["+15550000004","+15550000005"]}]`,
+	}
+	index := 0
+	for id, reactions := range wants {
+		index++
+		mustNoError(t, legacy.UpsertMessage(&legacydb.Message{MessageID: id, ConversationID: conversationID, SenderName: "Sender", SenderNumber: "+15559999999", Body: id, TimestampMS: fixtureBaseMS + int64(index), SourcePlatform: "sms", Reactions: reactions}))
+	}
+	legacyRows, err := legacy.GetMessagesByConversation(conversationID, 10)
+	mustNoError(t, err)
+	legacyServed := map[string]string{}
+	for _, message := range legacyRows {
+		legacyServed[message.MessageID] = message.Reactions
+	}
+	mustNoError(t, legacy.Close())
+
+	staged := filepath.Join(root, "staged.sqlite3")
+	report, err := Transform(context.Background(), Options{SourcePath: legacyPath, TempStorePath: staged, TempBlobPath: filepath.Join(root, "blobs"), TargetPath: filepath.Join(root, "target"), TargetStorePath: filepath.Join(root, "target", "store.sqlite3"), Check: true})
+	mustNoError(t, err)
+	if report.Reactions.ActorlessCountCollapsed != 2 || report.Reactions.ActorCountSurplusDropped != 2 {
+		t.Fatalf("reaction degradation report = %+v, want collapse=2 surplus=2", report.Reactions)
+	}
+	store, err := sqlite.Open(staged)
+	mustNoError(t, err)
+	defer store.Close()
+	served, err := v2read.New(store).GetMessagesByConversation(v2keys.DeriveID("conversation", "google-primary", conversationID), 10)
+	mustNoError(t, err)
+	got := map[string]string{}
+	for _, message := range served {
+		got[message.SourceID] = message.Reactions
+	}
+	if got["multi"] != wants["multi"] || got["multi"] != legacyServed["multi"] {
+		t.Fatalf("multi-emoji served JSON = %s, want byte parity %s (legacy=%s)", got["multi"], wants["multi"], legacyServed["multi"])
+	}
+	if got["collapse"] != `[{"emoji":"👍","count":1}]` {
+		t.Fatalf("actorless collapse served JSON = %s, want count 1", got["collapse"])
+	}
+	if got["surplus"] != `[{"emoji":"❤️","count":2,"actors":["+15550000004","+15550000005"]}]` {
+		t.Fatalf("surplus served JSON = %s, want actor-count 2", got["surplus"])
 	}
 }
 
@@ -426,7 +529,7 @@ func assertFixtureReport(t *testing.T, report Report, sourceHash string) {
 		"accounts": 5, "devices": 5, "people": 1, "person_identities": 2,
 		"conversations": 6, "inbox": 0, "messages": 14,
 		"message_attachments": 3, "outbox": 2, "outbox_attachments": 1,
-		"read_cursors": 6, "reactions": 0, "reaction_snapshot_fences": 0,
+		"read_cursors": 6, "reactions": 1, "reaction_snapshot_fences": 0,
 	}
 	for table, want := range wantTargetCounts {
 		if got := report.Target.Counts[table]; got != want {
@@ -468,12 +571,15 @@ func assertFixtureReport(t *testing.T, report Report, sourceHash string) {
 		t.Errorf("read state report = %+v", report.ReadState)
 	}
 	wantDropped := DroppedDimensions{
-		ReactionsBearingMessages: 1, TranscriptBearingMessages: 1,
-		ContactAvatars: 1, Drafts: 1, ContactMetaCRM: 1,
+		TranscriptBearingMessages: 1,
+		ContactAvatars:            1, Drafts: 1, ContactMetaCRM: 1,
 		OutgoingSendKeys: 1, Tabs: 1,
 	}
 	if !reflect.DeepEqual(report.Dropped, wantDropped) {
 		t.Errorf("dropped dimensions = %+v, want %+v", report.Dropped, wantDropped)
+	}
+	if report.Reactions.MessagesWithReactions != 1 || report.Reactions.MessagesSeeded != 1 || report.Reactions.RowsSeeded != 1 {
+		t.Errorf("reaction report = %+v, want one bearing message and one seeded row", report.Reactions)
 	}
 	if report.SignalLocalRows != 1 {
 		t.Errorf("signal local rows = %d, want 1", report.SignalLocalRows)
@@ -498,7 +604,7 @@ func assertFixtureReport(t *testing.T, report Report, sourceHash string) {
 		t.Errorf("validation report = %+v", report.Validation)
 	}
 	for _, required := range []string{
-		"legacy read state was lossy", "reactions", "transcripts", "contact avatars",
+		"legacy read state was lossy", "transcripts", "contact avatars",
 		"drafts", "IMPORTANT: 1 contact_meta CRM", "outgoing_send_keys", "custom tabs",
 		"ambiguous in-flight scheduled sends",
 	} {
@@ -666,6 +772,19 @@ func assertFixtureMessages(t *testing.T, database *sql.DB) {
 		if sender.Valid != (want.senderIdentityID != "") || sender.String != want.senderIdentityID {
 			t.Errorf("message %s sender_identity_id = %+v, want %q", messageID, sender, want.senderIdentityID)
 		}
+	}
+	var reactorKey, emoji, state string
+	var occurredAt int64
+	mustNoError(t, database.QueryRow(`
+		SELECT reactor_key, emoji, state, occurred_at_ms
+		FROM reactions
+		WHERE message_id = ?
+	`, v2keys.DeriveID("message", "google-primary", "sms-conversation\x1fgoogle-server-1")).Scan(
+		&reactorKey, &emoji, &state, &occurredAt,
+	))
+	wantReactor := v2keys.DeriveID("identity", "google-primary", "e164\x1f+15550100001")
+	if reactorKey != wantReactor || emoji != "👍" || state != "active" || occurredAt != fixtureBaseMS+1_000 {
+		t.Errorf("seeded reaction = %q/%q/%q/%d, want %q/👍/active/%d", reactorKey, emoji, state, occurredAt, wantReactor, fixtureBaseMS+1_000)
 	}
 	if got := mustQueryInt64(t, database, `SELECT COUNT(*) FROM inbox`); got != 0 {
 		t.Errorf("inbox rows = %d, want ImportMessage to leave historical inbox empty", got)

--- a/internal/migration/validate.go
+++ b/internal/migration/validate.go
@@ -198,8 +198,6 @@ func fillTableReconciliations(
 		name  string
 		count int64
 	}{
-		// RR-2 flips the reactions V2 value to the seeded count.
-		{"reactions", dataset.dropped.ReactionsBearingMessages},
 		{"transcripts", dataset.dropped.TranscriptBearingMessages},
 		{"contact_avatars", dataset.dropped.ContactAvatars},
 		{"drafts", dataset.dropped.Drafts},
@@ -213,9 +211,13 @@ func fillTableReconciliations(
 		{"unmappable_messages", dataset.dropped.UnmappableMessages},
 		{"malformed_participants", dataset.dropped.MalformedParticipants},
 		{"unmappable_unified_contacts", dataset.dropped.UnmappableUnifiedContacts},
+		{"reaction_messages_dropped_with_parent", dataset.dropped.ReactionMessagesDroppedWithParent},
 	} {
 		add(dropped.name, dropped.count, 0, dropped.count, "dropped_with_count")
 	}
+	add("reactions", report.Reactions.RowsPlannable, report.Target.Counts["reactions"],
+		report.Reactions.RowsSeeded,
+		"row_grained; see reaction collapse/surplus/dedup/drop counters")
 }
 
 func fillPlatformReconciliations(
@@ -334,8 +336,10 @@ func countsMatch(
 		report.Target.Counts["outbox"] != dataset.scheduleByStatus["pending"] ||
 		report.Target.Counts["outbox_attachments"] != state.expectedPendingMedia ||
 		report.Target.Counts["read_cursors"] != state.expectedCursors ||
-		// RR-2 flips reactions to the seeded count.
-		report.Target.Counts["reactions"] != 0 ||
+		report.Target.Counts["reactions"] != report.Reactions.RowsSeeded ||
+		report.Reactions.MessagesWithReactions != report.Reactions.MessagesSeeded+
+			report.Dropped.MalformedReactions+
+			report.Dropped.UnmappableReactions+report.Dropped.ReactionMessagesDroppedWithParent ||
 		report.Target.Counts["reaction_snapshot_fences"] != 0 ||
 		report.Target.Counts["inbox"] != 0 {
 		return false

--- a/internal/migration/validate_reactions_test.go
+++ b/internal/migration/validate_reactions_test.go
@@ -17,3 +17,19 @@ func TestCountsMatchRejectsStrayMigratedReaction(t *testing.T) {
 		t.Fatal("countsMatch accepted a migrated store with one stray reactions row")
 	}
 }
+
+func TestCountsMatchAcceptsExactlyReportedSeededReactions(t *testing.T) {
+	dataset := legacyDataset{}
+	state := &transformState{
+		accounts: map[string]accountSpec{}, identities: map[identityKey]*identityCandidate{},
+		conversations: map[string]*conversationPlan{}, contactIdentityKeys: map[identityKey]struct{}{},
+		expectedHistoryByPlatform: map[string]map[string]struct{}{}, scheduledMessages: map[string]struct{}{},
+	}
+	report := &Report{
+		Reactions: ReactionReport{RowsSeeded: 1},
+		Target:    TargetReport{Counts: map[string]int64{"reactions": 1}},
+	}
+	if !countsMatch(dataset, state, report, 0, 0, map[string]int64{}) {
+		t.Fatal("countsMatch rejected an exact seeded reaction reconciliation")
+	}
+}

--- a/internal/storage/sqlite/reactions.go
+++ b/internal/storage/sqlite/reactions.go
@@ -464,6 +464,36 @@ func (r *ReactionRepository) SeedReaction(
 	return nil
 }
 
+// SeedReactions writes a migration batch atomically. It delegates every row to
+// SeedReaction so the binding first-wins/no-snapshot-fence contract has one
+// implementation.
+func (r *ReactionRepository) SeedReactions(
+	ctx context.Context,
+	reactions []ReactionApply,
+) (int64, error) {
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("seed reactions: begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+	var before, after int64
+	if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM reactions").Scan(&before); err != nil {
+		return 0, fmt.Errorf("seed reactions: count before: %w", err)
+	}
+	for _, reaction := range reactions {
+		if err := r.SeedReaction(ctx, tx, reaction); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM reactions").Scan(&after); err != nil {
+		return 0, fmt.Errorf("seed reactions: count after: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("seed reactions: commit: %w", err)
+	}
+	return after - before, nil
+}
+
 // ReactionsForMessages loads active reactions for a batch of messages in a
 // stable order suitable for deterministic legacy-shape aggregation.
 func (r *ReactionRepository) ReactionsForMessages(

--- a/internal/v2read/map.go
+++ b/internal/v2read/map.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/maxghenis/openmessage/internal/db"
@@ -15,6 +16,12 @@ import (
 type participantDTO struct {
 	Name   string `json:"name"`
 	Number string `json:"number"`
+}
+
+type reactionDTO struct {
+	Emoji  string   `json:"emoji"`
+	Count  int      `json:"count"`
+	Actors []string `json:"actors,omitempty"`
 }
 
 func platformForBridgeKey(bridgeKey string) string {
@@ -113,9 +120,17 @@ func (s *Source) mapMessages(
 	if err != nil {
 		return nil, fmt.Errorf("map messages: %w", err)
 	}
+	messageIDs := make([]string, 0, len(messages))
+	for _, message := range messages {
+		messageIDs = append(messageIDs, message.MessageID)
+	}
+	reactions, err := s.reactions.ReactionsForMessages(context.Background(), messageIDs)
+	if err != nil {
+		return nil, fmt.Errorf("map messages: load reactions: %w", err)
+	}
 	mapped := make([]*db.Message, 0, len(messages))
 	for _, message := range messages {
-		dto, err := s.mapMessage(message, accounts)
+		dto, err := s.mapMessage(message, accounts, reactions[message.MessageID])
 		if err != nil {
 			return nil, err
 		}
@@ -127,6 +142,7 @@ func (s *Source) mapMessages(
 func (s *Source) mapMessage(
 	message sqlite.Message,
 	accounts map[string]sqlite.Account,
+	reactionRows []sqlite.ReactionRow,
 ) (*db.Message, error) {
 	account, ok := accounts[message.AccountID]
 	if !ok {
@@ -145,6 +161,11 @@ func (s *Source) mapMessage(
 		SourcePlatform: platformForBridgeKey(account.BridgeKey),
 		SourceID:       message.RemoteMessageID,
 	}
+	reactionJSON, err := mapReactions(reactionRows)
+	if err != nil {
+		return nil, fmt.Errorf("map message %q reactions: %w", message.MessageID, err)
+	}
+	dto.Reactions = reactionJSON
 	if message.SenderIdentityID != nil {
 		identity, err := s.store.GetIdentity(*message.SenderIdentityID)
 		if err != nil {
@@ -177,6 +198,57 @@ func (s *Source) mapMessage(
 		dto.MimeType = attachment.MIME
 	}
 	return dto, nil
+}
+
+func mapReactions(rows []sqlite.ReactionRow) (string, error) {
+	if len(rows) == 0 {
+		return "", nil
+	}
+	type group struct {
+		dto   reactionDTO
+		first int64
+		seen  map[string]struct{}
+	}
+	groups := map[string]*group{}
+	for _, row := range rows {
+		item := groups[row.Emoji]
+		if item == nil {
+			item = &group{dto: reactionDTO{Emoji: row.Emoji}, first: row.OccurredAtMS, seen: map[string]struct{}{}}
+			groups[row.Emoji] = item
+		}
+		actor := row.ReactorLabel
+		if row.ReactorIsSelf {
+			actor = "me"
+		} else if row.ReactorCanonical != "" {
+			actor = row.ReactorCanonical
+		}
+		if actor != "" {
+			if _, ok := item.seen[actor]; !ok {
+				item.seen[actor] = struct{}{}
+				item.dto.Actors = append(item.dto.Actors, actor)
+			}
+		}
+		item.dto.Count++
+	}
+	ordered := make([]*group, 0, len(groups))
+	for _, item := range groups {
+		ordered = append(ordered, item)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].first != ordered[j].first {
+			return ordered[i].first < ordered[j].first
+		}
+		return ordered[i].dto.Emoji < ordered[j].dto.Emoji
+	})
+	dtos := make([]reactionDTO, 0, len(ordered))
+	for _, item := range ordered {
+		dtos = append(dtos, item.dto)
+	}
+	encoded, err := json.Marshal(dtos)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
 }
 
 func (s *Source) messageAttachment(

--- a/internal/v2read/source.go
+++ b/internal/v2read/source.go
@@ -18,6 +18,7 @@ type Source struct {
 	messages    *sqlite.MessageRepository
 	attachments *sqlite.MessageAttachmentRepository
 	outbox      *sqlite.OutboxRepository
+	reactions   *sqlite.ReactionRepository
 }
 
 // New constructs a v2 canonical read source. A nil store is retained as an
@@ -31,11 +32,12 @@ func New(store *sqlite.Store) *Source {
 	source.messages, _ = sqlite.NewMessageRepository(store, time.Now)
 	source.attachments, _ = sqlite.NewMessageAttachmentRepository(store, time.Now)
 	source.outbox, _ = sqlite.NewOutboxRepository(store, time.Now)
+	source.reactions, _ = sqlite.NewReactionRepository(store, time.Now)
 	return source
 }
 
 func (s *Source) ready() error {
-	if s == nil || s.store == nil || s.messages == nil || s.attachments == nil || s.outbox == nil {
+	if s == nil || s.store == nil || s.messages == nil || s.attachments == nil || s.outbox == nil || s.reactions == nil {
 		return fmt.Errorf("v2 read source: store is nil")
 	}
 	return nil

--- a/internal/v2read/source_test.go
+++ b/internal/v2read/source_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maxghenis/openmessage/internal/bridge"
 	"github.com/maxghenis/openmessage/internal/db"
 	"github.com/maxghenis/openmessage/internal/readsource"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
@@ -95,6 +96,34 @@ func TestSourceMapsConversationAndMessagesToLegacyDTOs(t *testing.T) {
 		OccurredAtMS:    300,
 	}
 	importSourceMessage(t, messages, outgoing)
+	reactions, err := sqlite.NewReactionRepository(store, func() time.Time { return time.UnixMilli(sourceTestTimeMS) })
+	if err != nil {
+		t.Fatalf("NewReactionRepository(): %v", err)
+	}
+	for _, reaction := range []sqlite.ReactionApply{
+		{
+			AccountID: "google-account", ConversationID: "conversation-google", MessageID: incoming.MessageID,
+			ReactorKey: identity.IdentityID, ReactorIdentityID: stringPointer(identity.IdentityID),
+			ReactorLabel: identity.RawValue, Emoji: "👍", Action: bridge.ReactionAdd, OccurredAtMS: 201,
+		},
+		{
+			AccountID: "google-account", ConversationID: "conversation-google", MessageID: incoming.MessageID,
+			ReactorKey: "self", ReactorIsSelf: true, ReactorLabel: "me",
+			Emoji: "❤️", Action: bridge.ReactionAdd, OccurredAtMS: 202,
+		},
+		{
+			AccountID: "google-account", ConversationID: "conversation-google", MessageID: incoming.MessageID,
+			ReactorKey: "removed", ReactorLabel: "gone", Emoji: "😂", Action: bridge.ReactionAdd, OccurredAtMS: 203,
+		},
+		{
+			AccountID: "google-account", ConversationID: "conversation-google", MessageID: incoming.MessageID,
+			ReactorKey: "removed", ReactorLabel: "gone", Action: bridge.ReactionRemove, OccurredAtMS: 204,
+		},
+	} {
+		if _, err := reactions.ApplyReaction(context.Background(), reaction); err != nil {
+			t.Fatalf("ApplyReaction(%q): %v", reaction.ReactorKey, err)
+		}
+	}
 
 	conversation, err := source.GetConversation("conversation-google")
 	if err != nil {
@@ -158,7 +187,7 @@ func TestSourceMapsConversationAndMessagesToLegacyDTOs(t *testing.T) {
 		gotIncoming.MediaID != "v2msg:message-incoming:0" ||
 		gotIncoming.MimeType != "image/png" ||
 		gotIncoming.Status != "" ||
-		gotIncoming.Reactions != "" {
+		gotIncoming.Reactions != `[{"emoji":"👍","count":1,"actors":["+15550000001"]},{"emoji":"❤️","count":1,"actors":["me"]}]` {
 		t.Fatalf("mapped incoming = %+v", gotIncoming)
 	}
 }


### PR DESCRIPTION
## Rebuild RR-2 — seed legacy reactions in migration + serve from v2read

Completes the reactions read model behind cutover. With RR-1 (#138) writing live reactions and this PR seeding + serving historical ones, the top behavioral gap on the cutover list is closed: **9,441 reaction rows from 5,455 reaction-bearing messages on the real store survive migration and render in v2-primary**.

### What's in it
- **Seeding**: legacy `messages.reactions` JSON (`[{"emoji","count","actors"}]` — ground-truthed against all three platform writers + the UI parser) seeds through RR-1's first-wins `SeedReaction` contract. Seeds lose to any live write; **no fence rows** (first live Google snapshot establishes each fence).
- **Actor-key convergence** (the review's blocking finding, fixed): seeded keys are derived exactly as live ingest derives them — WhatsApp JID→E164 mirroring the live decoder, Signal resolved-E164 vs raw-ACI matching live's resolve-or-raw capture, and self-detection against per-platform own numbers derived from `is_from_me` rows → `self`/`is_self=1`/`"me"`, field-identical to the live worker. Without this, every seeded WhatsApp reaction (2,289 messages on the real store, incl. 84 self) would duplicate or go stale on the first post-cutover delta.
- **Accounting**: row-grained reconciliation (plannable vs seeded) with explicit collapse/surplus/dedup/dropped-with-parent counters; validation **enforces** `messages_with_reactions == seeded + malformed + unmappable + dropped_with_parent` exactly.
- **Serving**: one batched `ReactionsForMessages` per page (no N+1), active rows only, byte-compatible with the legacy read path including insertion order; conversation page, search, and message lists all covered.

### Review
Opus adversarial review: FIX-FIRST → all six findings fixed. The convergence discriminators now drive the **actual platform decoder → ingest worker** (not hand-built entries) for WhatsApp and Signal, migrate-then-live-apply, asserting exactly one row with live-shaped fields; each fails on the pre-fix key derivation (e.g. WA contact `24ea023f…`→`b8222756…`, WA self `f6d6c1ec…`→`self`). Served-JSON byte-parity pins non-lexicographic insertion order and the documented collapse/surplus degradations.

### Real-store rehearsal (third run, this exact build)
- 9,441/9,441 rows reconciled at ratio 1; integrity gates green; source untouched.
- **84 self-reactions** seed as `self` (was the proven duplicate/stuck-reaction bug — those rows previously seeded as ordinary identities keyed by Max's own JID).
- 13 reactions-on-dropped-messages attributed exactly via the new counter; I5 equation holds: 5,442 + 0 + 0 + 13 = 5,455.
- Fences 0; 5 actorless-collapse units counted (matches probe: 2 entries, both SMS).

### Verification
Independent full `GOWORK=off go test -race ./...` outside the sandbox: **31/31 packages, exit 0** (three runs: post-build, post-fixes, post-discriminators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
