### PR TITLE
Introduce two-stage local control auth, stage 6a: accept-and-log (rebuild W3 PR-G)

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -73,6 +73,11 @@ func newE2EServer(logger zerolog.Logger) (_ *e2eServer, cleanup func(), resultEr
 	if err != nil {
 		return nil, nil, err
 	}
+	controlAuth, err := web.NewControlAuth(dataDir, logger)
+	if err != nil {
+		_ = os.RemoveAll(dataDir)
+		return nil, nil, err
+	}
 	legacyPath := filepath.Join(dataDir, "messages.db")
 	store, err := db.New(legacyPath)
 	if err != nil {
@@ -188,6 +193,7 @@ func newE2EServer(logger zerolog.Logger) (_ *e2eServer, cleanup func(), resultEr
 		mime: "image/png",
 	})
 	base := web.APIHandlerWithOptions(store, nil, logger, nil, web.APIOptions{
+		Auth:      controlAuth,
 		Reads:     v2read.New(v2Store),
 		V2Primary: true,
 		V2: &web.V2Options{

--- a/cmd/send_outbox.go
+++ b/cmd/send_outbox.go
@@ -12,26 +12,30 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/web"
 )
 
 type sendCommandDeps struct {
-	mode       func() (v2RuntimeMode, error)
-	client     *http.Client
-	baseURL    string
-	newKey     func() (string, error)
-	output     io.Writer
-	legacySend func(conversationID, message string) error
+	mode         func() (v2RuntimeMode, error)
+	client       *http.Client
+	baseURL      string
+	newKey       func() (string, error)
+	output       io.Writer
+	legacySend   func(conversationID, message string) error
+	controlToken string
 }
 
 type sendGroupCommandDeps struct {
-	mode       func() (v2RuntimeMode, error)
-	client     *http.Client
-	baseURL    string
-	legacySend func(phones []string, message string) error
+	mode         func() (v2RuntimeMode, error)
+	client       *http.Client
+	baseURL      string
+	legacySend   func(phones []string, message string) error
+	controlToken string
 }
 
 type outboxSubmission struct {
@@ -54,11 +58,12 @@ func defaultSendCommandDeps(legacy func(string, string) error) sendCommandDeps {
 		mode: func() (v2RuntimeMode, error) {
 			return resolveV2RuntimeMode(app.DemoMode(), app.DefaultDataDir())
 		},
-		client:     &http.Client{Timeout: 10 * time.Second},
-		baseURL:    localAPIBaseURL(),
-		newKey:     newCLIIdempotencyKey,
-		output:     os.Stdout,
-		legacySend: legacy,
+		client:       &http.Client{Timeout: 10 * time.Second},
+		baseURL:      localAPIBaseURL(),
+		newKey:       newCLIIdempotencyKey,
+		output:       os.Stdout,
+		legacySend:   legacy,
+		controlToken: loadCLIControlToken(app.DefaultDataDir()),
 	}
 }
 
@@ -67,9 +72,10 @@ func defaultSendGroupCommandDeps(legacy func([]string, string) error) sendGroupC
 		mode: func() (v2RuntimeMode, error) {
 			return resolveV2RuntimeMode(app.DemoMode(), app.DefaultDataDir())
 		},
-		client:     &http.Client{Timeout: 10 * time.Second},
-		baseURL:    localAPIBaseURL(),
-		legacySend: legacy,
+		client:       &http.Client{Timeout: 10 * time.Second},
+		baseURL:      localAPIBaseURL(),
+		legacySend:   legacy,
+		controlToken: loadCLIControlToken(app.DefaultDataDir()),
 	}
 }
 
@@ -92,7 +98,7 @@ func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, 
 		deps.output = os.Stdout
 	}
 
-	status, reachable, err := probeV2Status(ctx, deps.client, deps.baseURL)
+	status, reachable, err := probeV2Status(ctx, deps.client, deps.baseURL, deps.controlToken)
 	if err != nil {
 		if reachable {
 			return fmt.Errorf("check running OpenMessage mode: %w", err)
@@ -106,6 +112,7 @@ func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, 
 		}
 		return deps.legacySend(conversationID, message)
 	}
+	deps.controlToken = controlTokenFromDaemonStatus(status, deps.controlToken)
 	if !status.V2Send && !status.V2Primary {
 		return deps.legacySend(conversationID, message)
 	}
