### PR TITLE
Make serve --mcp-stdio a transportless daemon client (fixes WhatsApp/Signal MCP fratricide)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,19 @@ openmessage import imessage                     # reads ~/Library/Messages/chat.
 openmessage import whatsapp /path/to/chat.txt --name "Your Name"
 ```
 
+### MCP serving modes
+
+`serve --mcp-stdio` (the shape MCP hosts spawn per session) runs as a
+**transportless client**: it starts zero transport supervisors, dispatchers,
+sync loops, or schedulers — the app daemon owns all live connections (two
+processes sharing WhatsApp/signal-cli credentials log each other out). Reads
+come from the local store (v2 when the daemon reports v2-primary for the same
+data dir); sends, reactions, and `get_status` route through the running
+daemon's HTTP API (`internal/localapi`) with the CLI's daemon-truth semantics.
+`--transports` / `--no-transports` override the default per shape. See
+[docs/agent-runbook.md](docs/agent-runbook.md) ("MCP serving") for the failure
+mode this prevents and the `~/.mcp.json` recipe.
+
 ### MCP tools
 
 24 tools registered (see internal/tools/tools.go Register for the authoritative list):

--- a/cmd/binary_test.go
+++ b/cmd/binary_test.go
@@ -209,6 +209,9 @@ func TestBuiltBinaryV2FlagOffDoesNotCreateV2Directory(t *testing.T) {
 		"OPENMESSAGES_MACOS_NOTIFICATIONS=0",
 		"OPENMESSAGES_LOG_LEVEL=info",
 		"OPENMESSAGE_TELEMETRY=0",
+		// Hermetic daemon probe for the MCP client shape: never reach a
+		// real daemon that may be running on the test machine.
+		"OPENMESSAGES_PORT=0",
 	)
 	cmd.Stdin = strings.NewReader("")
 	output, err := cmd.CombinedOutput()
@@ -224,10 +227,46 @@ func TestBuiltBinaryV2FlagOffDoesNotCreateV2Directory(t *testing.T) {
 	}
 }
 
-func TestBuiltBinaryV2IngestFlagCreatesV2Directory(t *testing.T) {
+// TestBuiltBinaryMCPStdioClientShapeStartsNoTransports is the end-to-end
+// regression test for the MCP fratricide bug: the per-session `serve
+// --mcp-stdio` spawn must not initialize any transport state — a second
+// process reusing the daemon's WhatsApp device credentials or signal-cli
+// account logs the daemon out.
+func TestBuiltBinaryMCPStdioClientShapeStartsNoTransports(t *testing.T) {
 	binary, dataDir := buildTestBinary(t)
 
 	cmd := exec.Command(binary, "serve", "--mcp-stdio")
+	cmd.Env = append(
+		os.Environ(),
+		"OPENMESSAGES_DATA_DIR="+dataDir,
+		"OPENMESSAGES_DEMO=0",
+		"OPENMESSAGES_APP_SANDBOX=1",
+		"OPENMESSAGES_MACOS_NOTIFICATIONS=0",
+		"OPENMESSAGES_LOG_LEVEL=info",
+		"OPENMESSAGE_TELEMETRY=0",
+		"OPENMESSAGES_PORT=0",
+	)
+	cmd.Stdin = strings.NewReader("")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("serve --mcp-stdio: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "MCP client mode") {
+		t.Fatalf("client mode was not engaged:\n%s", output)
+	}
+	for _, forbidden := range []string{"whatsapp-session.db", "signal-cli", "v2"} {
+		if _, err := os.Stat(filepath.Join(dataDir, forbidden)); !os.IsNotExist(err) {
+			t.Errorf("client shape created transport state %q (stat err = %v)\n%s", forbidden, err, output)
+		}
+	}
+}
+
+func TestBuiltBinaryV2IngestFlagCreatesV2Directory(t *testing.T) {
+	binary, dataDir := buildTestBinary(t)
+
+	// --transports keeps this the daemon shape: the MCP-stdio-only client
+	// shape intentionally never provisions the v2 stack.
+	cmd := exec.Command(binary, "serve", "--mcp-stdio", "--transports")
 	cmd.Env = append(
 		os.Environ(),
 		"OPENMESSAGES_DATA_DIR="+dataDir,
@@ -242,7 +281,7 @@ func TestBuiltBinaryV2IngestFlagCreatesV2Directory(t *testing.T) {
 	cmd.Stdin = strings.NewReader("")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("serve --mcp-stdio: %v\n%s", err, output)
+		t.Fatalf("serve --mcp-stdio --transports: %v\n%s", err, output)
 	}
 	if !strings.Contains(string(output), "Starting MCP stdio transport") {
 		t.Fatalf("serve did not reach MCP stdio startup:\n%s", output)

--- a/cmd/send_outbox.go
+++ b/cmd/send_outbox.go
@@ -1,23 +1,19 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/maxghenis/openmessage/internal/app"
-	"github.com/maxghenis/openmessage/internal/web"
+	"github.com/maxghenis/openmessage/internal/localapi"
 )
 
 type sendCommandDeps struct {
@@ -38,20 +34,13 @@ type sendGroupCommandDeps struct {
 	controlToken string
 }
 
-type outboxSubmission struct {
-	OutboxID       string `json:"outbox_id"`
-	State          string `json:"state"`
-	ScheduledForMS int64  `json:"scheduled_for_ms"`
-	Deduplicated   bool   `json:"deduplicated"`
-}
-
-type outboxDelivery struct {
-	OutboxID        string `json:"outbox_id"`
-	State           string `json:"state"`
-	RemoteMessageID string `json:"remote_message_id"`
-	ErrorClass      string `json:"error_class"`
-	Warning         string `json:"warning"`
-}
+// outboxSubmission and outboxDelivery are the CLI's names for the shared
+// local API wire types.
+type (
+	outboxSubmission = localapi.Submission
+	outboxDelivery   = localapi.Delivery
+	v2DaemonStatus   = localapi.DaemonStatus
+)
 
 func defaultSendCommandDeps(legacy func(string, string) error) sendCommandDeps {
 	return sendCommandDeps{
@@ -80,11 +69,15 @@ func defaultSendGroupCommandDeps(legacy func([]string, string) error) sendGroupC
 }
 
 func localAPIBaseURL() string {
-	port := strings.TrimSpace(os.Getenv("OPENMESSAGES_PORT"))
-	if port == "" {
-		port = "7007"
+	return localapi.DefaultBaseURL()
+}
+
+func (deps sendCommandDeps) daemonClient() *localapi.Client {
+	return &localapi.Client{
+		BaseURL: deps.baseURL,
+		HTTP:    deps.client,
+		Token:   deps.controlToken,
 	}
-	return "http://" + net.JoinHostPort("127.0.0.1", port)
 }
 
 func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, message string, notBeforeMS *int64) error {
@@ -98,7 +91,8 @@ func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, 
 		deps.output = os.Stdout
 	}
 
-	status, reachable, err := probeV2Status(ctx, deps.client, deps.baseURL, deps.controlToken)
+	daemon := deps.daemonClient()
+	status, reachable, err := daemon.Status(ctx)
 	if err != nil {
 		if reachable {
 			return fmt.Errorf("check running OpenMessage mode: %w", err)
@@ -112,7 +106,7 @@ func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, 
 		}
 		return deps.legacySend(conversationID, message)
 	}
-	deps.controlToken = controlTokenFromDaemonStatus(status, deps.controlToken)
+	daemon.Token = controlTokenFromDaemonStatus(status, deps.controlToken)
 	if !status.V2Send && !status.V2Primary {
 		return deps.legacySend(conversationID, message)
 	}
@@ -123,35 +117,17 @@ func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, 
 	if err != nil {
 		return err
 	}
-	payload := struct {
-		ConversationID string `json:"conversation_id"`
-		Body           string `json:"body"`
-		IdempotencyKey string `json:"idempotency_key"`
-		NotBeforeMS    *int64 `json:"not_before_ms,omitempty"`
-	}{conversationID, message, key, notBeforeMS}
-	body, err := json.Marshal(payload)
+	submission, err := daemon.SubmitText(ctx, localapi.TextSubmission{
+		ConversationID: conversationID,
+		Body:           message,
+		IdempotencyKey: key,
+		NotBeforeMS:    notBeforeMS,
+	})
 	if err != nil {
-		return fmt.Errorf("encode outbox submission: %w", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, deps.baseURL+"/api/v1/outbox/messages", bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	request.Header.Set("Content-Type", "application/json")
-	attachControlToken(request, deps.controlToken)
-	response, err := deps.client.Do(request)
-	if err != nil {
-		return ambiguousSendError(key, err)
-	}
-	var submission outboxSubmission
-	if err := decodeCLIResponse(response, &submission); err != nil {
-		if isDeterministicRejection(err) {
+		if localapi.IsDeterministicRejection(err) {
 			return deterministicRejectionError(err)
 		}
 		return ambiguousSendError(key, err)
-	}
-	if submission.OutboxID == "" {
-		return ambiguousSendError(key, fmt.Errorf("submission response omitted outbox_id"))
 	}
 
 	fmt.Fprintf(deps.output, "outbox_id=%s state=%s idempotency_key=%s deduplicated=%t", submission.OutboxID, submission.State, key, submission.Deduplicated)
@@ -164,7 +140,7 @@ func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, 
 		when := time.UnixMilli(submission.ScheduledForMS).Format(time.RFC3339)
 		fmt.Fprintf(deps.output, "scheduled; the app will send it at %s (%d ms). Do not resend.\n", when, submission.ScheduledForMS)
 	}
-	delivery, err := getOutboxDelivery(ctx, deps.client, deps.baseURL, submission.OutboxID, deps.controlToken)
+	delivery, err := daemon.Delivery(ctx, submission.OutboxID)
 	if err != nil {
 		if !scheduled {
 			fmt.Fprintf(deps.output, "queued; app continues in the background. Do not resend. Replay-check with the same idempotency key: %s\n", key)
@@ -174,14 +150,6 @@ func runSendWithDeps(ctx context.Context, deps sendCommandDeps, conversationID, 
 	return writeCLIDelivery(deps.output, delivery, key, scheduled)
 }
 
-type v2DaemonStatus struct {
-	V2Send    bool `json:"v2_send"`
-	V2Primary bool `json:"v2_primary"`
-	Auth      struct {
-		DataDir string `json:"data_dir"`
-	} `json:"auth"`
-}
-
 func controlTokenFromDaemonStatus(status v2DaemonStatus, fallback string) string {
 	if strings.TrimSpace(status.Auth.DataDir) == "" {
 		return fallback
@@ -189,75 +157,8 @@ func controlTokenFromDaemonStatus(status v2DaemonStatus, fallback string) string
 	return loadCLIControlToken(status.Auth.DataDir)
 }
 
-func probeV2Status(ctx context.Context, client *http.Client, baseURL, token string) (v2DaemonStatus, bool, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/status", nil)
-	if err != nil {
-		return v2DaemonStatus{}, false, err
-	}
-	attachControlToken(request, token)
-	response, err := client.Do(request)
-	if err != nil {
-		return v2DaemonStatus{}, false, err
-	}
-	var status v2DaemonStatus
-	if err := decodeCLIResponse(response, &status); err != nil {
-		return v2DaemonStatus{}, true, err
-	}
-	return status, true, nil
-}
-
-func getOutboxDelivery(ctx context.Context, client *http.Client, baseURL, id, token string) (outboxDelivery, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v1/outbox/"+id, nil)
-	if err != nil {
-		return outboxDelivery{}, err
-	}
-	attachControlToken(request, token)
-	response, err := client.Do(request)
-	if err != nil {
-		return outboxDelivery{}, err
-	}
-	var delivery outboxDelivery
-	err = decodeCLIResponse(response, &delivery)
-	return delivery, err
-}
-
-func decodeCLIResponse(response *http.Response, target any) error {
-	defer response.Body.Close()
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		body, _ := io.ReadAll(io.LimitReader(response.Body, 4096))
-		return &cliResponseError{StatusCode: response.StatusCode, Body: strings.TrimSpace(string(body))}
-	}
-	if err := json.NewDecoder(response.Body).Decode(target); err != nil {
-		return fmt.Errorf("decode local API response: %w", err)
-	}
-	return nil
-}
-
-type cliResponseError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *cliResponseError) Error() string {
-	return fmt.Sprintf("local API returned HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func isDeterministicRejection(err error) bool {
-	var responseErr *cliResponseError
-	if !errors.As(err, &responseErr) {
-		return false
-	}
-	switch responseErr.StatusCode {
-	case http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusRequestEntityTooLarge, http.StatusUnprocessableEntity:
-		return true
-	default:
-		return false
-	}
-}
-
 func deterministicRejectionError(err error) error {
-	var responseErr *cliResponseError
-	if errors.As(err, &responseErr) && responseErr.StatusCode == http.StatusConflict {
+	if responseErr, ok := localapi.AsResponseError(err); ok && responseErr.StatusCode == http.StatusConflict {
 		return fmt.Errorf("send rejected: %s; this key already carries different content; use a new key to send this message", responseErr.Body)
 	}
 	return fmt.Errorf("send rejected: %w", err)
@@ -332,17 +233,7 @@ func newCLIIdempotencyKey() (string, error) {
 }
 
 func loadCLIControlToken(dataDir string) string {
-	b, err := os.ReadFile(filepath.Join(dataDir, web.ControlTokenFile))
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(b))
-}
-
-func attachControlToken(request *http.Request, token string) {
-	if token != "" {
-		request.Header.Set("Authorization", "Bearer "+token)
-	}
+	return localapi.LoadControlToken(dataDir)
 }
 
 func runSendGroupWithDeps(deps sendGroupCommandDeps, phones []string, message string) error {
@@ -352,7 +243,8 @@ func runSendGroupWithDeps(deps sendGroupCommandDeps, phones []string, message st
 	if deps.baseURL == "" {
 		deps.baseURL = localAPIBaseURL()
 	}
-	status, reachable, err := probeV2Status(context.Background(), deps.client, deps.baseURL, deps.controlToken)
+	daemon := &localapi.Client{BaseURL: deps.baseURL, HTTP: deps.client, Token: deps.controlToken}
+	status, reachable, err := daemon.Status(context.Background())
 	if err != nil {
 		if reachable {
 			return fmt.Errorf("check running OpenMessage mode: %w", err)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"strings"
@@ -29,8 +30,10 @@ import (
 	"github.com/maxghenis/openmessage/internal/googlecookies"
 	"github.com/maxghenis/openmessage/internal/importer"
 	"github.com/maxghenis/openmessage/internal/ingest"
+	"github.com/maxghenis/openmessage/internal/localapi"
 	"github.com/maxghenis/openmessage/internal/notify"
 	"github.com/maxghenis/openmessage/internal/readsource"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 	"github.com/maxghenis/openmessage/internal/telemetry"
 	"github.com/maxghenis/openmessage/internal/tools"
 	"github.com/maxghenis/openmessage/internal/v2read"
@@ -43,6 +46,32 @@ type serveOptions struct {
 	web      bool
 	mcpSSE   bool
 	mcpStdio bool
+
+	// transportsSet/transportsOn record an explicit --transports or
+	// --no-transports override. When unset, transports follow the serve
+	// shape: any daemon-like shape runs them, the MCP-stdio-only client
+	// shape does not.
+	transportsSet bool
+	transportsOn  bool
+}
+
+// mcpClientShape reports the per-session MCP spawn shape: stdio as the only
+// enabled transport. Claude and other MCP hosts spawn one such process per
+// session, so this shape must never own live platform connections — a second
+// process holding the same WhatsApp device credentials or signal-cli account
+// logs the real daemon out ("401: logged out from another device").
+func (o serveOptions) mcpClientShape() bool {
+	return o.mcpStdio && !o.web && !o.mcpSSE
+}
+
+// transportsEnabled reports whether this process may start transport
+// supervisors and the other daemon-only subsystems (v2 dispatcher, sync
+// loops, scheduler, telemetry).
+func (o serveOptions) transportsEnabled() bool {
+	if o.transportsSet {
+		return o.transportsOn
+	}
+	return !o.mcpClientShape()
 }
 
 func mcpV2Dependencies(stack *v2Stack) []*tools.V2Dependencies {
@@ -108,6 +137,18 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	defer restoreEnv()
 
 	isDemo := app.DemoMode()
+
+	// The MCP-stdio-only shape serves one Claude/MCP session and must never
+	// run its own transport stack: it would connect with the same WhatsApp
+	// device credentials and signal-cli account as the real daemon and log
+	// it out. It becomes a transportless client of the running app instead.
+	// Demo mode keeps the legacy path (it never starts transports anyway),
+	// and --transports explicitly opts a standalone stdio deployment back in.
+	if !isDemo && opts.mcpClientShape() && !opts.transportsEnabled() {
+		return runServeMCPClient(logger, opts)
+	}
+	transports := opts.transportsEnabled()
+
 	v2Mode, err := resolveV2RuntimeMode(isDemo, app.DefaultDataDir())
 	if err != nil {
 		return err
@@ -175,7 +216,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	// Google has one lifecycle owner. Transient retry, liveness probes,
 	// credential repair, and terminal parking all flow through this supervisor;
 	// the legacy Connected flag remains a UI projection only.
-	if !isDemo {
+	if !isDemo && transports {
 		googleLifecycle = googleadapter.New(googleAccountID, a, canRefreshGoogleCookies)
 		a.SetGoogleLifecycleNotifier(googleLifecycle)
 		if v2Send || v2Ingest {
@@ -257,11 +298,13 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				startGoogleBackfill(a, logger)
 			}(googleSupervisor)
 		}
-	} else {
+	} else if isDemo {
 		logger.Info().Msg("Demo mode — skipping phone connection")
+	} else {
+		logger.Info().Msg("Transports disabled — skipping phone connection")
 	}
 
-	if !isDemo {
+	if !isDemo && transports {
 		whatsappBridge, initialized := initializeWhatsAppForServe(logger, a.InitializeWhatsApp)
 		if initialized {
 			whatsappLifecycle = whatsappadapter.New(whatsappAccountID, whatsappBridge)
@@ -329,11 +372,13 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				}(whatsappSupervisor)
 			}
 		}
-	} else {
+	} else if isDemo {
 		logger.Info().Msg("Demo mode — skipping WhatsApp live bridge")
+	} else {
+		logger.Info().Msg("Transports disabled — skipping WhatsApp live bridge")
 	}
 
-	if !isDemo {
+	if !isDemo && transports {
 		signalBridge, err := a.EnsureSignal()
 		if err != nil {
 			logger.Warn().Err(err).Msg("Signal live bridge unavailable")
@@ -393,8 +438,10 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				}()
 			}
 		}
-	} else {
+	} else if isDemo {
 		logger.Info().Msg("Demo mode — skipping Signal live bridge")
+	} else {
+		logger.Info().Msg("Transports disabled — skipping Signal live bridge")
 	}
 
 	if stack != nil {
@@ -470,14 +517,16 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		}()
 		syncLocalPlatforms()
 	}
-	go func() {
-		safeSync()
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-		for range ticker.C {
+	if transports {
+		go func() {
 			safeSync()
-		}
-	}()
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
+			for range ticker.C {
+				safeSync()
+			}
+		}()
+	}
 
 	// Belt-and-suspenders: periodically force a full Signal Desktop rescan
 	// so any drift that slipped past both the live signal-cli WebSocket AND
@@ -517,17 +566,19 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 			events.PublishMessages("")
 		}
 	}
-	go func() {
-		// First full rescan 2 minutes after startup so a crash-restart
-		// cycle doesn't hammer the DB immediately, then every 30 minutes.
-		time.Sleep(2 * time.Minute)
-		safeFullSignalSync()
-		ticker := time.NewTicker(30 * time.Minute)
-		defer ticker.Stop()
-		for range ticker.C {
+	if transports {
+		go func() {
+			// First full rescan 2 minutes after startup so a crash-restart
+			// cycle doesn't hammer the DB immediately, then every 30 minutes.
+			time.Sleep(2 * time.Minute)
 			safeFullSignalSync()
-		}
-	}()
+			ticker := time.NewTicker(30 * time.Minute)
+			defer ticker.Stop()
+			for range ticker.C {
+				safeFullSignalSync()
+			}
+		}()
+	}
 
 	var reads readsource.ReadSource = a.Store
 	if v2Primary {
@@ -598,8 +649,12 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 		}
 	}
 
-	// Background loop that sends due scheduled ("send later") messages.
-	startLegacyScheduler(v2Primary, a.StartScheduler)
+	// Background loop that sends due scheduled ("send later") messages. Only
+	// the transport-owning daemon may run it: a second scheduler over the
+	// same store double-sends every due message.
+	if transports {
+		startLegacyScheduler(v2Primary, a.StartScheduler)
+	}
 
 	v2Options := v2SendWebOptions(stack, v2Send)
 	v2IngestCounters := v2IngestCountersProvider(stack)
@@ -700,8 +755,9 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	}
 
 	// Send anonymous heartbeat (opt-in only, off by default).
-	// Enable with `OPENMESSAGE_TELEMETRY=1`. Skipped in demo mode.
-	if !isDemo && os.Getenv("OPENMESSAGE_TELEMETRY") == "1" {
+	// Enable with `OPENMESSAGE_TELEMETRY=1`. Skipped in demo mode and in
+	// transportless processes (one heartbeat per install, not per client).
+	if !isDemo && transports && os.Getenv("OPENMESSAGE_TELEMETRY") == "1" {
 		go func() {
 			tc := telemetry.New(app.DefaultDataDir(), buildVersion, true)
 			ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
@@ -716,6 +772,119 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 	<-sigCh
 	logger.Info().Msg("Shutting down")
 	return nil
+}
+
+// clientProbeTimeout bounds the startup daemon probe in MCP client mode so a
+// hung daemon cannot stall MCP initialization.
+const clientProbeTimeout = 3 * time.Second
+
+// runServeMCPClient serves the MCP-stdio-only shape as a transportless client
+// of the running OpenMessage daemon. It never starts transport supervisors,
+// the v2 dispatcher/ingest stack, sync loops, schedulers, or telemetry:
+// exactly one process (the app daemon) may own live platform connections,
+// because WhatsApp and signal-cli treat a second concurrent login as
+// credential theft and kill the session. Reads come from the local store;
+// sends and reactions route through the daemon's local HTTP API, mirroring
+// the CLI send path.
+func runServeMCPClient(logger zerolog.Logger, opts serveOptions) error {
+	// Probe before opening any store: daemon truth decides the read mode and,
+	// when OPENMESSAGES_DATA_DIR is unset, which data directory this client
+	// serves. The probe token comes from the pre-adoption data dir; the
+	// daemon may report the authoritative dir in its status payload.
+	daemon := localapi.NewClient("", localapi.LoadControlToken(app.DefaultDataDir()))
+	probeCtx, cancelProbe := context.WithTimeout(context.Background(), clientProbeTimeout)
+	status, _, probeErr := daemon.Status(probeCtx)
+	cancelProbe()
+	daemonUp := probeErr == nil
+
+	daemonDataDir := ""
+	if daemonUp {
+		daemonDataDir = strings.TrimSpace(status.Auth.DataDir)
+		if _, pinned := os.LookupEnv("OPENMESSAGES_DATA_DIR"); !pinned && daemonDataDir != "" {
+			if info, err := os.Stat(daemonDataDir); err == nil && info.IsDir() {
+				_ = os.Setenv("OPENMESSAGES_DATA_DIR", daemonDataDir)
+				logger.Info().Str("data_dir", daemonDataDir).Msg("MCP client mode: adopted the running app's data directory")
+			}
+		}
+		daemon.Token = controlTokenFromDaemonStatus(status, daemon.Token)
+	}
+
+	// Read mode. Daemon truth applies only when the daemon serves this same
+	// data directory; otherwise the environment decides, preserving the
+	// CLI's fail-fast diagnostics for invalid flag combinations. All
+	// refusals happen before app.New so a refused startup leaves no state
+	// behind.
+	dataDir := app.DefaultDataDir()
+	v2Primary := false
+	if daemonUp && daemonDataDir != "" && samePath(daemonDataDir, dataDir) {
+		v2Primary = status.V2Primary
+	} else {
+		mode, err := resolveV2RuntimeMode(false, dataDir)
+		if err != nil {
+			return err
+		}
+		v2Primary = mode.Primary
+	}
+	var v2Store *sqlite.Store
+	if v2Primary {
+		v2StorePath := filepath.Join(dataDir, "v2", "store.sqlite3")
+		// The daemon owns v2 provisioning; a client must attach to an
+		// existing store, never create one.
+		if _, err := os.Stat(v2StorePath); err != nil {
+			return fmt.Errorf("v2-primary reads selected but no migrated store at %s: %w", v2StorePath, err)
+		}
+		opened, err := sqlite.Open(v2StorePath)
+		if err != nil {
+			return fmt.Errorf("open v2 read store %q: %w", v2StorePath, err)
+		}
+		v2Store = opened
+		defer func() {
+			if err := v2Store.Close(); err != nil {
+				logger.Warn().Err(err).Msg("Failed to close v2 read store")
+			}
+		}()
+	}
+
+	a, err := app.New(logger)
+	if err != nil {
+		return fmt.Errorf("init app: %w", err)
+	}
+	defer a.Close()
+
+	var reads readsource.ReadSource = a.Store
+	if v2Store != nil {
+		reads = v2read.New(v2Store)
+	}
+
+	mcpSrv := mcpserver.NewMCPServer(
+		"openmessage",
+		buildVersion,
+		mcpserver.WithToolCapabilities(true),
+	)
+	tools.RegisterWithOptions(mcpSrv, a, tools.Options{
+		Reads:     reads,
+		V2Primary: v2Primary,
+		Daemon:    daemon,
+	})
+
+	logger.Info().
+		Bool("daemon_running", daemonUp).
+		Bool("v2_primary_reads", v2Primary).
+		Str("data_dir", a.DataDir).
+		Msg("MCP client mode: transports disabled; sends route through the running app")
+	logger.Info().Msg("Starting MCP stdio transport")
+	return mcpserver.ServeStdio(mcpSrv)
+}
+
+// samePath reports whether two paths name the same directory, tolerating
+// symlinks and cosmetic differences.
+func samePath(a, b string) bool {
+	if filepath.Clean(a) == filepath.Clean(b) {
+		return true
+	}
+	infoA, errA := os.Stat(a)
+	infoB, errB := os.Stat(b)
+	return errA == nil && errB == nil && os.SameFile(infoA, infoB)
 }
 
 func initializeWhatsAppForServe(
@@ -796,6 +965,12 @@ func parseServeOptions(args []string) (serveOptions, error) {
 		case "--no-mcp-stdio":
 			enableExplicitTransportMode()
 			opts.mcpStdio = false
+		case "--transports":
+			opts.transportsSet = true
+			opts.transportsOn = true
+		case "--no-transports":
+			opts.transportsSet = true
+			opts.transportsOn = false
 		case "":
 		default:
 			return serveOptions{}, fmt.Errorf("unknown serve option: %s", arg)

--- a/cmd/serve_client_test.go
+++ b/cmd/serve_client_test.go
@@ -178,6 +178,52 @@ func TestRunServeMCPClientAdoptsDaemonTruth(t *testing.T) {
 	}
 }
 
+// TestRunServeMCPClientAdoptsDaemonDataDir verifies that with no
+// OPENMESSAGES_DATA_DIR pinned, the client adopts the data directory the
+// running daemon reports, so an env-less MCP spawn serves the app's store
+// instead of the stale CLI-default directory.
+func TestRunServeMCPClientAdoptsDaemonDataDir(t *testing.T) {
+	daemonDataDir := t.TempDir()
+
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"connected": true,
+			"auth":      map[string]any{"data_dir": daemonDataDir},
+		})
+	}))
+	defer daemon.Close()
+	daemonURL, err := url.Parse(daemon.URL)
+	if err != nil {
+		t.Fatalf("parse daemon URL: %v", err)
+	}
+
+	// setClientModeTestEnv pins OPENMESSAGES_DATA_DIR (t.Setenv registers the
+	// restore); the unset afterwards is what this test is about. If adoption
+	// regresses, app.New would fall through to the real CLI-default dir, so
+	// fail fast on the log assertion rather than writing there.
+	setClientModeTestEnv(t, t.TempDir())
+	t.Setenv("OPENMESSAGES_PORT", daemonURL.Port())
+	if err := os.Unsetenv("OPENMESSAGES_DATA_DIR"); err != nil {
+		t.Fatalf("unset data dir: %v", err)
+	}
+
+	var logs bytes.Buffer
+	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
+		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
+	}
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "adopted the running app's data directory") {
+		t.Fatalf("data dir adoption did not happen:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, daemonDataDir) {
+		t.Fatalf("adopted dir was not the daemon's:\n%s", logOutput)
+	}
+	// The adopted directory now holds the client's read store.
+	if _, err := os.Stat(filepath.Join(daemonDataDir, "messages.db")); err != nil {
+		t.Fatalf("client did not open the store in the adopted dir: %v", err)
+	}
+}
+
 // TestControlTokenFileConstantsAgree pins the localapi copy of the control
 // token filename to the web package's authoritative constant.
 func TestControlTokenFileConstantsAgree(t *testing.T) {

--- a/cmd/serve_client_test.go
+++ b/cmd/serve_client_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/localapi"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/web"
+)
+
+// TestServeOptionsTransportMatrix pins which serve shapes may own live
+// platform connections. The MCP-stdio-only shape is the per-Claude-session
+// spawn and must default to transportless client mode.
+func TestServeOptionsTransportMatrix(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantClient     bool
+		wantTransports bool
+	}{
+		{name: "default web daemon", args: nil, wantClient: false, wantTransports: true},
+		{name: "mcp-stdio only is the client shape", args: []string{"--mcp-stdio"}, wantClient: true, wantTransports: false},
+		{name: "mcp-stdio can opt back into transports", args: []string{"--mcp-stdio", "--transports"}, wantClient: true, wantTransports: true},
+		{name: "web daemon can drop transports", args: []string{"--web", "--no-transports"}, wantClient: false, wantTransports: false},
+		{name: "web plus stdio is a daemon", args: []string{"--web", "--mcp-stdio"}, wantClient: false, wantTransports: true},
+		{name: "sse only is a daemon", args: []string{"--mcp-sse"}, wantClient: false, wantTransports: true},
+		{name: "sse plus stdio is a daemon", args: []string{"--mcp-sse", "--mcp-stdio"}, wantClient: false, wantTransports: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := parseServeOptions(tt.args)
+			if err != nil {
+				t.Fatalf("parseServeOptions(%v): %v", tt.args, err)
+			}
+			if got := opts.mcpClientShape(); got != tt.wantClient {
+				t.Fatalf("mcpClientShape() = %v, want %v", got, tt.wantClient)
+			}
+			if got := opts.transportsEnabled(); got != tt.wantTransports {
+				t.Fatalf("transportsEnabled() = %v, want %v", got, tt.wantTransports)
+			}
+		})
+	}
+}
+
+func setClientModeTestEnv(t *testing.T, dataDir string) {
+	t.Helper()
+	t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
+	t.Setenv("OPENMESSAGES_DEMO", "0")
+	t.Setenv("OPENMESSAGES_V2_PRIMARY", "")
+	t.Setenv("OPENMESSAGES_V2_SEND", "")
+	t.Setenv("OPENMESSAGES_V2_INGEST", "")
+	t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
+	t.Setenv("OPENMESSAGES_MACOS_NOTIFICATIONS", "0")
+	t.Setenv("OPENMESSAGE_TELEMETRY", "0")
+	// Hermetic daemon probe: never reach a real daemon on the test machine.
+	t.Setenv("OPENMESSAGES_PORT", "0")
+}
+
+// TestRunServeMCPStdioStartsZeroTransportSupervisors is the regression test
+// for the MCP fratricide bug: `serve --mcp-stdio` (the per-Claude-session
+// spawn) used to start the full Google/WhatsApp/Signal transport stack with
+// the same credentials as the running app daemon, which WhatsApp treats as a
+// second device login ("401: logged out from another device") and which
+// corrupts signal-cli state. The client shape must start zero transport
+// supervisors and leave zero transport state on disk; run-in stdin EOF makes
+// RunServe return once the MCP stdio session ends.
+func TestRunServeMCPStdioStartsZeroTransportSupervisors(t *testing.T) {
+	dataDir := t.TempDir()
+	setClientModeTestEnv(t, dataDir)
+
+	var logs bytes.Buffer
+	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
+		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
+	}
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "MCP client mode") {
+		t.Fatalf("client mode was not engaged:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "Starting MCP stdio transport") {
+		t.Fatalf("MCP stdio transport did not start:\n%s", logOutput)
+	}
+
+	// No transport supervisor state may exist: WhatsApp's whatsmeow store,
+	// Signal's signal-cli config, and the v2 dispatcher store are all
+	// daemon-owned.
+	for _, forbidden := range []string{"whatsapp-session.db", "signal-cli", "v2"} {
+		if _, err := os.Stat(filepath.Join(dataDir, forbidden)); !os.IsNotExist(err) {
+			t.Errorf("client mode created transport state %q (stat err = %v)", forbidden, err)
+		}
+	}
+	// Reads still work: the legacy store opens.
+	if _, err := os.Stat(filepath.Join(dataDir, "messages.db")); err != nil {
+		t.Fatalf("client mode did not open the local read store: %v", err)
+	}
+
+	// Contrast case: the same stdio shape with --transports is a standalone
+	// daemon and does initialize transport state. This guards the assertion
+	// above against silently passing because the fixtures changed.
+	daemonDataDir := t.TempDir()
+	setClientModeTestEnv(t, daemonDataDir)
+	var daemonLogs bytes.Buffer
+	if err := RunServe(zerolog.New(&daemonLogs), "--mcp-stdio", "--transports"); err != nil {
+		t.Fatalf("RunServe(--mcp-stdio --transports): %v\n%s", err, daemonLogs.String())
+	}
+	if _, err := os.Stat(filepath.Join(daemonDataDir, "whatsapp-session.db")); err != nil {
+		t.Fatalf("--transports did not initialize the WhatsApp bridge store (assertion above may be vacuous): %v", err)
+	}
+}
+
+// TestRunServeMCPClientAdoptsDaemonTruth verifies the daemon-truth read mode:
+// when the running app reports v2-primary for the same data directory, the
+// client serves v2 reads without any OPENMESSAGES_V2_* environment and
+// without running its own dispatcher.
+func TestRunServeMCPClientAdoptsDaemonTruth(t *testing.T) {
+	dataDir := t.TempDir()
+
+	// Provision a migrated v2 store the way the daemon would have.
+	v2Dir := filepath.Join(dataDir, "v2")
+	if err := os.MkdirAll(v2Dir, 0o700); err != nil {
+		t.Fatalf("create v2 dir: %v", err)
+	}
+	storePath := filepath.Join(v2Dir, "store.sqlite3")
+	store, err := sqlite.Open(storePath)
+	if err != nil {
+		t.Fatalf("provision v2 store: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close provisioned v2 store: %v", err)
+	}
+
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/status" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"connected":  true,
+			"v2_primary": true,
+			"v2_send":    true,
+			"auth":       map[string]any{"data_dir": dataDir},
+		})
+	}))
+	defer daemon.Close()
+	daemonURL, err := url.Parse(daemon.URL)
+	if err != nil {
+		t.Fatalf("parse daemon URL: %v", err)
+	}
+
+	setClientModeTestEnv(t, dataDir)
+	t.Setenv("OPENMESSAGES_PORT", daemonURL.Port())
+
+	var logs bytes.Buffer
+	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
+		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
+	}
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, `"daemon_running":true`) {
+		t.Fatalf("daemon probe did not succeed:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, `"v2_primary_reads":true`) {
+		t.Fatalf("daemon-truth v2-primary read mode was not adopted:\n%s", logOutput)
+	}
+	// Client mode attaches to the daemon's stores; it must not provision the
+	// blob store or any other dispatcher-side state.
+	if _, err := os.Stat(filepath.Join(v2Dir, "blobs")); !os.IsNotExist(err) {
+		t.Fatalf("client mode provisioned v2 blob state: %v", err)
+	}
+}
+
+// TestControlTokenFileConstantsAgree pins the localapi copy of the control
+// token filename to the web package's authoritative constant.
+func TestControlTokenFileConstantsAgree(t *testing.T) {
+	if localapi.ControlTokenFile != web.ControlTokenFile {
+		t.Fatalf("localapi.ControlTokenFile = %q, want %q", localapi.ControlTokenFile, web.ControlTokenFile)
+	}
+}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -84,6 +84,9 @@ func TestRunServeV2PrimaryFailsFast(t *testing.T) {
 			t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
 			t.Setenv("OPENMESSAGES_MACOS_NOTIFICATIONS", "0")
 			t.Setenv("OPENMESSAGE_TELEMETRY", "0")
+			// Keep the client shape's daemon probe hermetic: never reach a
+			// real daemon that may be running on the test machine.
+			t.Setenv("OPENMESSAGES_PORT", "0")
 
 			err := RunServe(zerolog.Nop(), tt.args...)
 			if err == nil {
@@ -109,38 +112,62 @@ func TestRunServeV2PrimaryFailsFast(t *testing.T) {
 }
 
 func TestRunServeV2PrimaryRejectsCorruptPresentStoreWithoutFallback(t *testing.T) {
-	dataDir := t.TempDir()
-	v2Dir := filepath.Join(dataDir, "v2")
-	if err := os.MkdirAll(v2Dir, 0o700); err != nil {
-		t.Fatalf("create v2 dir: %v", err)
+	tests := []struct {
+		name           string
+		args           []string
+		errorContains  string
+		wantNoLegacyDB bool
+	}{
+		// Daemon shape (explicit transports): the full v2 stack refuses.
+		{name: "daemon shape", args: []string{"--mcp-stdio", "--transports"}, errorContains: "init v2 stack"},
+		// MCP client shape: the read-store attach refuses before app init,
+		// so the refusal leaves no legacy store behind either.
+		{name: "client shape", args: []string{"--mcp-stdio"}, errorContains: "open v2 read store", wantNoLegacyDB: true},
 	}
-	storePath := filepath.Join(v2Dir, "store.sqlite3")
-	corrupt := []byte("not a sqlite database")
-	if err := os.WriteFile(storePath, corrupt, 0o600); err != nil {
-		t.Fatalf("write corrupt store: %v", err)
-	}
-	t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
-	t.Setenv("OPENMESSAGES_DEMO", "0")
-	t.Setenv("OPENMESSAGES_V2_PRIMARY", "1")
-	t.Setenv("OPENMESSAGES_V2_SEND", "")
-	t.Setenv("OPENMESSAGES_V2_INGEST", "")
-	t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
-	t.Setenv("OPENMESSAGES_MACOS_NOTIFICATIONS", "0")
-	t.Setenv("OPENMESSAGE_TELEMETRY", "0")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			v2Dir := filepath.Join(dataDir, "v2")
+			if err := os.MkdirAll(v2Dir, 0o700); err != nil {
+				t.Fatalf("create v2 dir: %v", err)
+			}
+			storePath := filepath.Join(v2Dir, "store.sqlite3")
+			corrupt := []byte("not a sqlite database")
+			if err := os.WriteFile(storePath, corrupt, 0o600); err != nil {
+				t.Fatalf("write corrupt store: %v", err)
+			}
+			t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
+			t.Setenv("OPENMESSAGES_DEMO", "0")
+			t.Setenv("OPENMESSAGES_V2_PRIMARY", "1")
+			t.Setenv("OPENMESSAGES_V2_SEND", "")
+			t.Setenv("OPENMESSAGES_V2_INGEST", "")
+			t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
+			t.Setenv("OPENMESSAGES_MACOS_NOTIFICATIONS", "0")
+			t.Setenv("OPENMESSAGE_TELEMETRY", "0")
+			// Keep the client shape's daemon probe hermetic: never reach a
+			// real daemon that may be running on the test machine.
+			t.Setenv("OPENMESSAGES_PORT", "0")
 
-	err := RunServe(zerolog.Nop(), "--mcp-stdio")
-	if err == nil || !strings.Contains(err.Error(), "init v2 stack") {
-		t.Fatalf("RunServe() error = %v, want corrupt v2 store startup failure", err)
-	}
-	got, readErr := os.ReadFile(storePath)
-	if readErr != nil {
-		t.Fatalf("read corrupt sentinel: %v", readErr)
-	}
-	if !bytes.Equal(got, corrupt) {
-		t.Fatalf("corrupt v2 store was replaced: got %q, want %q", got, corrupt)
-	}
-	if _, statErr := os.Stat(filepath.Join(v2Dir, "blobs")); !os.IsNotExist(statErr) {
-		t.Fatalf("corrupt-store refusal continued into v2 blob setup: %v", statErr)
+			err := RunServe(zerolog.Nop(), tt.args...)
+			if err == nil || !strings.Contains(err.Error(), tt.errorContains) {
+				t.Fatalf("RunServe() error = %v, want corrupt v2 store startup failure containing %q", err, tt.errorContains)
+			}
+			got, readErr := os.ReadFile(storePath)
+			if readErr != nil {
+				t.Fatalf("read corrupt sentinel: %v", readErr)
+			}
+			if !bytes.Equal(got, corrupt) {
+				t.Fatalf("corrupt v2 store was replaced: got %q, want %q", got, corrupt)
+			}
+			if _, statErr := os.Stat(filepath.Join(v2Dir, "blobs")); !os.IsNotExist(statErr) {
+				t.Fatalf("corrupt-store refusal continued into v2 blob setup: %v", statErr)
+			}
+			if tt.wantNoLegacyDB {
+				if _, statErr := os.Stat(filepath.Join(dataDir, "messages.db")); !os.IsNotExist(statErr) {
+					t.Fatalf("corrupt-store refusal touched the legacy store: %v", statErr)
+				}
+			}
+		})
 	}
 }
 

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -79,7 +79,12 @@ running app:
   never fall back to opening their own connections.
 - Escape hatches: `--transports` forces the old standalone full-stack stdio
   behavior (only for machines where the MCP process is the *only* OpenMessage
-  process, ever); `--no-transports` strips transports from any other shape.
+  process, ever); `--no-transports` strips transports from a **legacy-mode**
+  web/SSE shape (degraded debug instance: local reads work, sends fail with
+  "not connected"). On a **v2-primary** install a `--web --no-transports`
+  process refuses to start — the v2 read path there needs the dispatcher
+  stack — so use the MCP client shape or `openmessage read` for store access
+  instead.
 
 **MCP config (`~/.mcp.json`) for a macOS app install:**
 

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -43,6 +43,70 @@ GET /api/search?q=<term>
 Outgoing message rows carry a `Status`: `OUTGOING_SENDING` → `OUTGOING_SENT`/
 `OUTGOING_DELIVERED`, or `OUTGOING_FAILED:<STATUS>` when a send is rejected.
 
