### PR TITLE
Stop transient boot-time probe failures from permanently parking Signal needs_reauth

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -418,6 +418,7 @@ func RunServe(logger zerolog.Logger, args ...string) error {
 				newSignalSupervisor,
 				signalLifecycle.InputFingerprint,
 			)
+			signalControl.StartParkRetest(signalParkRetestInterval, logger)
 			signalStartupCtx, cancelSignalStartup := context.WithCancel(context.Background())
 			var signalStartupWG sync.WaitGroup
 			defer func() {

--- a/cmd/signal_supervisor.go
+++ b/cmd/signal_supervisor.go
@@ -8,13 +8,24 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/signallive"
 )
 
 const (
 	signalAccountID                = "signal-primary"
 	signalSupervisorStopTimeout    = 30 * time.Second
 	signalSupervisorCommandTimeout = 30 * time.Second
+
+	// signalParkRetestInterval paces the automatic retest of a reauth park
+	// whose only evidence was local (signal_account_unreadable: signal-cli
+	// could not read an account that accounts.json still lists). The retest
+	// is one supervisor RetryBlocked — a local listAccounts probe that either
+	// reconnects or re-parks — so the cadence can stay slow and still bound a
+	// false park to minutes instead of the 12-22h outages observed live.
+	signalParkRetestInterval = 15 * time.Minute
 )
 
 func signalSupervisorPolicy() bridge.Policy {
@@ -59,6 +70,10 @@ type signalSupervisorControl struct {
 	supervisorStopped bool
 	stopping          bool
 	closed            bool
+
+	retestOnce     sync.Once
+	retestStopOnce sync.Once
+	retestStop     chan struct{}
 }
 
 func newSignalSupervisorControl(
@@ -75,7 +90,64 @@ func newSignalSupervisorControl(
 		newSupervisor:    newSupervisor,
 		inputFingerprint: inputFingerprint,
 		lastFingerprint:  fingerprint,
+		retestStop:       make(chan struct{}),
 	}
+}
+
+// StartParkRetest launches the paced retest loop for the one Signal park that
+// is allowed to heal itself: StateBlocked with reauth_required and the
+// signal_account_unreadable fingerprint, which the bridge only reaches on
+// local evidence (listAccounts persistently empty while accounts.json still
+// lists a linked account — the boot-race false park observed live 2026-07-24
+// and 2026-08-06). Every other park stays user-owned: server-backed reauth
+// (signal_account_invalid), upgrade gates, and pairing failures are never
+// retried automatically, and nothing here ever unpairs. The loop stops with
+// Stop; a no-op interval disables it.
+func (c *signalSupervisorControl) StartParkRetest(interval time.Duration, logger zerolog.Logger) {
+	if c == nil || interval <= 0 {
+		return
+	}
+	c.retestOnce.Do(func() {
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-c.retestStop:
+					return
+				case <-ticker.C:
+					c.maybeRetestPark(logger)
+				}
+			}
+		}()
+	})
+}
+
+func (c *signalSupervisorControl) maybeRetestPark(logger zerolog.Logger) {
+	c.mu.Lock()
+	if c.closed || c.stopping || c.supervisorStopped {
+		c.mu.Unlock()
+		return
+	}
+	supervisor := c.supervisor
+	c.mu.Unlock()
+
+	snapshot := supervisor.Snapshot()
+	if snapshot.State != bridge.StateBlocked ||
+		snapshot.ErrorClass != bridge.FailureReauthRequired ||
+		snapshot.ErrorFingerprint != signallive.SignalAccountUnreadableFingerprint {
+		return
+	}
+	logger.Info().
+		Str("fingerprint", snapshot.ErrorFingerprint).
+		Msg("Signal reauth park retest: re-probing blocked supervisor")
+	if err := c.Connect(); err != nil {
+		logger.Warn().Err(err).Msg("Signal reauth park retest failed; will retry on next tick")
+	}
+}
+
+func (c *signalSupervisorControl) stopParkRetest() {
+	c.retestStopOnce.Do(func() { close(c.retestStop) })
 }
 
 // Connect admits one user-owned start/retry. All automatic retry remains in
