### PR TITLE
Fix flaky -race tests: dispatcher shutdown-error normalization, deterministic ingest drain asserts, signallive gate log-buffer sync

### DIFF
--- a/cmd/v2stack_test.go
+++ b/cmd/v2stack_test.go
@@ -539,9 +539,11 @@ func TestV2StackStopJoinsRunAndClosesStore(t *testing.T) {
 }
 
 func TestV2PrimaryStackDoesNotStartLegacyProjector(t *testing.T) {
+	// The stack's runner goroutines share this writer, and bytes.Buffer is not
+	// safe for concurrent writes.
 	var logs bytes.Buffer
 	stack, err := newV2Stack(v2StackDeps{
-		Logger:  zerolog.New(&logs),
+		Logger:  zerolog.New(zerolog.SyncWriter(&logs)),
 		DataDir: t.TempDir(),
 	})
 	if err != nil {
@@ -590,9 +592,11 @@ func TestV2PrimaryStackStartsPrimaryNotifier(t *testing.T) {
 }
 
 func TestLegacyPrimaryStackStillStartsLegacyProjector(t *testing.T) {
+	// The stack's runner goroutines share this writer, and bytes.Buffer is not
+	// safe for concurrent writes.
 	var logs bytes.Buffer
 	stack, err := newV2Stack(v2StackDeps{
-		Logger:  zerolog.New(&logs),
+		Logger:  zerolog.New(zerolog.SyncWriter(&logs)),
 		DataDir: t.TempDir(),
 	})
 	if err != nil {

--- a/internal/ingest/sink_worker_test.go
+++ b/internal/ingest/sink_worker_test.go
@@ -549,12 +549,22 @@ func i01WaitFor(t *testing.T, description string, ready func() bool) {
 
 func i01AssertNoPending(t *testing.T, messages *sqlite.MessageRepository) {
 	t.Helper()
-	pending, err := messages.Unprocessed(context.Background())
-	if err != nil {
-		t.Fatalf("Unprocessed(): %v", err)
-	}
-	if len(pending) != 0 {
-		t.Fatalf("unprocessed frames = %d, want 0", len(pending))
+	// Worker counters advance before MarkInboxProcessed commits, so a caller
+	// that just observed a counter can race the final inbox write; wait for the
+	// drain rather than reading it once.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		pending, err := messages.Unprocessed(context.Background())
+		if err != nil {
+			t.Fatalf("Unprocessed(): %v", err)
+		}
+		if len(pending) == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("unprocessed frames = %d after drain deadline, want 0", len(pending))
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/internal/ingest/worker_test.go
+++ b/internal/ingest/worker_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/maxghenis/openmessage/internal/bridge"
 )
@@ -86,9 +87,12 @@ func TestWorkerChangesDoesNotBroadcastForQuarantinedOrNoopDrain(t *testing.T) {
 
 func assertWorkerChangeClosed(t *testing.T, changes <-chan struct{}, description string) {
 	t.Helper()
+	// The worker broadcasts after the drain pass that advanced the counters a
+	// caller waited on, so closure is guaranteed but not yet observable; block
+	// rather than snapshot.
 	select {
 	case <-changes:
-	default:
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Changes() channel remained open after %s", description)
 	}
 }

--- a/internal/messaging/dispatch.go
+++ b/internal/messaging/dispatch.go
@@ -21,6 +21,12 @@ func (s *MessageService) Run(ctx context.Context) error {
 	}
 	recovered, err := s.outbox.RecoverExpiredLeases(ctx, s.clock.Now())
 	if err != nil {
+		// Cancellation mid-query surfaces as a driver interrupt, not
+		// context.Canceled, so a shutdown race would read as a startup fault.
+		// As in DispatchDue's lease path, surface the cancellation itself.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return fmt.Errorf("run message service: recover expired leases: %w", err)
 	}
 	if recovered.NotDispatched > 0 || recovered.Uncertain > 0 {
@@ -32,9 +38,15 @@ func (s *MessageService) Run(ctx context.Context) error {
 			return err
 		}
 		if _, err := s.reconcileStoreFailedDue(ctx, s.batchLimit); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			return fmt.Errorf("run message service: reconcile store-failed deliveries: %w", err)
 		}
 		if _, err := s.DispatchDue(ctx, s.batchLimit); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			return fmt.Errorf("run message service: %w", err)
 		}
 

--- a/internal/signallive/gate_test.go
+++ b/internal/signallive/gate_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,6 +20,26 @@ import (
 const realisticSignalGetSenderPoison = `WARN  IncomingMessageHandler - Failed to handle incoming message
 java.lang.NullPointerException: Cannot invoke "org.asamk.signal.manager.storage.recipients.RecipientId.getSender()" because "content" is null
 	at org.asamk.signal.manager.helper.IncomingMessageHandler.getSender(IncomingMessageHandler.java:412)`
+
+// syncBuffer protects test log access because the bridge's tmp-sweep goroutine,
+// started by maybeSweepTmp, can write while the test reads. zerolog.SyncWriter
+// only serializes writers, so it would not protect the test's String read.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 func TestSignalCLIVersionProbeUsesExactCommandAndPrivateTemp(t *testing.T) {
 	t.Setenv("TMPDIR", t.TempDir())
@@ -224,7 +245,7 @@ func TestSignalCLIVersionGateFailsOpenWithWarning(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			var log bytes.Buffer
+			var log syncBuffer
 			bridge := &Bridge{
 				account:   "+15551230000",
 				configDir: t.TempDir(),


### PR DESCRIPTION
Fixes the three flaky `-race` tests that intermittently fail CI on unrelated PRs (observed on [run 29658833081, attempt 1](https://github.com/MaxGhenis/openmessage/actions/runs/29658833081/attempts/1), a Swift-only diff). The third (#147, `internal/signallive`, hit on W4-A's run 2026-07-19) reproduces reliably once its temp-dir trigger is seeded — see below. Closes #147.

## 1. TestLegacyPrimaryStackStillStartsLegacyProjector — data race on the test's log buffer

**What the trace shows.** The race is write/write between two *sibling* runner goroutines, not goroutine-vs-test: goroutine 2248 (projector, `v2stack.go:366`, finished) logged its expected "V2 legacy projector stopped" for the nil-legacy sentinel, and goroutine 2247 (dispatcher, `v2stack.go:350`, running) *also* logged an error at `v2stack.go:353`. Both wrote to the test's `bytes.Buffer` through one zerolog logger. `WaitGroup.Done()` → `Done()` creates no happens-before between siblings and the buffer has no lock, so any second logging runner is a data race.

**Why the dispatcher logged at all.** `MessageService.Run` starts with `RecoverExpiredLeases` and loops through `reconcileStoreFailedDue`/`DispatchDue`. When `stop()`'s cancel lands mid-query, modernc.org/sqlite surfaces a driver interrupt that does **not** satisfy `errors.Is(err, context.Canceled)`, so the runner's is-canceled filter let it through and the dispatcher logged a spurious shutdown error. `DispatchDue` already guards exactly this class in its lease path ("Shutdown can race the lease transaction…"); the fix extends the same normalization to `Run`'s three call sites: once `ctx` is canceled, `Run` returns `ctx.Err()`. The existing regression test (`TestDispatchDueCanceledContextIsCleanStopNotLeaseFault`) only exercised the pre-canceled path, where database/sql short-circuits with bare `context.Canceled` before reaching the driver — the mid-query interrupt was the untested gap.

**Was there a production drain gap in `v2Stack.Stop()`? No.** `Stop()` cancels, then `runWG.Wait()` joins every runner goroutine Start spawned (worker, dispatcher, projector/notifier — each `Done()` in a defer after its final log write), and only then closes the store. Goroutine lifetimes and shutdown ordering are correct. The real production defect found instead: on shutdown, a cancel racing an in-flight dispatcher query made `Run` exit with a non-`Canceled` error — logging a scary `V2 message dispatcher stopped` at error level on clean shutdowns, and misleading anything supervising `Run`'s exit value. That's fixed at the source in `dispatch.go`.

**Harness hardening.** The two tests that capture logs now wrap the buffer in `zerolog.SyncWriter` (`cmd/v2stack_test.go`), so any future legitimately-concurrent runner logging can't race the buffer regardless. The projector's nil-legacy log line stays deterministic: `Projector.Run` validates deps before checking `ctx`, so the assertion the test exists for is unaffected.

## 2. TestWhatsAppReactionDeltasApplySwitchRemoveAndOrphanThroughWorker — counters used as durability barriers

CI failed at `whatsappdecoder_test.go:623` with `unprocessed frames = 1, want 0`. The test waits for `ReactionsOrphaned == 1`, then one-shot asserts the inbox is drained. But `countOrphanReaction` bumps the atomic counter mid-apply (`worker.go:636`) while `MarkInboxProcessed` commits only at the end of the pass (`worker.go:697`) — the counter is a progress signal, not a durability barrier, and under `-race` parallel load the one-shot read lands in that gap. (This is specific to the orphan path: `Projected`, `Quarantined`, and the reaction-apply counters all increment *after* their durable writes commit, so the test's other counter-then-read asserts — and the similar one in `google_echo_e2e_test.go` — are ordered correctly; audited each one.)

While shaking the fix at `-count=5` locally, a second latent flake in the same test reproduced at line 566: `assertWorkerChangeClosed` was a **non-blocking** select on the captured `Changes()` channel, but the worker closes it only after the drain pass that advanced the counter the test just waited on.

Both asserts now wait for the condition they actually mean instead of snapshotting it, keeping their discriminating power (a genuinely stuck frame or missing broadcast still fails, at the 10s deadline):
- `i01AssertNoPending` polls `Unprocessed()` until empty (same cadence as `i01WaitFor`, and the same pattern the test itself already used for the stale-add wait) — covers both call sites.
- `assertWorkerChangeClosed` blocks with a deadline; its two other call sites follow a synchronous `drain()`, where blocking is a no-op.

## 3. TestSignalCLIVersionGateFailsOpenWithWarning — tmp-sweep goroutine vs. the test's log read (#147)

**What the trace shows.** The write is `sweepLegacyLibsignalTemp` logging “Removed libsignal temp dirs…” (`tmpdir.go:130`) on the tracked goroutine `maybeSweepTmp` spawns from the receive loop (`client.go:1884`); the read is the test body's `log.String()` (`gate_test.go:263`) against the same unsynchronized `bytes.Buffer`. The test waits only on the `receiveCalls` atomic before reading, and nothing joins the sweeper first. #147's hypothesis pointed at the version-gate warning, but that write is ordered: it happens before the receive stub bumps `receiveCalls`, which the test observes before reading. The sweeper has no such edge.

**Why CI reddens intermittently.** The sweep only logs when it removes ≥1 stale `libsignal*` dir from the runner's temp dir — and removing them burns the trigger, so a racing run goes green on the next attempt. Redness is a function of runner temp-dir state, which is why `-count=3` sometimes reproduces and sometimes doesn't.

**Why not `zerolog.SyncWriter` this time.** Section 1's harness hardening used `SyncWriter` because those v2stack tests read their buffers after `stop()` joins every runner — only writers were concurrent. Here the read itself races a live writer, and `bytes.Buffer.String()` bypasses any writer-side lock. The fix is a test-local `syncBuffer` whose `Write` and `String` share one mutex (`internal/signallive/gate_test.go` only; no production code touched).

**Verification was seeded, not just repeated.** Plain `-count=N` goes green whenever the temp dir happens to be clean, so the repro harness plants stale (2020-mtime) `libsignal-seed-*` dirs into a private `TMPDIR` before every single `-race` run, forcing the sweep down its logging path: **30/30 races before the fix, 0/50 after** (plus 0/20 re-run on this branch).

## Verification

- `GOWORK=off go test -race -count=50 -run TestLegacyPrimaryStackStillStartsLegacyProjector ./cmd/` — ok
- `GOWORK=off go test -race -count=50 -run TestWhatsAppReactionDeltasApplySwitchRemoveAndOrphanThroughWorker ./internal/ingest/` — ok (plus 10× alongside `TestWorkerChanges*`)
- `GOWORK=off go test -race -count=3 -run TestDispatchDue ./internal/messaging/` — ok (existing shutdown regression test still green with the new normalization)
- Seeded harness (stale `libsignal*` dirs planted per run): 30/30 races pre-fix → 0/50 post-fix; 0/20 on this branch
- `GOWORK=off go test -race -count=50 -run TestSignalCLIVersionGateFailsOpenWithWarning ./internal/signallive/` — ok
- `GOWORK=off go test -race ./...` twice — both exit 0, no race warnings, all packages ok (re-run with all three fixes on the branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