+## MCP serving — exactly one process may own live transports
+
+**The failure mode (empirically confirmed 2026-07-20):** `openmessage serve
+--mcp-stdio` used to start the **full transport stack** — the Google,
+WhatsApp, and Signal supervisors auto-started in every serve mode. MCP hosts
+(Claude Code via `~/.mcp.json`, Claude Desktop) spawn one such process **per
+session**, each connecting with the **same WhatsApp device credentials and
+signal-cli account as the running app**. WhatsApp treats that as a second
+device login and kills the session — a fresh pairing at 20:40:41 was dead with
+`401: logged out from another device` by 20:41:07, seconds after two Claude
+MCP processes spawned. Concurrent signal-cli pollers likewise corrupt/deauth
+Signal (the 2026-07-13 WhatsApp logout and Signal's `needs_reauth` death were
+this same fratricide). `instance.lock` never protected against this — only
+`backup` and `migrate` honor it.
+
+**The fix: MCP client mode.** `serve --mcp-stdio` with no other transport
+(the exact shape MCP hosts spawn) is now a **transportless client** of the
+running app:
+
+- **Zero transport supervisors, zero dispatchers, zero sync loops, zero
+  schedulers, zero telemetry.** The app daemon owns all of those. Regression
+  tests: `TestRunServeMCPStdioStartsZeroTransportSupervisors` (cmd) and
+  `TestBuiltBinaryMCPStdioClientShapeStartsNoTransports` (binary-level).
+- **Reads stay local** (store attach, WAL-safe). At startup the client probes
+  the daemon (`/api/status`); if the daemon serves the same data dir and
+  reports v2-primary, the client reads the v2 store. With the daemon down it
+  falls back to `OPENMESSAGES_V2_*` env exactly like `openmessage read`.
+  If `OPENMESSAGES_DATA_DIR` is unset, the client adopts the data dir the
+  daemon reports — set it explicitly in the MCP config anyway (see below).
+- **Sends/reactions route through the daemon** (`/api/v1/outbox` on v2,
+  `/api/send`+`/api/react` on legacy), like the CLI has done since PR #140,
+  with the same do-not-resend idempotency contract. With the app closed,
+  send tools return an actionable "start the OpenMessage app" error — they
+  never fall back to opening their own connections.
+- Escape hatches: `--transports` forces the old standalone full-stack stdio
+  behavior (only for machines where the MCP process is the *only* OpenMessage
+  process, ever); `--no-transports` strips transports from any other shape.
+
+**MCP config (`~/.mcp.json`) for a macOS app install:**
+
+```json
+"openmessage": {
+  "command": "/usr/local/bin/openmessage",
+  "args": ["serve", "--mcp-stdio"],
+  "env": {
+    "OPENMESSAGES_DATA_DIR": "/Users/<user>/Library/Application Support/OpenMessage",
+    "OPENMESSAGES_V2_PRIMARY": "1"
+  }
+}
+```
+
+Pin `OPENMESSAGES_DATA_DIR` to the app's dir so reads, the control token, and
+daemon-truth detection all line up (two-data-dirs trap above). On a migrated
+(v2-primary) install, also set `OPENMESSAGES_V2_PRIMARY=1` — the legacy
+`messages.db` froze at cutover, and this keeps MCP reads on the v2 store even
+when the app is closed or predates the `auth.data_dir` status field (drop the
+line on a non-migrated install). Keep the PATH binary in lockstep with the
+installed app — both open the same SQLite stores and a version-skewed binary
+can migrate the schema under the older one.
+
+**Never** configure MCP to run `serve --web`, `serve --mcp-sse`, or
+`serve ... --transports` alongside the app: those are daemon shapes and will
+fight the app for the WhatsApp/Signal sessions exactly as described above.
+
 ## Pairing & the "zombie session"
 
 **Symptom:** sends fail with `OUTGOING_FAILED:UNKNOWN`; `/api/status` shows

