### PR TITLE
Stop dev builds from shadowing the installed app in LaunchServices

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,11 +109,31 @@ jobs:
 
       - name: Build macOS app + DMG
         env:
+          # RELEASE=1 is required: without it build.sh deliberately stamps the
+          # dev bundle id (com.openmessage.app.dev) and emits OpenMessage-dev.dmg,
+          # so a stale dev build can never shadow the installed app in
+          # LaunchServices. Shipping artifacts must carry the real id.
+          RELEASE: "1"
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_TEAM_ID: ${{ secrets.AC_TEAM_ID }}
         run: bash macos/build.sh
+
+      - name: Verify release bundle identity
+        run: |
+          id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+                 macos/build/OpenMessage.app/Contents/Info.plist)
+          echo "Built bundle id: $id"
+          if [ "$id" != "com.openmessage.app" ]; then
+            echo "::error::Release build has bundle id '$id', expected com.openmessage.app."
+            echo "::error::RELEASE=1 was not honored — refusing to ship a dev-id build."
+            exit 1
+          fi
+          test -f macos/build/OpenMessage.dmg || {
+            echo "::error::macos/build/OpenMessage.dmg missing (dev builds emit OpenMessage-dev.dmg)."
+            exit 1
+          }
 
       - name: Verify notarization
         if: ${{ env.HAS_CERT == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,12 +122,13 @@ jobs:
 
       - name: Verify release bundle identity
         run: |
-          id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
-                 macos/build/OpenMessage.app/Contents/Info.plist)
-          echo "Built bundle id: $id"
-          if [ "$id" != "com.openmessage.app" ]; then
-            echo "::error::Release build has bundle id '$id', expected com.openmessage.app."
-            echo "::error::RELEASE=1 was not honored — refusing to ship a dev-id build."
+          plist=macos/build/OpenMessage.app/Contents/Info.plist
+          id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")
+          name=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleName' "$plist")
+          echo "Built bundle id: $id, name: $name"
+          if [ "$id" != "com.openmessage.app" ] || [ "$name" != "OpenMessage" ]; then
+            echo "::error::Release build has id '$id' / name '$name', expected com.openmessage.app / OpenMessage."
+            echo "::error::RELEASE=1 was not honored — refusing to ship a dev-identity build."
             exit 1
           fi
           test -f macos/build/OpenMessage.dmg || {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,3 +152,31 @@ jobs:
 
       - name: Package macOS app
         run: bash macos/build.sh
+
+      - name: Verify dev build cannot shadow the installed app
+        run: |
+          # A default (non-RELEASE) build must NOT claim com.openmessage.app —
+          # that id collision let stale builds win LaunchServices resolution and
+          # caused two live outages. See docs/agent-runbook.md "Bundle-id shadowing".
+          id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+                 macos/build/OpenMessage.app/Contents/Info.plist)
+          echo "Dev build bundle id: $id"
+          if [ "$id" != "com.openmessage.app.dev" ]; then
+            echo "::error::Default build has bundle id '$id', expected com.openmessage.app.dev."
+            exit 1
+          fi
+
+      - name: Verify RELEASE=1 restores the shippable identity
+        run: |
+          RELEASE=1 bash macos/build.sh >/dev/null
+          id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+                 macos/build/OpenMessage.app/Contents/Info.plist)
+          echo "Release build bundle id: $id"
+          if [ "$id" != "com.openmessage.app" ]; then
+            echo "::error::RELEASE=1 build has bundle id '$id', expected com.openmessage.app."
+            exit 1
+          fi
+          test -f macos/build/OpenMessage.dmg || {
+            echo "::error::RELEASE=1 build did not emit macos/build/OpenMessage.dmg."
+            exit 1
+          }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,25 +158,43 @@ jobs:
           # A default (non-RELEASE) build must NOT claim com.openmessage.app —
           # that id collision let stale builds win LaunchServices resolution and
           # caused two live outages. See docs/agent-runbook.md "Bundle-id shadowing".
