### PR TITLE
fix(ingest): clamp updated_at_ms on clock-skew writes, closes #167

### DIFF
--- a/internal/ingest/counters.go
+++ b/internal/ingest/counters.go
@@ -32,6 +32,9 @@ type CounterSnapshot struct {
 	EchoNotFound      uint64 `json:"echo_notfound"`
 	EchoErrors        uint64 `json:"echo_errors"`
 	Ephemeral         uint64 `json:"ephemeral"`
+	// UpdatedAtClamped counts writes where updated_at_ms was clamped up to
+	// created_at_ms to satisfy the CHECK constraint (provider clock skew).
+	UpdatedAtClamped uint64 `json:"updated_at_clamped"`
 }
 
 type accountCounters struct {
@@ -57,6 +60,7 @@ type accountCounters struct {
 	echoNotFound      atomic.Uint64
 	echoErrors        atomic.Uint64
 	ephemeral         atomic.Uint64
+	updatedAtClamped  atomic.Uint64
 }
 
 // Counters owns atomic ingest counters partitioned by account. Its zero value
@@ -139,5 +143,6 @@ func snapshotCounters(c *accountCounters) CounterSnapshot {
 		EchoNotFound:      c.echoNotFound.Load(),
 		EchoErrors:        c.echoErrors.Load(),
 		Ephemeral:         c.ephemeral.Load(),
+		UpdatedAtClamped:  c.updatedAtClamped.Load(),
 	}
 }

--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -795,6 +795,19 @@ func (w *Worker) refreshConversation(
 		conversation.Title = event.Title
 		conversation.RemoteRevision = optionalTrimmed(event.RemoteRevision)
 		conversation.UpdatedAtMS = nowMS
+		if conversation.UpdatedAtMS < conversation.CreatedAtMS {
+			// Provider clock skew: the frame's effective wall time is behind the
+			// row's creation timestamp. Clamp to satisfy CHECK (updated_at_ms >=
+			// created_at_ms) and record the skew for observability.
+			w.logger.Warn().
+				Str("account_id", accountID).
+				Str("remote_conversation_id", remoteID).
+				Int64("created_at_ms", conversation.CreatedAtMS).
+				Int64("updated_at_ms", nowMS).
+				Msg("Clamped conversation updated_at_ms to created_at_ms: clock skew")
+			w.counters.account(accountID).updatedAtClamped.Add(1)
+			conversation.UpdatedAtMS = conversation.CreatedAtMS
+		}
 	}
 	if err := w.store.UpsertConversation(conversation); err != nil {
 		return sqlite.Conversation{}, err
@@ -913,6 +926,18 @@ func (w *Worker) resolveIdentity(
 		}
 		identity.IsSelf = identity.IsSelf || reference.IsSelf
 		identity.UpdatedAtMS = nowMS
+		if identity.UpdatedAtMS < identity.CreatedAtMS {
+			// Defensive clamp: system clock went backward since identity was
+			// created. Satisfies CHECK (updated_at_ms >= created_at_ms).
+			w.logger.Warn().
+				Str("account_id", accountID).
+				Str("identity_id", identity.IdentityID).
+				Int64("created_at_ms", identity.CreatedAtMS).
+				Int64("updated_at_ms", nowMS).
+				Msg("Clamped identity updated_at_ms to created_at_ms: clock skew")
+			w.counters.account(accountID).updatedAtClamped.Add(1)
+			identity.UpdatedAtMS = identity.CreatedAtMS
+		}
 	}
 	if err := w.store.UpsertIdentity(identity); err != nil {
 		return sqlite.Identity{}, err

--- a/internal/ingest/worker_paths_test.go
+++ b/internal/ingest/worker_paths_test.go
@@ -566,3 +566,86 @@ func workerPathAssertAllProcessed(t *testing.T, messages *sqlite.MessageReposito
 		t.Fatalf("unprocessed inbox records = %+v, want none", records)
 	}
 }