--- a/internal/localapi/localapi.go
+++ b/internal/localapi/localapi.go
@@ -1,0 +1,476 @@
+// Package localapi is the HTTP client for a running OpenMessage daemon's
+// local API. CLI commands and the transportless MCP serve mode use it to
+// detect the daemon ("daemon truth") and to route sends through the daemon's
+// durable outbox instead of opening their own platform transports — two
+// processes holding the same WhatsApp device credentials or signal-cli
+// account kill each other's sessions, so exactly one process (the daemon)
+// may own live connections.
+package localapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ControlTokenFile is the file inside the daemon's data directory that holds
+// the local control token. It mirrors web.ControlTokenFile; the two constants
+// are asserted equal in cmd tests so they cannot drift.
+const ControlTokenFile = "control.token"
+
+// DefaultBaseURL returns the local daemon base URL, honoring OPENMESSAGES_PORT.
+func DefaultBaseURL() string {
+	port := strings.TrimSpace(os.Getenv("OPENMESSAGES_PORT"))
+	if port == "" {
+		port = "7007"
+	}
+	return "http://" + net.JoinHostPort("127.0.0.1", port)
+}
+
+// LoadControlToken reads the local control token from dataDir. A missing or
+// unreadable token yields "" so callers degrade to unauthenticated requests
+// (the daemon decides whether those are acceptable).
+func LoadControlToken(dataDir string) string {
+	b, err := os.ReadFile(filepath.Join(dataDir, ControlTokenFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// Client talks to one OpenMessage daemon. The zero value is not usable; call
+// NewClient or populate BaseURL and HTTP explicitly.
+type Client struct {
+	BaseURL string
+	HTTP    *http.Client
+	Token   string
+}
+
+// NewClient returns a Client for baseURL with a conservative default timeout.
+// An empty baseURL falls back to DefaultBaseURL().
+func NewClient(baseURL, token string) *Client {
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = DefaultBaseURL()
+	}
+	return &Client{
+		BaseURL: baseURL,
+		HTTP:    &http.Client{Timeout: 10 * time.Second},
+		Token:   token,
+	}
+}
+
+// DaemonStatus is the subset of /api/status used for daemon-truth decisions.
+type DaemonStatus struct {
+	Connected bool `json:"connected"`
+	V2Send    bool `json:"v2_send"`
+	V2Primary bool `json:"v2_primary"`
+	Auth      struct {
+		DataDir string `json:"data_dir"`
+	} `json:"auth"`
+}
+
+// SendsViaOutbox reports whether the daemon expects sends on the durable
+// /api/v1/outbox surface rather than the legacy /api/send route.
+func (s DaemonStatus) SendsViaOutbox() bool {
+	return s.V2Send || s.V2Primary
+}
+
+// Status probes /api/status. The second result reports reachability: false
+// means no daemon answered at all (connection refused/timeout), while true
+// with a non-nil error means something answered but the response was not a
+// usable status document.
+func (c *Client) Status(ctx context.Context) (DaemonStatus, bool, error) {
+	var status DaemonStatus
+	reachable, err := c.getJSON(ctx, "/api/status", &status)
+	return status, reachable, err
+}
+
+// RawStatus returns the daemon's /api/status document verbatim, for callers
+// that surface daemon state to a human or agent rather than branching on it.
+func (c *Client) RawStatus(ctx context.Context) (map[string]any, error) {
+	raw := map[string]any{}
+	if _, err := c.getJSON(ctx, "/api/status", &raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+// TextSubmission is a durable text send routed at POST /api/v1/outbox/messages.
+type TextSubmission struct {
+	ConversationID string `json:"conversation_id"`
+	Body           string `json:"body"`
+	ReplyToID      string `json:"reply_to_id,omitempty"`
+	IdempotencyKey string `json:"idempotency_key"`
+	NotBeforeMS    *int64 `json:"not_before_ms,omitempty"`
+}
+
+// MediaSubmission is a durable media send routed at POST /api/v1/outbox/media.
+// Content is streamed; the daemon enforces its own size cap.
+type MediaSubmission struct {
+	ConversationID string
+	Filename       string
+	MIME           string
+	Caption        string
+	ReplyToID      string
+	IdempotencyKey string
+	NotBeforeMS    *int64
+	Content        io.Reader
+}
+
+// Submission mirrors the daemon's v1 submission response.
+type Submission struct {
+	OutboxID       string `json:"outbox_id"`
+	LocalMessageID string `json:"local_message_id"`
+	State          string `json:"state"`
+	ScheduledForMS int64  `json:"scheduled_for_ms"`
+	Deduplicated   bool   `json:"deduplicated"`
+}
+
+// Delivery mirrors the daemon's v1 delivery response.
+type Delivery struct {
+	OutboxID        string `json:"outbox_id"`
+	State           string `json:"state"`
+	LocalMessageID  string `json:"local_message_id"`
+	RemoteMessageID string `json:"remote_message_id"`
+	ErrorClass      string `json:"error_class"`
+	ErrorCode       string `json:"error_code"`
+	Warning         string `json:"warning"`
+}
+
+// Settled reports whether the delivery reached a state the dispatcher will
+// not advance on its own without new information: everything except the
+// in-flight queued/dispatching states. not_dispatched counts as settled here
+// because the daemon schedules its own retries; callers report it as an
+// auto-retrying outcome rather than polling forever.
+func (d Delivery) Settled() bool {
+	switch d.State {
+	case "", "queued", "dispatching":
+		return false
+	default:
+		return true
+	}
+}
+
+// SubmitText enqueues a text send on the daemon's durable outbox.
+func (c *Client) SubmitText(ctx context.Context, submission TextSubmission) (Submission, error) {
+	body, err := json.Marshal(submission)
+	if err != nil {
+		return Submission{}, fmt.Errorf("encode outbox submission: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/v1/outbox/messages", bytes.NewReader(body))
+	if err != nil {
+		return Submission{}, err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	c.authorize(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return Submission{}, err
+	}
+	var result Submission
+	if err := decodeResponse(response, &result); err != nil {
+		return Submission{}, err
+	}
+	if result.OutboxID == "" {
+		return Submission{}, fmt.Errorf("submission response omitted outbox_id")
+	}
+	return result, nil
+}
+
+// SubmitMedia enqueues a media send on the daemon's durable outbox, streaming
+// Content as a multipart upload.
+func (c *Client) SubmitMedia(ctx context.Context, submission MediaSubmission) (Submission, error) {
+	reader, contentType := multipartMediaBody(submission)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/v1/outbox/media", reader)
+	if err != nil {
+		_ = reader.Close()
+		return Submission{}, err
+	}
+	request.Header.Set("Content-Type", contentType)
+	c.authorize(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return Submission{}, err
+	}
+	var result Submission
+	if err := decodeResponse(response, &result); err != nil {
+		return Submission{}, err
+	}
+	if result.OutboxID == "" {
+		return Submission{}, fmt.Errorf("submission response omitted outbox_id")
+	}
+	return result, nil
+}
+
+func multipartMediaBody(submission MediaSubmission) (io.ReadCloser, string) {
+	pipeReader, pipeWriter := io.Pipe()
+	writer := multipart.NewWriter(pipeWriter)
+	go func() {
+		fail := func(err error) {
+			_ = pipeWriter.CloseWithError(err)
+		}
+		fields := map[string]string{
+			"conversation_id": submission.ConversationID,
+			"idempotency_key": submission.IdempotencyKey,
+			"caption":         submission.Caption,
+			"reply_to_id":     submission.ReplyToID,
+		}
+		if submission.NotBeforeMS != nil {
+			fields["not_before_ms"] = fmt.Sprintf("%d", *submission.NotBeforeMS)
+		}
+		for name, value := range fields {
+			if value == "" {
+				continue
+			}
+			if err := writer.WriteField(name, value); err != nil {
+				fail(err)
+				return
+			}
+		}
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", fmt.Sprintf(
+			`form-data; name="file"; filename=%q`, submission.Filename,
+		))
+		mimeType := strings.TrimSpace(submission.MIME)
+		if mimeType == "" {
+			mimeType = "application/octet-stream"
+		}
+		header.Set("Content-Type", mimeType)
+		part, err := writer.CreatePart(header)
+		if err != nil {
+			fail(err)
+			return
+		}
+		if _, err := io.Copy(part, submission.Content); err != nil {
+			fail(err)
+			return
+		}
+		if err := writer.Close(); err != nil {
+			fail(err)
+			return
+		}
+		_ = pipeWriter.Close()
+	}()
+	return pipeReader, writer.FormDataContentType()
+}
+
+// Delivery fetches the current durable state of one outbox item.
+func (c *Client) Delivery(ctx context.Context, outboxID string) (Delivery, error) {
+	var delivery Delivery
+	if _, err := c.getJSON(ctx, "/api/v1/outbox/"+outboxID, &delivery); err != nil {
+		return Delivery{}, err
+	}
+	return delivery, nil
+}
+
+// WaitDelivery polls the outbox item until it settles, ctx ends, or
+// settleTimeout elapses. It returns the last observed delivery; the bool
+// reports whether that delivery settled. A non-nil error means the state
+// could never be read — the send itself remains durably queued on the daemon.
+func (c *Client) WaitDelivery(ctx context.Context, outboxID string, settleTimeout time.Duration) (Delivery, bool, error) {
+	deadline := time.Now().Add(settleTimeout)
+	var last Delivery
+	var lastErr error
+	observed := false
+	for {
+		delivery, err := c.Delivery(ctx, outboxID)
+		if err == nil {
+			observed = true
+			last = delivery
+			lastErr = nil
+			if delivery.Settled() {
+				return delivery, true, nil
+			}
+		} else {
+			lastErr = err
+			if ctx.Err() != nil || !time.Now().Before(deadline) {
+				if observed {
+					return last, false, nil
+				}
+				return Delivery{}, false, lastErr
+			}
+		}
+		if ctx.Err() != nil || !time.Now().Before(deadline) {
+			if observed {
+				return last, false, nil
+			}
+			return Delivery{}, false, lastErr
+		}
+		select {
+		case <-ctx.Done():
+			if observed {
+				return last, false, nil
+			}
+			return Delivery{}, false, ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+// LegacySendResult is the daemon's legacy /api/send response.
+type LegacySendResult struct {
+	MessageID string `json:"message_id"`
+	Status    string `json:"status"`
+	Success   bool   `json:"success"`
+}
+
+// LegacySendText routes a text send through the daemon's legacy /api/send
+// surface. Only valid against daemons running with v2 send disabled; a
+// v2-primary daemon rejects this route deterministically.
+func (c *Client) LegacySendText(ctx context.Context, conversationID, message, replyToID, idempotencyKey string) (LegacySendResult, error) {
+	payload := struct {
+		ConversationID string `json:"conversation_id"`
+		Message        string `json:"message"`
+		ReplyToID      string `json:"reply_to_id,omitempty"`
+		IdempotencyKey string `json:"idempotency_key,omitempty"`
+	}{conversationID, message, replyToID, idempotencyKey}
+	var result LegacySendResult
+	if err := c.postJSON(ctx, "/api/send", payload, &result); err != nil {
+		return LegacySendResult{}, err
+	}
+	return result, nil
+}
+
+// LegacySendMedia routes a media send through the daemon's legacy
+// /api/send-media surface (multipart, same field names as the v1 outbox
+// media route). Only valid against daemons running with v2 send disabled.
+func (c *Client) LegacySendMedia(ctx context.Context, submission MediaSubmission) (LegacySendResult, error) {
+	reader, contentType := multipartMediaBody(submission)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/send-media", reader)
+	if err != nil {
+		_ = reader.Close()
+		return LegacySendResult{}, err
+	}
+	request.Header.Set("Content-Type", contentType)
+	c.authorize(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return LegacySendResult{}, err
+	}
+	var result LegacySendResult
+	if err := decodeResponse(response, &result); err != nil {
+		return LegacySendResult{}, err
+	}
+	return result, nil
+}
+
+// React routes a reaction through the daemon's /api/react surface, which
+// works in every daemon mode. Action is "add", "remove", or "switch".
+func (c *Client) React(ctx context.Context, conversationID, messageID, emoji, action string) error {
+	payload := struct {
+		ConversationID string `json:"conversation_id"`
+		MessageID      string `json:"message_id"`
+		Emoji          string `json:"emoji"`
+		Action         string `json:"action"`
+	}{conversationID, messageID, emoji, action}
+	return c.postJSON(ctx, "/api/react", payload, &map[string]any{})
+}
+
+func (c *Client) postJSON(ctx context.Context, path string, payload any, target any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode local API request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	c.authorize(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return err
+	}
+	return decodeResponse(response, target)
+}
+
+// getJSON performs a GET and decodes the response. The bool reports whether
+// anything answered the request at all.
+func (c *Client) getJSON(ctx context.Context, path string, target any) (bool, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+path, nil)
+	if err != nil {
+		return false, err
+	}
+	c.authorize(request)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return false, err
+	}
+	if err := decodeResponse(response, target); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+func (c *Client) authorize(request *http.Request) {
+	if c.Token != "" {
+		request.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+}
+
+func decodeResponse(response *http.Response, target any) error {
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 4096))
+		return &ResponseError{StatusCode: response.StatusCode, Body: strings.TrimSpace(string(body))}
+	}
+	if err := json.NewDecoder(response.Body).Decode(target); err != nil {
+		return fmt.Errorf("decode local API response: %w", err)
+	}
+	return nil
+}
+
+// ResponseError is a non-2xx local API response.
+type ResponseError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *ResponseError) Error() string {
+	return fmt.Sprintf("local API returned HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// AsResponseError unwraps err into a *ResponseError when it is one.
+func AsResponseError(err error) (*ResponseError, bool) {
+	var responseErr *ResponseError
+	if errors.As(err, &responseErr) {
+		return responseErr, true
+	}
+	return nil, false
+}
+
+// IsDeterministicRejection reports whether err is a daemon response that
+// proves the request was received and refused — safe to surface as a hard
+// failure with no replay ambiguity.
+func IsDeterministicRejection(err error) bool {
+	responseErr, ok := AsResponseError(err)
+	if !ok {
+		return false
+	}
+	switch responseErr.StatusCode {
+	case http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusRequestEntityTooLarge, http.StatusUnprocessableEntity:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsAuthError reports whether err is the daemon refusing our control token.
+func IsAuthError(err error) bool {
+	responseErr, ok := AsResponseError(err)
+	if !ok {
+		return false
+	}
+	return responseErr.StatusCode == http.StatusUnauthorized || responseErr.StatusCode == http.StatusForbidden
+}

--- a/internal/localapi/localapi_test.go
+++ b/internal/localapi/localapi_test.go
@@ -1,0 +1,283 @@
+package localapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return &Client{BaseURL: server.URL, HTTP: server.Client()}
+}
+
+func TestStatusReachability(t *testing.T) {
+	t.Run("daemon absent", func(t *testing.T) {
+		client := NewClient("http://127.0.0.1:1", "")
+		_, reachable, err := client.Status(context.Background())
+		if err == nil {
+			t.Fatal("expected probe error")
+		}
+		if reachable {
+			t.Fatal("connection refusal must report unreachable")
+		}
+	})
+
+	t.Run("daemon answers garbage", func(t *testing.T) {
+		client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, "not json")
+		}))
+		_, reachable, err := client.Status(context.Background())
+		if err == nil {
+			t.Fatal("expected decode error")
+		}
+		if !reachable {
+			t.Fatal("an answering daemon must report reachable")
+		}
+	})
+
+	t.Run("daemon reports mode", func(t *testing.T) {
+		client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]any{
+				"v2_primary": true,
+				"auth":       map[string]any{"data_dir": "/tmp/data"},
+			})
+		}))
+		status, reachable, err := client.Status(context.Background())
+		if err != nil || !reachable {
+			t.Fatalf("Status() = %v, reachable %v", err, reachable)
+		}
+		if !status.V2Primary || !status.SendsViaOutbox() {
+			t.Fatalf("status = %+v", status)
+		}
+		if status.Auth.DataDir != "/tmp/data" {
+			t.Fatalf("auth data dir = %q", status.Auth.DataDir)
+		}
+	})
+}
+
+func TestSubmitTextSendsTokenAndDecodes(t *testing.T) {
+	var sawAuth atomic.Value
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth.Store(r.Header.Get("Authorization"))
+		var request TextSubmission
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+		if request.ConversationID != "conv" || request.IdempotencyKey != "key" {
+			t.Errorf("request = %+v", request)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"outbox_id": "out", "state": "queued"})
+	}))
+	client.Token = "secret"
+
+	submission, err := client.SubmitText(context.Background(), TextSubmission{
+		ConversationID: "conv", Body: "hi", IdempotencyKey: "key",
+	})
+	if err != nil {
+		t.Fatalf("SubmitText: %v", err)
+	}
+	if submission.OutboxID != "out" {
+		t.Fatalf("submission = %+v", submission)
+	}
+	if got := sawAuth.Load(); got != "Bearer secret" {
+		t.Fatalf("Authorization = %v", got)
+	}
+}
+
+func TestSubmitTextRejectsMissingOutboxID(t *testing.T) {
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"state": "queued"})
+	}))
+	if _, err := client.SubmitText(context.Background(), TextSubmission{ConversationID: "c", IdempotencyKey: "k"}); err == nil {
+		t.Fatal("expected error for response without outbox_id")
+	}
+}
+
+func TestSubmitMediaStreamsMultipart(t *testing.T) {
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("parse multipart: %v", err)
+		}
+		if got := r.FormValue("conversation_id"); got != "conv" {
+			t.Errorf("conversation_id = %q", got)
+		}
+		if got := r.FormValue("idempotency_key"); got != "key" {
+			t.Errorf("idempotency_key = %q", got)
+		}
+		if got := r.FormValue("caption"); got != "look" {
+			t.Errorf("caption = %q", got)
+		}
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			t.Errorf("form file: %v", err)
+		} else {
+			defer file.Close()
+			data, _ := io.ReadAll(file)
+			if string(data) != "payload-bytes" {
+				t.Errorf("file body = %q", data)
+			}
+			if header.Filename != "photo.png" {
+				t.Errorf("filename = %q", header.Filename)
+			}
+			if got := header.Header.Get("Content-Type"); got != "image/png" {
+				t.Errorf("file content type = %q", got)
+			}
+		}
+		json.NewEncoder(w).Encode(map[string]any{"outbox_id": "out-media", "state": "queued"})
+	}))
+
+	submission, err := client.SubmitMedia(context.Background(), MediaSubmission{
+		ConversationID: "conv",
+		Filename:       "photo.png",
+		MIME:           "image/png",
+		Caption:        "look",
+		IdempotencyKey: "key",
+		Content:        strings.NewReader("payload-bytes"),
+	})
+	if err != nil {
+		t.Fatalf("SubmitMedia: %v", err)
+	}
+	if submission.OutboxID != "out-media" {
+		t.Fatalf("submission = %+v", submission)
+	}
+}
+
+func TestWaitDeliveryPollsUntilSettled(t *testing.T) {
+	var calls atomic.Int64
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		state := "queued"
+		if calls.Add(1) >= 3 {
+			state = "confirmed"
+		}
+		json.NewEncoder(w).Encode(map[string]any{"outbox_id": "out", "state": state})
+	}))
+
+	delivery, settled, err := client.WaitDelivery(context.Background(), "out", 5*time.Second)
+	if err != nil {
+		t.Fatalf("WaitDelivery: %v", err)
+	}
+	if !settled || delivery.State != "confirmed" {
+		t.Fatalf("delivery = %+v settled = %v", delivery, settled)
+	}
+	if calls.Load() < 3 {
+		t.Fatalf("expected at least 3 polls, got %d", calls.Load())
+	}
+}
+
+func TestWaitDeliveryTimeoutReturnsLastObserved(t *testing.T) {
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"outbox_id": "out", "state": "dispatching"})
+	}))
+
+	delivery, settled, err := client.WaitDelivery(context.Background(), "out", 300*time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitDelivery: %v", err)
+	}
+	if settled {
+		t.Fatal("expected unsettled result at timeout")
+	}
+	if delivery.State != "dispatching" {
+		t.Fatalf("delivery = %+v", delivery)
+	}
+}
+
+func TestWaitDeliveryNeverObservedReturnsError(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", "")
+	client.HTTP.Timeout = 100 * time.Millisecond
+	_, settled, err := client.WaitDelivery(context.Background(), "out", 250*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when the delivery state was never readable")
+	}
+	if settled {
+		t.Fatal("unreadable delivery cannot be settled")
+	}
+}
+
+func TestDeliverySettled(t *testing.T) {
+	for state, want := range map[string]bool{
+		"":               false,
+		"queued":         false,
+		"dispatching":    false,
+		"confirmed":      true,
+		"uncertain":      true,
+		"rejected":       true,
+		"canceled":       true,
+		"store_failed":   true,
+		"not_dispatched": true,
+	} {
+		if got := (Delivery{State: state}).Settled(); got != want {
+			t.Errorf("Settled(%q) = %v, want %v", state, got, want)
+		}
+	}
+}
+
+func TestErrorClassification(t *testing.T) {
+	notFound := &ResponseError{StatusCode: http.StatusNotFound, Body: "missing"}
+	if !IsDeterministicRejection(notFound) {
+		t.Fatal("404 must classify as deterministic rejection")
+	}
+	if IsDeterministicRejection(errors.New("network")) {
+		t.Fatal("transport errors are not deterministic rejections")
+	}
+	if !IsAuthError(&ResponseError{StatusCode: http.StatusUnauthorized}) {
+		t.Fatal("401 must classify as auth error")
+	}
+	if IsAuthError(notFound) {
+		t.Fatal("404 is not an auth error")
+	}
+	if got := notFound.Error(); got != "local API returned HTTP 404: missing" {
+		t.Fatalf("ResponseError text = %q", got)
+	}
+}
+
+func TestLoadControlToken(t *testing.T) {
+	dir := t.TempDir()
+	if got := LoadControlToken(dir); got != "" {
+		t.Fatalf("missing token file should load empty, got %q", got)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ControlTokenFile), []byte(" secret-token\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	if got := LoadControlToken(dir); got != "secret-token" {
+		t.Fatalf("token = %q", got)
+	}
+}
+
+func TestLegacySendText(t *testing.T) {
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/send" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"message_id": "m1", "status": "SUCCESS", "success": true})
+	}))
+	result, err := client.LegacySendText(context.Background(), "conv", "hi", "", "key")
+	if err != nil {
+		t.Fatalf("LegacySendText: %v", err)
+	}
+	if result.MessageID != "m1" || !result.Success {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestDefaultBaseURLHonorsPortEnv(t *testing.T) {
+	t.Setenv("OPENMESSAGES_PORT", "7100")
+	if got := DefaultBaseURL(); got != "http://127.0.0.1:7100" {
+		t.Fatalf("DefaultBaseURL() = %q", got)
+	}
+	t.Setenv("OPENMESSAGES_PORT", "")
+	if got := DefaultBaseURL(); got != "http://127.0.0.1:7007" {
+		t.Fatalf("DefaultBaseURL() = %q", got)
+	}
+}

--- a/internal/tools/daemon.go
+++ b/internal/tools/daemon.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -421,8 +422,12 @@ func daemonReactToMessageHandler(options Options) server.ToolHandlerFunc {
 }
 
 // findDirectSMSConversation scans recent conversations for a non-group
-// SMS/RCS thread whose participants include the phone number. Matching is by
-// digit suffix so +1 (650) 555-0100, 6505550100, and +16505550100 all meet.
+// SMS/RCS thread with one participant whose number matches the phone.
+// Matching compares each participant's number individually by digit suffix
+// (so +1 (650) 555-0100, 6505550100, and +16505550100 all meet) — never a
+// substring search over concatenated participant digits, which could match a
+// sequence straddling two different numbers and route the send to the wrong
+// person.
 func findDirectSMSConversation(reads readsource.ReadSource, phone string) (*db.Conversation, error) {
 	if reads == nil {
 		return nil, fmt.Errorf("no read source available")
@@ -442,19 +447,37 @@ func findDirectSMSConversation(reads readsource.ReadSource, phone string) (*db.C
 		if conversation == nil || conversation.IsGroup {
 			continue
 		}
-		platform := normalizedPlatform(conversation.SourcePlatform)
-		if platform != "sms" {
+		if normalizedPlatform(conversation.SourcePlatform) != "sms" {
 			continue
 		}
-		participantDigits := digitsOnly(conversation.Participants)
-		if participantDigits == "" {
+		var participants []struct {
+			Number string `json:"number"`
+			Phone  string `json:"phone"`
+		}
+		if err := json.Unmarshal([]byte(conversation.Participants), &participants); err != nil {
 			continue
 		}
-		if strings.Contains(participantDigits, digits) {
-			return conversation, nil
+		for _, participant := range participants {
+			if phoneDigitsMatch(digits, firstNonEmpty(participant.Number, participant.Phone)) {
+				return conversation, nil
+			}
 		}
 	}
 	return nil, nil
+}
+
+// phoneDigitsMatch reports whether a stored participant number denotes the
+// same line as the wanted digits (already trimmed to the last 10). One side
+// may carry a country prefix the other lacks, so the shorter digit string
+// must be a suffix of the longer; a 7-digit floor keeps short fragments from
+// matching everything.
+func phoneDigitsMatch(wantedDigits, participantNumber string) bool {
+	participantDigits := digitsOnly(participantNumber)
+	if len(participantDigits) < 7 || len(wantedDigits) < 7 {
+		return false
+	}
+	return strings.HasSuffix(participantDigits, wantedDigits) ||
+		strings.HasSuffix(wantedDigits, participantDigits)
 }
 
 // daemonGetStatusHandler serves get_status in client mode: daemon truth when

--- a/internal/tools/daemon.go
+++ b/internal/tools/daemon.go
@@ -1,0 +1,522 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/localapi"
+	"github.com/maxghenis/openmessage/internal/messaging"
+	"github.com/maxghenis/openmessage/internal/readsource"
+)
+
+// Daemon-routed MCP handlers back the transportless "client mode" serve. The
+// MCP process never opens platform transports of its own — a second process
+// holding the same WhatsApp device credentials or signal-cli account logs the
+// daemon out — so every live-network action is routed at the running app's
+// local HTTP API instead, exactly like the CLI send path.
+
+const daemonDownText = "the OpenMessage app isn't running, and this MCP server runs in transportless client mode (it never opens its own WhatsApp/Signal/Google connections — a second connection would log the app out). Start the OpenMessage app, then retry. Local reads (search, conversations, history) keep working without the app."
+
+// daemonSettleTimeout bounds how long a daemon-routed send waits for the
+// outbox item to settle before reporting the durable queued state.
+const daemonSettleTimeout = 25 * time.Second
+
+func daemonDownResult(err error) *mcp.CallToolResult {
+	if err != nil {
+		return errorResult(fmt.Sprintf("%s (probe error: %v)", daemonDownText, err))
+	}
+	return errorResult(daemonDownText)
+}
+
+func daemonProbeFailureResult(err error) *mcp.CallToolResult {
+	if localapi.IsAuthError(err) {
+		return errorResult(fmt.Sprintf(
+			"the OpenMessage app rejected this MCP server's control token: %v. Point OPENMESSAGES_DATA_DIR at the app's data directory (macOS: ~/Library/Application Support/OpenMessage) in the MCP server config so it reads the app's control token.", err,
+		))
+	}
+	return errorResult(fmt.Sprintf("check running OpenMessage mode: %v", err))
+}
+
+// daemonStatusOrResult probes the daemon and translates failures into
+// ready-to-return tool results.
+func daemonStatusOrResult(ctx context.Context, daemon *localapi.Client) (localapi.DaemonStatus, *mcp.CallToolResult) {
+	status, reachable, err := daemon.Status(ctx)
+	if err != nil {
+		if !reachable {
+			return localapi.DaemonStatus{}, daemonDownResult(err)
+		}
+		return localapi.DaemonStatus{}, daemonProbeFailureResult(err)
+	}
+	return status, nil
+}
+
+func deliveryFromLocalAPI(delivery localapi.Delivery) messaging.Delivery {
+	return messaging.Delivery{
+		OutboxID:        delivery.OutboxID,
+		State:           messaging.OutboxState(delivery.State),
+		LocalMessageID:  delivery.LocalMessageID,
+		RemoteMessageID: delivery.RemoteMessageID,
+		ErrorClass:      delivery.ErrorClass,
+		ErrorCode:       delivery.ErrorCode,
+		Warning:         delivery.Warning,
+	}
+}
+
+// daemonAmbiguousResult reports a send whose outcome the daemon may or may
+// not have recorded (the request failed mid-flight). It is intentionally not
+// an IsError result: an error invites the calling agent to resend, and the
+// daemon may already own this intent. The idempotency key is the safe replay
+// handle.
+func daemonAmbiguousResult(idempotencyKey string, cause error) *mcp.CallToolResult {
+	text := fmt.Sprintf(
+		"The send outcome is unknown (%v). Do NOT send this message again with a new key. To replay-check this exact send, repeat it with the same idempotency_key: %s. If the app is not running, start it first.",
+		cause, idempotencyKey,
+	)
+	return structuredResult(map[string]any{
+		"ok":              false,
+		"settled":         false,
+		"ambiguous":       true,
+		"idempotency_key": idempotencyKey,
+		"error":           cause.Error(),
+	}, text)
+}
+
+// daemonSubmitTextAndWait submits one durable text send to the daemon outbox
+// and waits (bounded) for it to settle, mirroring the in-process v2 result
+// contract so agents see identical semantics in both serve modes.
+func daemonSubmitTextAndWait(
+	ctx context.Context,
+	daemon *localapi.Client,
+	args map[string]any,
+	conversationID string,
+	body string,
+) *mcp.CallToolResult {
+	key, err := v2IdempotencyKey(args)
+	if err != nil {
+		return errorResult(err.Error())
+	}
+	submission, err := daemon.SubmitText(ctx, localapi.TextSubmission{
+		ConversationID: conversationID,
+		Body:           body,
+		IdempotencyKey: key,
+	})
+	if err != nil {
+		if localapi.IsDeterministicRejection(err) {
+			return errorResult(fmt.Sprintf("send rejected by the app: %v", err))
+		}
+		return daemonAmbiguousResult(key, err)
+	}
+	return daemonWaitForDelivery(ctx, daemon, submission, key)
+}
+
+func daemonWaitForDelivery(
+	ctx context.Context,
+	daemon *localapi.Client,
+	submission localapi.Submission,
+	idempotencyKey string,
+) *mcp.CallToolResult {
+	delivery, settled, err := daemon.WaitDelivery(ctx, submission.OutboxID, daemonSettleTimeout)
+	if err != nil {
+		// The intent is durably queued on the daemon; only our view failed.
+		return v2InterruptedResult(
+			messaging.Submission{OutboxID: submission.OutboxID, Deduplicated: submission.Deduplicated},
+			idempotencyKey,
+			messaging.Delivery{},
+			err,
+		)
+	}
+	converted := deliveryFromLocalAPI(delivery)
+	if !settled {
+		payload := map[string]any{
+			"ok":              false,
+			"settled":         false,
+			"auto_retry":      true,
+			"outbox_id":       delivery.OutboxID,
+			"state":           delivery.State,
+			"deduplicated":    submission.Deduplicated,
+			"idempotency_key": idempotencyKey,
+		}
+		if delivery.LocalMessageID != "" {
+			payload["local_message_id"] = delivery.LocalMessageID
+		}
+		text := fmt.Sprintf(
+			"The send is durably queued on the app (outbox %s, state %s) and the app finishes sending it in the background. Do NOT send this message again. To repeat the exact same send deliberately, reuse idempotency_key %s.",
+			delivery.OutboxID, delivery.State, idempotencyKey,
+		)
+		return structuredResult(payload, text)
+	}
+
+	settledState := converted.State != messaging.OutboxNotDispatched
+	payload := map[string]any{
+		"ok":               v2DeliveryOK(converted.State),
+		"settled":          settledState,
+		"outbox_id":        delivery.OutboxID,
+		"state":            delivery.State,
+		"deduplicated":     submission.Deduplicated,
+		"local_message_id": delivery.LocalMessageID,
+		"idempotency_key":  idempotencyKey,
+	}
+	if !settledState {
+		payload["auto_retry"] = true
+	}
+	if delivery.RemoteMessageID != "" {
+		payload["remote_message_id"] = delivery.RemoteMessageID
+	}
+	if delivery.ErrorClass != "" {
+		payload["error_class"] = delivery.ErrorClass
+	}
+	if delivery.ErrorCode != "" {
+		payload["error_code"] = delivery.ErrorCode
+	}
+	if delivery.Warning != "" {
+		payload["warning"] = delivery.Warning
+	}
+	return structuredResult(payload, v2DeliveryText(converted))
+}
+
+// daemonLegacySendText routes a text send through a legacy-mode daemon's
+// /api/send surface.
+func daemonLegacySendText(
+	ctx context.Context,
+	daemon *localapi.Client,
+	args map[string]any,
+	conversationID string,
+	body string,
+) *mcp.CallToolResult {
+	key, err := v2IdempotencyKey(args)
+	if err != nil {
+		return errorResult(err.Error())
+	}
+	result, err := daemon.LegacySendText(ctx, conversationID, body, "", key)
+	if err != nil {
+		if localapi.IsDeterministicRejection(err) {
+			return errorResult(fmt.Sprintf("send rejected by the app: %v", err))
+		}
+		if _, isResponse := localapi.AsResponseError(err); isResponse {
+			return errorResult(fmt.Sprintf("the app could not send the message: %v", err))
+		}
+		return daemonAmbiguousResult(key, err)
+	}
+	return structuredResult(map[string]any{
+		"ok":              true,
+		"message_id":      result.MessageID,
+		"conversation_id": conversationID,
+		"idempotency_key": key,
+		"via":             "app",
+	}, fmt.Sprintf("Message sent via the running OpenMessage app (message %s).", result.MessageID))
+}
+
+func daemonSendToConversationHandler(options Options) server.ToolHandlerFunc {
+	daemon := options.Daemon
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		conversationID := strArg(args, "conversation_id")
+		message := strArg(args, "message")
+		if conversationID == "" {
+			return errorResult("conversation_id is required"), nil
+		}
+		if message == "" {
+			return errorResult("message is required"), nil
+		}
+		status, failure := daemonStatusOrResult(ctx, daemon)
+		if failure != nil {
+			return failure, nil
+		}
+		if status.SendsViaOutbox() {
+			return daemonSubmitTextAndWait(ctx, daemon, args, conversationID, message), nil
+		}
+		return daemonLegacySendText(ctx, daemon, args, conversationID, message), nil
+	}
+}
+
+func daemonSendMessageHandler(options Options) server.ToolHandlerFunc {
+	daemon := options.Daemon
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		recipient := firstNonEmpty(strings.TrimSpace(strArg(args, "recipient")), strings.TrimSpace(strArg(args, "phone_number")))
+		platform := normalizeDirectSendPlatform(strArg(args, "platform"))
+		message := strArg(args, "message")
+		if recipient == "" {
+			return errorResult("recipient or phone_number is required"), nil
+		}
+		if message == "" {
+			return errorResult("message is required"), nil
+		}
+
+		var conversationID string
+		switch platform {
+		case "whatsapp":
+			id, _, _, _, err := canonicalWhatsAppDirectConversation(recipient)
+			if err != nil {
+				return errorResult(err.Error()), nil
+			}
+			conversationID = id
+		case "signal":
+			id, _, _, _, err := canonicalSignalDirectConversation(recipient)
+			if err != nil {
+				return errorResult(err.Error()), nil
+			}
+			conversationID = id
+		case "sms":
+			if !looksLikePhoneNumber(recipient) {
+				return errorResult(fmt.Sprintf("SMS recipient must be a phone number with country code (e.g. +15551234567), got %q", recipient)), nil
+			}
+			conversation, err := findDirectSMSConversation(options.Reads, recipient)
+			if err != nil {
+				return errorResult(fmt.Sprintf("resolve SMS conversation: %v", err)), nil
+			}
+			if conversation == nil {
+				return errorResult(fmt.Sprintf(
+					"no existing SMS conversation with %s. In transportless client mode, starting a brand-new SMS thread requires the OpenMessage app (send the first message there); replies to existing threads work here — use resolve_contact_routes to find the conversation, then send_to_conversation.", recipient,
+				)), nil
+			}
+			conversationID = conversation.ConversationID
+		default:
+			return errorResult(fmt.Sprintf("unsupported platform %q (supported: sms, whatsapp, signal)", platform)), nil
+		}
+
+		status, failure := daemonStatusOrResult(ctx, daemon)
+		if failure != nil {
+			return failure, nil
+		}
+		if status.SendsViaOutbox() {
+			return daemonSubmitTextAndWait(ctx, daemon, args, conversationID, message), nil
+		}
+		return daemonLegacySendText(ctx, daemon, args, conversationID, message), nil
+	}
+}
+
+func daemonSendMediaToConversationHandler(options Options) server.ToolHandlerFunc {
+	daemon := options.Daemon
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		conversationID := strArg(args, "conversation_id")
+		filePath := strArg(args, "file_path")
+		if conversationID == "" {
+			return errorResult("conversation_id is required"), nil
+		}
+		if filePath == "" {
+			return errorResult("file_path is required"), nil
+		}
+		info, err := os.Stat(filePath)
+		if err != nil {
+			return errorResult(fmt.Sprintf("stat file: %v", err)), nil
+		}
+		if info.IsDir() {
+			return errorResult("file_path must point to a file"), nil
+		}
+		if info.Size() > maxMediaUploadBytes {
+			return errorResult(fmt.Sprintf("file too large (%d bytes; limit %d MB)", info.Size(), maxMediaUploadBytes>>20)), nil
+		}
+		filename := filepath.Base(filePath)
+		if filename == "." || filename == string(filepath.Separator) || filename == "" {
+			return errorResult("file_path must point to a file"), nil
+		}
+
+		status, failure := daemonStatusOrResult(ctx, daemon)
+		if failure != nil {
+			return failure, nil
+		}
+		key, err := v2IdempotencyKey(args)
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+		file, err := os.Open(filePath)
+		if err != nil {
+			return errorResult(fmt.Sprintf("read file: %v", err)), nil
+		}
+		defer file.Close()
+		sniff := make([]byte, 512)
+		n, _ := file.Read(sniff)
+		if _, err := file.Seek(0, 0); err != nil {
+			return errorResult(fmt.Sprintf("read file: %v", err)), nil
+		}
+		submission := localapi.MediaSubmission{
+			ConversationID: conversationID,
+			Filename:       filename,
+			MIME:           detectMediaMimeType(filename, sniff[:n], strArg(args, "mime_type")),
+			Caption:        strArg(args, "caption"),
+			ReplyToID:      strArg(args, "reply_to_id"),
+			IdempotencyKey: key,
+			Content:        file,
+		}
+		if status.SendsViaOutbox() {
+			outboxSubmission, err := daemon.SubmitMedia(ctx, submission)
+			if err != nil {
+				if localapi.IsDeterministicRejection(err) {
+					return errorResult(fmt.Sprintf("media send rejected by the app: %v", err)), nil
+				}
+				return daemonAmbiguousResult(key, err), nil
+			}
+			return daemonWaitForDelivery(ctx, daemon, outboxSubmission, key), nil
+		}
+		result, err := daemon.LegacySendMedia(ctx, submission)
+		if err != nil {
+			if localapi.IsDeterministicRejection(err) {
+				return errorResult(fmt.Sprintf("media send rejected by the app: %v", err)), nil
+			}
+			if _, isResponse := localapi.AsResponseError(err); isResponse {
+				return errorResult(fmt.Sprintf("the app could not send the media: %v", err)), nil
+			}
+			return daemonAmbiguousResult(key, err), nil
+		}
+		return structuredResult(map[string]any{
+			"ok":              true,
+			"message_id":      result.MessageID,
+			"conversation_id": conversationID,
+			"idempotency_key": key,
+			"via":             "app",
+		}, fmt.Sprintf("Media sent via the running OpenMessage app (message %s): %s", result.MessageID, filename)), nil
+	}
+}
+
+func daemonSendGroupMessageHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return errorResult(
+			"creating a group conversation requires the OpenMessage app's live Google Messages connection, which transportless client mode does not hold. Send the first group message from the app; replies to existing groups work here via send_to_conversation.",
+		), nil
+	}
+}
+
+func daemonReactToMessageHandler(options Options) server.ToolHandlerFunc {
+	daemon := options.Daemon
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		messageID := strArg(args, "message_id")
+		emoji := strArg(args, "emoji")
+		action := strings.ToLower(strings.TrimSpace(strArg(args, "action")))
+		conversationID := strArg(args, "conversation_id")
+		if messageID == "" {
+			return errorResult("message_id is required"), nil
+		}
+		if emoji == "" {
+			return errorResult("emoji is required"), nil
+		}
+		if action == "" {
+			action = "add"
+		}
+		if err := daemon.React(ctx, conversationID, messageID, emoji, action); err != nil {
+			if responseErr, ok := localapi.AsResponseError(err); ok {
+				return errorResult(fmt.Sprintf("the app could not send the reaction: HTTP %d: %s", responseErr.StatusCode, responseErr.Body)), nil
+			}
+			return daemonDownResult(err), nil
+		}
+		return structuredResult(map[string]any{
+			"ok":         true,
+			"message_id": messageID,
+			"emoji":      emoji,
+			"action":     action,
+			"via":        "app",
+		}, fmt.Sprintf("Reaction %s (%s) sent via the running OpenMessage app.", emoji, action)), nil
+	}
+}
+
+// findDirectSMSConversation scans recent conversations for a non-group
+// SMS/RCS thread whose participants include the phone number. Matching is by
+// digit suffix so +1 (650) 555-0100, 6505550100, and +16505550100 all meet.
+func findDirectSMSConversation(reads readsource.ReadSource, phone string) (*db.Conversation, error) {
+	if reads == nil {
+		return nil, fmt.Errorf("no read source available")
+	}
+	digits := digitsOnly(phone)
+	if digits == "" {
+		return nil, fmt.Errorf("recipient %q has no digits", phone)
+	}
+	if len(digits) > 10 {
+		digits = digits[len(digits)-10:]
+	}
+	conversations, err := reads.ListConversations(2000)
+	if err != nil {
+		return nil, err
+	}
+	for _, conversation := range conversations {
+		if conversation == nil || conversation.IsGroup {
+			continue
+		}
+		platform := normalizedPlatform(conversation.SourcePlatform)
+		if platform != "sms" {
+			continue
+		}
+		participantDigits := digitsOnly(conversation.Participants)
+		if participantDigits == "" {
+			continue
+		}
+		if strings.Contains(participantDigits, digits) {
+			return conversation, nil
+		}
+	}
+	return nil, nil
+}
+
+// daemonGetStatusHandler serves get_status in client mode: daemon truth when
+// the app is running, an explicit "app not running" report otherwise.
+func daemonGetStatusHandler(a *app.App, options Options) server.ToolHandlerFunc {
+	daemon := options.Daemon
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		raw, err := daemon.RawStatus(ctx)
+		if err != nil {
+			var sb strings.Builder
+			sb.WriteString("OpenMessage app: NOT RUNNING\n")
+			sb.WriteString("This MCP server runs in transportless client mode: local reads (search, conversations, history) work from the store, but sends and live platform status require the app. Start the OpenMessage app to send.\n")
+			if stats, statsErr := options.Reads.PlatformStats(); statsErr == nil {
+				sb.WriteString("\nStored messages by platform:\n")
+				for _, stat := range stats {
+					latest := ""
+					if stat.LatestMS > 0 {
+						latest = " (latest " + time.UnixMilli(stat.LatestMS).Format(time.RFC3339) + ")"
+					}
+					fmt.Fprintf(&sb, "  %s: %d messages%s\n", stat.Platform, stat.Count, latest)
+				}
+			}
+			fmt.Fprintf(&sb, "\nData dir: %s\n", a.DataDir)
+			return structuredResult(map[string]any{
+				"mcp_mode":         "client",
+				"daemon_reachable": false,
+				"data_dir":         a.DataDir,
+				"probe_error":      err.Error(),
+			}, sb.String()), nil
+		}
+
+		var sb strings.Builder
+		sb.WriteString("OpenMessage app: RUNNING (status below is daemon truth from /api/status)\n")
+		sb.WriteString("This MCP server runs in transportless client mode; the app owns all live connections and sends are routed through it.\n\n")
+		appendPlatform := func(label, key string) {
+			platform, ok := raw[key].(map[string]any)
+			if !ok {
+				return
+			}
+			connected, _ := platform["connected"].(bool)
+			paired, _ := platform["paired"].(bool)
+			fmt.Fprintf(&sb, "%s: connected=%v paired=%v", label, connected, paired)
+			if lastError, ok := platform["last_error"].(string); ok && lastError != "" {
+				fmt.Fprintf(&sb, " last_error=%q", lastError)
+			}
+			sb.WriteString("\n")
+		}
+		if connected, ok := raw["connected"].(bool); ok {
+			fmt.Fprintf(&sb, "Overall connected: %v\n", connected)
+		}
+		appendPlatform("Google Messages", "google")
+		appendPlatform("WhatsApp", "whatsapp")
+		appendPlatform("Signal", "signal")
+		if v2Primary, ok := raw["v2_primary"].(bool); ok {
+			fmt.Fprintf(&sb, "App v2 mode: primary=%v send=%v\n", v2Primary, raw["v2_send"])
+		}
+		fmt.Fprintf(&sb, "Client data dir: %s\n", a.DataDir)
+		return structuredResult(map[string]any{
+			"mcp_mode":         "client",
+			"daemon_reachable": true,
+			"data_dir":         a.DataDir,
+			"daemon":           raw,
+		}, sb.String()), nil
+	}
+}