-          id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
-                 macos/build/OpenMessage.app/Contents/Info.plist)
-          echo "Dev build bundle id: $id"
+          # The NAME must differ too: `open -a OpenMessage` resolves by the
+          # registered name (CFBundleName/CFBundleDisplayName), not the id.
+          plist=macos/build/OpenMessage.app/Contents/Info.plist
+          id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")
+          name=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleName' "$plist")
+          echo "Dev build bundle id: $id, name: $name"
           if [ "$id" != "com.openmessage.app.dev" ]; then
             echo "::error::Default build has bundle id '$id', expected com.openmessage.app.dev."
+            exit 1
+          fi
+          if [ "$name" != "OpenMessage (dev)" ]; then
+            echo "::error::Default build has CFBundleName '$name', expected 'OpenMessage (dev)' — a dev build named 'OpenMessage' can still win 'open -a OpenMessage'."
             exit 1
           fi
 
       - name: Verify RELEASE=1 restores the shippable identity
         run: |
           RELEASE=1 bash macos/build.sh >/dev/null
-          id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
-                 macos/build/OpenMessage.app/Contents/Info.plist)
-          echo "Release build bundle id: $id"
+          plist=macos/build/OpenMessage.app/Contents/Info.plist
+          id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")
+          name=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleName' "$plist")
+          echo "Release build bundle id: $id, name: $name"
           if [ "$id" != "com.openmessage.app" ]; then
             echo "::error::RELEASE=1 build has bundle id '$id', expected com.openmessage.app."
+            exit 1
+          fi
+          if [ "$name" != "OpenMessage" ]; then
+            echo "::error::RELEASE=1 build has CFBundleName '$name', expected 'OpenMessage'."
             exit 1
           fi
           test -f macos/build/OpenMessage.dmg || {
             echo "::error::RELEASE=1 build did not emit macos/build/OpenMessage.dmg."
             exit 1
           }
+          # The rebuild must also have cleared the dev DMG — a stale
+          # OpenMessage-dev.dmg next to OpenMessage.dmg invites mixups.
+          if [ -f macos/build/OpenMessage-dev.dmg ]; then
+            echo "::error::Stale OpenMessage-dev.dmg survived the RELEASE=1 rebuild."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,21 @@ curl -s -o /dev/null -w "%{http_code}" https://openmessage.ai
 
 This builds: Go universal binary (arm64+amd64) → Swift app → .app bundle → .dmg
 
