### PR TITLE
Add MCP tools for headless Google Account pairing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Local-first universal message database with built-in MCP server. Ingests message
 │   ├── db/           SQLite store (conversations, messages, contacts, unified_contacts, drafts)
 │   ├── importer/     Multi-platform import adapters (gchat, imessage, whatsapp)
 │   ├── story/        Stats computation + narrative story generation
-│   ├── tools/        MCP tools (24 tools)
+│   ├── tools/        MCP tools (26 tools)
 │   ├── viz/          Relationship visualization renderer (self-contained HTML)
 │   └── web/          HTTP API + embedded React UI
 ├── macos/            Swift macOS app wrapper
@@ -91,7 +91,7 @@ mode this prevents and the `~/.mcp.json` recipe.
 
 ### MCP tools
 
-24 tools registered (see internal/tools/tools.go Register for the authoritative list):
+26 tools registered (see internal/tools/tools.go Register for the authoritative list):
 - `get_messages`, `get_conversation`, `search_messages` — cross-platform by default
 - `list_conversations` — optional `source_platform` filter (sms, gchat, imessage, whatsapp)
 - `get_person_messages` — all messages with a person across all platforms
@@ -104,6 +104,7 @@ mode this prevents and the `~/.mcp.json` recipe.
 - `generate_viz` — self-contained HTML visualization combining data dashboards + narrative (see below)
 - `render_story` — render a pre-built Story JSON into HTML viz; supports `photo_paths` (curated list) or `photos_dir`
 - `send_message`, `draft_message`, `download_media`, `list_contacts`, `get_status`