--- a/internal/tools/daemon.go
+++ b/internal/tools/daemon.go
@@ -487,8 +487,20 @@ func daemonGetStatusHandler(a *app.App, options Options) server.ToolHandlerFunc 
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		raw, err := daemon.RawStatus(ctx)
 		if err != nil {
+			// A ResponseError means something answered on the daemon port but
+			// refused or garbled the status request — that is not the same as
+			// "the app is closed", so say so.
+			reachable := false
+			if _, ok := localapi.AsResponseError(err); ok {
+				reachable = true
+			}
 			var sb strings.Builder
-			sb.WriteString("OpenMessage app: NOT RUNNING\n")
+			if reachable {
+				fmt.Fprintf(&sb, "OpenMessage app: ANSWERING but status unavailable (%v)\n", err)
+				sb.WriteString("Something is listening on the daemon port but did not return a usable status document. If this persists, check the app version and the control token (OPENMESSAGES_DATA_DIR must point at the app's data directory).\n")
+			} else {
+				sb.WriteString("OpenMessage app: NOT RUNNING\n")
+			}
 			sb.WriteString("This MCP server runs in transportless client mode: local reads (search, conversations, history) work from the store, but sends and live platform status require the app. Start the OpenMessage app to send.\n")
 			if stats, statsErr := options.Reads.PlatformStats(); statsErr == nil {
 				sb.WriteString("\nStored messages by platform:\n")
@@ -503,7 +515,7 @@ func daemonGetStatusHandler(a *app.App, options Options) server.ToolHandlerFunc 
 			fmt.Fprintf(&sb, "\nData dir: %s\n", a.DataDir)
 			return structuredResult(map[string]any{
 				"mcp_mode":         "client",
-				"daemon_reachable": false,
+				"daemon_reachable": reachable,
 				"data_dir":         a.DataDir,
 				"probe_error":      err.Error(),
 			}, sb.String()), nil

--- a/internal/tools/daemon_test.go
+++ b/internal/tools/daemon_test.go
@@ -418,6 +418,32 @@ func TestDaemonGetStatus(t *testing.T) {
 		}
 	})
 