-To install locally:
+**Dev builds get a distinct bundle id.** Plain `./macos/build.sh` stamps
+`com.openmessage.app.dev` and emits `OpenMessage-dev.dmg`, so a stale build can
+never shadow the installed app in LaunchServices (this caused two live outages —
+see [docs/agent-runbook.md](docs/agent-runbook.md) "Bundle-id shadowing").
+Anything installable or shippable **must** set `RELEASE=1`:
+
+```bash
+RELEASE=1 ./macos/build.sh
+```
+
+Building from a nested `.claude/worktrees/*` checkout also needs `GOWORK=off`
+(Go otherwise finds `~/openmessage/go.work` and resolves the main module to the
+parent).
+
+To install locally (requires `RELEASE=1` above):
 ```bash
 cp -R macos/build/OpenMessage.app /Applications/ && xattr -cr /Applications/OpenMessage.app
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,9 +144,10 @@ curl -s -o /dev/null -w "%{http_code}" https://openmessage.ai
 
 This builds: Go universal binary (arm64+amd64) → Swift app → .app bundle → .dmg
 
-**Dev builds get a distinct bundle id.** Plain `./macos/build.sh` stamps
-`com.openmessage.app.dev` and emits `OpenMessage-dev.dmg`, so a stale build can
-never shadow the installed app in LaunchServices (this caused two live outages —
+**Dev builds get a distinct bundle identity.** Plain `./macos/build.sh` stamps
+`com.openmessage.app.dev`, names the bundle `OpenMessage (dev)`, and emits
+`OpenMessage-dev.dmg`, so a stale build can never shadow the installed app in
+LaunchServices — by id or by name (this caused two live outages —
 see [docs/agent-runbook.md](docs/agent-runbook.md) "Bundle-id shadowing").
 Anything installable or shippable **must** set `RELEASE=1`:
 

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -427,12 +427,27 @@ Two fixes that **don't** work — verified 2026-07-25:
 
 What works:
 
-- **Build outputs:** `build.sh` stamps `com.openmessage.app.dev` unless
-  `RELEASE=1`, so a dev build structurally cannot win resolution.
+- **Build outputs:** unless `RELEASE=1`, `build.sh` stamps
+  `com.openmessage.app.dev` **and** names the bundle `OpenMessage (dev)`
+  (`CFBundleName` + `CFBundleDisplayName`). Both matter: id-based launches
+  (notification clicks, `open -b`) resolve by `CFBundleIdentifier`, but
+  name-based launches (`open -a OpenMessage`, Spotlight) resolve by the
+  registered *name*, which comes from the plist — **not** the `.app`
+  filename (a bundle renamed on disk still registered as "OpenMessage" from
+  its plist). With both stamped, neither launch path can land on a dev build.
 - **Backups/archives kept on disk:** rename `Contents/Info.plist` →
   `Contents/Info.plist.disabled`. With no `Info.plist` LaunchServices can't read
   a bundle id. Lossless and reversible; see `~/openmessage-ROLLBACK-README.md`
   for the restore recipe.
+
+**Sharp edge — don't run a dev GUI on the live machine.** Because the dev id
+differs, macOS no longer dedupes it against the installed app: launching a dev
+build alongside it starts a real second GUI. That GUI *adopts* the daemon
+already listening on port 7007 (`BackendManager.reuseExistingBackendIfNeeded`
+— transport-safe, it won't spawn a competing stack), but its stop path
+SIGTERMs the adopted PID — **quitting the dev GUI kills the live backend out
+from under the installed app.** If that happens, relaunch the installed app.
+Tracked with the other dev-id-scoped traps in issue #165.
 
 Audit (should print exactly `/Applications/OpenMessage.app`):
 

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -381,13 +381,73 @@ hardened the UI to ignore redundant status pushes.)
 
 ## Deploying a new build to a live install
 
+**`RELEASE=1` is required.** Without it `build.sh` stamps the dev bundle id
+(`com.openmessage.app.dev`) on purpose — see [bundle-id
+shadowing](#bundle-id-shadowing--only-one-app-may-claim-comopenmessageapp).
+Copying a dev-id build into `/Applications` would silently orphan the
+`defaults write com.openmessage.app V2Primary` lever and the notification grant.
+
 ```