@@ -247,6 +319,7 @@ func (c *signalSupervisorControl) Stop(ctx context.Context) error {
 	if ctx == nil {
 		return errors.New("Signal supervisor control: nil stop context")
 	}
+	c.stopParkRetest()
 	c.mu.Lock()
 	if c.supervisor == nil {
 		c.closed = true

--- a/cmd/signal_supervisor_test.go
+++ b/cmd/signal_supervisor_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/maxghenis/openmessage/internal/bridge"
+	"github.com/maxghenis/openmessage/internal/signallive"
 )
 
 func TestSignalSupervisorControlConnectStartsOnceAndActiveDuplicateIsNoop(t *testing.T) {
@@ -104,6 +107,51 @@ func TestSignalSupervisorControlBlockedCommandsRetryAndAcceptChangedInputs(t *te
 	control.mu.Unlock()
 	if gotFingerprint != "signal-input-v2" {
 		t.Fatalf("remembered input fingerprint = %q, want %q", gotFingerprint, "signal-input-v2")
+	}
+}
+
+func TestSignalSupervisorControlParkRetestRetriesOnlyUnreadablePark(t *testing.T) {
+	lifecycle := &signalControlTestLifecycle{}
+	supervisor := newSignalControlTestSupervisor(t, lifecycle)
+	control := newSignalSupervisorControl(supervisor, nil, func() string { return "signal-input-v1" })
+	t.Cleanup(func() { stopSignalControlForTest(t, control) })
+	control.StartParkRetest(20*time.Millisecond, zerolog.Nop())
+
+	if err := control.Connect(); err != nil {
+		t.Fatalf("initial Connect() error = %v", err)
+	}
+	awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateOnline, 1)
+
+	// A park whose only evidence was local (signal-cli unable to read an
+	// account that accounts.json still lists) must heal on the paced retest
+	// without any manual /api/signal/connect.
+	lifecycle.Run(0).Fail(bridge.OpError{
+		Class:       bridge.FailureReauthRequired,
+		Operation:   "probe_account",
+		Fingerprint: signallive.SignalAccountUnreadableFingerprint,
+		Cause:       errors.New("signal-cli cannot read the linked Signal account"),
+	})
+	awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateOnline, 2)
+	if got := lifecycle.StartCount(); got != 2 {
+		t.Fatalf("lifecycle starts after unreadable-park retest = %d, want 2", got)
+	}
+
+	// A server-backed reauth park stays user-owned: no retest tick may retry
+	// it, no matter how many elapse.
+	lifecycle.Run(1).Fail(bridge.OpError{
+		Class:       bridge.FailureReauthRequired,
+		Operation:   "receive",
+		Fingerprint: signallive.SignalAccountInvalidFingerprint,
+		Cause:       errors.New("account is not registered"),
+	})
+	awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateBlocked, 2)
+	time.Sleep(200 * time.Millisecond)
+	snapshot := awaitSignalSupervisorGenerationState(t, supervisor, bridge.StateBlocked, 2)
+	if snapshot.ErrorFingerprint != signallive.SignalAccountInvalidFingerprint {
+		t.Fatalf("blocked fingerprint = %q, want %q", snapshot.ErrorFingerprint, signallive.SignalAccountInvalidFingerprint)
+	}
+	if got := lifecycle.StartCount(); got != 2 {
+		t.Fatalf("lifecycle starts after genuine reauth park = %d, want 2 (no automatic retry)", got)
 	}
 }
 

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -379,6 +379,39 @@ poll — a crash loop that flaps the Signal `connected` flag every few seconds a
 makes the whole UI flicker. `brew upgrade signal-cli` fixes it. (PR #41 also
 hardened the UI to ignore redundant status pushes.)
 