+
+// TestWorkerPathsUpdatedAtClampedOnSkewedConversationCreate is a regression
+// test for issue #167. A Google Messages frame sometimes arrives with a future
+// provider timestamp. When that message is the first in a conversation,
+// ensureMessageConversation writes created_at_ms = future_ms. Any subsequent
+// write that sets updated_at_ms = nowMS (where nowMS < future_ms) violates the
+// schema CHECK (updated_at_ms >= created_at_ms) and was previously quarantined.
+// The fix clamps updated_at_ms = max(nowMS, created_at_ms) at the write site.
+func TestWorkerPathsUpdatedAtClampedOnSkewedConversationCreate(t *testing.T) {
+	const (
+		remoteConversationID = "skew-test-conversation"
+		remoteMessageID      = "skew-test-message"
+		// Simulate a provider timestamp 50 seconds ahead of the worker clock.
+		skewedFutureMS = workerPathNowMS + 50_000
+	)
+
+	harness := newWorkerPathHarness(t, bridge.PlatformGoogle, map[string][]bridge.Event{
+		// Step 1: a message whose OccurredAt is in the future relative to nowMS.
+		// applyEvents → messageProjection → ensureMessageConversation creates the
+		// conversation with CreatedAtMS = skewedFutureMS.
+		"future-message": {{
+			Kind: bridge.EventMessage,
+			Message: &bridge.MessageEvent{
+				RemoteConversationID: remoteConversationID,
+				RemoteMessageID:      remoteMessageID,
+				Sender:               bridge.IdentityRef{Raw: "+15550000001", Name: "Skew Contact"},
+				Direction:            "incoming",
+				Body:                 "message from the future",
+				OccurredAt:           time.UnixMilli(skewedFutureMS),
+			},
+		}},
+		// Step 2: a conversation snapshot processed at nowMS.
+		// refreshConversation reads the existing row (CreatedAtMS=skewedFutureMS)
+		// and would set UpdatedAtMS = nowMS < CreatedAtMS → CHECK violation → quarantine.
+		// The fix clamps UpdatedAtMS to CreatedAtMS instead.
+		"conversation-snapshot": {{
+			Kind: bridge.EventConversation,
+			Conversation: &bridge.ConversationEvent{
+				RemoteConversationID: remoteConversationID,
+				Kind:                 "direct",
+				Title:                "Skew Test",
+				Participants: []bridge.Participant{{
+					Identity: bridge.IdentityRef{
+						Raw:  "+15550000001",
+						Name: "Skew Contact",
+					},
+					Role:   "member",
+					Active: true,
+				}},
+			},
+		}},
+	})
+
+	harness.process(t, "future-message")
+	harness.process(t, "conversation-snapshot")
+
+	// The conversation snapshot must be stored, not quarantined.
+	storedConversation, err := harness.store.GetConversationByRemote(workerPathAccountID, remoteConversationID)
+	if err != nil {
+		t.Fatalf("GetConversationByRemote(): %v — conversation frame must be stored, not quarantined", err)
+	}
+	// updated_at_ms must be clamped to created_at_ms (skewedFutureMS), not nowMS.
+	if storedConversation.UpdatedAtMS < storedConversation.CreatedAtMS {
+		t.Fatalf(
+			"updated_at_ms=%d < created_at_ms=%d — clamp did not fire",
+			storedConversation.UpdatedAtMS,
+			storedConversation.CreatedAtMS,
+		)
+	}
+
+	snapshot := harness.worker.Counters().Snapshot(workerPathAccountID)
+	if snapshot.Quarantined != 0 {
+		t.Fatalf(
+			"quarantined=%d, want 0 — clock-skew updated_at must not quarantine the frame",
+			snapshot.Quarantined,
+		)
+	}
+	if snapshot.UpdatedAtClamped == 0 {
+		t.Fatalf("updated_at_clamped=0, want >0 — skew clamp must be counted")
+	}
+
+	workerPathAssertAllProcessed(t, harness.messages)
+}


### PR DESCRIPTION
## Problem

`internal/storage/sqlite/migrations/0002_identity_graph.sql` enforces `CHECK (updated_at_ms >= created_at_ms)` on all identity-graph tables. Google Messages frames sometimes arrive with a provider timestamp ahead of the local wall clock. When such a message is the **first** in a conversation, `ensureMessageConversation` stores `created_at_ms = provider_future_ms`. Any subsequent write that sets `updated_at_ms = nowMS` (where `nowMS < provider_future_ms`) then violates the check and causes the frame to be quarantined rather than projected. The journal recorded 5 such `Quarantined ingest frame` events since 2026-08-13 (post v2 cutover).

## Fix

At the two write-sites that perform monotone `updated_at_ms` advances on **existing** identity-graph rows:

- **`refreshConversation`** (`internal/ingest/worker.go`) — after setting `conversation.UpdatedAtMS = nowMS`, clamp it up to `conversation.CreatedAtMS` when the clock is behind the row's own creation timestamp.
- **`resolveIdentity`** (`internal/ingest/worker.go`) — same clamp for the identity table (defensive; guards the case where the system clock goes backward after identity creation).

Both sites emit a `Warn`-level log line with `created_at_ms` and `updated_at_ms` fields so the skew is visible, and increment the new `updated_at_clamped` counter that surfaces in `/api/status` under `per_account[*].updated_at_clamped`.

The schema `CHECK` constraint is left intact — this fix normalises the data before writing rather than relaxing the invariant, following the precedent of #160 (participant deduplication instead of quarantine).

## Test

`TestWorkerPathsUpdatedAtClampedOnSkewedConversationCreate` in `internal/ingest/worker_paths_test.go`:

1. Feed a message event with `OccurredAt = nowMS + 50_000` (50 s ahead of the worker clock) — `ensureMessageConversation` creates the conversation with `created_at_ms = nowMS + 50_000`.
2. Feed a conversation snapshot at `nowMS < created_at_ms` — this is the exact frame shape that previously quarantined.
3. Assert: conversation is stored (`GetConversationByRemote` succeeds), `Quarantined == 0`, `UpdatedAtClamped > 0`.

## Test run

Full suite green locally:

```
ok  github.com/maxghenis/openmessage/internal/ingest      2.232s
ok  github.com/maxghenis/openmessage/internal/storage/sqlite  1.895s
... (all 33 packages pass)
```

No live binary rebuilt, no container restarted, no live data dir touched.

Closes #167