-DEVELOPER_ID="Developer ID Application: Max Ghenis (8VB5UKQZC6)" ./macos/build.sh
+RELEASE=1 DEVELOPER_ID="Developer ID Application: Max Ghenis (8VB5UKQZC6)" ./macos/build.sh
 osascript -e 'quit app "OpenMessage"'      # fully quit; `open -a` on a running app won't relaunch it
 rm -rf /Applications/OpenMessage.app && cp -R macos/build/OpenMessage.app /Applications/
 xattr -cr /Applications/OpenMessage.app
 open -a OpenMessage
 ```
+
+Confirm the deployed bundle kept the release id:
+
+```
+/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' /Applications/OpenMessage.app/Contents/Info.plist
+# -> com.openmessage.app   (NOT ...app.dev)
+```
+
+**Building from a nested `.claude/worktrees/*` checkout needs `GOWORK=off`.**
+Go walks up, finds `~/openmessage/go.work`, and resolves the main module to the
+parent — `go build .` then fails with "main module … does not contain package
+…/.claude/worktrees/<name>". Prefix the build with `GOWORK=off`.
+
+## Bundle-id shadowing — only one .app may claim `com.openmessage.app`
+
+LaunchServices resolves "OpenMessage" (Spotlight, Dock, `open -a OpenMessage`,
+notification clicks) to *any* registered bundle declaring
+`CFBundleIdentifier = com.openmessage.app`. Every build output, backup, and
+Xcode archive used to declare it, so a stale build could be launched instead of
+the installed app. This caused two outages; on 2026-07-25 a build predating the
+self-heal OSID fix (PR #148) latched Google Messages in `needs_repair` for
+~10.5h (06:54 → ~17:20).
+
+Two fixes that **don't** work — verified 2026-07-25:
+
+- `lsregister -u <path>` is **not durable**. Any LaunchServices rescan
+  re-registers the bundle; a forced rescan brought all 14 straight back.
+- Renaming `Foo.app` → `Foo.app.disabled` does nothing. LaunchServices
+  registers on bundle *structure*, not the `.app` extension — it re-registered
+  every renamed bundle at its new path.
+
+What works:
+
+- **Build outputs:** `build.sh` stamps `com.openmessage.app.dev` unless
+  `RELEASE=1`, so a dev build structurally cannot win resolution.
+- **Backups/archives kept on disk:** rename `Contents/Info.plist` →
+  `Contents/Info.plist.disabled`. With no `Info.plist` LaunchServices can't read
+  a bundle id. Lossless and reversible; see `~/openmessage-ROLLBACK-README.md`
+  for the restore recipe.
+
+Audit (should print exactly `/Applications/OpenMessage.app`):
+
+```
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -dump \
+ | awk '/^[[:space:]]*path:[[:space:]]/ { p=$0; sub(/^[[:space:]]*path:[[:space:]]*/,"",p); sub(/ \(0x[0-9a-f]*\)$/,"",p) }
+        /^[[:space:]]*identifier:[[:space:]]/ { id=$0; sub(/^[[:space:]]*identifier:[[:space:]]*/,"",id);
+        if (id=="com.openmessage.app") print p; p="" }' | sort -u
+```
+
+Note `mdfind "kMDItemCFBundleIdentifier == 'com.openmessage.app'"` is **not** a
+reliable audit — Spotlight keeps stale metadata for neutralized bundles and
+skips dot-directories entirely (two hidden rollback bundles were found only by
+a forced `lsregister -R -f`). Filter the `lsregister` dump by `identifier:` as
+above.
 
 The user's data and pairing **persist** — they live in the data dir, not in the
 `.app` bundle. A fresh restart re-establishes the Google long-poll, which can

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -18,6 +18,34 @@ HELPER_ENTITLEMENTS="$SCRIPT_DIR/OpenMessageHelper.entitlements"
 #   APP_PASSWORD    - app-specific password from appleid.apple.com
 SIGN_IDENTITY="${DEVELOPER_ID:-}"
 
+# ── Bundle identity: dev builds must never shadow the installed app ──
+# Every OpenMessage .app that declares CFBundleIdentifier com.openmessage.app is
+# a candidate when LaunchServices resolves "OpenMessage" (Spotlight, Dock,
+# `open -a OpenMessage`, notification clicks). Stale build outputs sharing the
+# release id have twice caused the wrong binary to launch — most recently
+# 2026-07-25, when a build predating the Google self-heal OSID fix (PR #148)
+# latched Google Messages in needs_repair for ~10.5h.
+#
+# So: plain `./macos/build.sh` produces a *dev* bundle id that can never win
+# that resolution. Shippable builds must opt in explicitly:
+#
+#     RELEASE=1 ./macos/build.sh
+#
+# Note the data dir is NOT bundle-id-scoped (BackendManager.swift hardcodes
+# ~/Library/Application Support/OpenMessage), so a dev build still reads the
+# same store. What IS id-scoped: UserDefaults (the `defaults write
+# com.openmessage.app V2Primary` lever), the notification grant, and the
+# sandbox container.
+RELEASE_BUILD="${RELEASE:-0}"
+if [ "$RELEASE_BUILD" = "1" ]; then
+    BUNDLE_ID="com.openmessage.app"
+    BUNDLE_DISPLAY_NAME="OpenMessage"
+else
+    BUNDLE_ID="com.openmessage.app.dev"
+    BUNDLE_DISPLAY_NAME="OpenMessage (dev)"
+    DMG_PATH="$BUILD_DIR/$APP_NAME-dev.dmg"
+fi
+
 # Detect version from git tag (or VERSION env override). Falls back to "dev".
 VERSION="${VERSION:-$(git -C "$ROOT_DIR" describe --tags --always --dirty 2>/dev/null || echo dev)}"
 echo "==> Version: $VERSION"