@@ -131,6 +138,7 @@ func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, 
 		return err
 	}
 	request.Header.Set("Content-Type", "application/json")
+	attachControlToken(request, deps.controlToken)
 	response, err := deps.client.Do(request)
 	if err != nil {
 		return ambiguousSendError(key, err)
@@ -156,7 +164,7 @@ func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, 
 		when := time.UnixMilli(submission.ScheduledForMS).Format(time.RFC3339)
 		fmt.Fprintf(deps.output, "scheduled; the app will send it at %s (%d ms). Do not resend.\n", when, submission.ScheduledForMS)
 	}
-	delivery, err := getOutboxDelivery(ctx, deps.client, deps.baseURL, submission.OutboxID)
+	delivery, err := getOutboxDelivery(ctx, deps.client, deps.baseURL, submission.OutboxID, deps.controlToken)
 	if err != nil {
 		if !scheduled {
 			fmt.Fprintf(deps.output, "queued; app continues in the background. Do not resend. Replay-check with the same idempotency key: %s\n", key)
@@ -169,13 +177,24 @@ func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, 
 type v2DaemonStatus struct {
 	V2Send    bool `json:"v2_send"`
 	V2Primary bool `json:"v2_primary"`
+	Auth      struct {
+		DataDir string `json:"data_dir"`
+	} `json:"auth"`
 }
 
-func probeV2Status(ctx context.Context, client *http.Client, baseURL string) (v2DaemonStatus, bool, error) {
+func controlTokenFromDaemonStatus(status v2DaemonStatus, fallback string) string {
+	if strings.TrimSpace(status.Auth.DataDir) == "" {
+		return fallback
+	}
+	return loadCLIControlToken(status.Auth.DataDir)
+}
+
+func probeV2Status(ctx context.Context, client *http.Client, baseURL, token string) (v2DaemonStatus, bool, error) {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/status", nil)
 	if err != nil {
 		return v2DaemonStatus{}, false, err
 	}
+	attachControlToken(request, token)
 	response, err := client.Do(request)
 	if err != nil {
 		return v2DaemonStatus{}, false, err
@@ -187,11 +206,12 @@ func probeV2Status(ctx context.Context, client *http.Client, baseURL string) (v2
 	return status, true, nil
 }
 
-func getOutboxDelivery(ctx context.Context, client *http.Client, baseURL, id string) (outboxDelivery, error) {
+func getOutboxDelivery(ctx context.Context, client *http.Client, baseURL, id, token string) (outboxDelivery, error) {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v1/outbox/"+id, nil)
 	if err != nil {
 		return outboxDelivery{}, err
 	}
+	attachControlToken(request, token)
 	response, err := client.Do(request)
 	if err != nil {
 		return outboxDelivery{}, err
@@ -311,6 +331,20 @@ func newCLIIdempotencyKey() (string, error) {
 	}, "-"), nil
 }
 
+func loadCLIControlToken(dataDir string) string {
+	b, err := os.ReadFile(filepath.Join(dataDir, web.ControlTokenFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func attachControlToken(request *http.Request, token string) {
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+}
+
 func runSendGroupWithDeps(deps sendGroupCommandDeps, phones []string, message string) error {
 	if deps.client == nil {
 		deps.client = &http.Client{Timeout: 10 * time.Second}
@@ -318,7 +352,7 @@ func runSendGroupWithDeps(deps sendGroupCommandDeps, phones []string, message st
 	if deps.baseURL == "" {
 		deps.baseURL = localAPIBaseURL()
 	}
-	status, reachable, err := probeV2Status(context.Background(), deps.client, deps.baseURL)
+	status, reachable, err := probeV2Status(context.Background(), deps.client, deps.baseURL, deps.controlToken)
 	if err != nil {
 		if reachable {
 			return fmt.Errorf("check running OpenMessage mode: %w", err)

--- a/cmd/send_test.go
+++ b/cmd/send_test.go
@@ -9,10 +9,15 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/maxghenis/openmessage/internal/web"
 )
 
 type sendRoundTripper func(*http.Request) (*http.Response, error)
@@ -371,6 +376,78 @@ func TestRunSendRealTransportSequence(t *testing.T) {
 	}
 	if got := strings.Join(sequence, ","); got != "GET /api/status,POST /api/v1/outbox/messages,GET /api/v1/outbox/real-out" {
 		t.Fatalf("sequence = %s", got)
+	}
+}
+
+func TestCLIControlTokenHeaderPresentAndAbsent(t *testing.T) {
+	dir := t.TempDir()
+	if got := loadCLIControlToken(dir); got != "" {
+		t.Fatalf("missing token = %q", got)
+	}
+	if err := os.WriteFile(filepath.Join(dir, web.ControlTokenFile), []byte("secret-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadCLIControlToken(dir); got != "secret-token" {
+		t.Fatalf("loaded token = %q", got)
+	}
+	for _, tt := range []struct{ name, token, want string }{{"present", "secret-token", "Bearer secret-token"}, {"absent", "", ""}} {
+		t.Run(tt.name, func(t *testing.T) {
+			seen := 0
+			client := &http.Client{Transport: sendRoundTripper(func(req *http.Request) (*http.Response, error) {
+				seen++
+				if got := req.Header.Get("Authorization"); got != tt.want {
+					t.Fatalf("Authorization = %q, want %q", got, tt.want)
+				}
+				switch req.URL.Path {
+				case "/api/status":
+					return sendJSONResponse(200, `{"v2_primary":true}`), nil
+				case "/api/v1/outbox/messages":
+					return sendJSONResponse(200, `{"outbox_id":"out-1","state":"queued"}`), nil
+				case "/api/v1/outbox/out-1":
+					return sendJSONResponse(200, `{"outbox_id":"out-1","state":"confirmed"}`), nil
+				default:
+					t.Fatalf("unexpected path %s", req.URL.Path)
+					return nil, nil
+				}
+			})}
+			deps := sendCommandDeps{client: client, baseURL: "http://127.0.0.1", controlToken: tt.token, newKey: func() (string, error) { return "key", nil }, output: io.Discard, legacySend: func(string, string) error { t.Fatal("legacy path"); return nil }}
+			if err := runSendWithDeps(context.Background(), deps, "conv", "hello", nil); err != nil {
+				t.Fatal(err)
+			}
+			if seen != 3 {
+				t.Fatalf("requests = %d, want 3", seen)
+			}
+		})
+	}
+}
+
+func TestRunSendUsesDaemonDataDirControlToken(t *testing.T) {
+	serverDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(serverDir, web.ControlTokenFile), []byte("server-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var authenticated []string
+	client := &http.Client{Transport: sendRoundTripper(func(req *http.Request) (*http.Response, error) {
+		authenticated = append(authenticated, req.Header.Get("Authorization"))
+		switch req.URL.Path {
+		case "/api/status":
+			return sendJSONResponse(200, fmt.Sprintf(`{"v2_primary":true,"auth":{"data_dir":%q}}`, serverDir)), nil
+		case "/api/v1/outbox/messages":
+			return sendJSONResponse(200, `{"outbox_id":"out-1","state":"queued"}`), nil
+		case "/api/v1/outbox/out-1":
+			return sendJSONResponse(200, `{"outbox_id":"out-1","state":"confirmed"}`), nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+			return nil, nil
+		}
+	})}
+	deps := sendCommandDeps{client: client, baseURL: "http://127.0.0.1", controlToken: "cli-default-token", newKey: func() (string, error) { return "key", nil }, output: io.Discard, legacySend: func(string, string) error { t.Fatal("legacy path"); return nil }}
+	if err := runSendWithDeps(context.Background(), deps, "conv", "hello", nil); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"Bearer cli-default-token", "Bearer server-token", "Bearer server-token"}
+	if !reflect.DeepEqual(authenticated, want) {
+		t.Fatalf("Authorization headers = %#v, want %#v", authenticated, want)
 	}
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -606,9 +606,14 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 
 	httpEnabled := opts.web || opts.mcpSSE
 	if httpEnabled {
+		controlAuth, err := web.NewControlAuth(a.DataDir, logger)
+		if err != nil {
+			return fmt.Errorf("initialize local control authentication: %w", err)
+		}
 		httpHandler := http.Handler(nil)
 		if opts.web {
 			httpHandler = web.APIHandlerWithOptions(a.Store, nil, logger, mcpHTTPHandler, web.APIOptions{
+				Auth:                  controlAuth,
 				V2:                    v2Options,
 				V2IngestCounters:      v2IngestCounters,
 				Reads:                 reads,
@@ -654,7 +659,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				SyncGoogleContacts:    a.SyncGoogleContacts,
 			})
 		} else {
-			httpHandler = web.ProtectLocalControl(mcpHTTPHandler)
+			httpHandler = web.ProtectLocalControl(controlAuth.Handler(mcpHTTPHandler))
 		}
 
 		ln, err := net.Listen("tcp", listenAddr)
@@ -670,6 +675,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		go func() {
 			if opts.web {
 				logger.Info().Str("addr", listenAddr).Msg("Web UI available at " + baseURL)
+				fmt.Fprintf(os.Stderr, "Open this single-use URL to authorize the web UI (it redirects without exposing the control token):\n%s\n", controlAuth.BootstrapURL(baseURL))
 			}
 			if opts.mcpSSE {
 				logger.Info().Str("addr", listenAddr).Msg("MCP SSE available at " + baseURL + "/mcp/sse")

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -49,6 +49,8 @@ var maxUploadBytes int64 = messaging.DefaultMaxMediaBytes
 
 const maxTranscriptRequestBytes = db.MaxTranscriptBytes + db.MaxTranscriptModelBytes + 4096
 
+const sseWriteTimeout = 5 * time.Second
+
 func normalizeSendIdempotencyKey(raw string) (string, error) {
 	key := strings.TrimSpace(raw)
 	if key == "" {
@@ -84,6 +86,7 @@ type UnpairFunc func() error
 
 // APIOptions holds optional callbacks for the API handler.
 type APIOptions struct {
+	Auth                  *ControlAuth
 	V2                    *V2Options
 	V2IngestCounters      func() map[string]ingest.CounterSnapshot
 	Reads                 readsource.ReadSource
@@ -287,7 +290,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			}
 		}
 		payload := map[string]any{
-			"connected": connected,
+			"connected":  connected,
 			"v2_send":    opts.V2 != nil,
 			"v2_primary": opts.V2Primary,
 			"v2_ingest": map[string]any{
@@ -764,7 +767,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("X-Accel-Buffering", "no")
 
-		subID, ch := opts.Events.Subscribe()
+		subID, ch, ok := opts.Events.TrySubscribe()
+		if !ok {
+			httpError(w, "too many event stream subscribers", http.StatusServiceUnavailable)
+			return
+		}
 		defer opts.Events.Unsubscribe(subID)
 
 		connected := currentConnected()
@@ -2601,7 +2608,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	})
 
 	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, statusPayload(currentConnected()))
+		payload := statusPayload(currentConnected())
+		if opts.Auth != nil {
+			payload["auth"] = opts.Auth.Status()
+		}
+		writeJSON(w, payload)
 	})
 
 	mux.HandleFunc("/api/diagnostics", func(w http.ResponseWriter, r *http.Request) {
@@ -2922,6 +2933,9 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	// visits from talking to http://127.0.0.1:<port>/api/... or /mcp/... .
 	// Requiring a loopback Host and, when present, a same-origin loopback
 	// Origin/Referer closes that vector without affecting native app requests.
+	if opts.Auth != nil {
+		handler = opts.Auth.Handler(handler)
+	}
 	return ProtectLocalControl(handler)
 }
 
@@ -2934,6 +2948,9 @@ func ProtectLocalControl(handler http.Handler) http.Handler {
 			return
 		}
 		setSecurityHeaders(w)
+		if isProtectedLocalPath(r.URL.Path) {
+			w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
+		}
 		handler.ServeHTTP(w, r)
 	})
 }
@@ -3395,6 +3412,9 @@ func writeJSON(w http.ResponseWriter, v any) {
 }
 
 func writeSSEEvent(w http.ResponseWriter, evt StreamEvent) error {
+	// Bound writes so a half-open client cannot retain an event subscriber
+	// until the operating system's TCP retransmit timeout expires.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(sseWriteTimeout))
 	data, err := json.Marshal(evt)
 	if err != nil {
 		return err

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1,0 +1,228 @@
+package web
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/rs/zerolog"
+)
+
+const (
+	ControlTokenFile     = "control.token"
+	ControlCookieName    = "om_control"
+	AuthModeAcceptAndLog = "accept-and-log"
+	maxWarnedRemotes     = 1024
+)
+
+type ControlAuth struct {
+	token             string
+	bootstrap         string
+	logger            zerolog.Logger
+	dataDir           string
+	mu                sync.Mutex
+	warned            map[string]struct{}
+	warnedMapOverflow bool
+}
+
+func NewControlAuth(dataDir string, logger zerolog.Logger) (*ControlAuth, error) {
+	absDataDir, err := filepath.Abs(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve data directory: %w", err)
+	}
+	token, regenerated, err := loadOrMintControlToken(absDataDir)
+	if err != nil {
+		return nil, err
+	}
+	if regenerated {
+		// Regeneration invalidates cookies containing the old token, which is
+		// acceptable: a corrupt token cannot authenticate them anyway.
+		logger.Warn().Str("path", filepath.Join(absDataDir, ControlTokenFile)).Msg("Invalid control token was regenerated")
+	}
+	bootstrap, err := randomHex(32)
+	if err != nil {
+		return nil, fmt.Errorf("mint bootstrap code: %w", err)
+	}
+	return &ControlAuth{token: token, bootstrap: bootstrap, logger: logger, dataDir: absDataDir, warned: make(map[string]struct{})}, nil
+}
+
+func loadOrMintControlToken(dataDir string) (string, bool, error) {
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		return "", false, fmt.Errorf("create data directory: %w", err)
+	}
+	path := filepath.Join(dataDir, ControlTokenFile)
+	b, err := os.ReadFile(path)
+	if err == nil {
+		token := strings.TrimSpace(string(b))
+		decoded, decodeErr := hex.DecodeString(token)
+		if decodeErr == nil && len(decoded) == 32 {
+			if chmodErr := os.Chmod(path, 0o600); chmodErr != nil {
+				return "", false, fmt.Errorf("secure control token: %w", chmodErr)
+			}
+			return token, false, nil
+		}
+		token, mintErr := mintControlToken(path)
+		if mintErr != nil {
+			return "", false, mintErr
+		}
+		return token, true, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", false, fmt.Errorf("read control token: %w", err)
+	}
+	token, err := mintControlToken(path)
+	return token, false, err
+}
+
+func mintControlToken(path string) (token string, err error) {
+	token, err = randomHex(32)
+	if err != nil {
+		return "", fmt.Errorf("mint control token: %w", err)
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), ".control.token-*")
+	if err != nil {
+		return "", fmt.Errorf("create temporary control token: %w", err)
+	}
+	tempPath := f.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if err = f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return "", fmt.Errorf("secure temporary control token: %w", err)
+	}
+	if _, err = f.WriteString(token + "\n"); err != nil {
+		_ = f.Close()
+		return "", fmt.Errorf("write temporary control token: %w", err)
+	}
+	if err = f.Close(); err != nil {
+		return "", fmt.Errorf("close temporary control token: %w", err)
+	}
+	if err = os.Rename(tempPath, path); err != nil {
+		return "", fmt.Errorf("install control token: %w", err)
+	}
+	return token, nil
+}
+
+func randomHex(bytes int) (string, error) {
+	b := make([]byte, bytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func (a *ControlAuth) BootstrapURL(baseURL string) string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.bootstrap == "" {
+		return ""
+	}
+	return strings.TrimRight(baseURL, "/") + "/auth/bootstrap?t=" + a.bootstrap
+}
+
+func (a *ControlAuth) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth/bootstrap" {
+			if _, ok := localRequestOrigin(r); !ok {
+				http.NotFound(w, r)
+				return
+			}
+			a.handleBootstrap(w, r)
+			return
+		}
+		if isProtectedLocalPath(r.URL.Path) {
+			classification := a.classify(r)
+			fetchSite := strings.TrimSpace(r.Header.Get("Sec-Fetch-Site"))
+			if classification == "missing" || classification == "invalid" || (fetchSite != "" && fetchSite != "same-origin" && fetchSite != "same-site" && fetchSite != "none") {
+				a.warnOnce(r, classification, fetchSite)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (a *ControlAuth) classify(r *http.Request) string {
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	if auth != "" {
+		parts := strings.Fields(auth)
+		if len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") && secureEqual(parts[1], a.token) {
+			return "bearer-ok"
+		}
+		return "invalid"
+	}
+	cookie, err := r.Cookie(ControlCookieName)
+	if err == nil {
+		if secureEqual(cookie.Value, a.token) {
+			return "cookie-ok"
+		}
+		return "invalid"
+	}
+	return "missing"
+}
+
+func secureEqual(got, want string) bool {
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+func (a *ControlAuth) warnOnce(r *http.Request, classification, fetchSite string) {
+	key := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(key); err == nil {
+		key = host
+	}
+	if key == "" {
+		key = "unknown"
+	}
+	a.mu.Lock()
+	if _, ok := a.warned[key]; ok {
+		a.mu.Unlock()
+		return
+	}
+	overflow := false
+	if len(a.warned) >= maxWarnedRemotes {
+		clear(a.warned)
+		if !a.warnedMapOverflow {
+			a.warnedMapOverflow = true
+			overflow = true
+		}
+	}
+	a.warned[key] = struct{}{}
+	a.mu.Unlock()
+	if overflow {
+		a.logger.Warn().Int("limit", maxWarnedRemotes).Msg("Cleared full unauthenticated remote warning cache")
+	}
+	a.logger.Warn().Str("remote", key).Str("auth", classification).Str("sec_fetch_site", fetchSite).Msg("Local control request is not authenticated; allowed during accept-and-log rollout")
+}
+
+func (a *ControlAuth) handleBootstrap(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	code := r.URL.Query().Get("t")
+	a.mu.Lock()
+	valid := a.bootstrap != "" && secureEqual(code, a.bootstrap)
+	if valid {
+		a.bootstrap = ""
+	}
+	a.mu.Unlock()
+	if !valid {
+		httpError(w, "bootstrap code is invalid or already used", http.StatusGone)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{Name: ControlCookieName, Value: a.token, Path: "/", HttpOnly: true, SameSite: http.SameSiteStrictMode})
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+func (a *ControlAuth) Status() map[string]any {
+	if a == nil {
+		return map[string]any{"token_present": false, "mode": AuthModeAcceptAndLog}
+	}
+	return map[string]any{"token_present": a.token != "", "mode": AuthModeAcceptAndLog, "data_dir": a.dataDir}
+}

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -1,0 +1,229 @@
+package web
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/rs/zerolog"
+)
+
+func TestControlTokenMintLoadAndPermissions(t *testing.T) {
+	dir := t.TempDir()
+	first, err := NewControlAuth(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.token) != 64 {
+		t.Fatalf("token length = %d, want 64 hex chars", len(first.token))
+	}
+	info, err := os.Stat(filepath.Join(dir, ControlTokenFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %o, want 600", got)
+	}
+	second, err := NewControlAuth(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.token != first.token {
+		t.Fatal("token changed across restart")
+	}
+}
+
+func TestControlTokenRegeneratesInvalidExistingFile(t *testing.T) {
+	for _, contents := range []string{"", "abcd", "not-hex"} {
+		t.Run(fmt.Sprintf("length-%d", len(contents)), func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, ControlTokenFile)
+			if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var logs bytes.Buffer
+			a, err := NewControlAuth(dir, zerolog.New(&logs))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decoded, err := hex.DecodeString(a.token); err != nil || len(decoded) != 32 {
+				t.Fatalf("regenerated token = %q, decode error = %v", a.token, err)
+			}
+			if got := strings.Count(logs.String(), "Invalid control token was regenerated"); got != 1 {
+				t.Fatalf("regeneration warnings = %d, want 1; %s", got, logs.String())
+			}
+		})
+	}
+}
+
+func TestControlAuthAcceptAndLogClassifications(t *testing.T) {
+	var logs bytes.Buffer
+	a, err := NewControlAuth(t.TempDir(), zerolog.New(&logs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	h := ProtectLocalControl(a.Handler(next))
+	tests := []struct {
+		name     string
+		apply    func(*http.Request)
+		wantWarn bool
+	}{
+		{"bearer", func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+a.token) }, false},
+		{"cookie", func(r *http.Request) { r.AddCookie(&http.Cookie{Name: ControlCookieName, Value: a.token}) }, false},
+		{"missing", func(*http.Request) {}, true},
+		{"invalid", func(r *http.Request) { r.Header.Set("Authorization", "Bearer wrong") }, true},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs.Reset()
+			r := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/status", nil)
+			r.RemoteAddr = "127.0.0." + string(rune('1'+i)) + ":7007"
+			tt.apply(r)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			if w.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, accept-and-log must pass", w.Code)
+			}
+			if got := strings.Contains(logs.String(), `"level":"warn"`); got != tt.wantWarn {
+				t.Fatalf("warn = %t, want %t; %s", got, tt.wantWarn, logs.String())
+			}
+		})
+	}
+}
+
+func TestControlAuthWarnsOncePerRemoteHost(t *testing.T) {
+	var logs bytes.Buffer
+	a, err := NewControlAuth(t.TempDir(), zerolog.New(&logs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := a.Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) }))
+	for _, remote := range []string{"192.0.2.10:7001", "192.0.2.10:7002"} {
+		r := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/status", nil)
+		r.RemoteAddr = remote
+		h.ServeHTTP(httptest.NewRecorder(), r)
+	}
+	if got := strings.Count(logs.String(), `"level":"warn"`); got != 1 {
+		t.Fatalf("warnings = %d, want 1; %s", got, logs.String())
+	}
+}
+
+func TestControlAuthBoundsWarnedRemoteMap(t *testing.T) {
+	a, err := NewControlAuth(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i <= maxWarnedRemotes; i++ {
+		r := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/status", nil)
+		r.RemoteAddr = fmt.Sprintf("remote-%d", i)
+		a.warnOnce(r, "missing", "")
+	}
+	if got := len(a.warned); got != 1 {
+		t.Fatalf("warned map length after overflow = %d, want 1", got)
+	}
+	if !a.warnedMapOverflow {
+		t.Fatal("warned map overflow was not recorded")
+	}
+}
+
+func TestControlBootstrapSetsStrictCookieAndIsSingleUse(t *testing.T) {
+	a, err := NewControlAuth(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	url := a.BootstrapURL("http://127.0.0.1:7007")
+	h := a.Handler(http.NotFoundHandler())
+	first := httptest.NewRecorder()
+	h.ServeHTTP(first, httptest.NewRequest(http.MethodGet, url, nil))
+	if first.Code != http.StatusFound || first.Header().Get("Location") != "/" {
+		t.Fatalf("first = %d location %q", first.Code, first.Header().Get("Location"))
+	}
+	cookies := first.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != ControlCookieName || !cookies[0].HttpOnly || cookies[0].SameSite != http.SameSiteStrictMode || cookies[0].Secure || cookies[0].Path != "/" {
+		t.Fatalf("cookie = %+v", cookies)
+	}
+	second := httptest.NewRecorder()
+	h.ServeHTTP(second, httptest.NewRequest(http.MethodGet, url, nil))
+	if second.Code != http.StatusGone {
+		t.Fatalf("second status = %d, want 410", second.Code)
+	}
+}
+
+func TestControlBootstrapRejectsNonLoopbackHostWithoutConsumingCode(t *testing.T) {
+	a, err := NewControlAuth(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	url := a.BootstrapURL("http://127.0.0.1:7007")
+	h := a.Handler(http.NotFoundHandler())
+	nonLoopback := httptest.NewRequest(http.MethodGet, url, nil)
+	nonLoopback.Host = "example.com"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, nonLoopback)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("non-loopback status = %d, want 404", w.Code)
+	}
+	valid := httptest.NewRecorder()
+	h.ServeHTTP(valid, httptest.NewRequest(http.MethodGet, url, nil))
+	if valid.Code != http.StatusFound {
+		t.Fatalf("loopback status after rejection = %d, want 302", valid.Code)
+	}
+}
+
+func TestStatusReportsAcceptAndLogAuth(t *testing.T) {
+	store, err := db.New(filepath.Join(t.TempDir(), "messages.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	a, err := NewControlAuth(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := APIHandlerWithOptions(store, nil, zerolog.Nop(), nil, APIOptions{Auth: a})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/status", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	auth, ok := body["auth"].(map[string]any)
+	if !ok || auth["mode"] != AuthModeAcceptAndLog || auth["token_present"] != true || auth["data_dir"] != a.dataDir {
+		t.Fatalf("auth = %#v", body["auth"])
+	}
+	if got := w.Header().Get("Cross-Origin-Resource-Policy"); got != "same-origin" {
+		t.Fatalf("CORP = %q", got)
+	}
+}
+
+func TestEventStreamRejectsNewestSubscriberAtLimit(t *testing.T) {
+	store, err := db.New(filepath.Join(t.TempDir(), "messages.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	events := NewEventBroker()
+	for i := 0; i < maxEventSubscribers; i++ {
+		if _, _, ok := events.TrySubscribe(); !ok {
+			t.Fatalf("subscriber %d rejected", i)
+		}
+	}
+	h := APIHandlerWithOptions(store, nil, zerolog.Nop(), nil, APIOptions{Events: events})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/events", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+}

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -12,6 +12,7 @@ const (
 
 	subscriberChannelBuffer = 8
 	subscriberMaxPending    = 128
+	maxEventSubscribers     = 32
 )
 
 // StreamEvent is a small invalidation payload pushed to connected browsers.
@@ -148,7 +149,21 @@ func NewEventBroker() *EventBroker {
 func (b *EventBroker) Subscribe() (int, <-chan StreamEvent) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	return b.subscribeLocked()
+}
 
+func (b *EventBroker) TrySubscribe() (int, <-chan StreamEvent, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.subscribers) >= maxEventSubscribers {
+		return 0, nil, false
+	}
+
+	id, ch := b.subscribeLocked()
+	return id, ch, true
+}
+
+func (b *EventBroker) subscribeLocked() (int, <-chan StreamEvent) {
 	id := b.nextID
 	b.nextID++
 	sub := newEventSubscriber()

--- a/internal/web/events_test.go
+++ b/internal/web/events_test.go
@@ -65,6 +65,28 @@ func TestEventSubscriberCollapsePreservesLatestStatusAndGlobalRefreshes(t *testi
 	}
 }
 
+func TestEventBrokerRejectsNewestSubscriberAtLimit(t *testing.T) {
+	b := NewEventBroker()
+	ids := make([]int, 0, maxEventSubscribers)
+	for i := 0; i < maxEventSubscribers; i++ {
+		id, _, ok := b.TrySubscribe()
+		if !ok {
+			t.Fatalf("subscriber %d rejected before limit", i)
+		}
+		ids = append(ids, id)
+	}
+	if _, _, ok := b.TrySubscribe(); ok {
+		t.Fatal("subscriber above limit accepted")
+	}
+	b.Unsubscribe(ids[0])
+	if _, _, ok := b.TrySubscribe(); !ok {
+		t.Fatal("subscriber rejected after slot released")
+	}
+	for _, id := range ids[1:] {
+		b.Unsubscribe(id)
+	}
+}
+
 func TestEventBrokerOverflowFallsBackToGlobalRefresh(t *testing.T) {
 	broker := NewEventBroker()
 	id, ch := broker.Subscribe()


### PR DESCRIPTION
## Rebuild W3 PR-G — auth stage 6a (accept-and-log, never reject)

Final Wave-3 lane. The installation capability (`control.token`, cookie, bearer) now exists end-to-end, with **zero enforcement**: missing/invalid auth WARNs once per remote and passes through. 401s are stage 6b, one packaged-app release later, after the Swift wrapper attaches the token — so the live v2-primary install keeps working untouched.

### Review
Opus adversarial review: FIX-FIRST → all 6 findings fixed with discriminators. The two that mattered:
- **Availability trap (proven)**: a partial write during the one-time mint (disk full) left an empty `control.token` that **bricked every subsequent server start** — the exact denial the 6a contract forbids, via file robustness instead of the auth path. Now: atomic temp+rename mint, and empty/undecodable existing files regenerate with a WARN instead of failing startup.
- **Two-data-dirs trap (third sighting this rebuild)**: the CLI read the token from its XDG default while the macOS daemon mints under `~/Library/Application Support/OpenMessage` → nothing attached → `openmessage send` would 401 the day 6b lands. Now: the CLI resolves the token path from the daemon's own `/api/status auth.data_dir` (server-truth, like PR-E's mode probe); the 0600 file remains the capability — only the path travels over HTTP.

Plus: de-vacuized the once-per-remote WARN test (same host twice → exactly one WARN), SSE write deadlines so half-open sockets can't hold subscriber slots, warned-map bounded at 1024, bootstrap loopback-gated (defense in depth; wrong guesses never consumed the code even before).

### Verification
- Independent full `GOWORK=off go test -race ./...` outside the sandbox: **32/32 packages, exit 0**
- Full Playwright suite over the auth-wrapped middleware: **91 passed / 9 skipped / 0 failed** — the middleware is invisible to the UI, exactly as 6a demands
- Never-reject contract pinned by tests asserting unauthenticated requests SUCCEED

🤖 Generated with [Claude Code](https://claude.com/claude-code)