### PR TITLE
Correct Signal probe mechanism notes: listAccounts includes a server-side account check

### DIFF
--- a/cmd/signal_supervisor.go
+++ b/cmd/signal_supervisor.go
@@ -20,11 +20,16 @@ const (
 	signalSupervisorCommandTimeout = 30 * time.Second
 
 	// signalParkRetestInterval paces the automatic retest of a reauth park
-	// whose only evidence was local (signal_account_unreadable: signal-cli
-	// could not read an account that accounts.json still lists). The retest
-	// is one supervisor RetryBlocked — a local listAccounts probe that either
-	// reconnects or re-parks — so the cadence can stay slow and still bound a
-	// false park to minutes instead of the 12-22h outages observed live.
+	// whose evidence was an ambiguous empty probe (signal_account_unreadable:
+	// signal-cli could not load an account that accounts.json still lists).
+	// The retest is one supervisor RetryBlocked — a listAccounts probe that
+	// either reconnects or re-parks. While signal-cli still considers the
+	// account registered, that probe includes signal-cli's own account check
+	// against the server (one light round-trip per retest); once a real
+	// deregistration has persisted "registered": false, every retest fails
+	// locally with no network traffic. Either way the cadence stays slow and
+	// bounds a false park to minutes instead of the 12-22h outages observed
+	// live.
 	signalParkRetestInterval = 15 * time.Minute
 )
 