+	t.Run("answering-but-erroring daemon is not reported as closed", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "control token rejected", http.StatusUnauthorized)
+		})
+		a := testApp(t)
+		options := Options{Reads: a.Store, Daemon: daemonClientFor(t, mux)}
+		handler := daemonGetStatusHandler(a, options)
+
+		result, err := handler(context.Background(), mcp.CallToolRequest{})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		payload := structuredMap(t, result)
+		if payload["daemon_reachable"] != true {
+			t.Fatalf("payload = %v", payload)
+		}
+		text := resultText(t, result)
+		if strings.Contains(text, "NOT RUNNING") {
+			t.Fatalf("an answering daemon must not be reported as closed: %q", text)
+		}
+		if !strings.Contains(text, "ANSWERING but status unavailable") {
+			t.Fatalf("status text = %q", text)
+		}
+	})
+
 	t.Run("daemon down reports local-only mode", func(t *testing.T) {
 		a := testApp(t)
 		options := Options{Reads: a.Store, Daemon: deadDaemonClient()}

--- a/internal/tools/daemon_test.go
+++ b/internal/tools/daemon_test.go
@@ -1,0 +1,406 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/localapi"
+)
+
+func daemonClientFor(t *testing.T, handler http.Handler) *localapi.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return &localapi.Client{BaseURL: server.URL, HTTP: server.Client()}
+}
+
+func deadDaemonClient() *localapi.Client {
+	return localapi.NewClient("http://127.0.0.1:1", "")
+}
+
+func v2DaemonHandler(t *testing.T, deliveryState string) http.Handler {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"v2_send": true, "v2_primary": true, "connected": true})
+	})
+	mux.HandleFunc("/api/v1/outbox/messages", func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode submission: %v", err)
+		}
+		if request["conversation_id"] == "" || request["idempotency_key"] == "" {
+			t.Errorf("submission missing fields: %v", request)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"outbox_id": "out-1", "state": "queued"})
+	})
+	mux.HandleFunc("/api/v1/outbox/out-1", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"outbox_id":         "out-1",
+			"state":             deliveryState,
+			"remote_message_id": "remote-9",
+		})
+	})
+	return mux
+}
+
+func TestDaemonSendToConversationConfirmed(t *testing.T) {
+	options := Options{Daemon: daemonClientFor(t, v2DaemonHandler(t, "confirmed"))}
+	handler := daemonSendToConversationHandler(options)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"conversation_id": "conv-1",
+		"message":         "hello",
+		"idempotency_key": "key-123",
+	}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result)
+	}
+	payload := structuredMap(t, result)
+	if payload["ok"] != true {
+		t.Fatalf("payload.ok = %v, want true", payload["ok"])
+	}
+	if payload["outbox_id"] != "out-1" {
+		t.Fatalf("payload.outbox_id = %v", payload["outbox_id"])
+	}
+	if payload["idempotency_key"] != "key-123" {
+		t.Fatalf("payload.idempotency_key = %v", payload["idempotency_key"])
+	}
+	if payload["remote_message_id"] != "remote-9" {
+		t.Fatalf("payload.remote_message_id = %v", payload["remote_message_id"])
+	}
+}
+
+func TestDaemonSendToConversationDaemonDown(t *testing.T) {
+	options := Options{Daemon: deadDaemonClient()}
+	handler := daemonSendToConversationHandler(options)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"conversation_id": "conv-1", "message": "hello"}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result when the daemon is down")
+	}
+	payload := structuredMap(t, result)
+	message, _ := payload["error"].(string)
+	if !strings.Contains(message, "isn't running") || !strings.Contains(message, "transportless") {
+		t.Fatalf("daemon-down error is not actionable: %q", message)
+	}
+}
+
+func TestDaemonSendToConversationDeterministicRejection(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"v2_send": true})
+	})
+	mux.HandleFunc("/api/v1/outbox/messages", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "conversation not found", http.StatusNotFound)
+	})
+	options := Options{Daemon: daemonClientFor(t, mux)}
+	handler := daemonSendToConversationHandler(options)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"conversation_id": "missing", "message": "hello"}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected deterministic rejection to be an error result")
+	}
+	payload := structuredMap(t, result)
+	message, _ := payload["error"].(string)
+	if !strings.Contains(message, "send rejected by the app") {
+		t.Fatalf("rejection message = %q", message)
+	}
+}
+
+func TestDaemonSendToConversationAmbiguousSubmitIsNotAnErrorResult(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"v2_send": true})
+	})
+	mux.HandleFunc("/api/v1/outbox/messages", func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("response writer does not support hijacking")
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		conn.Close()
+	})
+	options := Options{Daemon: daemonClientFor(t, mux)}
+	handler := daemonSendToConversationHandler(options)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"conversation_id": "conv-1",
+		"message":         "hello",
+		"idempotency_key": "replay-key",
+	}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if result.IsError {
+		t.Fatal("ambiguous submission must not be an error result (it invites a blind resend)")
+	}
+	payload := structuredMap(t, result)
+	if payload["ambiguous"] != true {
+		t.Fatalf("payload.ambiguous = %v, want true", payload["ambiguous"])
+	}
+	if payload["idempotency_key"] != "replay-key" {
+		t.Fatalf("payload.idempotency_key = %v, want replay-key", payload["idempotency_key"])
+	}
+}
+
+func TestDaemonSendToConversationLegacyDaemon(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"connected": true})
+	})
+	mux.HandleFunc("/api/send", func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode legacy send: %v", err)
+		}
+		if request["conversation_id"] != "conv-legacy" {
+			t.Errorf("legacy send conversation_id = %v", request["conversation_id"])
+		}
+		json.NewEncoder(w).Encode(map[string]any{"message_id": "msg-7", "status": "SUCCESS", "success": true})
+	})
+	options := Options{Daemon: daemonClientFor(t, mux)}
+	handler := daemonSendToConversationHandler(options)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"conversation_id": "conv-legacy", "message": "hello"}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result)
+	}
+	payload := structuredMap(t, result)
+	if payload["ok"] != true || payload["message_id"] != "msg-7" {
+		t.Fatalf("legacy payload = %v", payload)
+	}
+}
+
+func TestDaemonSendMessageResolvesPlatformsWithoutTransports(t *testing.T) {
+	options := Options{Daemon: daemonClientFor(t, v2DaemonHandler(t, "confirmed"))}
+	handler := daemonSendMessageHandler(options)
+
+	t.Run("whatsapp recipient", func(t *testing.T) {
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"recipient": "+16505550100",
+			"platform":  "whatsapp",
+			"message":   "hi",
+		}
+		result, err := handler(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got %+v", result)
+		}
+	})
+
+	t.Run("sms without existing conversation", func(t *testing.T) {
+		store, err := db.New(":memory:")
+		if err != nil {
+			t.Fatalf("create db: %v", err)
+		}
+		t.Cleanup(func() { store.Close() })
+		withReads := options
+		withReads.Reads = store
+		handler := daemonSendMessageHandler(withReads)
+
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"recipient": "+16505550100",
+			"message":   "hi",
+		}
+		result, err := handler(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if !result.IsError {
+			t.Fatal("expected error result for a brand-new SMS thread in client mode")
+		}
+		payload := structuredMap(t, result)
+		message, _ := payload["error"].(string)
+		if !strings.Contains(message, "no existing SMS conversation") {
+			t.Fatalf("sms error = %q", message)
+		}
+	})
+
+	t.Run("sms with existing conversation", func(t *testing.T) {
+		store, err := db.New(":memory:")
+		if err != nil {
+			t.Fatalf("create db: %v", err)
+		}
+		t.Cleanup(func() { store.Close() })
+		if err := store.UpsertConversation(&db.Conversation{
+			ConversationID: "conv-1",
+			Name:           "Alice",
+			Participants:   `[{"name":"Alice","number":"+1 (650) 555-0100"}]`,
+			SourcePlatform: "sms",
+		}); err != nil {
+			t.Fatalf("seed conversation: %v", err)
+		}
+		withReads := options
+		withReads.Reads = store
+		handler := daemonSendMessageHandler(withReads)
+
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"recipient": "6505550100",
+			"message":   "hi",
+		}
+		result, err := handler(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success via existing conversation, got %+v", result)
+		}
+		payload := structuredMap(t, result)
+		if payload["ok"] != true {
+			t.Fatalf("payload = %v", payload)
+		}
+	})
+}
+
+func TestDaemonSendGroupMessageAlwaysDirectsToApp(t *testing.T) {
+	handler := daemonSendGroupMessageHandler()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"phone_numbers": []any{"+15551", "+15552"}, "message": "hi"}
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected group creation to be refused in client mode")
+	}
+}
+
+func TestDaemonReactToMessage(t *testing.T) {
+	t.Run("routes through the app", func(t *testing.T) {
+		reacted := false
+		mux := http.NewServeMux()
+		mux.HandleFunc("/api/react", func(w http.ResponseWriter, r *http.Request) {
+			reacted = true
+			var request map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode react: %v", err)
+			}
+			if request["message_id"] != "msg-1" || request["emoji"] != "👍" {
+				t.Errorf("react payload = %v", request)
+			}
+			json.NewEncoder(w).Encode(map[string]any{"success": true})
+		})
+		options := Options{Daemon: daemonClientFor(t, mux)}
+		handler := daemonReactToMessageHandler(options)
+
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{"message_id": "msg-1", "emoji": "👍"}
+		result, err := handler(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got %+v", result)
+		}
+		if !reacted {
+			t.Fatal("daemon /api/react was never called")
+		}
+	})
+
+	t.Run("daemon down", func(t *testing.T) {
+		options := Options{Daemon: deadDaemonClient()}
+		handler := daemonReactToMessageHandler(options)
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{"message_id": "msg-1", "emoji": "👍"}
+		result, err := handler(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if !result.IsError {
+			t.Fatal("expected error result when the daemon is down")
+		}
+	})
+}
+
+func TestDaemonGetStatus(t *testing.T) {
+	t.Run("daemon reachable serves daemon truth", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]any{
+				"connected":  true,
+				"v2_primary": true,
+				"v2_send":    true,
+				"whatsapp":   map[string]any{"connected": true, "paired": true},
+			})
+		})
+		a := testApp(t)
+		options := Options{Reads: a.Store, Daemon: daemonClientFor(t, mux)}
+		handler := daemonGetStatusHandler(a, options)
+
+		result, err := handler(context.Background(), mcp.CallToolRequest{})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("expected success, got %+v", result)
+		}
+		payload := structuredMap(t, result)
+		if payload["daemon_reachable"] != true || payload["mcp_mode"] != "client" {
+			t.Fatalf("payload = %v", payload)
+		}
+		text := resultText(t, result)
+		if !strings.Contains(text, "RUNNING") || !strings.Contains(text, "WhatsApp: connected=true") {
+			t.Fatalf("status text = %q", text)
+		}
+	})
+
+	t.Run("daemon down reports local-only mode", func(t *testing.T) {
+		a := testApp(t)
+		options := Options{Reads: a.Store, Daemon: deadDaemonClient()}
+		handler := daemonGetStatusHandler(a, options)
+
+		result, err := handler(context.Background(), mcp.CallToolRequest{})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("status must not be an error result when the app is closed, got %+v", result)
+		}
+		payload := structuredMap(t, result)
+		if payload["daemon_reachable"] != false {
+			t.Fatalf("payload = %v", payload)
+		}
+		text := resultText(t, result)
+		if !strings.Contains(text, "NOT RUNNING") {
+			t.Fatalf("status text = %q", text)
+		}
+	})
+}