+### Signal `needs_reauth` — read the fingerprint before believing the park
+
+`needs_reauth: true` is the bridge's **interpretation** of a signal-cli error,
+not server truth. Three live episodes (2026-07-20, 2026-07-24, 2026-08-06)
+parked a **valid** link for 12–22h because one boot-time `listAccounts` came up
+empty (signal-cli racing its own account bootstrap logs
+`Ignoring <number>: User is not registered.` and exits 0) and the bridge
+latched a permanent park; a single `POST /api/signal/connect` reconnected in
+~5s each time. The bridge now classifies with corroboration instead:
+
+- The receive-start probe **retries in-generation** (3 attempts, paced),
+  then checks `data/accounts.json`. Probe empty but accounts.json still lists
+  the account → **transient** exit (`signal_account_probe_empty`), retried on
+  supervisor backoff — no park, no `needs_reauth`.
+- Only 3 **consecutive generations** of that disagreement park, under
+  `signal_account_unreadable` — and that park **self-retests every 15 min**
+  (one local `RetryBlocked`; log line "Signal reauth park retest"), so a
+  lingering false park heals without manual intervention.
+- Server-backed evidence still parks fast and stays parked:
+  a receive-loop "not registered" / "authorization failed" needs 2
+  consecutive confirmations (seconds), then parks under
+  `signal_account_invalid` with **no** automatic retest. Probe empty with
+  accounts.json **also** empty parks immediately (`signal_account_invalid`).
+
+Debugging a parked Signal: check `/api/status` and the supervisor fingerprint
+before recommending a re-pair. `signal_account_unreadable` → local read
+problem, wait for the retest or `POST /api/signal/connect`; verify contention
+first (`pgrep -fl signal-cli`, `lsof` on the config dir — see the MCP
+fratricide section above). `signal_account_invalid` from `receive` → genuine
+server-side unlink, re-pair is real. **Never unpair to "fix" a park**: unpair
+`os.RemoveAll`s the signal-cli dir including CDN-expired media — permanent
+loss.
+
 ## Deploying a new build to a live install
 
 ```

--- a/internal/signallive/client.go
+++ b/internal/signallive/client.go
@@ -42,6 +42,28 @@ const (
 	versionProbeTimeout   = 5 * time.Second
 	historySyncQuietAfter = 45 * time.Second
 
+	// receiveAccountInvalidLimit is how many consecutive receive attempts must
+	// report an account-invalid error ("not registered" / "authorization
+	// failed" / "invalid account") before the generation parks reauth. Receive
+	// errors are server-backed evidence, so the bar stays low — a genuinely
+	// unlinked account fails every attempt and still parks within seconds —
+	// but a single glitched invocation can no longer latch a permanent park.
+	receiveAccountInvalidLimit = 2
+
+	// accountProbeAttemptTimeout bounds one listAccounts invocation inside the
+	// receive-start probe. The probe used to run on the bare generation
+	// context; a signal-cli hang (account-db contention) would stall the
+	// generation instead of failing an attempt that the retry loop can pace.
+	accountProbeAttemptTimeout = 30 * time.Second
+
+	// accountUnreadableStreakLimit is how many consecutive generations the
+	// local account probe must stay empty — while accounts.json still lists a
+	// linked account — before the bridge parks reauth under
+	// SignalAccountUnreadableFingerprint. One empty probe is routine at boot
+	// (signal-cli races its own account bootstrap); a persistent
+	// listAccounts/accounts.json disagreement is real and must still surface.
+	accountUnreadableStreakLimit = 3
+
 	signalGetSenderPoisonFingerprint = "incoming_message_get_sender_content_null"
 )
 
@@ -98,6 +120,12 @@ func isSignalIdleReceiveTimeout(err error, timedOut bool, output []byte) bool {
 
 var (
 	now = time.Now
+
+	// accountProbeRetryDelays paces the in-generation listAccounts retries: a
+	// probe that races signal-cli's own account bootstrap at boot (observed
+	// live 2026-07-24 and 2026-08-06: exit 0, zero accounts, link intact)
+	// usually recovers within seconds. Swapped by tests to keep them fast.
+	accountProbeRetryDelays = []time.Duration{2 * time.Second, 4 * time.Second}
 
 	signalCLILookPath     = exec.LookPath
 	signalCLIStat         = os.Stat
@@ -196,6 +224,21 @@ const (
 	SignalAccountProbeFingerprint      = "signal_account_probe_failed"
 	SignalReceivePanicFingerprint      = "signal_receive_panic"
 	SignalPairingIncompleteFingerprint = "signal_pairing_incomplete"
+
+	// SignalAccountProbeEmptyFingerprint marks a transient generation exit
+	// where listAccounts succeeded but reported no accounts while
+	// accounts.json still lists a linked one. The supervisor retries it on
+	// ordinary backoff; it never trips the non-transient circuit.
+	SignalAccountProbeEmptyFingerprint = "signal_account_probe_empty"
+
+	// SignalAccountUnreadableFingerprint marks the reauth park reached only
+	// after accountUnreadableStreakLimit consecutive generations of the probe
+	// disagreeing with accounts.json. Unlike SignalAccountInvalidFingerprint
+	// (server-backed receive failures, or an account missing from disk too)
+	// its only evidence is local, so the cmd-layer park retest is allowed to
+	// re-probe it periodically instead of waiting forever for a manual
+	// /api/signal/connect.
+	SignalAccountUnreadableFingerprint = "signal_account_unreadable"
 )
 
 // PollerExit is the terminal result of exactly one retained poller lifecycle.
@@ -311,9 +354,13 @@ type StatusSnapshot struct {
 	// NeedsReauth is set when signal-cli reports that the stored account is
 	// no longer registered / authorized (e.g. user re-registered Signal on a
 	// new phone, or the linked device was unlinked remotely). When true,
-	// automatic reconnects should stop — the user has to visit Platforms and
+	// automatic reconnects stop — the user has to visit Platforms and
 	// re-pair manually. The UI should surface this prominently; otherwise
-	// Signal silently stops receiving with no indication.
+	// Signal silently stops receiving with no indication. The one exception
+	// is the signal_account_unreadable park, whose only evidence is local
+	// (signal-cli could not read an account that accounts.json still lists):
+	// the cmd-layer park retest re-probes that state on a slow cadence, so a
+	// transient false park heals without a manual /api/signal/connect.
 	NeedsReauth     bool                   `json:"needs_reauth,omitempty"`
 	HistorySync     *HistorySyncSnapshot   `json:"history_sync,omitempty"`
 	ReceiveRecovery *ReceiveRecoveryStatus `json:"receive_recovery,omitempty"`
@@ -380,6 +427,13 @@ type Bridge struct {
 	// signal-cli version or its known poison-envelope crash. Automatic
 	// reconnects stay parked until a manual connect re-runs the version gate.
 	upgradeRequired bool
+	// probeEmptyStreak counts consecutive receive generations whose local
+	// account probe stayed empty (or reported account-invalid text) while
+	// accounts.json still listed a linked account. It gates the
+	// signal_account_unreadable reauth park: one boot-time race must not park
+	// a valid link, but a persistent listAccounts/accounts.json disagreement
+	// still surfaces needs_reauth. Reset by a successful probe or an unpair.
+	probeEmptyStreak int
 
 	pairCancel    context.CancelFunc
 	receiveCancel context.CancelFunc
@@ -820,6 +874,7 @@ func (b *Bridge) UnpairContext(ctx context.Context) error {
 	b.account = ""
 	b.needsReauth = false
 	b.upgradeRequired = false
+	b.probeEmptyStreak = 0
 	b.lastError = ""
 	b.qr = QRSnapshot{}
 	b.historySync = struct {
@@ -1664,38 +1719,19 @@ func (b *Bridge) runReceiveLoop(
 		event.Msg("Unable to detect signal-cli version; continuing receive without version gate")
 	}
 
-	probedAccount, err := b.probeAccount(ctx, account)
-	if err != nil || probedAccount == "" {
-		accountInvalid := (err == nil && probedAccount == "") || isSignalAccountInvalid(err, nil)
+	probedAccount, probeErr := b.probeAccountWithRetry(ctx, account, run)
+	if ctx.Err() != nil {
 		b.mu.Lock()
-		b.connected = false
-		b.connecting = false
-		b.needsReauth = accountInvalid
-		b.upgradeRequired = false
-		if err != nil {
-			b.lastError = err.Error()
-		} else {
-			b.lastError = "Signal account is not paired"
-		}
 		if b.receiveToken == token {
 			b.receiveCancel = nil
+			b.connected = false
+			b.connecting = false
 		}
 		b.mu.Unlock()
-		b.emitStatusChange()
-		if accountInvalid {
-			return PollerExit{
-				Kind:        PollerFailureReauth,
-				Operation:   "probe_account",
-				Fingerprint: SignalAccountInvalidFingerprint,
-				Err:         errors.New(b.Status().LastError),
-			}
-		}
-		return PollerExit{
-			Kind:        PollerFailureTransient,
-			Operation:   "probe_account",
-			Fingerprint: SignalAccountProbeFingerprint,
-			Err:         err,
-		}
+		return PollerExit{Err: ctx.Err()}
+	}
+	if probeErr != nil || probedAccount == "" {
+		return b.classifyFailedAccountProbe(token, probeErr)
 	}
 
 	b.mu.Lock()
@@ -1704,6 +1740,7 @@ func (b *Bridge) runReceiveLoop(
 	b.connecting = false
 	b.needsReauth = false // successful connect clears any prior re-auth flag
 	b.upgradeRequired = false
+	b.probeEmptyStreak = 0
 	b.lastError = ""
 	b.mu.Unlock()
 	b.emitStatusChange()
@@ -1722,6 +1759,7 @@ func (b *Bridge) runReceiveLoop(
 
 	consecutiveFailures := 0
 	consecutivePoisonFailures := 0
+	consecutiveAccountInvalid := 0
 	lastPoisonFingerprint := ""
 	for {
 		select {
@@ -1754,6 +1792,7 @@ func (b *Bridge) runReceiveLoop(
 			if isSignalIdleReceiveTimeout(err, timedOut, output) {
 				consecutiveFailures = 0
 				consecutivePoisonFailures = 0
+				consecutiveAccountInvalid = 0
 				lastPoisonFingerprint = ""
 				if run != nil {
 					run.beat("receive_idle")
@@ -1762,7 +1801,25 @@ func (b *Bridge) runReceiveLoop(
 			}
 			if isSignalAccountInvalid(err, output) {
 				// Signal-side says the account is no longer registered /
-				// authorized. Don't clear b.account — we want the UI to
+				// authorized. That is server-backed evidence, but one glitched
+				// invocation must not latch a permanent park: require
+				// receiveAccountInvalidLimit consecutive confirmations. A
+				// genuinely unlinked account fails every attempt the same way
+				// and still parks within seconds.
+				consecutiveAccountInvalid++
+				if consecutiveAccountInvalid < receiveAccountInvalidLimit {
+					consecutiveFailures++
+					consecutivePoisonFailures = 0
+					lastPoisonFingerprint = ""
+					b.logger.Warn().
+						Err(commandError("receive Signal messages", err, output)).
+						Int("confirmations", consecutiveAccountInvalid).
+						Int("required", receiveAccountInvalidLimit).
+						Msg("Signal receive reported an invalid account; retrying once before parking reauth")
+					time.Sleep(500 * time.Millisecond)
+					continue
+				}
+				// Don't clear b.account — we want the UI to
 				// know *which* account needs re-pairing. Instead flip
 				// needsReauth so the supervisor parks and the UI surfaces a
 				// clear "re-pair Signal" banner.
@@ -1784,6 +1841,7 @@ func (b *Bridge) runReceiveLoop(
 					Err:         commandError("receive Signal messages", err, output),
 				}
 			}
+			consecutiveAccountInvalid = 0
 			poisonFingerprint := signalReceivePoisonFingerprint(err, output)
 			if poisonFingerprint == "" {
 				consecutivePoisonFailures = 0
@@ -1833,6 +1891,7 @@ func (b *Bridge) runReceiveLoop(
 		}
 		consecutiveFailures = 0
 		consecutivePoisonFailures = 0
+		consecutiveAccountInvalid = 0
 		lastPoisonFingerprint = ""
 		if run != nil {
 			detail := "receive_poll"
@@ -1848,6 +1907,131 @@ func (b *Bridge) runReceiveLoop(
 			b.logger.Debug().Err(err).Msg("Failed to process Signal receive payload")
 		}
 	}
+}
+
+// probeAccountWithRetry runs the local listAccounts probe up to
+// len(accountProbeRetryDelays)+1 times before letting the caller classify the
+// failure. A signal-cli invocation that races the JVM's own account bootstrap
+// at backend boot can transiently report zero accounts (MultiAccountManager
+// logs "Ignoring <number>: User is not registered." and exits 0) even though
+// the stored link is intact — observed live on 2026-07-24 and 2026-08-06,
+// where one boot-time empty probe parked the bridge in needs_reauth for
+// 12-22h while a manual reconnect succeeded in seconds. Retrying inside the
+// generation keeps that transient from ever reaching the terminal classifier.
+// Returns ctx.Err() as the error when the generation is cancelled mid-retry.
+func (b *Bridge) probeAccountWithRetry(
+	ctx context.Context,
+	account string,
+	run *pollerRun,
+) (string, error) {
+	var probedAccount string
+	var probeErr error
+	for attempt := 0; ; attempt++ {
+		attemptCtx, cancelAttempt := context.WithTimeout(ctx, accountProbeAttemptTimeout)
+		probedAccount, probeErr = b.probeAccount(attemptCtx, account)
+		cancelAttempt()
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		if probeErr == nil && probedAccount != "" {
+			return probedAccount, nil
+		}
+		if attempt >= len(accountProbeRetryDelays) {
+			return probedAccount, probeErr
+		}
+		event := b.logger.Warn().Int("attempt", attempt+1)
+		if probeErr != nil {
+			event = event.Err(probeErr)
+		}
+		event.Msg("Signal account probe came up empty; retrying before classifying")
+		if run != nil {
+			run.beat("account_probe_retry")
+		}
+		timer := time.NewTimer(accountProbeRetryDelays[attempt])
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// classifyFailedAccountProbe turns an exhausted account probe into the
+// generation's terminal exit. The probe is local-only evidence — listAccounts
+// never consults the Signal server — so an empty or account-invalid result
+// can prove at most "signal-cli cannot see the account right now", never "the
+// server unlinked this device". Parking reauth therefore needs corroboration:
+//
+//   - accounts.json no longer lists any account: the link is locally gone, so
+//     the pre-existing immediate reauth park stands.
+//   - accounts.json still lists an account: count one strike and exit
+//     transient so supervisor backoff retries a fresh generation. Only
+//     accountUnreadableStreakLimit consecutive generations of the same
+//     disagreement park reauth, under SignalAccountUnreadableFingerprint so
+//     the cmd-layer park retest may re-probe it periodically.
+//
+// A probe error without account-invalid text stays a plain transient exit,
+// exactly as before. Nothing here ever unpairs: unpair deletes signal-cli
+// state (including CDN-expired media) and remains a manual-only action.
+func (b *Bridge) classifyFailedAccountProbe(token uint64, probeErr error) PollerExit {
+	locallyInvalid := probeErr == nil || isSignalAccountInvalid(probeErr, nil)
+	storedAccount := ""
+	if locallyInvalid {
+		storedAccount = b.firstStoredAccount()
+	}
+
+	b.mu.Lock()
+	b.connected = false
+	b.connecting = false
+	b.upgradeRequired = false
+	exit := PollerExit{Operation: "probe_account"}
+	switch {
+	case !locallyInvalid:
+		b.needsReauth = false
+		b.lastError = probeErr.Error()
+		exit.Kind = PollerFailureTransient
+		exit.Fingerprint = SignalAccountProbeFingerprint
+		exit.Err = probeErr
+	case storedAccount == "":
+		b.needsReauth = true
+		if probeErr != nil {
+			b.lastError = probeErr.Error()
+		} else {
+			b.lastError = "Signal account is not paired"
+		}
+		exit.Kind = PollerFailureReauth
+		exit.Fingerprint = SignalAccountInvalidFingerprint
+		exit.Err = errors.New(b.lastError)
+	default:
+		b.probeEmptyStreak++
+		if b.probeEmptyStreak >= accountUnreadableStreakLimit {
+			b.needsReauth = true
+			b.lastError = fmt.Sprintf(
+				"signal-cli cannot read the linked Signal account %s after %d consecutive attempts; the paced park retest will keep re-probing it",
+				storedAccount, b.probeEmptyStreak,
+			)
+			exit.Kind = PollerFailureReauth
+			exit.Fingerprint = SignalAccountUnreadableFingerprint
+			exit.Err = errors.New(b.lastError)
+		} else {
+			b.needsReauth = false
+			if probeErr != nil {
+				b.lastError = probeErr.Error()
+			} else {
+				b.lastError = "signal-cli reported no linked Signal account; retrying"
+			}
+			exit.Kind = PollerFailureTransient
+			exit.Fingerprint = SignalAccountProbeEmptyFingerprint
+			exit.Err = errors.New(b.lastError)
+		}
+	}
+	if b.receiveToken == token {
+		b.receiveCancel = nil
+	}
+	b.mu.Unlock()
+	b.emitStatusChange()
+	return exit
 }
 
 func (b *Bridge) parkUpgradeRequired(token uint64, detail string) {
@@ -4244,10 +4428,12 @@ func IsAccountInvalidError(err error) bool {
 // "not registered" phrasing it uses for an unregistered local account, so send
 // paths must NOT treat that phrase as a local-account fault: the account-scoped
 // receive probe (probe_account -> PollerFailureReauth) is the authoritative
-// detector and parks reauth on its own within seconds. "authorization failed"
-// and "invalid account" name the local account/credentials and never a
-// recipient, so they stay safe to act on from a send. See isSignalAccountInvalid
-// for the broader receive/probe matcher that also accepts "not registered".
+// detector and — after its in-generation retries and accounts.json
+// corroboration — still parks a genuinely missing account within seconds.
+// "authorization failed" and "invalid account" name the local
+// account/credentials and never a recipient, so they stay safe to act on from
+// a send. See isSignalAccountInvalid for the broader receive/probe matcher
+// that also accepts "not registered".
 func IsSendAccountInvalidError(err error) bool {
 	return isSignalSendAccountInvalid(err, nil)
 }

--- a/internal/signallive/gate_test.go
+++ b/internal/signallive/gate_test.go
@@ -528,17 +528,20 @@ func TestStartPollerPublishesRealReadyActivityAndJoinedDone(t *testing.T) {
 }
 
 func TestStartPollerClassifiesAccountInvalidAtInitialProbe(t *testing.T) {
+	shrinkAccountProbeRetryDelays(t)
 	bridge := &Bridge{
 		account:   "+15551230000",
 		configDir: t.TempDir(),
 		logger:    zerolog.Nop(),
 	}
+	var probeCalls atomic.Int32
 	installSignalGateStubs(t, bridge,
 		func(context.Context) ([]byte, error) {
 			return []byte("signal-cli 0.14.5\n"), nil
 		},
 		func(_ context.Context, _ string, args ...string) ([]byte, error) {
 			if hasSignalCLIArg(args, "listAccounts") {
+				probeCalls.Add(1)
 				return []byte("User +15551230000 is not registered."), errors.New("exit status 1")
 			}
 			return nil, nil
@@ -557,8 +560,333 @@ func TestStartPollerClassifiesAccountInvalidAtInitialProbe(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("account-invalid poller did not exit")
 	}
+	// Nothing on disk corroborates a link (no accounts.json), so the park is
+	// immediate — but only after every in-generation retry came up invalid.
+	if got := probeCalls.Load(); got != int32(len(accountProbeRetryDelays)+1) {
+		t.Fatalf("account probe attempts = %d, want %d", got, len(accountProbeRetryDelays)+1)
+	}
 	if status := bridge.Status(); !status.NeedsReauth || status.Connected || status.Connecting {
 		t.Fatalf("account-invalid status = %+v, want parked reauth", status)
+	}
+}
+
+// shrinkAccountProbeRetryDelays makes the in-generation probe retries
+// immediate so classification tests stay fast. Register it before
+// installSignalGateStubs: cleanups run LIFO, so the stub cleanup joins the
+// bridge's goroutines (Close) before the delays are restored here.
+func shrinkAccountProbeRetryDelays(t *testing.T) {
+	t.Helper()
+	original := accountProbeRetryDelays
+	accountProbeRetryDelays = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { accountProbeRetryDelays = original })
+}
+
+func writeSignalAccountsFixture(t *testing.T, configDir, account string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(configDir, "data"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`[{"number":"` + account + `"}]`)
+	if err := os.WriteFile(filepath.Join(configDir, "data", "accounts.json"), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStartPollerRetriesEmptyAccountProbeBeforeConnecting(t *testing.T) {
+	shrinkAccountProbeRetryDelays(t)
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+	var probeCalls atomic.Int32
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			return []byte("signal-cli 0.14.5\n"), nil
+		},
+		func(ctx context.Context, _ string, args ...string) ([]byte, error) {
+			switch {
+			case hasSignalCLIArg(args, "listAccounts"):
+				if probeCalls.Add(1) == 1 {
+					// Boot race: signal-cli exits 0 with zero accounts while
+					// its own account bootstrap is still settling.
+					return []byte("[]"), nil
+				}
+				return []byte(`[{"number":"+15551230000"}]`), nil
+			case hasSignalCLIArg(args, "receive"):
+				<-ctx.Done()
+				return nil, ctx.Err()
+			default:
+				return []byte("[]"), nil
+			}
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	run, err := bridge.StartPoller(ctx)
+	if err != nil {
+		t.Fatalf("StartPoller(): %v", err)
+	}
+	select {
+	case <-run.Ready():
+	case <-time.After(2 * time.Second):
+		t.Fatal("poller did not become ready after retried account probe")
+	}
+	if got := probeCalls.Load(); got != 2 {
+		t.Fatalf("account probe calls = %d, want 2 (one empty, one success)", got)
+	}
+	status := bridge.Status()
+	if !status.Connected || status.NeedsReauth || status.LastError != "" {
+		t.Fatalf("post-retry status = %+v, want connected without reauth", status)
+	}
+	cancel()
+	select {
+	case <-run.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("poller did not exit after cancel")
+	}
+}
+
+func TestStartPollerEmptyProbeWithStoredAccountStaysTransientUntilStreakParks(t *testing.T) {
+	shrinkAccountProbeRetryDelays(t)
+	configDir := t.TempDir()
+	writeSignalAccountsFixture(t, configDir, "+15551230000")
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: configDir,
+		logger:    zerolog.Nop(),
+	}
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			return []byte("signal-cli 0.14.5\n"), nil
+		},
+		func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			return []byte("[]"), nil
+		},
+	)
+
+	runGeneration := func(generation int) PollerExit {
+		t.Helper()
+		run, err := bridge.StartPoller(context.Background())
+		if err != nil {
+			t.Fatalf("generation %d StartPoller(): %v", generation, err)
+		}
+		select {
+		case exit := <-run.Done():
+			return exit
+		case <-time.After(2 * time.Second):
+			t.Fatalf("generation %d did not exit", generation)
+			return PollerExit{}
+		}
+	}
+
+	for generation := 1; generation < accountUnreadableStreakLimit; generation++ {
+		exit := runGeneration(generation)
+		if exit.Kind != PollerFailureTransient || exit.Fingerprint != SignalAccountProbeEmptyFingerprint {
+			t.Fatalf(
+				"generation %d exit = %+v, want transient/%s",
+				generation, exit, SignalAccountProbeEmptyFingerprint,
+			)
+		}
+		if status := bridge.Status(); status.NeedsReauth {
+			t.Fatalf("generation %d parked reauth early: %+v", generation, status)
+		}
+	}
+	exit := runGeneration(accountUnreadableStreakLimit)
+	if exit.Kind != PollerFailureReauth || exit.Fingerprint != SignalAccountUnreadableFingerprint {
+		t.Fatalf("streak-limit exit = %+v, want reauth/%s", exit, SignalAccountUnreadableFingerprint)
+	}
+	if status := bridge.Status(); !status.NeedsReauth || !status.Paired || status.Connected {
+		t.Fatalf("streak-limit status = %+v, want parked reauth on a still-paired account", status)
+	}
+}
+
+func TestStartPollerEmptyProbeStreakResetsAfterSuccessfulProbe(t *testing.T) {
+	shrinkAccountProbeRetryDelays(t)
+	configDir := t.TempDir()
+	writeSignalAccountsFixture(t, configDir, "+15551230000")
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: configDir,
+		logger:    zerolog.Nop(),
+	}
+	var probeHealthy atomic.Bool
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			return []byte("signal-cli 0.14.5\n"), nil
+		},
+		func(ctx context.Context, _ string, args ...string) ([]byte, error) {
+			switch {
+			case hasSignalCLIArg(args, "listAccounts"):
+				if probeHealthy.Load() {
+					return []byte(`[{"number":"+15551230000"}]`), nil
+				}
+				return []byte("[]"), nil
+			case hasSignalCLIArg(args, "receive"):
+				<-ctx.Done()
+				return nil, ctx.Err()
+			default:
+				return []byte("[]"), nil
+			}
+		},
+	)
+
+	runEmptyGeneration := func(label string) PollerExit {
+		t.Helper()
+		run, err := bridge.StartPoller(context.Background())
+		if err != nil {
+			t.Fatalf("%s StartPoller(): %v", label, err)
+		}
+		select {
+		case exit := <-run.Done():
+			return exit
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s generation did not exit", label)
+			return PollerExit{}
+		}
+	}
+
+	if exit := runEmptyGeneration("first empty"); exit.Kind != PollerFailureTransient {
+		t.Fatalf("first empty exit = %+v, want transient", exit)
+	}
+
+	probeHealthy.Store(true)
+	ctx, cancel := context.WithCancel(context.Background())
+	run, err := bridge.StartPoller(ctx)
+	if err != nil {
+		cancel()
+		t.Fatalf("healthy StartPoller(): %v", err)
+	}
+	select {
+	case <-run.Ready():
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("healthy generation did not become ready")
+	}
+	cancel()
+	select {
+	case <-run.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("healthy generation did not exit after cancel")
+	}
+
+	// The successful probe reset the streak: the same number of empty
+	// generations that would previously have parked must stay transient.
+	probeHealthy.Store(false)
+	for generation := 1; generation < accountUnreadableStreakLimit; generation++ {
+		exit := runEmptyGeneration("post-reset empty")
+		if exit.Kind != PollerFailureTransient || exit.Fingerprint != SignalAccountProbeEmptyFingerprint {
+			t.Fatalf(
+				"post-reset generation %d exit = %+v, want transient/%s",
+				generation, exit, SignalAccountProbeEmptyFingerprint,
+			)
+		}
+	}
+	if status := bridge.Status(); status.NeedsReauth {
+		t.Fatalf("post-reset status = %+v, want no reauth park before a fresh streak completes", status)
+	}
+}
+
+func TestReceiveAccountInvalidGlitchDoesNotParkReauth(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+	var receiveCalls atomic.Int32
+	recoveredReceiveSeen := make(chan struct{})
+	var recoveredOnce sync.Once
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			return []byte("signal-cli 0.14.5\n"), nil
+		},
+		func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			switch {
+			case hasSignalCLIArg(args, "listAccounts"):
+				return []byte(`[{"number":"+15551230000"}]`), nil
+			case hasSignalCLIArg(args, "receive"):
+				if receiveCalls.Add(1) == 1 {
+					// One glitched invocation reports the account invalid.
+					return []byte("User +15551230000 is not registered."), errors.New("exit status 1")
+				}
+				recoveredOnce.Do(func() { close(recoveredReceiveSeen) })
+				return nil, context.DeadlineExceeded
+			default:
+				return []byte("[]"), nil
+			}
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	run, err := bridge.StartPoller(ctx)
+	if err != nil {
+		t.Fatalf("StartPoller(): %v", err)
+	}
+	select {
+	case <-recoveredReceiveSeen:
+	case <-time.After(3 * time.Second):
+		t.Fatal("receive did not continue past a single account-invalid glitch")
+	}
+	status := bridge.Status()
+	if !status.Connected || status.NeedsReauth {
+		t.Fatalf("post-glitch status = %+v, want still connected without reauth", status)
+	}
+	cancel()
+	select {
+	case exit := <-run.Done():
+		if exit.Kind != "" || !errors.Is(exit.Err, context.Canceled) {
+			t.Fatalf("post-glitch exit = %+v, want plain cancellation", exit)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("poller did not exit after cancel")
+	}
+}
+
+func TestReceiveAccountInvalidConsecutiveFailuresParkReauth(t *testing.T) {
+	bridge := &Bridge{
+		account:   "+15551230000",
+		configDir: t.TempDir(),
+		logger:    zerolog.Nop(),
+	}
+	var receiveCalls atomic.Int32
+	installSignalGateStubs(t, bridge,
+		func(context.Context) ([]byte, error) {
+			return []byte("signal-cli 0.14.5\n"), nil
+		},
+		func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			switch {
+			case hasSignalCLIArg(args, "listAccounts"):
+				return []byte(`[{"number":"+15551230000"}]`), nil
+			case hasSignalCLIArg(args, "receive"):
+				receiveCalls.Add(1)
+				return []byte("User +15551230000 is not registered."), errors.New("exit status 1")
+			default:
+				return []byte("[]"), nil
+			}
+		},
+	)
+
+	run, err := bridge.StartPoller(context.Background())
+	if err != nil {
+		t.Fatalf("StartPoller(): %v", err)
+	}
+	select {
+	case exit := <-run.Done():
+		if exit.Kind != PollerFailureReauth ||
+			exit.Operation != "receive" ||
+			exit.Fingerprint != SignalAccountInvalidFingerprint {
+			t.Fatalf("consecutive account-invalid exit = %+v, want reauth/%s", exit, SignalAccountInvalidFingerprint)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("consecutive account-invalid receive did not park")
+	}
+	if got := receiveCalls.Load(); got != receiveAccountInvalidLimit {
+		t.Fatalf("receive attempts before park = %d, want %d", got, receiveAccountInvalidLimit)
+	}
+	if status := bridge.Status(); !status.NeedsReauth || status.Connected {
+		t.Fatalf("consecutive account-invalid status = %+v, want parked reauth", status)
 	}
 }
 


### PR DESCRIPTION
## Problem

The Signal bridge recurrently latched a **permanent `needs_reauth` park from a transient boot-time failure** on a link that was actually valid. Three live episodes on the production install:

- **2026-07-20** — real signal-cli contention (pre-#149 mcp-stdio fleet)
- **2026-07-24, 2026-08-06** — **no contention** (transportless fleet, no signal-cli process, `lsof` on the config dir empty). The park held **12–22h with zero receipts** while `accounts.json` was untouched since April; a single `POST /api/signal/connect` reconnected in ~5 seconds.

Root cause: `runReceiveLoop`'s startup probe ran **one** `listAccounts` and treated an empty success (`err == nil && account == ""`) as terminal proof of an unlinked account (`last_error: "Signal account is not paired"`, `needs_reauth: true` → `PollerFailureReauth` → supervisor `StateBlocked`, forever). But `listAccounts` is **local-only evidence**: signal-cli racing its own account bootstrap at backend boot logs `Ignoring <number>: User is not registered.` and exits 0 with zero accounts — the exact signature the existing `TestParseSignalAccountsIgnoresSignalCLIErrorOutput` fixture documents.

## Fix (all three prongs from the incident analysis)

**(a) Retry before classifying** — the receive-start probe now makes 3 paced in-generation attempts (each bounded to 30s; previously a single unbounded call) before any terminal classification. The observed boot race heals on attempt 2 without even churning a generation.

**(b) Verify absence before demanding re-pair** — an exhausted empty/invalid probe parks reauth immediately only when `data/accounts.json` **also** lists no account (locally gone — unchanged semantics, same `signal_account_invalid` fingerprint). While `accounts.json` still lists the link — both live false-park episodes — the generation exits **transient** (`signal_account_probe_empty`, retried on supervisor backoff), and only **3 consecutive disagreeing generations** park, under a new distinct fingerprint `signal_account_unreadable`.

**(c) The local-evidence park self-retests** — `signalSupervisorControl.StartParkRetest` retries a `signal_account_unreadable` park every 15 minutes via `RetryBlocked` (one local probe; server traffic only on success). A lingering false park is now bounded to minutes instead of manual-connect-or-nothing.

## Guardrails preserved

- **Genuine server-side unlink still surfaces `needs_reauth`**: a receive-loop `not registered`/`authorization failed` is server-backed evidence — it now takes 2 consecutive confirmations (still parks within seconds for a real unlink), keeps the `signal_account_invalid` fingerprint, and is **never** auto-retried.
- **Nothing auto-unpairs**, ever — unpair `os.RemoveAll`s the signal-cli dir including CDN-expired media.
- Pairing/upgrade parks and the manual `/api/signal/connect` escape hatch are untouched.

## Tests

New coverage in `internal/signallive/gate_test.go` (StartPoller harness style) and `cmd/signal_supervisor_test.go` (supervisor-control fake-lifecycle style):

- boot-race empty probe retries and connects (no park, 2 probe calls)
- empty probe with stored account: transient × 2 → `signal_account_unreadable` park at streak 3
- a successful probe resets the streak
- single receive account-invalid glitch keeps the loop connected; consecutive ones park under `signal_account_invalid`
- the park retest exits an `signal_account_unreadable` park automatically and **never** touches a `signal_account_invalid` park
- existing probe-park test updated for the retry attempts (final classification unchanged)

`GOWORK=off go test ./...`: 33 packages pass; `-race` clean on `internal/signallive`, `internal/bridgeadapters/signal`, `internal/bridge`; `go vet` clean.

Runbook: new "Signal `needs_reauth` — read the fingerprint before believing the park" section documents the fingerprints and the debug flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)