+- `start_google_pairing` / `complete_google_pairing` — Google Account (Gaia) pairing from browser cookies, for headless installs where the QR flow's interactive terminal is unavailable. Gaia pairing blocks until the user taps a confirmation emoji on their phone, so it is split in two: `start_google_pairing` returns the emoji plus an opaque `pairing_handle` immediately (the emoji has to be shown *before* anyone waits), and `complete_google_pairing` takes that handle and waits for the tap. Handles are single-use and live in a server-side registry with a 10 minute TTL, because libgm's `PairingSession` holds a client-bound private key and cannot round-trip through the caller.
 
 ### HTTP API
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ To let a client connect over HTTP, start OpenMessage with `--mcp-sse` (or `--web
 | `list_contacts` | List/search contacts |
 | `resolve_contact_routes` | Resolve a person or phone number to the available SMS/WhatsApp/Signal routes |
 | `get_status` | Google Messages, WhatsApp, and Signal connection status |
+| `start_google_pairing` | Begin Google Account pairing from browser cookies — the headless alternative to the interactive QR flow. Returns the confirmation emoji and a pairing handle |
+| `complete_google_pairing` | Finish pairing once the user has tapped the emoji on their phone |
 | `download_media` | Return the local `/api/media/<message-id>` URL and metadata for an attachment |
 | `draft_message` | Save a draft for the local app to review/send later |
 | `import_messages` | Import Google Chat, iMessage, WhatsApp export, or Signal Desktop history |

--- a/cmd/pair.go
+++ b/cmd/pair.go
@@ -2,13 +2,10 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -18,7 +15,6 @@ import (
 	"go.mau.fi/mautrix-gmessages/pkg/libgm"
 	"go.mau.fi/mautrix-gmessages/pkg/libgm/events"
 	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
-	utilcurl "go.mau.fi/util/curl"
 	"golang.org/x/term"
 
 	"github.com/maxghenis/openmessage/internal/app"
@@ -129,6 +125,13 @@ func runQRPairing(logger zerolog.Logger, cli *client.Client, sessionPath string)
 	return pairErr
 }
 
+// parseGoogleCookiesInput is retained as a thin alias so the cookie-parsing
+// tests keep exercising the CLI's entry point; the implementation now lives in
+// internal/client so the MCP pairing tool shares it.
+func parseGoogleCookiesInput(raw string) (map[string]string, error) {
+	return client.ParseGoogleCookiesInput(raw)
+}
+
 func displayQR(url string) {
 	fmt.Println("\nScan this QR code with Google Messages:")
 	fmt.Println("(Settings > Device pairing > Pair a device)")
@@ -173,83 +176,18 @@ func resolvePairMode(args []string) (pairMode, string, error) {
 }
 
 func runGoogleAccountPairing(cli *client.Client, sessionPath, rawInput string) error {
-	cookies, err := parseGoogleCookiesInput(rawInput)
-	if err != nil {
-		return fmt.Errorf("parse Google cookies: %w", err)
-	}
-	cli.GM.AuthData.Cookies = cookies
-
 	fmt.Println("Starting Google account pairing...")
-	err = cli.GM.DoGaiaPairing(context.Background(), func(emoji string) {
+	err := client.PairWithGoogleCookies(context.Background(), cli, sessionPath, rawInput, func(emoji string) {
 		fmt.Println("EMOJI:", emoji)
 		fmt.Println("Tap this emoji in Google Messages on your phone.")
 	})
 	if err != nil {
-		return fmt.Errorf("google account pairing: %w", err)
-	}
-
-	sessionData, err := cli.SessionData()
-	if err != nil {
-		return fmt.Errorf("get session data: %w", err)
-	}
-	if err := client.SaveSession(sessionPath, sessionData); err != nil {
-		return fmt.Errorf("save session: %w", err)
+		return err
 	}
 	fmt.Println("\nPairing successful!")
 	fmt.Println("Session saved to", sessionPath)
 	fmt.Println("You can now run: openmessage serve")
 	return nil
-}
-
-func parseGoogleCookiesInput(raw string) (map[string]string, error) {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return nil, fmt.Errorf("no cookies provided")
-	}
-
-	var cookieMap map[string]string
-	if strings.HasPrefix(trimmed, "{") {
-		if err := json.Unmarshal([]byte(trimmed), &cookieMap); err == nil && len(cookieMap) > 0 {
-			return cookieMap, nil
-		}
-	}
-
-	if strings.HasPrefix(trimmed, "curl ") {
-		parsed, err := utilcurl.Parse(trimmed)
-		if err != nil {
-			return nil, fmt.Errorf("parse cURL command: %w", err)
-		}
-		if cookies, err := parseCookieHeader(parsed.Header.Get("Cookie")); err == nil {
-			return cookies, nil
-		}
-		return nil, fmt.Errorf("cURL command did not include a Cookie header")
-	}
-
-	return parseCookieHeader(trimmed)
-}
-
-func parseCookieHeader(raw string) (map[string]string, error) {
-	header := strings.TrimSpace(raw)
-	if header == "" {
-		return nil, fmt.Errorf("no cookie header provided")
-	}
-	if strings.HasPrefix(strings.ToLower(header), "cookie:") {
-		header = strings.TrimSpace(header[len("cookie:"):])
-	}
-	req := &http.Request{Header: make(http.Header)}
-	req.Header.Set("Cookie", header)
-	parsed := map[string]string{}
-	for _, cookie := range req.Cookies() {
-		name := strings.TrimSpace(cookie.Name)
-		if name == "" {
-			continue
-		}
-		parsed[name] = cookie.Value
-	}
-	if len(parsed) == 0 {
-		return nil, fmt.Errorf("no cookies found")
-	}
-	return parsed, nil
 }
 
 // Ensure PairCallback type matches what libgm expects

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/maxghenis/openmessage
 go 1.25.0
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/mdp/qrterminal/v3 v3.2.1
 	github.com/rs/zerolog v1.35.1
@@ -26,7 +27,6 @@ require (
 	github.com/coder/websocket v1.8.15 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elliotchance/orderedmap/v3 v3.1.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,14 +75,10 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
-go.mau.fi/libsignal v0.2.1 h1:vRZG4EzTn70XY6Oh/pVKrQGuMHBkAWlGRC22/85m9L0=
-go.mau.fi/libsignal v0.2.1/go.mod h1:iVvjrHyfQqWajOUaMEsIfo3IqgVMrhWcPiiEzk7NgoU=
 go.mau.fi/libsignal v0.2.2 h1:QV+XdzQkm3x3aSG7FcqfGSZuFXz83pRZPBFaPygHbOU=
 go.mau.fi/libsignal v0.2.2/go.mod h1:CRlIQg2J8uYTfDFvNoO8/KcZjs5cey0vbc6oj/bssY0=
 go.mau.fi/util v0.9.10 h1:wzvz5iDHyqDXB8vgisD4d3SzucLXNM3iNY+1O1RoHtg=
 go.mau.fi/util v0.9.10/go.mod h1:YQOxySn+ZE3qSYqNxvyX7Yi3suA8YK17PS6QqBREW7A=
-go.mau.fi/whatsmeow v0.0.0-20260327181659-02ec817e7cf4 h1:E4A6eca9vMJQctC9DIfzUIg27TrJ8IrDHgkJwJ8WPUQ=
-go.mau.fi/whatsmeow v0.0.0-20260327181659-02ec817e7cf4/go.mod h1:mXCRFyPEPn4jqWz6Afirn8vY7DpHCPnlKq6I2cWwFHM=
 go.mau.fi/whatsmeow v0.0.0-20260630180629-b572e5bcb92b h1:ZUk1ErarDNpnbosXR/MeOz2gkqA4S1bh8zjaSRj7N+Y=
 go.mau.fi/whatsmeow v0.0.0-20260630180629-b572e5bcb92b/go.mod h1:9dmNTYZ/1pHjPw/bz+azBsGjAkcrZbqzMrKcvG5bJ8U=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=

--- a/internal/client/gaiapair.go
+++ b/internal/client/gaiapair.go
@@ -1,0 +1,128 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"go.mau.fi/mautrix-gmessages/pkg/libgm"
+	utilcurl "go.mau.fi/util/curl"
+)
+
+// ParseGoogleCookiesInput accepts the three shapes people can realistically
+// copy out of browser devtools and normalizes them to a cookie map:
+//
+//   - a JSON object of cookie name/value pairs,
+//   - a full `curl ...` command (the "Copy as cURL" menu item, whose cookies
+//     may arrive either as `-b '...'` or as `-H 'Cookie: ...'`),
+//   - a raw `Cookie:` header value.
+func ParseGoogleCookiesInput(raw string) (map[string]string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, fmt.Errorf("no cookies provided")
+	}
+
+	var cookieMap map[string]string
+	if strings.HasPrefix(trimmed, "{") {
+		if err := json.Unmarshal([]byte(trimmed), &cookieMap); err == nil && len(cookieMap) > 0 {
+			return cookieMap, nil
+		}
+	}
+
+	if strings.HasPrefix(trimmed, "curl ") {
+		parsed, err := utilcurl.Parse(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("parse cURL command: %w", err)
+		}
+		if cookies, err := ParseCookieHeader(parsed.Header.Get("Cookie")); err == nil {
+			return cookies, nil
+		}
+		return nil, fmt.Errorf("cURL command did not include a Cookie header")
+	}
+
+	return ParseCookieHeader(trimmed)
+}
+
+// ParseCookieHeader parses a `Cookie:` header value into a cookie map. The
+// leading `Cookie:` is optional so a header copied verbatim also works.
+func ParseCookieHeader(raw string) (map[string]string, error) {
+	header := strings.TrimSpace(raw)
+	if header == "" {
+		return nil, fmt.Errorf("no cookie header provided")
+	}
+	if strings.HasPrefix(strings.ToLower(header), "cookie:") {
+		header = strings.TrimSpace(header[len("cookie:"):])
+	}
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Cookie", header)
+	parsed := map[string]string{}
+	for _, cookie := range req.Cookies() {
+		name := strings.TrimSpace(cookie.Name)
+		if name == "" {
+			continue
+		}
+		parsed[name] = cookie.Value
+	}
+	if len(parsed) == 0 {
+		return nil, fmt.Errorf("no cookies found")
+	}
+	return parsed, nil
+}
+
+// StartGaiaPairing performs the first half of Google Account pairing: it
+// authenticates with the supplied cookies and asks Google to display a
+// confirmation emoji on the phone. It returns that emoji plus the pairing
+// session needed to finish.
+//
+// The returned session holds an ECDSA private key and is bound to cli, so it
+// cannot be serialized or moved between processes — the same cli must be used
+// to call FinishGaiaPairing.
+func StartGaiaPairing(ctx context.Context, cli *Client, rawCookies string) (string, *libgm.PairingSession, error) {
+	cookies, err := ParseGoogleCookiesInput(rawCookies)
+	if err != nil {
+		return "", nil, fmt.Errorf("parse Google cookies: %w", err)
+	}
+	cli.GM.AuthData.Cookies = cookies
+
+	emoji, session, err := cli.GM.StartGaiaPairing(ctx)
+	if err != nil {
+		return "", nil, fmt.Errorf("start google account pairing: %w", err)
+	}
+	return emoji, session, nil
+}
+
+// FinishGaiaPairing completes pairing once the user has tapped the emoji on
+// their phone, and writes the resulting session to sessionPath. It blocks
+// until the tap is confirmed, so callers should bound ctx.
+func FinishGaiaPairing(ctx context.Context, cli *Client, session *libgm.PairingSession, sessionPath string) error {
+	if _, err := cli.GM.FinishGaiaPairing(ctx, session); err != nil {
+		return fmt.Errorf("finish google account pairing: %w", err)
+	}
+
+	sessionData, err := cli.SessionData()
+	if err != nil {
+		return fmt.Errorf("get session data: %w", err)
+	}
+	if err := SaveSession(sessionPath, sessionData); err != nil {
+		return fmt.Errorf("save session: %w", err)
+	}
+	return nil
+}
+
+// PairWithGoogleCookies runs both halves back to back, reporting the emoji via
+// emojiCB in between. Suited to the CLI, where the emoji can be printed while
+// the handshake is still in flight; request/response callers should use
+// StartGaiaPairing and FinishGaiaPairing so the emoji can be delivered before
+// the wait begins.
+func PairWithGoogleCookies(ctx context.Context, cli *Client, sessionPath, rawCookies string, emojiCB func(emoji string)) error {
+	emoji, session, err := StartGaiaPairing(ctx, cli, rawCookies)
+	if err != nil {
+		return err
+	}
+	if emojiCB != nil {
+		emojiCB(emoji)
+	}
+	return FinishGaiaPairing(ctx, cli, session, sessionPath)
+}

--- a/internal/tools/pair_google.go
+++ b/internal/tools/pair_google.go
@@ -1,0 +1,226 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/rs/zerolog"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm"
+
+	"github.com/maxghenis/openmessage/internal/app"
+	"github.com/maxghenis/openmessage/internal/client"
+)
+
+const (
+	// pairingSessionTTL bounds how long a started pairing stays resumable.
+	// Google expires the handshake on its own side too; this keeps abandoned
+	// sessions (and their live clients) from accumulating.
+	pairingSessionTTL = 10 * time.Minute
+	// finishPairingTimeout bounds the blocking wait for the user's tap.
+	finishPairingTimeout = 2 * time.Minute
+)
+
+// pendingPairing is a started-but-unconfirmed Gaia handshake.
+//
+// libgm's PairingSession holds an ECDSA private key and is bound to the client
+// that created it, so unlike an opaque OTP challenge token it cannot be handed
+// to the caller and passed back. We keep it server-side and give the caller an
+// opaque handle instead.
+type pendingPairing struct {
+	cli     *client.Client
+	session *libgm.PairingSession
+	emoji   string
+	started time.Time
+}
+
+type pairingRegistry struct {
+	mu       sync.Mutex
+	pending  map[string]*pendingPairing
+	nowFn    func() time.Time
+	newUUIDs func() string
+}
+
+func newPairingRegistry() *pairingRegistry {
+	return &pairingRegistry{
+		pending:  map[string]*pendingPairing{},
+		nowFn:    time.Now,
+		newUUIDs: func() string { return uuid.NewString() },
+	}
+}
+
+var pairings = newPairingRegistry()
+
+func (r *pairingRegistry) add(p *pendingPairing) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.evictExpiredLocked()
+	handle := r.newUUIDs()
+	r.pending[handle] = p
+	return handle
+}
+
+// take removes and returns a pending pairing. Pairings are single-use: a
+// failed finish leaves the libgm session spent, so the caller must start over.
+func (r *pairingRegistry) take(handle string) (*pendingPairing, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.evictExpiredLocked()
+	p, ok := r.pending[handle]
+	if ok {
+		delete(r.pending, handle)
+	}
+	return p, ok
+}
+
+func (r *pairingRegistry) evictExpiredLocked() {
+	for handle, p := range r.pending {
+		if r.nowFn().Sub(p.started) > pairingSessionTTL {
+			p.cli.GM.Disconnect()
+			delete(r.pending, handle)
+		}
+	}
+}
+
+// Indirected for tests.
+var (
+	startGaiaPairing = func(ctx context.Context, cli *client.Client, rawCookies string) (string, *libgm.PairingSession, error) {
+		return client.StartGaiaPairing(ctx, cli, rawCookies)
+	}
+	finishGaiaPairing = func(ctx context.Context, cli *client.Client, session *libgm.PairingSession, sessionPath string) error {
+		return client.FinishGaiaPairing(ctx, cli, session, sessionPath)
+	}
+	newPairingClient = func(logger zerolog.Logger) *client.Client {
+		return client.NewForPairing(logger)
+	}
+)
+
+func startGooglePairingTool() mcp.Tool {
+	return mcp.NewTool("start_google_pairing",
+		mcp.WithDescription(
+			"First step of Google Messages pairing. Authenticates with Google Account cookies "+
+				"copied from a browser and returns a confirmation emoji plus a `pairing_handle`. "+
+				"This is the supported pairing method for headless installs, where the QR flow "+
+				"(which needs an interactive terminal) is unavailable. "+
+				"The caller must supply cookies from a browser already signed in to "+
+				"messages.google.com — they cannot be obtained from this server. "+
+				"Show the emoji to the user immediately: they tap it in Google Messages on their "+
+				"phone, then you call `complete_google_pairing` with the handle. "+
+				"The handle is valid for 10 minutes.",
+		),
+		mcp.WithString("cookies",
+			mcp.Required(),
+			mcp.Description(
+				"Google cookies from browser devtools, in any of: a JSON object of "+
+					"cookie name/value pairs, a full 'curl ...' command (Copy as cURL), "+
+					"or a raw Cookie: header value.",
+			),
+		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+	)
+}
+
+func startGooglePairingHandler(a *app.App) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		cookies, err := req.RequireString("cookies")
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+		if strings.TrimSpace(cookies) == "" {
+			return errorResult("cookies must not be empty"), nil
+		}
+
+		cli := newPairingClient(a.Logger)
+		emoji, session, err := startGaiaPairing(ctx, cli, cookies)
+		if err != nil {
+			cli.GM.Disconnect()
+			return errorResult(fmt.Sprintf("start Google pairing: %v", err)), nil
+		}
+
+		handle := pairings.add(&pendingPairing{
+			cli:     cli,
+			session: session,
+			emoji:   emoji,
+			started: time.Now(),
+		})
+
+		text := fmt.Sprintf(
+			"Google Messages is showing the emoji %s on your phone.\n\n"+
+				"Tap %s in Google Messages (a prompt should appear; otherwise Settings > "+
+				"Device pairing), then call complete_google_pairing with "+
+				"pairing_handle=%q.",
+			emoji, emoji, handle,
+		)
+		return structuredResult(map[string]any{
+			"ok":             true,
+			"emoji":          emoji,
+			"pairing_handle": handle,
+			"expires_in_s":   int(pairingSessionTTL.Seconds()),
+		}, text), nil
+	}
+}
+
+func completeGooglePairingTool() mcp.Tool {
+	return mcp.NewTool("complete_google_pairing",
+		mcp.WithDescription(
+			"Second step of Google Messages pairing. Call after the user has tapped the emoji "+
+				"returned by `start_google_pairing`. Waits up to 2 minutes for the tap to be "+
+				"confirmed, then saves the session. "+
+				"A pairing handle is single-use: if this fails, call `start_google_pairing` again "+
+				"for a fresh emoji.",
+		),
+		mcp.WithString("pairing_handle",
+			mcp.Required(),
+			mcp.Description("The `pairing_handle` returned by start_google_pairing."),
+		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+	)
+}
+
+func completeGooglePairingHandler(a *app.App) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		handle, err := req.RequireString("pairing_handle")
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+
+		pending, ok := pairings.take(strings.TrimSpace(handle))
+		if !ok {
+			return errorResult(
+				"unknown or expired pairing_handle — call start_google_pairing for a fresh emoji",
+			), nil
+		}
+		defer pending.cli.GM.Disconnect()
+
+		ctx, cancel := context.WithTimeout(ctx, finishPairingTimeout)
+		defer cancel()
+
+		if err := finishGaiaPairing(ctx, pending.cli, pending.session, a.SessionPath); err != nil {
+			if ctx.Err() != nil {
+				return errorResult(fmt.Sprintf(
+					"Timed out after %s waiting for the tap to be confirmed. The emoji was %s. "+
+						"Call start_google_pairing again for a fresh emoji.",
+					finishPairingTimeout, pending.emoji,
+				)), nil
+			}
+			return errorResult(fmt.Sprintf("complete Google pairing: %v", err)), nil
+		}
+
+		return structuredResult(map[string]any{
+			"ok":           true,
+			"session_path": a.SessionPath,
+			"data_dir":     a.DataDir,
+		}, fmt.Sprintf("Google Messages paired. Session saved to %s.", a.SessionPath)), nil
+	}
+}

--- a/internal/tools/pair_google_test.go
+++ b/internal/tools/pair_google_test.go
@@ -1,0 +1,262 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/rs/zerolog"
+	"go.mau.fi/mautrix-gmessages/pkg/libgm"
+
+	"github.com/maxghenis/openmessage/internal/client"
+)
+
+// stubPairing swaps the pairing indirections and gives each test a fresh
+// registry, so handles never leak between tests.
+func stubPairing(
+	t *testing.T,
+	start func(ctx context.Context, cli *client.Client, rawCookies string) (string, *libgm.PairingSession, error),
+	finish func(ctx context.Context, cli *client.Client, session *libgm.PairingSession, sessionPath string) error,
+) {
+	t.Helper()
+	origStart, origFinish, origNew, origRegistry := startGaiaPairing, finishGaiaPairing, newPairingClient, pairings
+	startGaiaPairing = start
+	finishGaiaPairing = finish
+	newPairingClient = func(zerolog.Logger) *client.Client { return client.NewForPairing(zerolog.Nop()) }
+	pairings = newPairingRegistry()
+	t.Cleanup(func() {
+		startGaiaPairing, finishGaiaPairing, newPairingClient, pairings = origStart, origFinish, origNew, origRegistry
+	})
+}
+
+func callTool(t *testing.T, handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error), args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	result, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	return result
+}
+
+func TestStartGooglePairingReturnsEmojiAndHandle(t *testing.T) {
+	a := testApp(t)
+	stubPairing(t,
+		func(context.Context, *client.Client, string) (string, *libgm.PairingSession, error) {
+			return "🛋", &libgm.PairingSession{}, nil
+		},
+		func(context.Context, *client.Client, *libgm.PairingSession, string) error { return nil },
+	)
+
+	result := callTool(t, startGooglePairingHandler(a), map[string]any{"cookies": "SID=abc"})
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+
+	payload := structuredMap(t, result)
+	if payload["emoji"] != "🛋" {
+		t.Errorf("expected emoji in payload, got %v", payload["emoji"])
+	}
+	if h, _ := payload["pairing_handle"].(string); h == "" {
+		t.Error("expected a pairing_handle")
+	}
+	// The emoji must be in the text too — that is what the user is shown while
+	// the tap is still pending.
+	if text := result.Content[0].(mcp.TextContent).Text; !strings.Contains(text, "🛋") {
+		t.Errorf("expected emoji in result text, got: %s", text)
+	}
+}
+
+func TestStartGooglePairingRejectsEmptyCookies(t *testing.T) {
+	a := testApp(t)
+	called := false
+	stubPairing(t,
+		func(context.Context, *client.Client, string) (string, *libgm.PairingSession, error) {
+			called = true
+			return "", nil, nil
+		},
+		func(context.Context, *client.Client, *libgm.PairingSession, string) error { return nil },
+	)
+
+	result := callTool(t, startGooglePairingHandler(a), map[string]any{"cookies": "   "})
+	if !result.IsError {
+		t.Fatal("expected an error result for blank cookies")
+	}
+	if called {
+		t.Error("pairing should not be attempted with blank cookies")
+	}
+}
+
+func TestStartGooglePairingReportsFailure(t *testing.T) {
+	a := testApp(t)
+	stubPairing(t,
+		func(context.Context, *client.Client, string) (string, *libgm.PairingSession, error) {
+			return "", nil, errors.New("parse Google cookies: no cookies found")
+		},
+		func(context.Context, *client.Client, *libgm.PairingSession, string) error { return nil },
+	)
+
+	result := callTool(t, startGooglePairingHandler(a), map[string]any{"cookies": "garbage"})
+	if !result.IsError {
+		t.Fatal("expected an error result when starting fails")
+	}
+	if text := result.Content[0].(mcp.TextContent).Text; !strings.Contains(text, "no cookies found") {
+		t.Errorf("expected underlying error in text, got: %s", text)
+	}
+}
+
+func TestCompleteGooglePairingSuccess(t *testing.T) {
+	a := testApp(t)
+	a.DataDir = t.TempDir()
+	a.SessionPath = a.DataDir + "/session.json"
+
+	var gotSessionPath string
+	stubPairing(t,
+		func(context.Context, *client.Client, string) (string, *libgm.PairingSession, error) {
+			return "🛋", &libgm.PairingSession{}, nil
+		},
+		func(_ context.Context, _ *client.Client, _ *libgm.PairingSession, sessionPath string) error {
+			gotSessionPath = sessionPath
+			return nil
+		},
+	)
+
+	start := callTool(t, startGooglePairingHandler(a), map[string]any{"cookies": "SID=abc"})
+	handle := structuredMap(t, start)["pairing_handle"].(string)
+
+	result := callTool(t, completeGooglePairingHandler(a), map[string]any{"pairing_handle": handle})
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	if gotSessionPath != a.SessionPath {
+		t.Errorf("expected session path %q, got %q", a.SessionPath, gotSessionPath)
+	}
+	if payload := structuredMap(t, result); payload["ok"] != true {
+		t.Errorf("expected ok=true, got %v", payload["ok"])
+	}
+}
+
+func TestCompleteGooglePairingRejectsUnknownHandle(t *testing.T) {
+	a := testApp(t)
+	stubPairing(t,
+		func(context.Context, *client.Client, string) (string, *libgm.PairingSession, error) {
+			return "🛋", &libgm.PairingSession{}, nil
+		},
+		func(context.Context, *client.Client, *libgm.PairingSession, string) error { return nil },
+	)
+
+	result := callTool(t, completeGooglePairingHandler(a), map[string]any{"pairing_handle": "nope"})
+	if !result.IsError {
+		t.Fatal("expected an error result for an unknown handle")
+	}
+	if text := result.Content[0].(mcp.TextContent).Text; !strings.Contains(text, "start_google_pairing") {
+		t.Errorf("expected recovery instructions, got: %s", text)
+	}
+}
+
+// A handle is single-use: reusing one must not silently re-run a spent session.
+func TestCompleteGooglePairingHandleIsSingleUse(t *testing.T) {
+	a := testApp(t)
+	a.SessionPath = t.TempDir() + "/session.json"
+	stubPairing(t,
+		func(context.Context, *client.Client, string) (string, *libgm.PairingSession, error) {
+			return "🛋", &libgm.PairingSession{}, nil
+		},
+		func(context.Context, *client.Client, *libgm.PairingSession, string) error { return nil },
+	)
+
+	start := callTool(t, startGooglePairingHandler(a), map[string]any{"cookies": "SID=abc"})
+	handle := structuredMap(t, start)["pairing_handle"].(string)
+
+	if first := callTool(t, completeGooglePairingHandler(a), map[string]any{"pairing_handle": handle}); first.IsError {
+		t.Fatalf("first completion should succeed: %v", first.Content)
+	}
+	second := callTool(t, completeGooglePairingHandler(a), map[string]any{"pairing_handle": handle})
+	if !second.IsError {
+		t.Error("expected reusing a handle to fail")
+	}
+}
+
+// The timeout message must name the emoji, so a user who missed the prompt
+// knows what they were looking for.
+func TestCompleteGooglePairingTimeoutReportsEmoji(t *testing.T) {
+	a := testApp(t)
+	a.SessionPath = t.TempDir() + "/session.json"
+	stubPairing(t,
+		func(context.Context, *client.Client, string) (string, *libgm.PairingSession, error) {
+			return "🚀", &libgm.PairingSession{}, nil
+		},
+		func(ctx context.Context, _ *client.Client, _ *libgm.PairingSession, _ string) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	)
+
+	start := callTool(t, startGooglePairingHandler(a), map[string]any{"cookies": "SID=abc"})
+	handle := structuredMap(t, start)["pairing_handle"].(string)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"pairing_handle": handle}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := completeGooglePairingHandler(a)(ctx, req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result when the tap is not confirmed")
+	}
+	if text := result.Content[0].(mcp.TextContent).Text; !strings.Contains(text, "🚀") {
+		t.Errorf("expected the emoji in the timeout message, got: %s", text)
+	}
+}
+
+func TestPairingRegistryEvictsExpired(t *testing.T) {
+	r := newPairingRegistry()
+	now := time.Now()
+	r.nowFn = func() time.Time { return now }
+
+	handle := r.add(&pendingPairing{cli: client.NewForPairing(zerolog.Nop()), started: now})
+	now = now.Add(pairingSessionTTL + time.Second)
+
+	if _, ok := r.take(handle); ok {
+		t.Error("expected an expired pairing to be evicted")
+	}
+}
+
+func TestParseGoogleCookiesInputShapes(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"json object", `{"SID":"abc","HSID":"def"}`},
+		{"raw cookie header", "SID=abc; HSID=def"},
+		{"cookie header with name", "Cookie: SID=abc; HSID=def"},
+		{"curl with -H", `curl 'https://messages.google.com/' -H 'Cookie: SID=abc; HSID=def'`},
+		{"curl with -b", `curl 'https://messages.google.com/' -b 'SID=abc; HSID=def'`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cookies, err := client.ParseGoogleCookiesInput(tc.input)
+			if err != nil {
+				t.Fatalf("parse %s: %v", tc.name, err)
+			}
+			if cookies["SID"] != "abc" || cookies["HSID"] != "def" {
+				t.Errorf("unexpected cookies for %s: %v", tc.name, cookies)
+			}
+		})
+	}
+}
+
+func TestParseGoogleCookiesInputRejectsGarbage(t *testing.T) {
+	for _, input := range []string{"", "   ", "not cookies at all"} {
+		if _, err := client.ParseGoogleCookiesInput(input); err == nil {
+			t.Errorf("expected an error for %q", input)
+		}
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -88,6 +88,8 @@ func RegisterWithOptions(s *server.MCPServer, a *app.App, options Options) {
 	} else {
 		s.AddTool(getStatusTool(), getStatusHandler(a, options))
 	}
+	s.AddTool(startGooglePairingTool(), startGooglePairingHandler(a))
+	s.AddTool(completeGooglePairingTool(), completeGooglePairingHandler(a))
 	s.AddTool(draftMessageTool(), draftMessageHandler(a))
 	s.AddTool(downloadMediaTool(), downloadMediaHandler(a))
 	s.AddTool(importMessagesTool(), importMessagesHandler(a))


### PR DESCRIPTION
## Problem

Google Account (Gaia) pairing is the working pairing path — `CLAUDE.md` notes QR is dead — but it's only reachable through `openmessage pair --google`, which reads cookies from stdin and prints the confirmation emoji to a terminal.

That leaves a gap for headless installs, which the Dockerfile explicitly targets ("Useful when you want to keep the inbox running on a home server / NAS"): a deployment driven entirely over MCP can't pair or re-pair without shell access to the host. Since Google sessions need periodic re-pairing, that's a recurring need, not just first-run setup.

## Why two tools rather than one

Gaia pairing is a two-party handshake: Google returns a confirmation emoji, then blocks until the user taps it on their phone.

That doesn't fit in a single tool call. A call is one request/response, so the emoji is only readable once the call returns — by which point the user already needed it. I tried the one-tool version first and it fails exactly this way: it times out, with the user never learning which emoji to look for.

So it's split, mirroring the start/complete shape common to OTP flows:

- **`start_google_pairing(cookies)`** — returns immediately with the emoji and an opaque `pairing_handle`, so the emoji can be surfaced while the tap is still pending.
- **`complete_google_pairing(pairing_handle)`** — waits for confirmation (2 min) and saves the session.

`libgm.PairingSession` holds an ECDSA private key bound to its client, so unlike an opaque OTP challenge token it can't round-trip through the caller. It's kept in a server-side registry keyed by a UUID handle — single-use, with a 10 minute TTL that disconnects abandoned clients.

## Changes

- `internal/client/gaiapair.go` — `StartGaiaPairing` / `FinishGaiaPairing`, thin wrappers over the two libgm methods `DoGaiaPairing` already composes, plus the cookie parsing lifted from `cmd/pair.go` so the CLI and the tools share one implementation. `PairWithGoogleCookies` remains for the CLI, where the emoji can be printed mid-handshake.
- `internal/tools/pair_google.go` — the two tools and the pairing registry.
- `cmd/pair.go` — now delegates to `internal/client`; keeps a thin `parseGoogleCookiesInput` alias so its existing tests are unchanged.
- Cookie parsing gains a test for `curl -b '...'` — the form Chrome's "Copy as cURL" actually produces for `messages.google.com`. Only `-H 'Cookie:'` was covered before, and this was a real failure when testing against a live account.

## Testing

`go test ./...` passes. The new tools have unit coverage for the emoji/handle round trip, blank and malformed cookies, unknown and reused handles, TTL eviction, the timeout path, and all five accepted cookie input shapes.

Verified end-to-end against a real Google account over MCP stdio: `start_google_pairing` returned the emoji, tapping it on the phone let `complete_google_pairing` write `session.json`, and messages were then readable through the other tools.

## Notes

- No behaviour change to the CLI — the refactor is a pure move, still covered by the existing `cmd/pair_test.go`.
- `github.com/google/uuid` moves from an indirect to a direct dependency (it was already in the module graph).
- Happy to adjust naming, the TTL/timeout values, or split the refactor into its own commit if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)