### PR TITLE
Route CLI send through the v2 outbox API with daemon-truth mode detection (rebuild W3 PR-E)

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rs/zerolog"
@@ -9,6 +10,29 @@ import (
 )
 
 func RunSend(logger zerolog.Logger, conversationID, message string) error {
+	return RunSendWithOptions(logger, conversationID, message, SendOptions{})
+}
+
+func RunSendScheduled(logger zerolog.Logger, conversationID, message string, notBeforeMS *int64) error {
+	return RunSendWithOptions(logger, conversationID, message, SendOptions{NotBeforeMS: notBeforeMS})
+}
+
+type SendOptions struct {
+	NotBeforeMS    *int64
+	IdempotencyKey string
+}
+
+func RunSendWithOptions(logger zerolog.Logger, conversationID, message string, options SendOptions) error {
+	deps := defaultSendCommandDeps(func(conversationID, message string) error {
+		return runLegacySend(logger, conversationID, message)
+	})
+	if options.IdempotencyKey != "" {
+		deps.newKey = func() (string, error) { return options.IdempotencyKey, nil }
+	}
+	return runSendWithDeps(context.Background(), deps, conversationID, message, options.NotBeforeMS)
+}
+
+func runLegacySend(logger zerolog.Logger, conversationID, message string) error {
 	a, err := app.New(logger)
 	if err != nil {
 		return fmt.Errorf("init app: %w", err)

--- a/cmd/send_group.go
+++ b/cmd/send_group.go
@@ -11,6 +11,12 @@ import (
 )
 
 func RunSendGroup(logger zerolog.Logger, phones []string, message string) error {
+	return runSendGroupWithDeps(defaultSendGroupCommandDeps(func(phones []string, message string) error {
+		return runLegacySendGroup(logger, phones, message)
+	}), phones, message)
+}
+
+func runLegacySendGroup(logger zerolog.Logger, phones []string, message string) error {
 	a, err := app.New(logger)
 	if err != nil {
 		return fmt.Errorf("init app: %w", err)

--- a/cmd/send_outbox.go
+++ b/cmd/send_outbox.go
@@ -1,0 +1,339 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/app"
+)
+
+type sendCommandDeps struct {
+	mode       func() (v2RuntimeMode, error)
+	client     *http.Client
+	baseURL    string
+	newKey     func() (string, error)
+	output     io.Writer
+	legacySend func(conversationID, message string) error
+}
+
+type sendGroupCommandDeps struct {
+	mode       func() (v2RuntimeMode, error)
+	client     *http.Client
+	baseURL    string
+	legacySend func(phones []string, message string) error
+}
+
+type outboxSubmission struct {
+	OutboxID       string `json:"outbox_id"`
+	State          string `json:"state"`
+	ScheduledForMS int64  `json:"scheduled_for_ms"`
+	Deduplicated   bool   `json:"deduplicated"`
+}
+
+type outboxDelivery struct {
+	OutboxID        string `json:"outbox_id"`
+	State           string `json:"state"`
+	RemoteMessageID string `json:"remote_message_id"`
+	ErrorClass      string `json:"error_class"`
+	Warning         string `json:"warning"`
+}
+
+func defaultSendCommandDeps(legacy func(string, string) error) sendCommandDeps {
+	return sendCommandDeps{
+		mode: func() (v2RuntimeMode, error) {
+			return resolveV2RuntimeMode(app.DemoMode(), app.DefaultDataDir())
+		},
+		client:     &http.Client{Timeout: 10 * time.Second},
+		baseURL:    localAPIBaseURL(),
+		newKey:     newCLIIdempotencyKey,
+		output:     os.Stdout,
+		legacySend: legacy,
+	}
+}
+
+func defaultSendGroupCommandDeps(legacy func([]string, string) error) sendGroupCommandDeps {
+	return sendGroupCommandDeps{
+		mode: func() (v2RuntimeMode, error) {
+			return resolveV2RuntimeMode(app.DemoMode(), app.DefaultDataDir())
+		},
+		client:     &http.Client{Timeout: 10 * time.Second},
+		baseURL:    localAPIBaseURL(),
+		legacySend: legacy,
+	}
+}
+
+func localAPIBaseURL() string {
+	port := strings.TrimSpace(os.Getenv("OPENMESSAGES_PORT"))
+	if port == "" {
+		port = "7007"
+	}
+	return "http://" + net.JoinHostPort("127.0.0.1", port)
+}
+
+func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, message string, notBeforeMS *int64) error {
+	if deps.client == nil {
+		deps.client = &http.Client{Timeout: 10 * time.Second}
+	}
+	if deps.baseURL == "" {
+		deps.baseURL = localAPIBaseURL()
+	}
+	if deps.output == nil {
+		deps.output = os.Stdout
+	}
+
+	status, reachable, err := probeV2Status(ctx, deps.client, deps.baseURL)
+	if err != nil {
+		if reachable {
+			return fmt.Errorf("check running OpenMessage mode: %w", err)
+		}
+		mode, modeErr := deps.mode()
+		if modeErr != nil {
+			return modeErr
+		}
+		if mode.Primary || mode.Send {
+			return fmt.Errorf("OpenMessage isn't running; start it to send: %w", err)
+		}
+		return deps.legacySend(conversationID, message)
+	}
+	if !status.V2Send && !status.V2Primary {
+		return deps.legacySend(conversationID, message)
+	}
+	if deps.newKey == nil {
+		deps.newKey = newCLIIdempotencyKey
+	}
+	key, err := deps.newKey()
+	if err != nil {
+		return err
+	}
+	payload := struct {
+		ConversationID string `json:"conversation_id"`
+		Body           string `json:"body"`
+		IdempotencyKey string `json:"idempotency_key"`
+		NotBeforeMS    *int64 `json:"not_before_ms,omitempty"`
+	}{conversationID, message, key, notBeforeMS}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode outbox submission: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, deps.baseURL+"/api/v1/outbox/messages", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := deps.client.Do(request)
+	if err != nil {
+		return ambiguousSendError(key, err)
+	}
+	var submission outboxSubmission
+	if err := decodeCLIResponse(response, &submission); err != nil {
+		if isDeterministicRejection(err) {
+			return deterministicRejectionError(err)
+		}
+		return ambiguousSendError(key, err)
+	}
+	if submission.OutboxID == "" {
+		return ambiguousSendError(key, fmt.Errorf("submission response omitted outbox_id"))
+	}
+
+	fmt.Fprintf(deps.output, "outbox_id=%s state=%s idempotency_key=%s deduplicated=%t", submission.OutboxID, submission.State, key, submission.Deduplicated)
+	if submission.ScheduledForMS > 0 {
+		fmt.Fprintf(deps.output, " scheduled_for_ms=%d", submission.ScheduledForMS)
+	}
+	fmt.Fprintln(deps.output)
+	scheduled := submission.ScheduledForMS > time.Now().UnixMilli()
+	if scheduled {
+		when := time.UnixMilli(submission.ScheduledForMS).Format(time.RFC3339)
+		fmt.Fprintf(deps.output, "scheduled; the app will send it at %s (%d ms). Do not resend.\n", when, submission.ScheduledForMS)
+	}
+	delivery, err := getOutboxDelivery(ctx, deps.client, deps.baseURL, submission.OutboxID)
+	if err != nil {
+		if !scheduled {
+			fmt.Fprintf(deps.output, "queued; app continues in the background. Do not resend. Replay-check with the same idempotency key: %s\n", key)
+		}
+		return nil
+	}
+	return writeCLIDelivery(deps.output, delivery, key, scheduled)
+}
+
+type v2DaemonStatus struct {
+	V2Send    bool `json:"v2_send"`
+	V2Primary bool `json:"v2_primary"`
+}
+
+func probeV2Status(ctx context.Context, client *http.Client, baseURL string) (v2DaemonStatus, bool, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/status", nil)
+	if err != nil {
+		return v2DaemonStatus{}, false, err
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return v2DaemonStatus{}, false, err
+	}
+	var status v2DaemonStatus
+	if err := decodeCLIResponse(response, &status); err != nil {
+		return v2DaemonStatus{}, true, err
+	}
+	return status, true, nil
+}
+
+func getOutboxDelivery(ctx context.Context, client *http.Client, baseURL, id string) (outboxDelivery, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v1/outbox/"+id, nil)
+	if err != nil {
+		return outboxDelivery{}, err
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return outboxDelivery{}, err
+	}
+	var delivery outboxDelivery
+	err = decodeCLIResponse(response, &delivery)
+	return delivery, err
+}
+
+func decodeCLIResponse(response *http.Response, target any) error {
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 4096))
+		return &cliResponseError{StatusCode: response.StatusCode, Body: strings.TrimSpace(string(body))}
+	}
+	if err := json.NewDecoder(response.Body).Decode(target); err != nil {
+		return fmt.Errorf("decode local API response: %w", err)
+	}
+	return nil
+}
+
+type cliResponseError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *cliResponseError) Error() string {
+	return fmt.Sprintf("local API returned HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+func isDeterministicRejection(err error) bool {
+	var responseErr *cliResponseError
+	if !errors.As(err, &responseErr) {
+		return false
+	}
+	switch responseErr.StatusCode {
+	case http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusRequestEntityTooLarge, http.StatusUnprocessableEntity:
+		return true
+	default:
+		return false
+	}
+}
+
+func deterministicRejectionError(err error) error {
+	var responseErr *cliResponseError
+	if errors.As(err, &responseErr) && responseErr.StatusCode == http.StatusConflict {
+		return fmt.Errorf("send rejected: %s; this key already carries different content; use a new key to send this message", responseErr.Body)
+	}
+	return fmt.Errorf("send rejected: %w", err)
+}
+
+type ambiguousCLIError struct {
+	key   string
+	cause error
+}
+
+func (e *ambiguousCLIError) Error() string {
+	return fmt.Sprintf("send outcome is unknown (%v). %s", e.cause, e.OperatorInstruction())
+}
+
+func (e *ambiguousCLIError) OperatorInstruction() string {
+	return fmt.Sprintf("Do not send with a new key. To replay-check this exact invocation, repeat it with the same idempotency key: %s", e.key)
+}
+
+func ambiguousSendError(key string, cause error) error {
+	return &ambiguousCLIError{key: key, cause: cause}
+}
+
+func OperatorInstruction(err error) string {
+	var ambiguous *ambiguousCLIError
+	if errors.As(err, &ambiguous) {
+		return ambiguous.OperatorInstruction()
+	}
+	return ""
+}
+
+func writeCLIDelivery(output io.Writer, delivery outboxDelivery, key string, scheduled bool) error {
+	fmt.Fprintf(output, "outbox_id=%s state=%s idempotency_key=%s\n", delivery.OutboxID, delivery.State, key)
+	switch delivery.State {
+	case "confirmed":
+		fmt.Fprintln(output, "message delivery confirmed")
+	case "not_dispatched":
+		if !scheduled {
+			fmt.Fprintln(output, "queued; app retries automatically. Do not resend.")
+		}
+	case "queued", "dispatching":
+		if !scheduled {
+			fmt.Fprintln(output, "queued; app continues sending in the background. Do not resend.")
+		}
+	case "uncertain":
+		fmt.Fprintln(output, "delivery is uncertain; the transport may have accepted it. Do not retry automatically.")
+		// Exit zero because re-running an uncertain delivery risks a double-send.
+	case "store_failed":
+		fmt.Fprintln(output, "transport accepted the message; the local record is being repaired automatically. Do not resend.")
+	case "rejected":
+		fmt.Fprintln(output, "delivery was rejected; the app will not retry it")
+		return fmt.Errorf("delivery was rejected; the app will not retry it")
+	case "canceled":
+		fmt.Fprintln(output, "delivery was canceled")
+	default:
+		fmt.Fprintln(output, "send is durably queued; check the outbox before taking further action")
+	}
+	return nil
+}
+
+func newCLIIdempotencyKey() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate CLI idempotency key: %w", err)
+	}
+	value[6] = (value[6] & 0x0f) | 0x40
+	value[8] = (value[8] & 0x3f) | 0x80
+	return strings.Join([]string{
+		hex.EncodeToString(value[0:4]), hex.EncodeToString(value[4:6]),
+		hex.EncodeToString(value[6:8]), hex.EncodeToString(value[8:10]),
+		hex.EncodeToString(value[10:16]),
+	}, "-"), nil
+}
+
+func runSendGroupWithDeps(deps sendGroupCommandDeps, phones []string, message string) error {
+	if deps.client == nil {
+		deps.client = &http.Client{Timeout: 10 * time.Second}
+	}
+	if deps.baseURL == "" {
+		deps.baseURL = localAPIBaseURL()
+	}
+	status, reachable, err := probeV2Status(context.Background(), deps.client, deps.baseURL)
+	if err != nil {
+		if reachable {
+			return fmt.Errorf("check running OpenMessage mode: %w", err)
+		}
+		mode, modeErr := deps.mode()
+		if modeErr != nil {
+			return modeErr
+		}
+		if mode.Primary || mode.Send {
+			return fmt.Errorf("OpenMessage isn't running; start it to send: %w", err)
+		}
+		return deps.legacySend(phones, message)
+	}
+	if status.V2Send || status.V2Primary {
+		return fmt.Errorf("creating a new group isn't supported in v2 yet — send to an existing conversation")
+	}
+	return deps.legacySend(phones, message)
+}

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -1,0 +1,397 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type sendRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f sendRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func sendJSONResponse(status int, body string) *http.Response {
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+}
+
+func TestRunSendV2PrimaryUsesOutboxAPI(t *testing.T) {
+	var output bytes.Buffer
+	var requests []string
+	notBefore := time.Now().Add(time.Hour).UnixMilli()
+	deps := sendCommandDeps{
+		mode:   func() (v2RuntimeMode, error) { return v2RuntimeMode{}, nil },
+		newKey: func() (string, error) { return "stable-key", nil },
+		output: &output,
+		client: &http.Client{Transport: sendRoundTripper(func(r *http.Request) (*http.Response, error) {
+			requests = append(requests, r.Method+" "+r.URL.Path)
+			switch r.URL.Path {
+			case "/api/status":
+				return sendJSONResponse(http.StatusOK, `{"v2_send":true,"v2_primary":true}`), nil
+			case "/api/v1/outbox/messages":
+				var body struct {
+					ConversationID string `json:"conversation_id"`
+					Message        string `json:"body"`
+					Key            string `json:"idempotency_key"`
+					NotBeforeMS    *int64 `json:"not_before_ms"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				if body.ConversationID != "conv-1" || body.Message != "hello" || body.Key != "stable-key" {
+					t.Fatalf("POST body = %+v", body)
+				}
+				if body.NotBeforeMS == nil || *body.NotBeforeMS != notBefore {
+					t.Fatalf("not_before_ms = %v", body.NotBeforeMS)
+				}
+				return sendJSONResponse(http.StatusOK, fmt.Sprintf(`{"outbox_id":"out-1","state":"queued","scheduled_for_ms":%d,"deduplicated":false}`, *body.NotBeforeMS)), nil
+			case "/api/v1/outbox/out-1":
+				return sendJSONResponse(http.StatusOK, `{"outbox_id":"out-1","state":"not_dispatched","error_class":"transient"}`), nil
+			default:
+				t.Fatalf("unexpected request %s", r.URL.Path)
+				return nil, nil
+			}
+		})},
+		legacySend: func(string, string) error { t.Fatal("legacy send called"); return nil },
+	}
+	if err := runSendWithDeps(context.Background(), deps, "conv-1", "hello", &notBefore); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(requests, ","); got != "GET /api/status,POST /api/v1/outbox/messages,GET /api/v1/outbox/out-1" {
+		t.Fatalf("requests = %s", got)
+	}
+	for _, want := range []string{"outbox_id=out-1", "state=not_dispatched", "idempotency_key=stable-key", fmt.Sprintf("scheduled_for_ms=%d", notBefore), "scheduled; the app will send it at"} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("output %q missing %q", output.String(), want)
+		}
+	}
+}
+
+func TestRunSendAmbiguousSubmissionDoesNotRetry(t *testing.T) {
+	var output bytes.Buffer
+	posts := 0
+	deps := sendCommandDeps{
+		mode:   func() (v2RuntimeMode, error) { return v2RuntimeMode{Primary: true}, nil },
+		newKey: func() (string, error) { return "replay-key", nil }, output: &output,
+		client: &http.Client{Transport: sendRoundTripper(func(r *http.Request) (*http.Response, error) {
+			if r.URL.Path == "/api/status" {
+				return sendJSONResponse(200, `{"v2_primary":true}`), nil
+			}
+			posts++
+			return nil, errors.New("timeout")
+		})},
+		legacySend: func(string, string) error { t.Fatal("legacy send called"); return nil },
+	}
+	err := runSendWithDeps(context.Background(), deps, "conv-1", "hello", nil)
+	if err == nil {
+		t.Fatal("expected ambiguous error")
+	}
+	if posts != 1 {
+		t.Fatalf("POST count = %d", posts)
+	}
+	for _, want := range []string{"replay-key", "same idempotency key", "Do not send with a new key"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+func TestRunSendFallsBackToLegacyOutsideV2Primary(t *testing.T) {
+	legacyCalls := 0
+	deps := sendCommandDeps{
+		mode: func() (v2RuntimeMode, error) { return v2RuntimeMode{}, nil },
+		client: &http.Client{Transport: sendRoundTripper(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("connection refused")
+		})},
+		legacySend: func(conversationID, message string) error {
+			legacyCalls++
+			if conversationID != "conv-1" || message != "hello" {
+				t.Fatalf("legacy args = %q %q", conversationID, message)
+			}
+			return nil
+		},
+	}
+	if err := runSendWithDeps(context.Background(), deps, "conv-1", "hello", nil); err != nil {
+		t.Fatal(err)
+	}
+	if legacyCalls != 1 {
+		t.Fatalf("legacy calls = %d", legacyCalls)
+	}
+}
+
+func TestRunSendDaemonNotV2PrimaryFallsBackToLegacy(t *testing.T) {
+	legacyCalls := 0
+	deps := sendCommandDeps{
+		mode: func() (v2RuntimeMode, error) {
+			t.Fatal("local mode consulted despite reachable daemon")
+			return v2RuntimeMode{}, nil
+		},
+		client: &http.Client{Transport: sendRoundTripper(func(r *http.Request) (*http.Response, error) {
+			if r.URL.Path != "/api/status" {
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+			return sendJSONResponse(200, `{"v2_primary":false}`), nil
+		})},
+		legacySend: func(string, string) error { legacyCalls++; return nil },
+	}
+	if err := runSendWithDeps(context.Background(), deps, "conv-1", "hello", nil); err != nil {
+		t.Fatal(err)
+	}
+	if legacyCalls != 1 {
+		t.Fatalf("legacy calls = %d", legacyCalls)
+	}
+}
+
+func TestRunSendDeduplicatedReplayIsSuccess(t *testing.T) {
+	var output bytes.Buffer
+	deps := sendCommandDeps{
+		mode:   func() (v2RuntimeMode, error) { return v2RuntimeMode{Primary: true}, nil },
+		newKey: func() (string, error) { return "reused-key", nil }, output: &output,
+		client: &http.Client{Transport: sendRoundTripper(func(r *http.Request) (*http.Response, error) {
+			switch r.URL.Path {
+			case "/api/status":
+				return sendJSONResponse(200, `{"v2_primary":true}`), nil
+			case "/api/v1/outbox/messages":
+				return sendJSONResponse(200, `{"outbox_id":"out-1","state":"confirmed","deduplicated":true}`), nil
+			case "/api/v1/outbox/out-1":
+				return sendJSONResponse(200, `{"outbox_id":"out-1","state":"confirmed"}`), nil
+			default:
+				t.Fatalf("unexpected path %s", r.URL.Path)
+				return nil, nil
+			}
+		})},
+		legacySend: func(string, string) error { t.Fatal("legacy send called"); return nil },
+	}
+	if err := runSendWithDeps(context.Background(), deps, "conv-1", "hello", nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "deduplicated=true") {
+		t.Fatalf("output = %q", output.String())
+	}
+}
+
+func TestRunSendV2PrimaryDaemonAbsentDoesNotConnect(t *testing.T) {
+	deps := sendCommandDeps{
+		mode:       func() (v2RuntimeMode, error) { return v2RuntimeMode{Primary: true}, nil },
+		client:     &http.Client{Transport: sendRoundTripper(func(*http.Request) (*http.Response, error) { return nil, errors.New("connection refused") })},
+		legacySend: func(string, string) error { t.Fatal("legacy send called"); return nil },
+	}
+	err := runSendWithDeps(context.Background(), deps, "conv-1", "hello", nil)
+	if err == nil || !strings.Contains(err.Error(), "OpenMessage isn't running; start it to send") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestRunSendGroupV2PrimaryRejectsCreationWithoutConnecting(t *testing.T) {
+	legacyCalls := 0
+	err := runSendGroupWithDeps(sendGroupCommandDeps{
+		mode: func() (v2RuntimeMode, error) { t.Fatal("local mode consulted"); return v2RuntimeMode{}, nil },
+		client: &http.Client{Transport: sendRoundTripper(func(*http.Request) (*http.Response, error) {
+			return sendJSONResponse(200, `{"v2_send":true,"v2_primary":true}`), nil
+		})},
+		legacySend: func([]string, string) error { legacyCalls++; return nil },
+	}, []string{"+15551234567"}, "hello")
+	if err == nil || !strings.Contains(err.Error(), "creating a new group isn't supported in v2 yet") {
+		t.Fatalf("error = %v", err)
+	}
+	if legacyCalls != 0 {
+		t.Fatalf("legacy calls = %d", legacyCalls)
+	}
+}
+
+func TestRunSendGroupRoutingCells(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		probeErr   error
+		local      v2RuntimeMode
+		wantLegacy bool
+		wantStop   bool
+	}{
+		{"v2 daemon bare terminal", `{"v2_send":true}`, nil, v2RuntimeMode{}, false, false},
+		{"legacy daemon primary terminal", `{"v2_send":false,"v2_primary":false}`, nil, v2RuntimeMode{Primary: true}, true, false},
+		{"no daemon legacy terminal", "", errors.New("refused"), v2RuntimeMode{}, true, false},
+		{"no daemon send terminal", "", errors.New("refused"), v2RuntimeMode{Send: true}, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			legacyCalls := 0
+			deps := sendGroupCommandDeps{
+				mode: func() (v2RuntimeMode, error) { return tt.local, nil },
+				client: &http.Client{Transport: sendRoundTripper(func(*http.Request) (*http.Response, error) {
+					if tt.probeErr != nil {
+						return nil, tt.probeErr
+					}
+					return sendJSONResponse(200, tt.status), nil
+				})},
+				legacySend: func([]string, string) error { legacyCalls++; return nil },
+			}
+			err := runSendGroupWithDeps(deps, []string{"+15551234567"}, "hello")
+			if tt.wantStop && (err == nil || !strings.Contains(err.Error(), "OpenMessage isn't running")) {
+				t.Fatalf("error = %v", err)
+			}
+			if !tt.wantStop && !tt.wantLegacy && (err == nil || !strings.Contains(err.Error(), "isn't supported in v2")) {
+				t.Fatalf("error = %v", err)
+			}
+			if legacyCalls != btoi(tt.wantLegacy) {
+				t.Fatalf("legacy calls = %d", legacyCalls)
+			}
+		})
+	}
+}
+
+func TestAmbiguousErrorExposesCleanOperatorInstruction(t *testing.T) {
+	err := ambiguousSendError("stable-key", errors.New("timeout"))
+	if got := OperatorInstruction(err); !strings.Contains(got, "same idempotency key: stable-key") || strings.Contains(got, "timeout") {
+		t.Fatalf("instruction = %q", got)
+	}
+}
+
+func TestRunSendRoutingCells(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		probeErr   error
+		local      v2RuntimeMode
+		wantLegacy bool
+		wantStop   bool
+	}{
+		{"gui primary daemon bare terminal", `{"v2_send":true,"v2_primary":true}`, nil, v2RuntimeMode{}, false, false},
+		{"send daemon bare terminal", `{"v2_send":true,"v2_primary":false}`, nil, v2RuntimeMode{}, false, false},
+		{"legacy daemon primary terminal", `{"v2_send":false,"v2_primary":false}`, nil, v2RuntimeMode{Primary: true}, true, false},
+		{"no daemon legacy terminal", "", errors.New("refused"), v2RuntimeMode{}, true, false},
+		{"no daemon send terminal", "", errors.New("refused"), v2RuntimeMode{Send: true}, false, true},
+		{"no daemon primary terminal", "", errors.New("refused"), v2RuntimeMode{Primary: true}, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			legacyCalls := 0
+			deps := sendCommandDeps{
+				mode:   func() (v2RuntimeMode, error) { return tt.local, nil },
+				newKey: func() (string, error) { return "routing-key", nil },
+				output: io.Discard,
+				client: &http.Client{Transport: sendRoundTripper(func(r *http.Request) (*http.Response, error) {
+					if r.URL.Path == "/api/status" {
+						if tt.probeErr != nil {
+							return nil, tt.probeErr
+						}
+						return sendJSONResponse(200, tt.status), nil
+					}
+					if r.Method == http.MethodPost {
+						return sendJSONResponse(200, `{"outbox_id":"out","state":"confirmed"}`), nil
+					}
+					return sendJSONResponse(200, `{"outbox_id":"out","state":"confirmed"}`), nil
+				})},
+				legacySend: func(string, string) error { legacyCalls++; return nil },
+			}
+			err := runSendWithDeps(context.Background(), deps, "conv", "hello", nil)
+			if tt.wantStop != (err != nil && strings.Contains(err.Error(), "OpenMessage isn't running")) {
+				t.Fatalf("error = %v", err)
+			}
+			if legacyCalls != btoi(tt.wantLegacy) {
+				t.Fatalf("legacy calls = %d", legacyCalls)
+			}
+		})
+	}
+}
+
+func btoi(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func TestRunSendDeterministicRejections(t *testing.T) {
+	for _, status := range []int{400, 404, 409, 413, 422} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			deps := sendCommandDeps{
+				mode:   func() (v2RuntimeMode, error) { return v2RuntimeMode{}, nil },
+				newKey: func() (string, error) { return "conflicting-key", nil }, output: io.Discard,
+				client: &http.Client{Transport: sendRoundTripper(func(r *http.Request) (*http.Response, error) {
+					if r.URL.Path == "/api/status" {
+						return sendJSONResponse(200, `{"v2_send":true}`), nil
+					}
+					return sendJSONResponse(status, `{"error":"specific rejection"}`), nil
+				})},
+				legacySend: func(string, string) error { t.Fatal("legacy send called"); return nil },
+			}
+			err := runSendWithDeps(context.Background(), deps, "conv", "hello", nil)
+			if err == nil || !strings.Contains(err.Error(), "specific rejection") {
+				t.Fatalf("error = %v", err)
+			}
+			if strings.Contains(err.Error(), "outcome is unknown") || strings.Contains(err.Error(), "same idempotency key") {
+				t.Fatalf("deterministic error was ambiguous: %v", err)
+			}
+			if status == 409 && !strings.Contains(err.Error(), "use a new key") {
+				t.Fatalf("409 error = %v", err)
+			}
+		})
+	}
+}
+
+func TestWriteCLIDeliveryExitSemantics(t *testing.T) {
+	var output bytes.Buffer
+	if err := writeCLIDelivery(&output, outboxDelivery{OutboxID: "out", State: "uncertain"}, "key", false); err != nil {
+		t.Fatalf("uncertain error = %v", err)
+	}
+	if err := writeCLIDelivery(&output, outboxDelivery{OutboxID: "out", State: "rejected"}, "key", false); err == nil || !strings.Contains(err.Error(), "will not retry") {
+		t.Fatalf("rejected error = %v", err)
+	}
+}
+
+func TestRunSendRealTransportSequence(t *testing.T) {
+	var sequence []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sequence = append(sequence, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/status":
+			fmt.Fprint(w, `{"v2_send":true}`)
+		case "/api/v1/outbox/messages":
+			fmt.Fprint(w, `{"outbox_id":"real-out","state":"queued"}`)
+		case "/api/v1/outbox/real-out":
+			fmt.Fprint(w, `{"outbox_id":"real-out","state":"confirmed"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	deps := sendCommandDeps{mode: func() (v2RuntimeMode, error) { return v2RuntimeMode{}, nil }, client: server.Client(), baseURL: server.URL, newKey: func() (string, error) { return "real-key", nil }, output: io.Discard, legacySend: func(string, string) error { t.Fatal("legacy"); return nil }}
+	if err := runSendWithDeps(context.Background(), deps, "conv", "hello", nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(sequence, ","); got != "GET /api/status,POST /api/v1/outbox/messages,GET /api/v1/outbox/real-out" {
+		t.Fatalf("sequence = %s", got)
+	}
+}
+
+func TestRunSendRealTransportDoesNotRetry500(t *testing.T) {
+	var posts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/status" {
+			fmt.Fprint(w, `{"v2_send":true}`)
+			return
+		}
+		posts.Add(1)
+		http.Error(w, "temporary", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	deps := sendCommandDeps{mode: func() (v2RuntimeMode, error) { return v2RuntimeMode{}, nil }, client: server.Client(), baseURL: server.URL, newKey: func() (string, error) { return "real-key", nil }, output: io.Discard, legacySend: func(string, string) error { t.Fatal("legacy"); return nil }}
+	err := runSendWithDeps(context.Background(), deps, "conv", "hello", nil)
+	if err == nil || !strings.Contains(err.Error(), "outcome is unknown") {
+		t.Fatalf("error = %v", err)
+	}
+	if got := posts.Load(); got != 1 {
+		t.Fatalf("POST count = %d", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -32,7 +33,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "  thread <name|number|conversation_id> [--limit N] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--json] - Print a full conversation chronologically")
 		fmt.Fprintln(os.Stderr, "  threads [--limit N] [--json]             - List recent conversations (find an id/name for thread)")
 		fmt.Fprintln(os.Stderr, "  status [--json]                          - Show per-platform message counts and sync freshness")
-		fmt.Fprintln(os.Stderr, "  send <conversation_id> <msg>              - Send text to an existing conversation across supported platforms")
+		fmt.Fprintln(os.Stderr, "  send <conversation_id> <msg> [--not-before-ms N] [--idempotency-key K] - Send text to an existing conversation")
 		fmt.Fprintln(os.Stderr, "  send-group <phone1,phone2,...> <msg>       - Send group message (MMS)")
 		fmt.Fprintln(os.Stderr, "  import gchat <groups-dir> [--email you@]  - Import Google Chat Takeout")
 		fmt.Fprintln(os.Stderr, "  import gchat-conversation <messages.json> - Import single GChat conversation")
@@ -72,10 +73,39 @@ func main() {
 		err = cmd.RunStatus(logger, os.Args[2:]...)
 	case "send":
 		if len(os.Args) < 4 {
-			fmt.Fprintln(os.Stderr, "Usage: openmessage send <conversation_id> <message>")
+			fmt.Fprintln(os.Stderr, "Usage: openmessage send <conversation_id> <message> [--not-before-ms N] [--idempotency-key K]")
 			os.Exit(1)
 		}
-		err = cmd.RunSend(logger, os.Args[2], os.Args[3])
+		var notBeforeMS *int64
+		var idempotencyKey string
+		for index := 4; index < len(os.Args); index += 2 {
+			if index+1 >= len(os.Args) {
+				err = fmt.Errorf("send option %s requires a value", os.Args[index])
+				break
+			}
+			switch os.Args[index] {
+			case "--not-before-ms":
+				value, parseErr := strconv.ParseInt(os.Args[index+1], 10, 64)
+				if parseErr != nil {
+					err = fmt.Errorf("--not-before-ms must be an integer: %w", parseErr)
+					break
+				}
+				notBeforeMS = &value
+			case "--idempotency-key":
+				idempotencyKey = os.Args[index+1]
+			default:
+				err = fmt.Errorf("unknown send option %s", os.Args[index])
+			}
+			if err != nil {
+				break
+			}
+		}
+		if err != nil {
+			break
+		}
+		err = cmd.RunSendWithOptions(logger, os.Args[2], os.Args[3], cmd.SendOptions{
+			NotBeforeMS: notBeforeMS, IdempotencyKey: idempotencyKey,
+		})
 	case "send-group":
 		if len(os.Args) < 4 {
 			fmt.Fprintln(os.Stderr, "Usage: openmessage send-group <phone1,phone2,...> <message>")
@@ -102,6 +132,9 @@ func main() {
 	}
 
 	if err != nil {
+		if instruction := cmd.OperatorInstruction(err); instruction != "" {
+			fmt.Fprintln(os.Stderr, instruction)
+		}
 		if exitCode := cmd.ExitCode(err); exitCode != 1 {
 			logger.Error().Err(err).Msg("Command failed")
 			os.Exit(exitCode)


### PR DESCRIPTION
## Rebuild W3 PR-E — CLI send via the v2 outbox, daemon-truth routing

Last terminal-sender gap. `openmessage send` now submits through the durable outbox whenever the **running daemon** serves it, carrying the full double-send honesty contract from the MCP leg.

### The review catch that shaped this
Opus review (FIX-FIRST → all 7 findings fixed): the first build routed on the CLI's **own** `OPENMESSAGES_V2_PRIMARY` env — so a GUI-launched v2-primary daemon plus a bare terminal took the legacy path and opened a **second live transport** against the running daemon (the A6 hazard this PR exists to kill). Now the CLI probes `GET /api/status` first and routes on the daemon's advertised `v2_send`/`v2_primary`; local env only matters when no daemon is reachable. Discriminator test pins the GUI-daemon+bare-terminal cell to the outbox path.

### Contract
- Fresh UUID idempotency key per invocation, echoed; `--idempotency-key` replays; **no auto-retry** — ambiguous outcomes print a clean stderr instruction to repeat with the SAME key.
- Deterministic 4xx ≠ ambiguous: 400/409/413/422 surface the server's reason (409 conflict: "use a NEW key for different content"); only network/timeout/5xx get the replay instruction.
- `not_dispatched` → exit 0, "queued; app retries automatically". `rejected` → **nonzero** (was exit 0 pre-review). `uncertain` → exit 0 (re-run risks a duplicate; commented).
- `--not-before-ms` scheduling with `scheduled_for_ms` echoed in scheduled wording.
- `send-group` refuses in v2 mode (no existing-conversation form in the phone-list CLI; refusing beats inventing a group-creation vector).

### Verification
- Independent full `GOWORK=off go test -race ./...` outside the sandbox: **31/31 packages, exit 0** — including the new `httptest`-backed real-transport tests (full status→submit→delivery sequence; exactly ONE observed POST on a 500, proving no client-level re-POST).
- Scope: CLI + tests only (`cmd/send*.go`, `main.go`); no server/UI/MCP/auth changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