@@ -65,8 +93,15 @@ cp "$SWIFT_BIN" "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 cp "$SCRIPT_DIR/build/openmessage" "$APP_BUNDLE/Contents/Resources/openmessage"
 chmod +x "$APP_BUNDLE/Contents/Resources/openmessage"
 
-# Copy Info.plist
+# Copy Info.plist, then stamp the bundle identity for this build mode.
 cp "$SCRIPT_DIR/OpenMessage/Sources/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_ID" "$APP_BUNDLE/Contents/Info.plist"
+if /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$APP_BUNDLE/Contents/Info.plist" >/dev/null 2>&1; then
+    /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName $BUNDLE_DISPLAY_NAME" "$APP_BUNDLE/Contents/Info.plist"
+else
+    /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string $BUNDLE_DISPLAY_NAME" "$APP_BUNDLE/Contents/Info.plist"
+fi
+echo "   Bundle id: $BUNDLE_ID"
 
 # Generate and copy app icon
 ICON_SRC="$SCRIPT_DIR/OpenMessage/Sources/Assets.xcassets/AppIcon.appiconset"
@@ -168,10 +203,34 @@ else
     echo "   To sign + notarize, set: DEVELOPER_ID (e.g. \"Developer ID Application: Max Ghenis (8VB5UKQZC6)\")"
 fi
 
+# ── Keep the build output out of LaunchServices ──
+# Belt-and-braces alongside the dev bundle id. Note this alone is NOT durable:
+# any LaunchServices rescan re-registers the bundle, so it narrows the window
+# rather than closing it. The dev bundle id above is what actually closes it.
+LSREGISTER=/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister
+if [ -x "$LSREGISTER" ]; then
+    "$LSREGISTER" -u "$APP_BUNDLE" >/dev/null 2>&1 || true
+fi
+
 echo ""
 echo "==> Done!"
 echo "   App: $APP_BUNDLE"
 echo "   DMG: $DMG_PATH"
+echo "   Bundle id: $BUNDLE_ID"
+if [ "$RELEASE_BUILD" != "1" ]; then
+    echo ""
+    echo "   ┌─────────────────────────────────────────────────────────────┐"
+    echo "   │  DEV BUILD — bundle id com.openmessage.app.dev              │"
+    echo "   │  Deliberately cannot shadow /Applications/OpenMessage.app.  │"
+    echo "   │  Do NOT ship this or copy it over the installed app.        │"
+    echo "   │  For a shippable build:  RELEASE=1 ./macos/build.sh         │"
+    echo "   └─────────────────────────────────────────────────────────────┘"
+fi
 echo ""
 echo "To run:  open $APP_BUNDLE"
-echo "To install: cp -R $APP_BUNDLE /Applications/"
+if [ "$RELEASE_BUILD" = "1" ]; then
+    echo "To install: cp -R $APP_BUNDLE /Applications/"
+else
+    echo "To install: rebuild with RELEASE=1 first — installing this dev-id"
+    echo "            bundle would orphan the V2Primary lever + notification grant."
+fi

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -36,13 +36,20 @@ SIGN_IDENTITY="${DEVELOPER_ID:-}"
 # same store. What IS id-scoped: UserDefaults (the `defaults write
 # com.openmessage.app V2Primary` lever), the notification grant, and the
 # sandbox container.
