### PR TITLE
Dedupe duplicated conversation participants instead of quarantining the snapshot

### DIFF
--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -715,7 +715,8 @@ func (w *Worker) refreshConversation(
 		role        sqlite.ParticipantRole
 	}
 	prepared := make([]preparedParticipant, 0, len(event.Participants))
-	seenIdentities := make(map[string]struct{}, len(event.Participants))
+	seenIdentities := make(map[string]int, len(event.Participants))
+	deduplicated := 0
 	for _, participant := range event.Participants {
 		raw := identityRaw(participant.Identity)
 		key, keyErr := v2keys.IdentityKey(accountID, string(platform), raw)
@@ -723,26 +724,40 @@ func (w *Worker) refreshConversation(
 			return sqlite.Conversation{}, keyErr
 		}
 		naturalKey := key.Kind + "\x1f" + key.Canonical
-		if _, duplicate := seenIdentities[naturalKey]; duplicate {
-			// Google conversation snapshots can list the same identity twice
-			// (observed live 2026-08-01: the account's own number appeared
-			// twice in three group rosters). Identical natural key means
-			// identical identity, so keep the first entry — erroring here
-			// quarantines the whole snapshot and permanently drops the
-			// conversation's roster/title updates.
-			w.logger.Warn().
-				Str("account_id", accountID).
-				Str("remote_conversation_id", remoteID).
-				Str("identity", key.Canonical).
-				Msg("Skipping duplicated conversation participant")
-			continue
-		}
-		seenIdentities[naturalKey] = struct{}{}
 		role, roleErr := participantRole(participant.Role)
 		if roleErr != nil {
 			return sqlite.Conversation{}, roleErr
 		}
+		if index, duplicate := seenIdentities[naturalKey]; duplicate {
+			// Google conversation snapshots can list the same identity twice
+			// (observed live 2026-08-01: three group rosters carried the
+			// account's own number both as the self entry and as a plain
+			// member). Identical natural key means identical identity, so a
+			// state-agreeing duplicate is benign: keep the first entry and
+			// fold in IsSelf (same OR semantics as ensureIdentity). Only
+			// duplicates that disagree on membership state (role/active) are
+			// ambiguous enough to refuse the snapshot.
+			kept := &prepared[index]
+			if kept.role != role || kept.participant.Active != participant.Active {
+				return sqlite.Conversation{}, fmt.Errorf(
+					"conversation participant identity %q is duplicated with conflicting state",
+					key.Canonical,
+				)
+			}
+			kept.participant.Identity.IsSelf = kept.participant.Identity.IsSelf ||
+				participant.Identity.IsSelf
+			deduplicated++
+			continue
+		}
+		seenIdentities[naturalKey] = len(prepared)
 		prepared = append(prepared, preparedParticipant{participant: participant, role: role})
+	}
+	if deduplicated > 0 {
+		w.logger.Warn().
+			Str("account_id", accountID).
+			Str("remote_conversation_id", remoteID).
+			Int("deduplicated", deduplicated).
+			Msg("Deduplicated conversation snapshot participants")
 	}
 	nowMS, err := w.nowMS()
 	if err != nil {

--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -724,10 +724,18 @@ func (w *Worker) refreshConversation(
 		}
 		naturalKey := key.Kind + "\x1f" + key.Canonical
 		if _, duplicate := seenIdentities[naturalKey]; duplicate {
-			return sqlite.Conversation{}, fmt.Errorf(
-				"conversation participant identity %q is duplicated",
-				key.Canonical,
-			)
+			// Google conversation snapshots can list the same identity twice
+			// (observed live 2026-08-01: the account's own number appeared
+			// twice in three group rosters). Identical natural key means
+			// identical identity, so keep the first entry — erroring here
+			// quarantines the whole snapshot and permanently drops the
+			// conversation's roster/title updates.
+			w.logger.Warn().
+				Str("account_id", accountID).
+				Str("remote_conversation_id", remoteID).
+				Str("identity", key.Canonical).
+				Msg("Skipping duplicated conversation participant")
+			continue
 		}
 		seenIdentities[naturalKey] = struct{}{}
 		role, roleErr := participantRole(participant.Role)

--- a/internal/ingest/worker_conversation_dedupe_test.go
+++ b/internal/ingest/worker_conversation_dedupe_test.go
@@ -1,83 +1,163 @@
 package ingest
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/maxghenis/openmessage/internal/bridge"
 	"github.com/maxghenis/openmessage/internal/v2keys"
 )
 
 // Regression for the 2026-08-01 live quarantine: Google conversation snapshots