--- a/internal/tools/daemon_test.go
+++ b/internal/tools/daemon_test.go
@@ -253,6 +253,42 @@ func TestDaemonSendMessageResolvesPlatformsWithoutTransports(t *testing.T) {
 		}
 	})
 
+	t.Run("sms never matches digits straddling two participant numbers", func(t *testing.T) {
+		store, err := db.New(":memory:")
+		if err != nil {
+			t.Fatalf("create db: %v", err)
+		}
+		t.Cleanup(func() { store.Close() })
+		// Concatenated participant digits are 1650555010|0123456789, which
+		// contains the target 6505550100 straddling the two numbers — yet
+		// neither participant is the target line. A substring match over
+		// joined digits would send to this wrong conversation.
+		if err := store.UpsertConversation(&db.Conversation{
+			ConversationID: "conv-straddle",
+			Name:           "Wrong people",
+			Participants:   `[{"name":"A","number":"+1650555010"},{"name":"B","number":"+0123456789"}]`,
+			SourcePlatform: "sms",
+		}); err != nil {
+			t.Fatalf("seed conversation: %v", err)
+		}
+		withReads := options
+		withReads.Reads = store
+		handler := daemonSendMessageHandler(withReads)
+
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"recipient": "+16505550100",
+			"message":   "hi",
+		}
+		result, err := handler(context.Background(), req)
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if !result.IsError {
+			t.Fatal("straddling digit sequence must not resolve to a conversation")
+		}
+	})
+
 	t.Run("sms with existing conversation", func(t *testing.T) {
 		store, err := db.New(":memory:")
 		if err != nil {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/localapi"
 	"github.com/maxghenis/openmessage/internal/readsource"
 )
 
@@ -20,6 +21,13 @@ type Options struct {
 	Reads     readsource.ReadSource
 	V2Primary bool
 	V2        *V2Dependencies
+
+	// Daemon switches the send-path tools into transportless client mode:
+	// this process holds no live platform connections, and every send,
+	// reaction, and live-status read is routed at the running app's local
+	// HTTP API. Mutually exclusive with V2 (client mode never runs its own
+	// dispatcher).
+	Daemon *localapi.Client
 }
 
 func Register(s *server.MCPServer, a *app.App, v2 ...*V2Dependencies) {
@@ -52,21 +60,34 @@ func RegisterWithOptions(s *server.MCPServer, a *app.App, options Options) {
 	s.AddTool(getMessagesTool(), getMessagesHandler(a, options))
 	s.AddTool(getConversationTool(), getConversationHandler(a, options))
 	s.AddTool(searchMessagesTool(), searchMessagesHandler(a, options))
-	if configuredV2 == nil {
+	switch {
+	case options.Daemon != nil:
+		s.AddTool(sendMessageTool(true), daemonSendMessageHandler(options))
+		s.AddTool(sendToConversationTool(true), daemonSendToConversationHandler(options))
+		s.AddTool(sendMediaToConversationTool(true), daemonSendMediaToConversationHandler(options))
+	case configuredV2 == nil:
 		s.AddTool(sendMessageTool(), sendMessageHandler(a))
 		s.AddTool(sendToConversationTool(), sendToConversationHandler(a))
 		s.AddTool(sendMediaToConversationTool(), sendMediaToConversationHandler(a))
-	} else {
+	default:
 		s.AddTool(sendMessageTool(true), sendMessageHandler(a, configuredV2))
 		s.AddTool(sendToConversationTool(true), sendToConversationHandler(a, configuredV2))
 		s.AddTool(sendMediaToConversationTool(true), sendMediaToConversationHandler(a, configuredV2))
 	}
-	s.AddTool(reactToMessageTool(), reactToMessageHandler(a))
+	if options.Daemon != nil {
+		s.AddTool(reactToMessageTool(), daemonReactToMessageHandler(options))
+	} else {
+		s.AddTool(reactToMessageTool(), reactToMessageHandler(a))
+	}
 	s.AddTool(setMessageTranscriptTool(), setMessageTranscriptHandler(a))
 	s.AddTool(listConversationsTool(), listConversationsHandler(a, options))
 	s.AddTool(listContactsTool(), listContactsHandler(a))
 	s.AddTool(resolveContactRoutesTool(), resolveContactRoutesHandler(a))
-	s.AddTool(getStatusTool(), getStatusHandler(a, options))
+	if options.Daemon != nil {
+		s.AddTool(getStatusTool(), daemonGetStatusHandler(a, options))
+	} else {
+		s.AddTool(getStatusTool(), getStatusHandler(a, options))
+	}
 	s.AddTool(draftMessageTool(), draftMessageHandler(a))
 	s.AddTool(downloadMediaTool(), downloadMediaHandler(a))
 	s.AddTool(importMessagesTool(), importMessagesHandler(a))
@@ -78,9 +99,12 @@ func RegisterWithOptions(s *server.MCPServer, a *app.App, options Options) {
 	s.AddTool(generateVizTool(), unavailableInV2Primary(v2Primary, generateVizHandler(a)))
 	s.AddTool(getPersonMessagesRangeTool(), unavailableInV2Primary(v2Primary, getPersonMessagesRangeHandler(a)))
 	s.AddTool(renderStoryTool(), unavailableInV2Primary(v2Primary, renderStoryHandler(a)))
-	if configuredV2 == nil {
+	switch {
+	case options.Daemon != nil:
+		s.AddTool(sendGroupMessageTool(true), daemonSendGroupMessageHandler())
+	case configuredV2 == nil:
 		s.AddTool(sendGroupMessageTool(), sendGroupMessageHandler(a))
-	} else {
+	default:
 		s.AddTool(sendGroupMessageTool(true), sendGroupMessageHandler(a, configuredV2))
 	}
 }


### PR DESCRIPTION
## The bug

`openmessage serve --mcp-stdio` — the exact process MCP hosts spawn **per Claude session** — ran the full transport stack: the Google, WhatsApp, and Signal bridge supervisors auto-started gated only on `!isDemo`, regardless of serve mode. Each spawned MCP process connected with the **same WhatsApp device credentials and signal-cli account as the live macOS app daemon**. WhatsApp treats that as a second device login and kills the session; concurrent signal-cli pollers corrupt/deauth Signal.

Empirically confirmed 2026-07-20: MCP processes spawned at 20:40:57/20:41:03 killed a WhatsApp pairing that was 16 seconds old (paired 20:40:41, `401: logged out from another device` by 20:41:07). This also explains the 2026-07-13 WhatsApp logout and Signal's `needs_reauth` death. `instance.lock` never applied — only `backup`/`migrate` honor it.

## The fix: MCP client mode (daemon truth)

The MCP-stdio-only shape now runs as a **transportless client** of the running app, extending PR #140's daemon-truth pattern from the CLI to the whole MCP surface:

- **Zero transport supervisors, zero v2 dispatcher/ingest, zero sync loops, zero legacy scheduler, zero telemetry.** All of those are daemon-owned (the scheduler alone would double-send every due message from a second process).
- **Reads stay local and WAL-safe.** Startup probes `/api/status`: a daemon reporting v2-primary for the same data dir routes reads at the v2 store; with the daemon down or serving another dir, `OPENMESSAGES_V2_*` env decides exactly like `openmessage read` (all CLI fail-fast diagnostics preserved). An unset `OPENMESSAGES_DATA_DIR` adopts the daemon's reported dir, killing the two-data-dirs trap for bare spawns.
- **Sends, reactions, and `get_status` route through the daemon's local HTTP API** via the new `internal/localapi` client: `/api/v1/outbox` on v2 daemons (same durable do-not-resend idempotency contract as the in-process v2 tools, including non-error ambiguous-outcome results with a replay key), `/api/send` + `/api/react` on legacy daemons. App closed → actionable "start the OpenMessage app" error; the client never falls back to opening its own connections.
- `cmd/send_outbox.go` now shares `internal/localapi` (CLI behavior unchanged — routing-cell tests pass verbatim).
- Escape hatches: `--transports` (standalone stdio deployments that are the only OpenMessage process) and `--no-transports` (strip daemon subsystems from any shape).

## Regression coverage

- `TestRunServeMCPStdioStartsZeroTransportSupervisors` — the requested regression test: `serve --mcp-stdio` without `--web` leaves zero transport state (no whatsmeow store, no signal-cli config, no v2 dir), with a `--transports` contrast case proving the assertion isn't vacuous.
- `TestBuiltBinaryMCPStdioClientShapeStartsNoTransports` — same assertion against the compiled binary.
- `TestRunServeMCPClientAdoptsDaemonTruth` — v2-primary read adoption from a fake daemon, no dispatcher state provisioned.
- Daemon-routed tool tests: confirmed/deterministic-rejection/ambiguous/legacy-daemon/daemon-down cells, group-send refusal, react routing, status daemon-truth + app-closed reports.
- `internal/localapi` unit tests: reachability semantics, token attach, streaming multipart, delivery polling, error classification.
- Existing suites pass unchanged (`go test ./...` and `-race` on changed packages). Existing tests that intentionally pinned the old behavior were updated: the corrupt-store refusal now pins **both** shapes, and the v2-ingest binary test uses `--transports` (the client shape must never provision the stack).

## Verified live

Against the running macOS app: a real MCP handshake (initialize → tools/list → tool calls) on the app's data dir held for 20+ seconds — the old code killed WhatsApp in ~25s — with the daemon's WhatsApp staying connected (0 days behind) and `get_status`/`list_conversations` serving daemon truth and current v2 messages through the actual protocol.

## Docs

`docs/agent-runbook.md` gains an "MCP serving — exactly one process may own live transports" section (failure mode, client-mode semantics, safe `~/.mcp.json` recipe); CLAUDE.md summarizes the serving modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)