@@ -97,12 +102,12 @@ func newSignalSupervisorControl(
 // StartParkRetest launches the paced retest loop for the one Signal park that
 // is allowed to heal itself: StateBlocked with reauth_required and the
 // signal_account_unreadable fingerprint, which the bridge only reaches on
-// local evidence (listAccounts persistently empty while accounts.json still
-// lists a linked account — the boot-race false park observed live 2026-07-24
-// and 2026-08-06). Every other park stays user-owned: server-backed reauth
-// (signal_account_invalid), upgrade gates, and pairing failures are never
-// retried automatically, and nothing here ever unpairs. The loop stops with
-// Stop; a no-op interval disables it.
+// ambiguous evidence (listAccounts persistently empty while accounts.json
+// still lists a linked account — the shape of the transient account-check
+// false parks observed live 2026-07-24 and 2026-08-06). Every other park
+// stays user-owned: server-confirmed reauth (signal_account_invalid), upgrade
+// gates, and pairing failures are never retried automatically, and nothing
+// here ever unpairs. The loop stops with Stop; a no-op interval disables it.
 func (c *signalSupervisorControl) StartParkRetest(interval time.Duration, logger zerolog.Logger) {
 	if c == nil || interval <= 0 {
 		return

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -382,12 +382,31 @@ hardened the UI to ignore redundant status pushes.)
 ### Signal `needs_reauth` — read the fingerprint before believing the park
 
 `needs_reauth: true` is the bridge's **interpretation** of a signal-cli error,
-not server truth. Three live episodes (2026-07-20, 2026-07-24, 2026-08-06)
-parked a **valid** link for 12–22h because one boot-time `listAccounts` came up
-empty (signal-cli racing its own account bootstrap logs
-`Ignoring <number>: User is not registered.` and exits 0) and the bridge
-latched a permanent park; a single `POST /api/signal/connect` reconnected in
-~5s each time. The bridge now classifies with corroboration instead:
+not necessarily server truth. Three live episodes (2026-07-20, 2026-07-24,
+2026-08-06) parked a **valid** link for 12–22h because one boot-time
+`listAccounts` came up empty and the bridge latched a permanent park; a single
+`POST /api/signal/connect` reconnected in ~5s each time.
+
+**Why an empty `listAccounts` is ambiguous** (mechanism verified live
+2026-08-23 on signal-cli 0.14.5 with `--verbose --verbose`): `listAccounts` is
+not a pure local read. signal-cli loads every account in `accounts.json`, and
+the load runs its own account check (`AccountHelper.checkAccountState`) — a
+**server round-trip** while the stored account is marked registered. Any
+failure there makes signal-cli print one `WARN … Ignoring <number>: …` /
+`Failed to load <number>: …` line and report **zero accounts with exit 0**:
+
+- **Transient check failure** (network not up at login-time autostart, server
+  hiccup): the account file keeps `"registered": true`, so the next probe can
+  succeed — this is the false-park shape the episodes above match.
+- **Genuine deregistration**: the server answers the check with
+  `DeviceDeregisteredException: device was deregistered` → `[403]
+  Authorization failed! (AccountCheckException)`, and signal-cli **persists
+  `"registered": false`** into `data/<account>`. From then on every load
+  throws `NotRegisteredException` *before* any network call — the park is
+  real and only a re-link fixes it (observed live 2026-08-23; flipping the
+  flag back to true just reproduced the 403 and re-persisted false).
+
+The bridge classifies with corroboration instead of trusting one probe:
 
 - The receive-start probe **retries in-generation** (3 attempts, paced),
   then checks `data/accounts.json`. Probe empty but accounts.json still lists
@@ -395,22 +414,43 @@ latched a permanent park; a single `POST /api/signal/connect` reconnected in
   supervisor backoff — no park, no `needs_reauth`.
 - Only 3 **consecutive generations** of that disagreement park, under
   `signal_account_unreadable` — and that park **self-retests every 15 min**
-  (one local `RetryBlocked`; log line "Signal reauth park retest"), so a
-  lingering false park heals without manual intervention.
-- Server-backed evidence still parks fast and stays parked:
+  (one `RetryBlocked`; log line "Signal reauth park retest"), so a lingering
+  transient park heals without manual intervention. While signal-cli still
+  considers the account registered each retest costs one light server check;
+  after a persisted `"registered": false` the retests fail locally with zero
+  network traffic, so a genuinely deregistered account is never hammered. The
+  streak count in `last_error` grows by one per retest — a large number means
+  the park has been standing for hours, not that anything is thrashing.
+- Server-confirmed evidence still parks fast and stays parked:
   a receive-loop "not registered" / "authorization failed" needs 2
   consecutive confirmations (seconds), then parks under
   `signal_account_invalid` with **no** automatic retest. Probe empty with
   accounts.json **also** empty parks immediately (`signal_account_invalid`).
 
-Debugging a parked Signal: check `/api/status` and the supervisor fingerprint
-before recommending a re-pair. `signal_account_unreadable` → local read
-problem, wait for the retest or `POST /api/signal/connect`; verify contention
-first (`pgrep -fl signal-cli`, `lsof` on the config dir — see the MCP
-fratricide section above). `signal_account_invalid` from `receive` → genuine
-server-side unlink, re-pair is real. **Never unpair to "fix" a park**: unpair
-`os.RemoveAll`s the signal-cli dir including CDN-expired media — permanent
-loss.
+Debugging a parked Signal — check, in order:
+
+1. `/api/status` fingerprint/error. `signal_account_invalid` from `receive` →
+   server-confirmed unlink; re-pair is real.
+2. Contention: `pgrep -fl signal-cli`, `lsof` on the config dir (see the MCP
+   fratricide section above).
+3. The persisted server verdict:
+   `jq .registered "$DATADIR/signal-cli/data/<account-file>"` — **`false`
+   means the server rejected the device** (genuine; only a re-link fixes it);
+   `true` with an `signal_account_unreadable` park means transient check
+   failures — wait for the retest or fire `POST /api/signal/connect`.
+4. To see the verdict live (only while the app's Signal supervisor is parked
+   and no signal-cli process is running):
+   `signal-cli --verbose --verbose --config "$DATADIR/signal-cli" listAccounts`
+   — genuine shows `DeviceDeregisteredException` + `[403] Authorization
+   failed!`; transient shows an IO-flavored "Error while checking account"
+   with `registered` still true afterwards.
+
+**Never unpair to "fix" a park**: unpair `os.RemoveAll`s the signal-cli dir
+including CDN-expired media — permanent loss. Before a *genuine* re-link, back
+up the whole `signal-cli/` dir first and restore the media subdirs
+(`attachments`, `avatars`, `stickers`, `outgoing-attachments`) — not `data/` —
+after the new link (recipe proven 2026-07-20; backups live under
+`<datadir>/app-backups/`).
 
 ## Deploying a new build to a live install
 

--- a/internal/signallive/client.go
+++ b/internal/signallive/client.go
@@ -122,8 +122,9 @@ var (
 	now = time.Now
 
 	// accountProbeRetryDelays paces the in-generation listAccounts retries: a
-	// probe that races signal-cli's own account bootstrap at boot (observed
-	// live 2026-07-24 and 2026-08-06: exit 0, zero accounts, link intact)
+	// transient failure of signal-cli's per-account check (network not up at
+	// login-time autostart, a server hiccup) reports zero accounts with exit 0
+	// (observed live 2026-07-24 and 2026-08-06: empty probe, link intact) and
 	// usually recovers within seconds. Swapped by tests to keep them fast.
 	accountProbeRetryDelays = []time.Duration{2 * time.Second, 4 * time.Second}
 
@@ -235,9 +236,13 @@ const (
 	// after accountUnreadableStreakLimit consecutive generations of the probe
 	// disagreeing with accounts.json. Unlike SignalAccountInvalidFingerprint
 	// (server-backed receive failures, or an account missing from disk too)
-	// its only evidence is local, so the cmd-layer park retest is allowed to
-	// re-probe it periodically instead of waiting forever for a manual
-	// /api/signal/connect.
+	// its evidence is an ambiguous empty listAccounts — a transient failure
+	// of signal-cli's account check looks identical to a deregistered device
+	// — so the cmd-layer park retest is allowed to re-probe it periodically
+	// instead of waiting forever for a manual /api/signal/connect. A genuine
+	// deregistration stays cheap under that retest: signal-cli persists
+	// "registered": false after the server 403, and every later probe fails
+	// locally without network traffic.
 	SignalAccountUnreadableFingerprint = "signal_account_unreadable"
 )
 
@@ -1909,15 +1914,19 @@ func (b *Bridge) runReceiveLoop(
 	}
 }
 
-// probeAccountWithRetry runs the local listAccounts probe up to
+// probeAccountWithRetry runs the listAccounts probe up to
 // len(accountProbeRetryDelays)+1 times before letting the caller classify the
-// failure. A signal-cli invocation that races the JVM's own account bootstrap
-// at backend boot can transiently report zero accounts (MultiAccountManager
-// logs "Ignoring <number>: User is not registered." and exits 0) even though
-// the stored link is intact — observed live on 2026-07-24 and 2026-08-06,
-// where one boot-time empty probe parked the bridge in needs_reauth for
-// 12-22h while a manual reconnect succeeded in seconds. Retrying inside the
-// generation keeps that transient from ever reaching the terminal classifier.
+// failure. listAccounts is not a pure local read: signal-cli loads every
+// account listed in accounts.json and runs its own account check
+// (AccountHelper.checkAccountState), which performs a server round-trip while
+// the stored account is still marked registered. Any failure of that load —
+// transient network trouble at login-time autostart just as much as a real
+// server rejection — makes signal-cli print a "Ignoring <number>: …" /
+// "Failed to load <number>: …" warning and report zero accounts with exit 0
+// (verified live 2026-08-23 with --verbose). One such empty probe parked the
+// bridge in needs_reauth for 12-22h on 2026-07-24 and 2026-08-06 while a
+// manual reconnect succeeded in seconds. Retrying inside the generation keeps
+// a transient check failure from ever reaching the terminal classifier.
 // Returns ctx.Err() as the error when the generation is cancelled mid-retry.
 func (b *Bridge) probeAccountWithRetry(
 	ctx context.Context,
@@ -1958,10 +1967,14 @@ func (b *Bridge) probeAccountWithRetry(
 }
 
 // classifyFailedAccountProbe turns an exhausted account probe into the
-// generation's terminal exit. The probe is local-only evidence — listAccounts
-// never consults the Signal server — so an empty or account-invalid result
-// can prove at most "signal-cli cannot see the account right now", never "the
-// server unlinked this device". Parking reauth therefore needs corroboration:
+// generation's terminal exit. An empty listAccounts is ambiguous evidence:
+// signal-cli reports zero accounts (exit 0) for a transient failure of its
+// per-account load check exactly as it does for a server-confirmed
+// deregistration (a 403 there persists "registered": false into the account
+// file, after which every later load throws NotRegisteredException before any
+// network call — both observed live 2026-08-23). The probe output alone
+// cannot distinguish "couldn't check the account this instant" from "the
+// server unlinked this device", so parking reauth needs corroboration:
 //
 //   - accounts.json no longer lists any account: the link is locally gone, so
 //     the pre-existing immediate reauth park stands.


### PR DESCRIPTION
Comments/docs only — no behavior change. Follow-up to #170.

Live debugging on Max's install today (signal-cli 0.14.5, `--verbose --verbose`) falsified a mechanism claim in #170's comments and runbook: `listAccounts` is **not** a pure local read. signal-cli's per-account load runs `AccountHelper.checkAccountState` — a server round-trip while the stored account is marked registered — and **any** failure there (transient network trouble or a genuine rejection) prints one `Ignoring/Failed to load <number>` warning and reports zero accounts with exit 0. That's the observed ambiguity behind the false parks:

- **transient check failure** → `"registered"` stays `true`, next probe can succeed — the 2026-07-24 / 2026-08-06 false-park shape that #170's retry + streak + paced retest heals;
- **genuine deregistration** → `DeviceDeregisteredException` → `[403] Authorization failed!` persists `"registered": false`, after which every load fails locally before any network call (observed live; re-flipping the flag reproduced the 403 and re-persisted `false`).

Runbook additions: a persisted-verdict check (`jq .registered data/<account>`) and the verbose `listAccounts` recipe as steps 3–4 of the parked-Signal debug flow; a note that the 15-min park retest is local-only (zero server traffic) once a genuine deregistration is persisted, and that the growing streak number in `last_error` measures park age, not thrashing; the pre-re-link media backup recipe.

`go build`, gofmt, and the Signal supervisor/probe tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)