-// can list the same participant identity twice (the account's own number
-// duplicated in group rosters). The worker must keep the first entry and apply
-// the snapshot instead of quarantining it, which permanently dropped those
-// conversations' roster and title updates.
+// listed the account's own number twice in three group rosters — once as the
+// self entry, once as a plain member (same role, same active state). The
+// worker must treat state-agreeing duplicates as benign (keep the first entry,
+// OR-merge IsSelf) and apply the snapshot; before the fix the whole snapshot
+// quarantined and those conversations' roster/title updates were dropped
+// permanently. Duplicates that disagree on membership state remain an error.
 func TestWorkerConversationSnapshotDedupesDuplicateParticipants(t *testing.T) {
 	const remoteID = "1690"
-	harness := newWorkerPathHarness(t, bridge.PlatformGoogle, map[string][]bridge.Event{
-		"snapshot": {{
+	events := func(participants []bridge.Participant) []bridge.Event {
+		return []bridge.Event{{
 			Kind: bridge.EventConversation,
 			Conversation: &bridge.ConversationEvent{
 				RemoteConversationID: remoteID,
 				Kind:                 "group",
 				Title:                "Group with duplicated self",
 				RemoteRevision:       "revision-1",
-				Participants: []bridge.Participant{
-					{
-						Identity: bridge.IdentityRef{Raw: "+16506303657", Name: "Self primary"},
-						Role:     "member",
-						Active:   true,
-					},
-					{
-						Identity: bridge.IdentityRef{Raw: "+15551112222", Name: "Member"},
-						Role:     "member",
-						Active:   true,
-					},
-					{
-						Identity: bridge.IdentityRef{Raw: "+16506303657", Name: "Self duplicate"},
-						Role:     "member",
-						Active:   true,
-					},
-				},
+				Participants:         participants,
+			},
+		}}
+	}
+	member := bridge.Participant{
+		Identity: bridge.IdentityRef{Raw: "+15551112222", Name: "Member"},
+		Role:     "member",
+		Active:   true,
+	}
+	selfEntry := bridge.Participant{
+		Identity: bridge.IdentityRef{Raw: "+16506303657", Name: "Self primary", IsSelf: true},
+		Role:     "member",
+		Active:   true,
+	}
+	plainDuplicate := bridge.Participant{
+		Identity: bridge.IdentityRef{Raw: "+16506303657", Name: "Self duplicate"},
+		Role:     "member",
+		Active:   true,
+	}
+
+	tests := []struct {
+		name         string
+		participants []bridge.Participant
+	}{
+		// The exact live shape: self entry first, plain duplicate later.
+		{"self entry first", []bridge.Participant{selfEntry, member, plainDuplicate}},
+		// Reversed order must still surface IsSelf on the kept entry.
+		{"plain entry first", []bridge.Participant{plainDuplicate, member, selfEntry}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			harness := newWorkerPathHarness(t, bridge.PlatformGoogle, map[string][]bridge.Event{
+				"snapshot": events(test.participants),
+			})
+
+			// process fails the test on any apply error, so reaching the
+			// assertions proves the duplicated roster no longer poisons the
+			// snapshot.
+			harness.process(t, "snapshot")
+
+			normalized := v2keys.NormalizeRemoteConversationID(
+				string(bridge.PlatformGoogle),
+				remoteID,
+			)
+			conversation, err := harness.store.GetConversationByRemote(workerPathAccountID, normalized)
+			if err != nil {
+				t.Fatalf("GetConversationByRemote(): %v", err)
+			}
+			if conversation.Title != "Group with duplicated self" {
+				t.Fatalf("conversation title = %q, want snapshot title applied", conversation.Title)
+			}
+
+			participants, err := harness.store.ListParticipants(conversation.ConversationID)
+			if err != nil {
+				t.Fatalf("ListParticipants(): %v", err)
+			}
+			if len(participants) != 2 {
+				t.Fatalf("participants after dedupe = %d (%+v), want 2", len(participants), participants)
+			}
+			for _, row := range participants {
+				if row.Role != "member" || !row.IsActive {
+					t.Fatalf("participant row = %+v, want role=member active=true", row)
+				}
+			}
+
+			identities, err := harness.store.ListIdentities(workerPathAccountID)
+			if err != nil {
+				t.Fatalf("ListIdentities(): %v", err)
+			}
+			var self *[3]string
+			for _, identity := range identities {
+				if identity.CanonicalValue == "+16506303657" {
+					isSelf := "false"
+					if identity.IsSelf {
+						isSelf = "true"
+					}
+					self = &[3]string{identity.DisplayName, isSelf, identity.RawValue}
+				}
+			}
+			if self == nil {
+				t.Fatal("deduped identity not found")
+			}
+			// First occurrence's display name wins; IsSelf is OR-merged, so
+			// it must be true regardless of which entry came first.
+			wantName := test.participants[0].Identity.Name
+			if self[0] != wantName || self[1] != "true" {
+				t.Fatalf("deduped identity name=%q isSelf=%s, want name=%q isSelf=true",
+					self[0], self[1], wantName)
+			}
+		})
+	}
+}
+
+// Duplicates that disagree on membership state (role or active) are ambiguous
+// — refusing the snapshot (quarantine) is still the contract there.
+func TestWorkerConversationSnapshotConflictingDuplicateStillQuarantines(t *testing.T) {
+	departed := bridge.Participant{
+		Identity: bridge.IdentityRef{Raw: "+16506303657", Name: "Self departed"},
+		Role:     "member",
+		Active:   false,
+	}
+	active := bridge.Participant{
+		Identity: bridge.IdentityRef{Raw: "+16506303657", Name: "Self active", IsSelf: true},
+		Role:     "member",
+		Active:   true,
+	}
+	harness := newWorkerPathHarness(t, bridge.PlatformGoogle, map[string][]bridge.Event{
+		"conflict": {{
+			Kind: bridge.EventConversation,
+			Conversation: &bridge.ConversationEvent{
+				RemoteConversationID: "1691",
+				Kind:                 "group",
+				Title:                "Conflicting duplicate",
+				RemoteRevision:       "revision-1",
+				Participants:         []bridge.Participant{departed, active},
 			},
 		}},
 	})
 
-	// process fails the test on any quarantine, so reaching the assertions
-	// already proves the duplicated roster no longer poisons the snapshot.
-	harness.process(t, "snapshot")
-
-	normalized := v2keys.NormalizeRemoteConversationID(
-		string(bridge.PlatformGoogle),
-		remoteID,
-	)
-	conversation, err := harness.store.GetConversationByRemote(workerPathAccountID, normalized)
-	if err != nil {
-		t.Fatalf("GetConversationByRemote(): %v", err)
+	record := bridge.RawIngressRecord{
+		AccountID:    workerPathAccountID,
+		Generation:   1,
+		DedupeKey:    "conflict-dedupe",
+		Codec:        workerPathCodec,
+		CodecVersion: 1,
+		ReceivedAt:   time.UnixMilli(workerPathNowMS),
+		Payload:      []byte("conflict"),
 	}
-	if conversation.Title != "Group with duplicated self" {
-		t.Fatalf("conversation title = %q, want snapshot title applied", conversation.Title)
-	}
-
-	participants, err := harness.store.ListParticipants(conversation.ConversationID)
-	if err != nil {
-		t.Fatalf("ListParticipants(): %v", err)
-	}
-	if len(participants) != 2 {
-		t.Fatalf("participants after dedupe = %d (%+v), want 2", len(participants), participants)
-	}
-
-	identities, err := harness.store.ListIdentities(workerPathAccountID)
-	if err != nil {
-		t.Fatalf("ListIdentities(): %v", err)
-	}
-	var selfName string
-	for _, identity := range identities {
-		if identity.CanonicalValue == "+16506303657" {
-			selfName = identity.DisplayName
-		}
-	}
-	if selfName != "Self primary" {
-		t.Fatalf("deduped identity display name = %q, want first occurrence kept", selfName)
+	_, err := harness.worker.processRecordResult(context.Background(), "conflict-inbox", record)
+	var quarantined quarantineError
+	if !errors.As(err, &quarantined) {
+		t.Fatalf("processRecordResult() error = %v, want quarantine classification", err)
 	}
 }

--- a/internal/ingest/worker_conversation_dedupe_test.go
+++ b/internal/ingest/worker_conversation_dedupe_test.go
@@ -1,0 +1,83 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/v2keys"
+)
+
+// Regression for the 2026-08-01 live quarantine: Google conversation snapshots
+// can list the same participant identity twice (the account's own number
+// duplicated in group rosters). The worker must keep the first entry and apply
+// the snapshot instead of quarantining it, which permanently dropped those
+// conversations' roster and title updates.
+func TestWorkerConversationSnapshotDedupesDuplicateParticipants(t *testing.T) {
+	const remoteID = "1690"
+	harness := newWorkerPathHarness(t, bridge.PlatformGoogle, map[string][]bridge.Event{
+		"snapshot": {{
+			Kind: bridge.EventConversation,
+			Conversation: &bridge.ConversationEvent{
+				RemoteConversationID: remoteID,
+				Kind:                 "group",
+				Title:                "Group with duplicated self",
+				RemoteRevision:       "revision-1",
+				Participants: []bridge.Participant{
+					{
+						Identity: bridge.IdentityRef{Raw: "+16506303657", Name: "Self primary"},
+						Role:     "member",
+						Active:   true,
+					},
+					{
+						Identity: bridge.IdentityRef{Raw: "+15551112222", Name: "Member"},
+						Role:     "member",
+						Active:   true,
+					},
+					{
+						Identity: bridge.IdentityRef{Raw: "+16506303657", Name: "Self duplicate"},
+						Role:     "member",
+						Active:   true,
+					},
+				},
+			},
+		}},
+	})
+
+	// process fails the test on any quarantine, so reaching the assertions
+	// already proves the duplicated roster no longer poisons the snapshot.
+	harness.process(t, "snapshot")
+
+	normalized := v2keys.NormalizeRemoteConversationID(
+		string(bridge.PlatformGoogle),
+		remoteID,
+	)
+	conversation, err := harness.store.GetConversationByRemote(workerPathAccountID, normalized)
+	if err != nil {
+		t.Fatalf("GetConversationByRemote(): %v", err)
+	}
+	if conversation.Title != "Group with duplicated self" {
+		t.Fatalf("conversation title = %q, want snapshot title applied", conversation.Title)
+	}
+
+	participants, err := harness.store.ListParticipants(conversation.ConversationID)
+	if err != nil {
+		t.Fatalf("ListParticipants(): %v", err)
+	}
+	if len(participants) != 2 {
+		t.Fatalf("participants after dedupe = %d (%+v), want 2", len(participants), participants)
+	}
+
+	identities, err := harness.store.ListIdentities(workerPathAccountID)
+	if err != nil {
+		t.Fatalf("ListIdentities(): %v", err)
+	}
+	var selfName string
+	for _, identity := range identities {
+		if identity.CanonicalValue == "+16506303657" {
+			selfName = identity.DisplayName
+		}
+	}
+	if selfName != "Self primary" {
+		t.Fatalf("deduped identity display name = %q, want first occurrence kept", selfName)
+	}
+}


### PR DESCRIPTION
## What

Google conversation snapshots can list the same participant identity twice. Live occurrence 2026-08-01 ~04:54 ET: a burst of 8 conversation snapshots arrived on `google-primary`; 3 of them (revisions of 3 group threads) carried the account's own number twice in the roster and were quarantined by `refreshConversation`'s duplicate-identity check. Their roster/title updates were silently dropped, and every future revision of those groups would quarantine the same way.

Diagnosed by replaying the live inbox frames (from a read-only copy of the v2 store) through the real worker apply path: exact error `conversation participant identity "+1650…" is duplicated` on exactly the 3 quarantined frames; all 8 apply cleanly with this fix. No messages were involved — conversation metadata only.

## The fix

Identical natural key (kind + canonical) means identical identity, so the second entry can only be a duplicate — keep the first, log a warning, apply the snapshot. Quarantining the whole snapshot over a benign roster artifact permanently drops metadata the next revision won't restore.

## Verification

- New regression test `TestWorkerConversationSnapshotDedupesDuplicateParticipants` replays the duplicated-roster shape through the worker-path harness: snapshot applies, 2 participants after dedupe, first occurrence's display name kept.
- `GOWORK=off go test ./...` green.
- The 8 live frames (including the 3 quarantined) all apply under this change; unfixed main reproduces the 3 quarantines.

## Notes

- The error path had no test coverage before this.
- Quarantined frames are terminal today (marked processed, never re-driven). A maintenance re-drive for previously quarantined frames is a possible follow-up; the next Google snapshot revision of each group will repopulate the metadata anyway once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)