### PR TITLE
Repair-free app.NewClient: per-session MCP clients and read-only CLI stop write-bursting the live store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,10 @@ before touching anything. The traps that cost the most:
 
 ## Local CLI (read-only, no transports)
 
-These commands open the store directly and start no live transports, so they
-work in a one-shot terminal session without pairing or Full Disk Access:
+These commands open the store directly (repair-free, via `app.NewClient` — no
+startup repair writes to the shared live store) and start no live transports,
+so they work in a one-shot terminal session without pairing or Full Disk
+Access:
 
 ```bash
 openmessage read "<query>" [--limit N] [--phone NUMBER] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--json]
@@ -80,6 +82,9 @@ processes sharing WhatsApp/signal-cli credentials log each other out). Reads
 come from the local store (v2 when the daemon reports v2-primary for the same
 data dir); sends, reactions, and `get_status` route through the running
 daemon's HTTP API (`internal/localapi`) with the CLI's daemon-truth semantics.
+The client opens the store via `app.NewClient`, which skips the startup repair
+sweeps — those stay daemon-owned, so N concurrent sessions don't each burst
+repair writes into the live `messages.db`.
 `--transports` / `--no-transports` override the default per shape. See
 [docs/agent-runbook.md](docs/agent-runbook.md) ("MCP serving") for the failure
 mode this prevents and the `~/.mcp.json` recipe.

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -60,7 +60,10 @@ func openCommandReadSource(
 		}, nil
 	}
 
-	a, err := app.New(logger)
+	// NewClient, not New: read and status are advertised as read-only
+	// commands, and the daemon owns the startup repair sweeps — a one-shot
+	// reader must not write to the live store it shares with the running app.
+	a, err := app.NewClient(logger)
 	if err != nil {
 		return nil, fmt.Errorf("init app: %w", err)
 	}

--- a/cmd/read_test.go
+++ b/cmd/read_test.go
@@ -172,3 +172,41 @@ func TestParseDayBound(t *testing.T) {
 		t.Error("expected error for invalid date")
 	}
 }
+
+// TestOpenCommandReadSourceLegacyDoesNotRepairStore pins the read-only
+// contract of the one-shot CLI reader behind `read` and `status`: opening the
+// legacy store for reads must not run the startup repair sweeps against the
+// live store it shares with the running app. (The app.New contrast leg of
+// TestRunServeMCPClientDoesNotRepairStore proves the same seeded row does
+// trigger a sweep under a store-owning open, so this cannot pass vacuously.)
+func TestOpenCommandReadSourceLegacyDoesNotRepairStore(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
+	t.Setenv("OPENMESSAGES_DEMO", "0")
+	t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
+	t.Setenv("OPENMESSAGES_V2_PRIMARY", "0")
+	t.Setenv("OPENMESSAGES_V2_SEND", "0")
+	t.Setenv("OPENMESSAGES_V2_INGEST", "0")
+
+	seedLegacyReactionPlaceholder(t, dataDir)
+
+	var banner bytes.Buffer
+	session, err := openCommandReadSource(zerolog.Nop(), &banner)
+	if err != nil {
+		t.Fatalf("openCommandReadSource(): %v", err)
+	}
+	conversation, err := session.Reads.GetConversation("whatsapp:group@g.us")
+	if err != nil {
+		session.Close()
+		t.Fatalf("GetConversation(): %v", err)
+	}
+	if conversation == nil {
+		session.Close()
+		t.Fatal("seeded conversation not readable through the session")
+	}
+	session.Close()
+
+	if !legacyReactionPlaceholderPresent(t, dataDir) {
+		t.Fatal("openCommandReadSource ran the startup repair sweeps: the legacy reaction placeholder was repaired away")
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -783,9 +783,10 @@ const clientProbeTimeout = 3 * time.Second
 // the v2 dispatcher/ingest stack, sync loops, schedulers, or telemetry:
 // exactly one process (the app daemon) may own live platform connections,
 // because WhatsApp and signal-cli treat a second concurrent login as
-// credential theft and kill the session. Reads come from the local store;
-// sends and reactions route through the daemon's local HTTP API, mirroring
-// the CLI send path.
+// credential theft and kill the session. Reads come from the local store,
+// opened repair-free (app.NewClient) because the daemon owns the startup
+// repair sweeps; sends and reactions route through the daemon's local HTTP
+// API, mirroring the CLI send path.
 func runServeMCPClient(logger zerolog.Logger, opts serveOptions) error {
 	// Probe before opening any store: daemon truth decides the read mode and,
 	// when OPENMESSAGES_DATA_DIR is unset, which data directory this client
@@ -812,8 +813,8 @@ func runServeMCPClient(logger zerolog.Logger, opts serveOptions) error {
 	// Read mode. Daemon truth applies only when the daemon serves this same
 	// data directory; otherwise the environment decides, preserving the
 	// CLI's fail-fast diagnostics for invalid flag combinations. All
-	// refusals happen before app.New so a refused startup leaves no state
-	// behind.
+	// refusals happen before the store opens so a refused startup leaves no
+	// state behind.
 	dataDir := app.DefaultDataDir()
 	v2Primary := false
 	if daemonUp && daemonDataDir != "" && samePath(daemonDataDir, dataDir) {
@@ -845,7 +846,11 @@ func runServeMCPClient(logger zerolog.Logger, opts serveOptions) error {
 		}()
 	}
 
-	a, err := app.New(logger)
+	// NewClient, not New: MCP hosts spawn one of these processes per session,
+	// and the daemon already repairs the shared store on its own startup —
+	// N per-session repair sweeps against the live messages.db would be
+	// redundant concurrent write bursts.
+	a, err := app.NewClient(logger)
 	if err != nil {
 		return fmt.Errorf("init app: %w", err)
 	}

--- a/cmd/serve_client_test.go
+++ b/cmd/serve_client_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/db"
 	"github.com/maxghenis/openmessage/internal/localapi"
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 	"github.com/maxghenis/openmessage/internal/web"
@@ -221,6 +223,89 @@ func TestRunServeMCPClientAdoptsDaemonDataDir(t *testing.T) {
 	// The adopted directory now holds the client's read store.
 	if _, err := os.Stat(filepath.Join(daemonDataDir, "messages.db")); err != nil {
 		t.Fatalf("client did not open the store in the adopted dir: %v", err)
+	}
+}
+
+// seedLegacyReactionPlaceholder writes the canonical RepairLegacyArtifacts
+// trigger — a WhatsApp "[Reaction]" placeholder row — into the data dir's
+// legacy store, then closes it. Store-owning startup (app.New) deletes the
+// row; repair-free client opens (app.NewClient) must leave it in place.
+func seedLegacyReactionPlaceholder(t *testing.T, dataDir string) {
+	t.Helper()
+	store, err := db.New(filepath.Join(dataDir, "messages.db"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertConversation(&db.Conversation{
+		ConversationID: "whatsapp:group@g.us",
+		Name:           "Group",
+		IsGroup:        true,
+		LastMessageTS:  3000,
+		SourcePlatform: "whatsapp",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(): %v", err)
+	}
+	if err := store.UpsertMessage(&db.Message{
+		MessageID:      "whatsapp:reaction-placeholder",
+		ConversationID: "whatsapp:group@g.us",
+		Body:           "[Reaction]",
+		TimestampMS:    3000,
+		SourcePlatform: "whatsapp",
+		SourceID:       "reaction-placeholder",
+	}); err != nil {
+		t.Fatalf("UpsertMessage(): %v", err)
+	}
+}
+
+func legacyReactionPlaceholderPresent(t *testing.T, dataDir string) bool {
+	t.Helper()
+	store, err := db.New(filepath.Join(dataDir, "messages.db"))
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+	m, err := store.GetMessageByID("whatsapp:reaction-placeholder")
+	if err != nil {
+		t.Fatalf("GetMessageByID(): %v", err)
+	}
+	return m != nil
+}
+
+// TestRunServeMCPClientDoesNotRepairStore pins the repair-free client open:
+// MCP hosts spawn one `serve --mcp-stdio` process per session, and the daemon
+// repairs the shared live store on its own startup — so the per-session
+// client shape must not replay the startup repair sweeps against it. A
+// store-owning open (app.New) run afterwards must repair the same row,
+// proving the seed genuinely triggers a sweep (the client assertion cannot
+// pass vacuously).
+func TestRunServeMCPClientDoesNotRepairStore(t *testing.T) {
+	dataDir := t.TempDir()
+	setClientModeTestEnv(t, dataDir)
+	seedLegacyReactionPlaceholder(t, dataDir)
+
+	var logs bytes.Buffer
+	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
+		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
+	}
+	if !strings.Contains(logs.String(), "MCP client mode") {
+		t.Fatalf("client mode was not engaged:\n%s", logs.String())
+	}
+	if !legacyReactionPlaceholderPresent(t, dataDir) {
+		t.Fatal("MCP client mode ran the startup repair sweeps: the legacy reaction placeholder was repaired away")
+	}
+
+	// Contrast: app.New — the store-owning open the daemon runs at startup —
+	// must repair the row. Called directly rather than through a full daemon
+	// RunServe, whose transport stack keeps background goroutines holding the
+	// store briefly past return and races this verification open.
+	daemonApp, err := app.New(zerolog.Nop())
+	if err != nil {
+		t.Fatalf("app.New(): %v", err)
+	}
+	daemonApp.Close()
+	if legacyReactionPlaceholderPresent(t, dataDir) {
+		t.Fatal("app.New left the legacy reaction placeholder unrepaired (the client assertion above may be vacuous)")
 	}
 }
 

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -72,6 +72,16 @@ running app:
   falls back to `OPENMESSAGES_V2_*` env exactly like `openmessage read`.
   If `OPENMESSAGES_DATA_DIR` is unset, the client adopts the data dir the
   daemon reports — set it explicitly in the MCP config anyway (see below).
+- **The store opens repair-free** (`app.NewClient`): the startup repair
+  sweeps (legacy artifacts, contentless recency, tapbacks, empty stubs,
+  WhatsApp media placeholders) run only in store-owning entrypoints
+  (`app.New` — the daemon and write-capable CLI commands). One client spawns
+  per Claude session, so dozens of concurrent sessions must not each burst
+  repair writes into the live `messages.db`. The read-only CLI
+  (`read`/`status`) opens the legacy store the same way. Regression tests:
+  `TestNewClientPerformsNoStoreWrites` (internal/app),
+  `TestRunServeMCPClientDoesNotRepairStore` and
+  `TestOpenCommandReadSourceLegacyDoesNotRepairStore` (cmd).
 - **Sends/reactions route through the daemon** (`/api/v1/outbox` on v2,
   `/api/send`+`/api/react` on legacy), like the CLI has done since PR #140,
   with the same do-not-resend idempotency contract. With the app closed,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -280,7 +280,28 @@ func DemoMode() bool {
 	}
 }
 
+// New opens the app state for store-owning entrypoints — the daemon and
+// one-shot commands that may write (send, import) — and runs the startup
+// repair sweeps that clean legacy artifacts out of messages.db.
 func New(logger zerolog.Logger) (*App, error) {
+	return newApp(logger, true)
+}
+
+// NewClient opens the app state exactly like New — same data-dir resolution
+// and permission hardening, same store open (including schema migration) —
+// but skips the startup repair sweeps, the only write-y startup step beyond
+// the SQLite open itself. Per-session client processes use it: MCP hosts
+// spawn one `serve --mcp-stdio` per session, so with many sessions open the
+// daemon's live messages.db would otherwise absorb N concurrent repair-sweep
+// write bursts at every session start. The daemon still repairs on each of
+// its own startups via New, so the sweeps run once per daemon lifecycle
+// instead of once per client process. Demo mode still seeds its isolated
+// per-process temp store.
+func NewClient(logger zerolog.Logger) (*App, error) {
+	return newApp(logger, false)
+}
+
+func newApp(logger zerolog.Logger, runRepairSweeps bool) (*App, error) {
 	dataDir := DefaultDataDir()
 	tempDataDir := ""
 	if DemoMode() {
@@ -343,6 +364,42 @@ func New(logger zerolog.Logger) (*App, error) {
 			return nil, fmt.Errorf("secure database file %q: %w", path, err)
 		}
 	}
+	if runRepairSweeps {
+		repairStartupArtifacts(logger, store)
+	}
+
+	// Seed demo data
+	if DemoMode() {
+		if err := store.SeedDemo(); err != nil {
+			store.Close()
+			if tempDataDir != "" {
+				_ = os.RemoveAll(tempDataDir)
+			}
+			return nil, fmt.Errorf("seed demo data: %w", err)
+		}
+		logger.Info().
+			Str("data_dir", dataDir).
+			Str("db", dbPath).
+			Msg("Demo mode — using isolated fake data")
+	}
+
+	app := &App{
+		Store:               store,
+		Logger:              logger,
+		DataDir:             dataDir,
+		SessionPath:         sessionPath,
+		WhatsAppSessionPath: whatsAppSessionPath,
+		SignalConfigPath:    signalConfigPath,
+		tempDataDir:         tempDataDir,
+	}
+	return app, nil
+}
+
+// repairStartupArtifacts runs the write-y startup repair sweeps that clean
+// legacy artifacts out of the store. Every sweep is idempotent and
+// best-effort: failures are logged, never fatal. Only store-owning
+// entrypoints (New) run them; per-session clients (NewClient) must not.
+func repairStartupArtifacts(logger zerolog.Logger, store *db.Store) {
 	if report, err := store.RepairLegacyArtifacts(); err != nil {
 		logger.Warn().Err(err).Msg("Failed to repair legacy message artifacts")
 	} else {
@@ -404,32 +461,6 @@ func New(logger zerolog.Logger) (*App, error) {
 				Msg("Repaired legacy WhatsApp media placeholders from local desktop store")
 		}
 	}
-
-	// Seed demo data
-	if DemoMode() {
-		if err := store.SeedDemo(); err != nil {
-			store.Close()
-			if tempDataDir != "" {
-				_ = os.RemoveAll(tempDataDir)
-			}
-			return nil, fmt.Errorf("seed demo data: %w", err)
-		}
-		logger.Info().
-			Str("data_dir", dataDir).
-			Str("db", dbPath).
-			Msg("Demo mode — using isolated fake data")
-	}
-
-	app := &App{
-		Store:               store,
-		Logger:              logger,
-		DataDir:             dataDir,
-		SessionPath:         sessionPath,
-		WhatsAppSessionPath: whatsAppSessionPath,
-		SignalConfigPath:    signalConfigPath,
-		tempDataDir:         tempDataDir,
-	}
-	return app, nil
 }
 
 func chmodIfExists(path string, mode os.FileMode) error {

--- a/internal/app/app_client_test.go
+++ b/internal/app/app_client_test.go
@@ -1,0 +1,205 @@
+package app
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+// seedRepairableStore writes one trigger row for each startup repair sweep
+// into a fresh legacy store, then closes it. Each row is the canonical shape
+// the corresponding sweep exists to fix (mirroring internal/db's repair
+// tests):
+//   - RepairLegacyArtifacts: a WhatsApp "[Reaction]" placeholder (deleted, and
+//     its conversation's recency recomputed).
+//   - RepairTapbacks: an iMessage `Loved "..."` text whose target message
+//     exists (converted into a reaction, row deleted).
+//   - RepairEmptyStubMessages: an empty body/media/reactions row with a
+//     terminal status (deleted).
+//   - RepairContentlessRecency: a contentless newest message currently setting
+//     its conversation's last_message_ts (recency lowered). Status stays empty
+//     so the empty-stub sweep leaves the row itself alone.
+func seedRepairableStore(t *testing.T, dbPath string) {
+	t.Helper()
+	store, err := db.New(dbPath)
+	if err != nil {
+		t.Fatalf("db.New(): %v", err)
+	}
+	defer store.Close()
+
+	conv := func(c *db.Conversation) {
+		t.Helper()
+		if err := store.UpsertConversation(c); err != nil {
+			t.Fatalf("UpsertConversation(%s): %v", c.ConversationID, err)
+		}
+	}
+	msg := func(m *db.Message) {
+		t.Helper()
+		if err := store.UpsertMessage(m); err != nil {
+			t.Fatalf("UpsertMessage(%s): %v", m.MessageID, err)
+		}
+	}
+
+	conv(&db.Conversation{ConversationID: "whatsapp:group@g.us", Name: "Group", IsGroup: true, LastMessageTS: 3000, SourcePlatform: "whatsapp"})
+	msg(&db.Message{MessageID: "whatsapp:real", ConversationID: "whatsapp:group@g.us", Body: "real message", TimestampMS: 1000, SourcePlatform: "whatsapp", SourceID: "real"})
+	msg(&db.Message{MessageID: "whatsapp:reaction-placeholder", ConversationID: "whatsapp:group@g.us", Body: "[Reaction]", TimestampMS: 3000, SourcePlatform: "whatsapp", SourceID: "reaction-placeholder"})
+
+	conv(&db.Conversation{ConversationID: "imessage:chat", Name: "Chat", LastMessageTS: 2000, SourcePlatform: "imessage"})
+	msg(&db.Message{MessageID: "imessage:target", ConversationID: "imessage:chat", Body: "great idea", TimestampMS: 1000, IsFromMe: true, SourcePlatform: "imessage"})
+	msg(&db.Message{MessageID: "imessage:tapback", ConversationID: "imessage:chat", SenderNumber: "+15550100", Body: `Loved "great idea"`, TimestampMS: 2000, SourcePlatform: "imessage"})
+
+	conv(&db.Conversation{ConversationID: "sms:stub", Name: "Stub", LastMessageTS: 4000, SourcePlatform: "sms"})
+	msg(&db.Message{MessageID: "sms:stub-real", ConversationID: "sms:stub", Body: "hello", TimestampMS: 1000, SourcePlatform: "sms"})
+	msg(&db.Message{MessageID: "sms:stub-empty", ConversationID: "sms:stub", Body: "", Status: "READ", TimestampMS: 4000, SourcePlatform: "sms"})
+
+	conv(&db.Conversation{ConversationID: "sms:phantom", Name: "Phantom", LastMessageTS: 5000, SourcePlatform: "sms"})
+	msg(&db.Message{MessageID: "sms:phantom-real", ConversationID: "sms:phantom", Body: "hey", TimestampMS: 1000, SourcePlatform: "sms"})
+	msg(&db.Message{MessageID: "sms:phantom-empty", ConversationID: "sms:phantom", Body: "", TimestampMS: 5000, SourcePlatform: "sms"})
+}
+
+// snapshotStore captures every messages and conversations row (all columns)
+// plus a row count for every other real table, through a read-only connection
+// that provably writes nothing. FTS shadow tables are excluded: db.New's
+// count-guarded FTS rebuild belongs to "the SQLite open itself", and every
+// repair sweep that rewrites FTS also rewrites messages rows, which the
+// full-row dump catches.
+func snapshotStore(t *testing.T, dbPath string) string {
+	t.Helper()
+	conn, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro")
+	if err != nil {
+		t.Fatalf("open read-only snapshot connection: %v", err)
+	}
+	defer conn.Close()
+	conn.SetMaxOpenConns(1)
+
+	var b strings.Builder
+	dumpTable(t, &b, conn, "messages", "message_id")
+	dumpTable(t, &b, conn, "conversations", "conversation_id")
+
+	rows, err := conn.Query(`
+		SELECT name FROM sqlite_master
+		WHERE type = 'table'
+			AND name NOT LIKE 'sqlite_%'
+			AND name NOT LIKE '%\_fts%' ESCAPE '\'
+			AND name NOT IN ('messages', 'conversations')
+		ORDER BY name`)
+	if err != nil {
+		t.Fatalf("list tables: %v", err)
+	}
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			rows.Close()
+			t.Fatalf("scan table name: %v", err)
+		}
+		tables = append(tables, name)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate tables: %v", err)
+	}
+	for _, table := range tables {
+		var count int
+		if err := conn.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		fmt.Fprintf(&b, "count %s=%d\n", table, count)
+	}
+	return b.String()
+}
+
+func dumpTable(t *testing.T, b *strings.Builder, conn *sql.DB, table, orderColumn string) {
+	t.Helper()
+	rows, err := conn.Query("SELECT * FROM " + table + " ORDER BY " + orderColumn)
+	if err != nil {
+		t.Fatalf("dump %s: %v", table, err)
+	}
+	defer rows.Close()
+	columns, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("columns of %s: %v", table, err)
+	}
+	values := make([]any, len(columns))
+	pointers := make([]any, len(columns))
+	for i := range values {
+		pointers[i] = &values[i]
+	}
+	for rows.Next() {
+		if err := rows.Scan(pointers...); err != nil {
+			t.Fatalf("scan %s row: %v", table, err)
+		}
+		fmt.Fprintf(b, "%s|", table)
+		for i, v := range values {
+			if raw, ok := v.([]byte); ok {
+				v = string(raw)
+			}
+			fmt.Fprintf(b, "%s=%v|", columns[i], v)
+		}
+		b.WriteString("\n")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate %s: %v", table, err)
+	}
+}
+
+// TestNewClientPerformsNoStoreWrites is the client-mode no-writes contract:
+// NewClient must leave every row in messages.db untouched — the startup
+// repair sweeps (RepairLegacyArtifacts, RepairContentlessRecency,
+// RepairTapbacks, RepairEmptyStubMessages, and the WhatsApp media-placeholder
+// repair) run only in New. MCP hosts spawn one client process per session, so
+// with dozens of sessions open, per-client sweeps would hit the daemon's live
+// store with that many concurrent write bursts at every session start.
+func TestNewClientPerformsNoStoreWrites(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("OPENMESSAGES_DATA_DIR", dataDir)
+	t.Setenv("OPENMESSAGES_DEMO", "0")
+	// Keep the control leg below off the machine's real WhatsApp desktop
+	// store; the four store-level sweeps run regardless.
+	t.Setenv("OPENMESSAGES_APP_SANDBOX", "1")
+
+	dbPath := filepath.Join(dataDir, "messages.db")
+	seedRepairableStore(t, dbPath)
+	before := snapshotStore(t, dbPath)
+
+	a, err := NewClient(zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewClient(): %v", err)
+	}
+	a.Close()
+
+	if after := snapshotStore(t, dbPath); after != before {
+		t.Fatalf("NewClient wrote to the store beyond the SQLite open itself:\n--- before ---\n%s\n--- after ---\n%s", before, after)
+	}
+
+	// Control: New on the same store must fire every sweep. This proves the
+	// seeded rows genuinely trigger repairs, i.e. the no-writes assertion
+	// above cannot pass vacuously.
+	a2, err := New(zerolog.Nop())
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+	defer a2.Close()
+
+	if m, err := a2.Store.GetMessageByID("whatsapp:reaction-placeholder"); err != nil || m != nil {
+		t.Errorf("RepairLegacyArtifacts did not delete the WhatsApp reaction placeholder (m=%v, err=%v)", m, err)
+	}
+	if m, err := a2.Store.GetMessageByID("imessage:tapback"); err != nil || m != nil {
+		t.Errorf("RepairTapbacks did not delete the tapback row (m=%v, err=%v)", m, err)
+	}
+	if target, err := a2.Store.GetMessageByID("imessage:target"); err != nil || target == nil || !strings.Contains(target.Reactions, "❤️") {
+		t.Errorf("RepairTapbacks did not attach the reaction to the target (target=%+v, err=%v)", target, err)
+	}
+	if m, err := a2.Store.GetMessageByID("sms:stub-empty"); err != nil || m != nil {
+		t.Errorf("RepairEmptyStubMessages did not delete the empty stub (m=%v, err=%v)", m, err)
+	}
+	if c, err := a2.Store.GetConversation("sms:phantom"); err != nil || c == nil || c.LastMessageTS != 1000 {
+		t.Errorf("RepairContentlessRecency did not lower the phantom conversation's recency (c=%+v, err=%v)", c, err)
+	}
+}


### PR DESCRIPTION
Follow-up to #149 (now merged), addressing its adversarial review's non-blocking nit: `runServeMCPClient` opened the store via `app.New`, which runs the full startup repair-sweep suite — and MCP hosts spawn one client process per Claude session, so the daemon's live `messages.db` absorbed N concurrent repair-sweep write bursts at every session start (25 concurrent clients observed live on 2026-07-21).

## What changed

- **`app.NewClient`** (internal/app/app.go): repair-free twin of `app.New` — identical data-dir resolution, permission hardening, and store open (schema migration included), but skips `RepairLegacyArtifacts`, `RepairContentlessRecency`, `RepairTapbacks`, `RepairEmptyStubMessages`, and the WhatsApp media-placeholder repair. `app.New` delegates to the same `newApp` with sweeps on; the sweep block moved verbatim into `repairStartupArtifacts`. Daemon behavior is unchanged — sweeps still run once per daemon startup.
- **`runServeMCPClient`** now opens via `NewClient` (the per-session MCP client shape).
- **`openCommandReadSource`'s legacy branch** now opens via `NewClient`, so the advertised read-only CLI commands (`read`, `status`) genuinely stop writing to the store they share with the running app.
- Docs: CLAUDE.md + docs/agent-runbook.md note the repair-free client contract.

## Tests

- `TestNewClientPerformsNoStoreWrites` (internal/app): seeds one canonical trigger row per sweep, snapshots **every** messages/conversations row (all columns) plus row counts of all other non-FTS tables through a read-only connection, asserts `NewClient` leaves the store identical at the row level — then a control leg proves `app.New` repairs every seeded row, so the no-writes assertion cannot pass vacuously. Mutation-tested: wiring `NewClient` to run sweeps fails the test.
- `TestRunServeMCPClientDoesNotRepairStore` (cmd): runs the real `RunServe --mcp-stdio` shape to stdin EOF and asserts the trigger row survives, with an `app.New` contrast leg (called directly — a full daemon `RunServe` keeps background goroutines holding the store briefly past return, which races the verification open).
- `TestOpenCommandReadSourceLegacyDoesNotRepairStore` (cmd): pins the read-only CLI contract.

`GOWORK=off go test ./cmd ./internal/app ./internal/tools -count=1` green on the rebase; full `go test ./...` green; the three new tests green under `-race -count=3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)