+# Both the id AND the name must differ in dev mode: LaunchServices resolves
+# id-based launches (notification clicks, `open -b`) by CFBundleIdentifier,
+# but name-based launches (`open -a OpenMessage`, Spotlight) by the registered
+# name, which comes from CFBundleName/CFBundleDisplayName — NOT the .app
+# filename (verified: a bundle renamed on disk still registered as
+# "OpenMessage" from its plist). Stamping only the id would leave dev builds
+# winning `open -a OpenMessage`.
 RELEASE_BUILD="${RELEASE:-0}"
 if [ "$RELEASE_BUILD" = "1" ]; then
     BUNDLE_ID="com.openmessage.app"
-    BUNDLE_DISPLAY_NAME="OpenMessage"
+    BUNDLE_NAME="OpenMessage"
 else
     BUNDLE_ID="com.openmessage.app.dev"
-    BUNDLE_DISPLAY_NAME="OpenMessage (dev)"
+    BUNDLE_NAME="OpenMessage (dev)"
     DMG_PATH="$BUILD_DIR/$APP_NAME-dev.dmg"
 fi
 
@@ -94,14 +101,17 @@ cp "$SCRIPT_DIR/build/openmessage" "$APP_BUNDLE/Contents/Resources/openmessage"
 chmod +x "$APP_BUNDLE/Contents/Resources/openmessage"
 
 # Copy Info.plist, then stamp the bundle identity for this build mode.
+# Stamped BEFORE codesigning so the signature seals the final plist.
 cp "$SCRIPT_DIR/OpenMessage/Sources/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_ID" "$APP_BUNDLE/Contents/Info.plist"
-if /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$APP_BUNDLE/Contents/Info.plist" >/dev/null 2>&1; then
-    /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName $BUNDLE_DISPLAY_NAME" "$APP_BUNDLE/Contents/Info.plist"
-else
-    /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string $BUNDLE_DISPLAY_NAME" "$APP_BUNDLE/Contents/Info.plist"
-fi
+plist_set() { # key type value — Set with Add fallback
+    /usr/libexec/PlistBuddy -c "Set :$1 $3" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || \
+        /usr/libexec/PlistBuddy -c "Add :$1 $2 $3" "$APP_BUNDLE/Contents/Info.plist"
+}
+plist_set CFBundleIdentifier string "$BUNDLE_ID"
+plist_set CFBundleName string "$BUNDLE_NAME"
+plist_set CFBundleDisplayName string "$BUNDLE_NAME"
 echo "   Bundle id: $BUNDLE_ID"
+echo "   Bundle name: $BUNDLE_NAME"
 
 # Generate and copy app icon
 ICON_SRC="$SCRIPT_DIR/OpenMessage/Sources/Assets.xcassets/AppIcon.appiconset"
@@ -154,7 +164,11 @@ echo "   Size: $(du -sh "$APP_BUNDLE" | cut -f1)"
 
 # ── Create DMG ──
 echo "==> Creating DMG..."
-rm -f "$DMG_PATH"
+# Remove BOTH mode variants, not just the current one: a dev build must not
+# leave last week's OpenMessage.dmg sitting in build/ looking shippable
+# (and vice versa) — uploading a stale DMG is the exact mistake this whole
+# bundle-identity scheme exists to prevent.
+rm -f "$BUILD_DIR/$APP_NAME.dmg" "$BUILD_DIR/$APP_NAME-dev.dmg"
 hdiutil create -volname "$APP_NAME" -srcfolder "$APP_BUNDLE" -ov -format UDZO "$DMG_PATH" 2>&1 | tail -1
 echo "   DMG: $(du -h "$DMG_PATH" | cut -f1)"
 


### PR DESCRIPTION
## Problem

Every OpenMessage `.app` on a dev machine declared the same `CFBundleIdentifier` (`com.openmessage.app`), so LaunchServices could resolve "OpenMessage" — Spotlight, Dock, `open -a OpenMessage`, notification clicks — to **any** of them.

This caused two live outages. Most recently 2026-07-25: a build predating the Google self-heal OSID fix (#148) launched instead of `/Applications/OpenMessage.app` and latched Google Messages in `needs_repair` from 06:54 to ~17:20 (~10.5h dead) before it was diagnosed.

An audit of the machine found **19 bundles** claiming the id — build outputs, rollback backups, dated app-backups, and Xcode archives. 15 of them declared version `1.0.0` against the real app's `0.2.9`.

## Fix

Make it structurally impossible for a build output to win that resolution:

| | bundle id | DMG |
|---|---|---|
| `./macos/build.sh` | `com.openmessage.app.dev` | `OpenMessage-dev.dmg` |
| `RELEASE=1 ./macos/build.sh` | `com.openmessage.app` | `OpenMessage.dmg` |

The build also unregisters its own output from LaunchServices, but that is belt-and-braces only — see below. The dev bundle id is what actually closes the hole.

**Blast radius, checked before choosing this.** The data dir is *not* bundle-id-scoped — `BackendManager.swift` hardcodes `~/Library/Application Support/OpenMessage` — so a dev build still reads the same store. What *is* id-scoped: `UserDefaults` (the `defaults write com.openmessage.app V2Primary` R8 lever), the notification grant, and the sandbox container. So a dev build's output refuses to suggest installing, and both `CLAUDE.md` and the deploy runbook now require `RELEASE=1`.

## CI would have shipped a dev-id release — also fixed

`release.yml` ran `bash macos/build.sh` with no `RELEASE=1`. Under this change that would have produced a `com.openmessage.app.dev` app and an `OpenMessage-dev.dmg`, breaking every downstream step that references `macos/build/OpenMessage.dmg` (Gatekeeper assessment, artifact upload, release upload).

- `release.yml` now sets `RELEASE=1` and **asserts** the built app carries `com.openmessage.app` and that `OpenMessage.dmg` exists, before notarization.
- `test.yml` asserts both directions: the default build must claim `com.openmessage.app.dev`, and a `RELEASE=1` build must restore `com.openmessage.app` + `OpenMessage.dmg`.

## Two fixes that do NOT work (verified, and recorded so they aren't retried)

- **`lsregister -u <path>` is not durable.** Unregistered all 14 stale bundles, forced a rescan — every one came straight back.
- **Renaming `Foo.app` → `Foo.app.disabled` does nothing.** LaunchServices registers on bundle *structure*, not the `.app` extension; it re-registered every renamed bundle at its new path. This is why an earlier rename of the r8 rollback never stuck.

What works for bundles kept on disk: rename `Contents/Info.plist` → `Contents/Info.plist.disabled`. Lossless, reversible, survives forced rescans.

## Also documented

- `mdfind "kMDItemCFBundleIdentifier == ..."` is an unreliable audit — stale metadata, and it skips dot-directories (two hidden rollback bundles were found only via a forced `lsregister -R -f`). Filter the `lsregister -dump` by `identifier:` instead; the audit command is in the runbook.
- Building from a nested `.claude/worktrees/*` checkout needs `GOWORK=off` — Go walks up, finds `~/openmessage/go.work`, and resolves the main module to the parent.

## Verification

Ran a real end-to-end build locally, then forced a LaunchServices rescan of the output:

- fresh build registers as `com.openmessage.app.dev`
- `/Applications/OpenMessage.app` remains the **sole** claimant of `com.openmessage.app`
- Finder resolves `com.openmessage.app` → `/Applications/OpenMessage.app/`

Machine cleanup was done separately (not in this diff): 219 MB of regenerable build outputs deleted, all 21 remaining bundles neutralized losslessly, live app confirmed healthy with all three transports connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)