### PR TITLE
Serve get_person_messages on v2 and add message-level HTTP search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,9 +107,11 @@ mode this prevents and the `~/.mcp.json` recipe.
 
 On a v2-primary install the message-read tools (including `get_person_messages`
 and `get_person_messages_range`) serve the v2 store through the canonical read
-seam; their `limit` is capped (500 and 2,000) because the v2 batch path fans
-out per matching conversation. Date arguments are YYYY-MM-DD in local time on
-every surface (CLI, HTTP, MCP) via `db.ParseDayBound`. The stats/story/viz tools (`conversation_stats`, `generate_story`,
+seam; on v2 their `limit` is capped (500 and 2,000, and the output says when
+the cap applied) because the v2 batch path fans out per matching conversation,
+while the legacy single-query path keeps the caller's value. Date arguments
+are YYYY-MM-DD in local time on every surface (CLI, HTTP, MCP) via
+`db.ParseDayBound`, and the range tool labels rows in that same local time. The stats/story/viz tools (`conversation_stats`, `generate_story`,
 `person_stats`, `generate_person_story`, `generate_viz`, `render_story`) still
 load full histories from the legacy store, which froze at cutover, so they
 return an error naming the working read tools instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,9 @@ mode this prevents and the `~/.mcp.json` recipe.
 
 On a v2-primary install the message-read tools (including `get_person_messages`
 and `get_person_messages_range`) serve the v2 store through the canonical read
-seam. The stats/story/viz tools (`conversation_stats`, `generate_story`,
+seam; their `limit` is capped (500 and 2,000) because the v2 batch path fans
+out per matching conversation. Date arguments are YYYY-MM-DD in local time on
+every surface (CLI, HTTP, MCP) via `db.ParseDayBound`. The stats/story/viz tools (`conversation_stats`, `generate_story`,
 `person_stats`, `generate_person_story`, `generate_viz`, `render_story`) still
 load full histories from the legacy store, which froze at cutover, so they
 return an error naming the working read tools instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,12 +105,27 @@ mode this prevents and the `~/.mcp.json` recipe.
 - `render_story` — render a pre-built Story JSON into HTML viz; supports `photo_paths` (curated list) or `photos_dir`
 - `send_message`, `draft_message`, `download_media`, `list_contacts`, `get_status`
 
+On a v2-primary install the message-read tools (including `get_person_messages`
+and `get_person_messages_range`) serve the v2 store through the canonical read
+seam. The stats/story/viz tools (`conversation_stats`, `generate_story`,
+`person_stats`, `generate_person_story`, `generate_viz`, `render_story`) still
+load full histories from the legacy store, which froze at cutover, so they
+return an error naming the working read tools instead.
+
 ### HTTP API
 
 - `GET /api/stats/{conversation_id}` — conversation statistics JSON
 - `GET /api/story/{conversation_id}?style=intimate&api_key=...` — generated story JSON
 - `GET /api/conversations?limit=50` — list all conversations (all platforms)
-- `GET /api/search?q=...` — search across all platforms
+- `GET /api/search?q=...` — **conversation-level** search: one row per matching
+  conversation (`ConversationID`/`Name`/`Participants`/`preview`), matched by
+  message text and by conversation name/participants. This feeds the web UI's
+  search box — it does not return message rows.
+- `GET /api/search/messages?q=...` — **message-level** search: raw message DTOs
+  (`MessageID`/`Body`/`TimestampMS`…, same shape as
+  `/api/conversations/<id>/messages`), the HTTP twin of the `search_messages`
+  MCP tool. Optional `phone`, `conversation_id`, `since`/`until` (YYYY-MM-DD,
+  local time, `until` inclusive to end of day), `limit` (default 50, max 500).
 
 ### Schema
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,9 +109,11 @@ On a v2-primary install the message-read tools (including `get_person_messages`
 and `get_person_messages_range`) serve the v2 store through the canonical read
 seam; on v2 their `limit` is capped (500 and 2,000, and the output says when
 the cap applied) because the v2 batch path fans out per matching conversation,
-while the legacy single-query path keeps the caller's value. Date arguments
-are YYYY-MM-DD in local time on every surface (CLI, HTTP, MCP) via
-`db.ParseDayBound`, and the range tool labels rows in that same local time. The stats/story/viz tools (`conversation_stats`, `generate_story`,
+while the legacy single-query path keeps the caller's value above a floor of 1
+(a negative SQLite LIMIT means no limit). Date arguments are YYYY-MM-DD in
+local time on every surface (CLI, HTTP, MCP) via `db.ParseDayBound`, and the
+range tool labels rows in that same local time. The stats/story/viz tools
+(`conversation_stats`, `generate_story`,
 `person_stats`, `generate_person_story`, `generate_viz`, `render_story`) still
 load full histories from the legacy store, which froze at cutover, so they
 return an error naming the working read tools instead.

--- a/cmd/r5_backend_it_test.go
+++ b/cmd/r5_backend_it_test.go
@@ -978,7 +978,9 @@ func assertR5MCPReadSurfaces(
 		{name: "get_status", args: map[string]any{}, want: "Serving store (v2)"},
 		// The person tools un-gated for v2: matched by the migrated title and
 		// served through the tool → v2read batch seam against the real store.
-		{name: "get_person_messages", args: map[string]any{"name": fixture.Conversations[0].Name, "limit": float64(50)}, want: "r5 google ingest projected"},
+		// (The ingest-projected frame is routed by sender identity since #176
+		// and may land in a minted thread, so target a migrated row instead.)
+		{name: "get_person_messages", args: map[string]any{"name": fixture.Conversations[0].Name, "limit": float64(50)}, want: "google second incoming byte-exact"},
 		{name: "get_person_messages_range", args: map[string]any{
 			"name":   fixture.Conversations[0].Name,
 			"after":  time.UnixMilli(fixture.BaseMS).Add(-24 * time.Hour).Format("2006-01-02"),

--- a/cmd/r5_backend_it_test.go
+++ b/cmd/r5_backend_it_test.go
@@ -976,6 +976,15 @@ func assertR5MCPReadSurfaces(
 		{name: "get_messages", args: map[string]any{"limit": float64(100)}, want: "r5 google ingest projected"},
 		{name: "search_messages", args: map[string]any{"query": r5SharedSearchToken, "limit": float64(50)}, want: r5SharedSearchToken},
 		{name: "get_status", args: map[string]any{}, want: "Serving store (v2)"},
+		// The person tools un-gated for v2: matched by the migrated title and
+		// served through the tool → v2read batch seam against the real store.
+		{name: "get_person_messages", args: map[string]any{"name": fixture.Conversations[0].Name, "limit": float64(50)}, want: "r5 google ingest projected"},
+		{name: "get_person_messages_range", args: map[string]any{
+			"name":   fixture.Conversations[0].Name,
+			"after":  time.UnixMilli(fixture.BaseMS).Add(-24 * time.Hour).Format("2006-01-02"),
+			"before": time.UnixMilli(fixture.BaseMS).Add(24 * time.Hour).Format("2006-01-02"),
+			"limit":  float64(50),
+		}, want: "google incoming media"},
 	}
 	for _, check := range checks {
 		registered := server.GetTool(check.name)

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -165,25 +165,8 @@ func firstNonEmpty(vals ...string) string {
 }
 
 // parseDayBound parses a --since/--until value into a millisecond timestamp.
-// It accepts a bare date (YYYY-MM-DD), a date-time, or RFC3339, all in local
-// time. An empty string returns 0 (no bound). When endOfDay is true, a bare
-// date resolves to 23:59:59.999 so that "--until 2026-05-28" includes all of
-// that day rather than stopping at midnight.
+// The parsing lives in db.ParseDayBound so the HTTP API's message search
+// accepts the same date forms as the CLI.
 func parseDayBound(s string, endOfDay bool) (int64, error) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return 0, nil
-	}
-	if t, err := time.ParseInLocation("2006-01-02", s, time.Local); err == nil {
-		if endOfDay {
-			t = t.Add(24*time.Hour - time.Millisecond)
-		}
-		return t.UnixMilli(), nil
-	}
-	for _, layout := range []string{"2006-01-02 15:04", "2006-01-02T15:04", time.RFC3339} {
-		if t, err := time.ParseInLocation(layout, s, time.Local); err == nil {
-			return t.UnixMilli(), nil
-		}
-	}
-	return 0, fmt.Errorf("invalid date %q (use YYYY-MM-DD)", s)
+	return db.ParseDayBound(s, endOfDay)
 }

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -37,8 +37,16 @@ but misses WAL-only (recent) writes. **Prefer the running app's HTTP API**
 GET /api/status
 GET /api/conversations?limit=500
 GET /api/conversations/<conversation_id>/messages?limit=N
-GET /api/search?q=<term>
+GET /api/search?q=<term>            # conversation summaries (one row per thread)
+GET /api/search/messages?q=<term>   # raw message rows (MessageID/Body/TimestampMS…)
 ```
+
+**`/api/search` returns conversation-level results** (`ConversationID`, `Name`,
+`Participants`, `preview`) for the web UI's search box — parsing message fields
+out of it silently yields nothing. For message hits use `/api/search/messages`,
+which returns the same DTO as `/api/conversations/<id>/messages` and accepts
+`phone`, `conversation_id`, `since`/`until` (YYYY-MM-DD, local; `until`
+inclusive to end of day), and `limit` (default 50, max 500).
 
 Outgoing message rows carry a `Status`: `OUTGOING_SENDING` → `OUTGOING_SENT`/
 `OUTGOING_DELIVERED`, or `OUTGOING_FAILED:<STATUS>` when a send is rejected.

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -255,6 +255,30 @@ type SearchFilter struct {
 	Limit          int    // max rows (<=0 → 20)
 }
 
+// ParseDayBound parses a since/until value into a millisecond timestamp for
+// SearchFilter. It accepts a bare date (YYYY-MM-DD), a date-time, or RFC3339,
+// all in local time. An empty string returns 0 (no bound). When endOfDay is
+// true, a bare date resolves to 23:59:59.999 so that "until 2026-05-28"
+// includes all of that day rather than stopping at midnight.
+func ParseDayBound(s string, endOfDay bool) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02", s, time.Local); err == nil {
+		if endOfDay {
+			t = t.Add(24*time.Hour - time.Millisecond)
+		}
+		return t.UnixMilli(), nil
+	}
+	for _, layout := range []string{"2006-01-02 15:04", "2006-01-02T15:04", time.RFC3339} {
+		if t, err := time.ParseInLocation(layout, s, time.Local); err == nil {
+			return t.UnixMilli(), nil
+		}
+	}
+	return 0, fmt.Errorf("invalid date %q (use YYYY-MM-DD)", s)
+}
+
 func (s *Store) SearchMessages(query, phoneNumber string, limit int) ([]*Message, error) {
 	return s.SearchMessagesFiltered(query, SearchFilter{Phone: phoneNumber, Limit: limit})
 }

--- a/internal/readsource/readsource.go
+++ b/internal/readsource/readsource.go
@@ -13,6 +13,8 @@ type ReadSource interface {
 	GetMessagesByConversationBefore(conversationID string, beforeMS int64, beforeID string, limit int) ([]*db.Message, error)
 	GetMessagesByConversationAfter(conversationID string, afterMS int64, afterID string, limit int) ([]*db.Message, error)
 	GetMessagesAroundMessage(conversationID, messageID string, before, after int) ([]*db.Message, error)
+	GetMessagesByConversations(conversationIDs []string, limit int) ([]*db.Message, error)
+	GetMessagesByConversationsRange(conversationIDs []string, afterMS, beforeMS int64, limit int) ([]*db.Message, error)
 	SearchMessagesFiltered(query string, filter db.SearchFilter) ([]*db.Message, error)
 	PlatformStats() ([]db.PlatformStat, error)
 	MessageCount(sourcePlatform string) (int, error)

--- a/internal/readsource/readsource.go
+++ b/internal/readsource/readsource.go
@@ -8,6 +8,7 @@ import "github.com/maxghenis/openmessage/internal/db"
 // callers use the existing store without an adapter.
 type ReadSource interface {
 	ListConversations(limit int) ([]*db.Conversation, error)
+	SearchConversationsByMetadata(query string, limit int) ([]*db.Conversation, error)
 	GetConversation(id string) (*db.Conversation, error)
 	GetMessagesByConversation(conversationID string, limit int) ([]*db.Message, error)
 	GetMessagesByConversationBefore(conversationID string, beforeMS int64, beforeID string, limit int) ([]*db.Message, error)

--- a/internal/storage/sqlite/repositories.go
+++ b/internal/storage/sqlite/repositories.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	moderncsqlite "modernc.org/sqlite"
 )
@@ -781,6 +782,49 @@ func (s *Store) ListConversationsByRecencyAllAccounts(limit int) ([]Conversation
 		conversations = conversations[:limit]
 	}
 	return conversations, nil
+}
+
+// SearchConversationsByName returns conversations whose title, or whose
+// participants' display names or canonical addresses, contain query as a
+// case-insensitive substring — newest first, at most limit rows. It is the
+// bounded v2 counterpart of the legacy metadata search: the match runs in SQL
+// so callers map only the hits instead of every conversation.
+func (s *Store) SearchConversationsByName(query string, limit int) ([]Conversation, error) {
+	if limit <= 0 || strings.TrimSpace(query) == "" {
+		return []Conversation{}, nil
+	}
+	pattern := "%" + escapeLikePattern(query) + "%"
+	rows, err := s.db.QueryContext(
+		context.Background(),
+		"SELECT "+conversationColumns+`
+		 FROM conversations
+		 WHERE title LIKE ? ESCAPE '\'
+		    OR conversation_id IN (
+		        SELECT cp.conversation_id
+		        FROM conversation_participants cp
+		        JOIN identities i ON i.identity_id = cp.identity_id
+		        WHERE cp.display_name LIKE ? ESCAPE '\'
+		           OR i.display_name LIKE ? ESCAPE '\'
+		           OR i.canonical_value LIKE ? ESCAPE '\'
+		    )
+		 ORDER BY last_message_at_ms DESC, conversation_id
+		 LIMIT ?`,
+		pattern, pattern, pattern, pattern, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("search conversations by name: %w", err)
+	}
+	conversations, err := collectRows(rows, scanConversation)
+	if err != nil {
+		return nil, fmt.Errorf("search conversations by name: %w", err)
+	}
+	return conversations, nil
+}
+
+// escapeLikePattern makes user text match literally inside a LIKE pattern
+// that declares '\' as its escape character.
+func escapeLikePattern(text string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(text)
 }
 
 func scanConversation(row rowScanner) (Conversation, error) {

--- a/internal/tools/get_messages.go
+++ b/internal/tools/get_messages.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -17,8 +16,8 @@ func getMessagesTool() mcp.Tool {
 	return mcp.NewTool("get_messages",
 		mcp.WithDescription("Get recent messages with optional filters by phone number, date range, and limit"),
 		mcp.WithString("phone_number", mcp.Description("Filter by sender phone number")),
-		mcp.WithString("after", mcp.Description("Only messages after this ISO-8601 date (e.g., 2026-02-01)")),
-		mcp.WithString("before", mcp.Description("Only messages before this ISO-8601 date")),
+		mcp.WithString("after", mcp.Description("Only messages on/after this date (YYYY-MM-DD, local time, e.g. 2026-02-01)")),
+		mcp.WithString("before", mcp.Description("Only messages on/before this date (YYYY-MM-DD, local time, inclusive to end of day)")),
 		mcp.WithNumber("limit", mcp.Description("Maximum messages to return (default 20)")),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
@@ -32,26 +31,18 @@ func getMessagesHandler(a *app.App, configured ...Options) server.ToolHandlerFun
 		phone := strArg(args, "phone_number")
 		limit := intArg(args, "limit", 20)
 
-		var afterMS, beforeMS int64
-		if after := strArg(args, "after"); after != "" {
-			t, err := time.Parse("2006-01-02", after)
-			if err != nil {
-				return errorResult(fmt.Sprintf("invalid 'after' date: %v", err)), nil
-			}
-			afterMS = t.UnixMilli()
+		// Same parser as the CLI, /api/search/messages, and the person tools,
+		// so one date string selects the same local-time window everywhere.
+		afterMS, err := db.ParseDayBound(strArg(args, "after"), false)
+		if err != nil {
+			return errorResult(fmt.Sprintf("invalid 'after' date: %v", err)), nil
 		}
-		if before := strArg(args, "before"); before != "" {
-			t, err := time.Parse("2006-01-02", before)
-			if err != nil {
-				return errorResult(fmt.Sprintf("invalid 'before' date: %v", err)), nil
-			}
-			beforeMS = t.Add(24*time.Hour - time.Millisecond).UnixMilli()
+		beforeMS, err := db.ParseDayBound(strArg(args, "before"), true)
+		if err != nil {
+			return errorResult(fmt.Sprintf("invalid 'before' date: %v", err)), nil
 		}
 
-		var (
-			msgs []*db.Message
-			err  error
-		)
+		var msgs []*db.Message
 		if options.V2Primary {
 			// v2 has no separate unscoped-list query. An empty substring query is
 			// deliberately LIKE '%%', with the same filters and recency ordering.

--- a/internal/tools/get_person_messages.go
+++ b/internal/tools/get_person_messages.go
@@ -29,7 +29,7 @@ func getPersonMessagesHandler(a *app.App, configured ...Options) server.ToolHand
 		if name == "" {
 			return errorResult("name is required"), nil
 		}
-		limit := clampLimit(intArg(args, "limit", 50), maxPersonMessagesLimit)
+		limit, capped := personReadLimit(intArg(args, "limit", 50), maxPersonMessagesLimit, options.V2Primary)
 
 		// Find all conversations that mention this person
 		allConvs, err := options.Reads.ListConversations(1000)
@@ -73,7 +73,11 @@ func getPersonMessagesHandler(a *app.App, configured ...Options) server.ToolHand
 		// Group messages by conversation for display
 		var sb strings.Builder
 		sb.WriteString(messagePreamble)
-		fmt.Fprintf(&sb, "Messages with '%s' across %d conversation(s):\n\n", name, len(matchingConvIDs))
+		fmt.Fprintf(&sb, "Messages with '%s' across %d conversation(s):\n", name, len(matchingConvIDs))
+		if capped {
+			fmt.Fprintf(&sb, "(limit capped at %d on the v2 store — the newest %d messages are shown)\n", maxPersonMessagesLimit, limit)
+		}
+		sb.WriteString("\n")
 
 		currentConv := ""
 		totalMsgs := 0

--- a/internal/tools/get_person_messages.go
+++ b/internal/tools/get_person_messages.go
@@ -15,7 +15,7 @@ func getPersonMessagesTool() mcp.Tool {
 	return mcp.NewTool("get_person_messages",
 		mcp.WithDescription("Get all messages with a person across all platforms (SMS, Google Chat, iMessage, WhatsApp). Searches by name or identifier."),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Person's name to search for (case-insensitive partial match)")),
-		mcp.WithNumber("limit", mcp.Description("Maximum messages to return (default 50, max 500)")),
+		mcp.WithNumber("limit", mcp.Description("Maximum messages to return (default 50; capped at 500 on the v2 store)")),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 	)
@@ -59,7 +59,7 @@ func getPersonMessagesHandler(a *app.App, configured ...Options) server.ToolHand
 					if platform == "" {
 						platform = "sms"
 					}
-					convMap[id] = &struct{ name, platform string }{c.Name, platform}
+					convMap[id] = &struct{ name, platform string }{personConversationLabel(c), platform}
 				}
 			}
 		}

--- a/internal/tools/get_person_messages.go
+++ b/internal/tools/get_person_messages.go
@@ -15,7 +15,7 @@ func getPersonMessagesTool() mcp.Tool {
 	return mcp.NewTool("get_person_messages",
 		mcp.WithDescription("Get all messages with a person across all platforms (SMS, Google Chat, iMessage, WhatsApp). Searches by name or identifier."),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Person's name to search for (case-insensitive partial match)")),
-		mcp.WithNumber("limit", mcp.Description("Maximum messages to return (default 50)")),
+		mcp.WithNumber("limit", mcp.Description("Maximum messages to return (default 50, max 500)")),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 	)
@@ -29,7 +29,7 @@ func getPersonMessagesHandler(a *app.App, configured ...Options) server.ToolHand
 		if name == "" {
 			return errorResult("name is required"), nil
 		}
-		limit := intArg(args, "limit", 50)
+		limit := clampLimit(intArg(args, "limit", 50), maxPersonMessagesLimit)
 
 		// Find all conversations that mention this person
 		allConvs, err := options.Reads.ListConversations(1000)

--- a/internal/tools/get_person_messages.go
+++ b/internal/tools/get_person_messages.go
@@ -21,7 +21,8 @@ func getPersonMessagesTool() mcp.Tool {
 	)
 }
 
-func getPersonMessagesHandler(a *app.App) server.ToolHandlerFunc {
+func getPersonMessagesHandler(a *app.App, configured ...Options) server.ToolHandlerFunc {
+	options := resolvedOptions(a, configured)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
 		name := strArg(args, "name")
@@ -31,7 +32,7 @@ func getPersonMessagesHandler(a *app.App) server.ToolHandlerFunc {
 		limit := intArg(args, "limit", 50)
 
 		// Find all conversations that mention this person
-		allConvs, err := a.Store.ListConversations(1000)
+		allConvs, err := options.Reads.ListConversations(1000)
 		if err != nil {
 			return errorResult(fmt.Sprintf("list conversations: %v", err)), nil
 		}
@@ -64,7 +65,7 @@ func getPersonMessagesHandler(a *app.App) server.ToolHandlerFunc {
 		}
 
 		// Batch fetch all messages in one query
-		msgs, err := a.Store.GetMessagesByConversations(matchingConvIDs, limit)
+		msgs, err := options.Reads.GetMessagesByConversations(matchingConvIDs, limit)
 		if err != nil {
 			return errorResult(fmt.Sprintf("get messages: %v", err)), nil
 		}

--- a/internal/tools/get_person_messages.go
+++ b/internal/tools/get_person_messages.go
@@ -74,8 +74,10 @@ func getPersonMessagesHandler(a *app.App, configured ...Options) server.ToolHand
 		var sb strings.Builder
 		sb.WriteString(messagePreamble)
 		fmt.Fprintf(&sb, "Messages with '%s' across %d conversation(s):\n", name, len(matchingConvIDs))
-		if capped {
-			fmt.Fprintf(&sb, "(limit capped at %d on the v2 store — the newest %d messages are shown)\n", maxPersonMessagesLimit, limit)
+		// Only when the read actually hit the cap: a complete result must not
+		// tell the agent to re-query.
+		if capped && len(msgs) >= limit {
+			fmt.Fprintf(&sb, "(limit capped at %d on the v2 store — only the newest %d messages are shown)\n", maxPersonMessagesLimit, len(msgs))
 		}
 		sb.WriteString("\n")
 

--- a/internal/tools/person_label_test.go
+++ b/internal/tools/person_label_test.go
@@ -1,0 +1,32 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/db"
+)
+
+func TestPersonConversationLabel(t *testing.T) {
+	const roster = `[{"name":"Me","number":"+15550009999","is_me":true},{"name":"Alice","number":"+15550000001"},{"name":"","number":"+15550000002"},{"name":"Carol","number":"+15550000003"},{"name":"Dan","number":"+15550000004"}]`
+	for name, tc := range map[string]struct {
+		conv *db.Conversation
+		want string
+	}{
+		"nil":                 {conv: nil, want: ""},
+		"title wins":          {conv: &db.Conversation{ConversationID: "c1", Name: " Titled ", IsGroup: true, Participants: roster}, want: "Titled"},
+		"direct: peer name":   {conv: &db.Conversation{ConversationID: "c2", Participants: `[{"name":"Me","number":"+15550009999","is_me":true},{"name":"Alice","number":"+15550000001"}]`}, want: "Alice"},
+		"direct: peer number": {conv: &db.Conversation{ConversationID: "c3", Participants: `[{"name":"","number":"+15550000002"},{"name":"Me","number":"+15550009999","is_me":true}]`}, want: "+15550000002"},
+		"direct: only self":   {conv: &db.Conversation{ConversationID: "c4", Participants: `[{"name":"Me","number":"+15550009999","is_me":true}]`}, want: "c4"},
+		"direct: no roster":   {conv: &db.Conversation{ConversationID: "c5", Participants: ""}, want: "c5"},
+		// A titleless group is never presented as one member's 1:1 thread.
+		"group: members":   {conv: &db.Conversation{ConversationID: "g1", IsGroup: true, Participants: roster}, want: "Group: Alice, +15550000002, Carol +1 more"},
+		"group: no roster": {conv: &db.Conversation{ConversationID: "g2", IsGroup: true, Participants: `[]`}, want: "Group g2"},
+		"group: only self": {conv: &db.Conversation{ConversationID: "g3", IsGroup: true, Participants: `[{"name":"Me","is_me":true}]`}, want: "Group g3"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := personConversationLabel(tc.conv); got != tc.want {
+				t.Fatalf("label = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tools/person_v2_seam_test.go
+++ b/internal/tools/person_v2_seam_test.go
@@ -1,0 +1,109 @@
+package tools
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+	"github.com/maxghenis/openmessage/internal/v2read"
+)
+
+// The person tools against a real v2 store, on the shape the fakes can only
+// imitate: a titleless direct thread whose self participant sorts before the
+// peer (ListParticipants orders by identity_id). The label must name the
+// peer, never the account owner.
+func TestPersonToolsLabelTitlelessV2DirectThreadByPeer(t *testing.T) {
+	a := testApp(t)
+	store, err := sqlite.Open(filepath.Join(t.TempDir(), "v2.sqlite3"))
+	if err != nil {
+		t.Fatalf("sqlite.Open(): %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	now := time.Now().UnixMilli()
+	if err := store.UpsertAccount(sqlite.Account{
+		AccountID: "wa-account", BridgeKey: "whatsmeow", DisplayName: "WhatsApp",
+		Mode: sqlite.AccountModeLive, Enabled: true, ConfigJSON: "{}",
+		CreatedAtMS: now, UpdatedAtMS: now,
+	}); err != nil {
+		t.Fatalf("UpsertAccount(): %v", err)
+	}
+	if err := store.UpsertConversation(sqlite.Conversation{
+		ConversationID: "conv-direct", AccountID: "wa-account", RemoteConversationID: "remote-direct",
+		Kind: sqlite.ConversationKindDirect, Title: "", NotificationMode: sqlite.NotificationModeAll,
+		MetadataJSON: "{}", LastMessageAtMS: now, CreatedAtMS: now, UpdatedAtMS: now,
+	}); err != nil {
+		t.Fatalf("UpsertConversation(): %v", err)
+	}
+	for _, identity := range []sqlite.Identity{
+		{IdentityID: "identity-aaa-self", AccountID: "wa-account", Kind: sqlite.IdentityKind("e164"),
+			CanonicalValue: "+15550009999", RawValue: "+15550009999", DisplayName: "Me", IsSelf: true,
+			MetadataJSON: "{}", CreatedAtMS: now, UpdatedAtMS: now},
+		{IdentityID: "identity-zzz-peer", AccountID: "wa-account", Kind: sqlite.IdentityKind("e164"),
+			CanonicalValue: "+15550000001", RawValue: "+15550000001", DisplayName: "Real Peer",
+			MetadataJSON: "{}", CreatedAtMS: now, UpdatedAtMS: now},
+	} {
+		if err := store.UpsertIdentity(identity); err != nil {
+			t.Fatalf("UpsertIdentity(%s): %v", identity.IdentityID, err)
+		}
+	}
+	if err := store.ReplaceConversationParticipants("conv-direct", []sqlite.ConversationParticipant{
+		{AccountID: "wa-account", ConversationID: "conv-direct", IdentityID: "identity-aaa-self", Role: sqlite.ParticipantRoleMember, IsActive: true},
+		{AccountID: "wa-account", ConversationID: "conv-direct", IdentityID: "identity-zzz-peer", Role: sqlite.ParticipantRoleMember, IsActive: true},
+	}); err != nil {
+		t.Fatalf("ReplaceConversationParticipants(): %v", err)
+	}
+	messages, err := sqlite.NewMessageRepository(store, time.Now)
+	if err != nil {
+		t.Fatalf("NewMessageRepository(): %v", err)
+	}
+	peerID := "identity-zzz-peer"
+	if err := messages.ImportMessage(context.Background(), sqlite.MessageProjection{Message: sqlite.Message{
+		MessageID: "msg-1", ConversationID: "conv-direct", AccountID: "wa-account", RemoteMessageID: "remote-msg-1",
+		SenderIdentityID: &peerID, Direction: sqlite.MessageDirectionIncoming, Body: "hello from the peer",
+		State: sqlite.MessageStateActive, OccurredAtMS: now,
+	}}); err != nil {
+		t.Fatalf("ImportMessage(): %v", err)
+	}
+
+	options := Options{Reads: v2read.New(store), V2Primary: true}
+	for name, handler := range map[string]func() (string, error){
+		"get_person_messages": func() (string, error) {
+			result, err := getPersonMessagesHandler(a, options)(context.Background(), toolRequest(map[string]any{"name": "real peer"}))
+			if err != nil {
+				return "", err
+			}
+			return resultText(t, result), nil
+		},
+		"get_person_messages_range": func() (string, error) {
+			day := time.UnixMilli(now)
+			result, err := getPersonMessagesRangeHandler(a, options)(context.Background(), toolRequest(map[string]any{
+				"name":   "real peer",
+				"after":  day.Add(-24 * time.Hour).Format("2006-01-02"),
+				"before": day.Add(24 * time.Hour).Format("2006-01-02"),
+			}))
+			if err != nil {
+				return "", err
+			}
+			return resultText(t, result), nil
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			text, err := handler()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(text, "hello from the peer") {
+				t.Fatalf("%s did not serve the v2 message: %q", name, text)
+			}
+			if !strings.Contains(text, "Real Peer [whatsapp]") {
+				t.Fatalf("%s did not label the titleless thread by its peer: %q", name, text)
+			}
+			if strings.Contains(text, "Me [whatsapp]") || strings.Contains(text, "+15550009999 [whatsapp]") {
+				t.Fatalf("%s labelled the thread with the account owner: %q", name, text)
+			}
+		})
+	}
+}

--- a/internal/tools/r5_routing_test.go
+++ b/internal/tools/r5_routing_test.go
@@ -16,14 +16,14 @@ import (
 
 type toolRoutingReadSource struct {
 	readsource.ReadSource
-	listCalls    int
-	searchCalls  int
-	statusCalls  int
-	getConvCalls int
-	batchCalls   int
-	rangeCalls   int
-	lastQuery   string
-	lastFilter  db.SearchFilter
+	listCalls      int
+	searchCalls    int
+	statusCalls    int
+	getConvCalls   int
+	batchCalls     int
+	rangeCalls     int
+	lastQuery      string
+	lastFilter     db.SearchFilter
 	lastBatchIDs   []string
 	lastBatchLimit int
 	lastAfterMS    int64
@@ -308,14 +308,83 @@ func TestR5MCPGetPersonMessagesRangeRoutesToConfiguredSourceInV2Primary(t *testi
 	if reads.listCalls != 1 || reads.rangeCalls != 1 {
 		t.Fatalf("calls = list %d range %d, want 1/1", reads.listCalls, reads.rangeCalls)
 	}
-	wantAfter, _ := time.Parse("2006-01-02", "2024-01-01")
-	wantBefore, _ := time.Parse("2006-01-02", "2024-03-31")
-	wantBeforeMS := wantBefore.Add(24*time.Hour - time.Millisecond).UnixMilli()
-	if reads.lastAfterMS != wantAfter.UnixMilli() || reads.lastBeforeMS != wantBeforeMS {
-		t.Fatalf("range = [%d, %d], want [%d, %d]", reads.lastAfterMS, reads.lastBeforeMS, wantAfter.UnixMilli(), wantBeforeMS)
+	// Same local-time day bounds as the CLI and /api/search/messages.
+	wantAfterMS, err := db.ParseDayBound("2024-01-01", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantBeforeMS, err := db.ParseDayBound("2024-03-31", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reads.lastAfterMS != wantAfterMS || reads.lastBeforeMS != wantBeforeMS {
+		t.Fatalf("range = [%d, %d], want [%d, %d]", reads.lastAfterMS, reads.lastBeforeMS, wantAfterMS, wantBeforeMS)
 	}
 	if len(reads.lastBatchIDs) != 1 || reads.lastBatchIDs[0] != "v2-conversation" {
 		t.Fatalf("range conversation ids = %v", reads.lastBatchIDs)
+	}
+}
+
+func TestR5MCPPersonMessageToolsClampAgentSuppliedLimits(t *testing.T) {
+	a := testApp(t)
+	reads := &toolRoutingReadSource{}
+	options := Options{Reads: reads, V2Primary: true}
+
+	if _, err := getPersonMessagesHandler(a, options)(context.Background(), toolRequest(map[string]any{
+		"name":  "V2 Conversation",
+		"limit": float64(1_000_000),
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if reads.lastBatchLimit != maxPersonMessagesLimit {
+		t.Fatalf("get_person_messages limit = %d, want clamped to %d", reads.lastBatchLimit, maxPersonMessagesLimit)
+	}
+
+	if _, err := getPersonMessagesRangeHandler(a, options)(context.Background(), toolRequest(map[string]any{
+		"name":   "V2 Conversation",
+		"after":  "2024-01-01",
+		"before": "2024-03-31",
+		"limit":  float64(-5),
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if reads.lastBatchLimit != 1 {
+		t.Fatalf("get_person_messages_range limit = %d, want clamped to 1", reads.lastBatchLimit)
+	}
+}
+
+// The un-gating itself, asserted at registration level: re-wrapping either
+// tool in unavailableInV2Primary would fail here, not just in the direct
+// handler tests above.
+func TestR5MCPPersonMessageToolsRegisteredUngatedInV2Primary(t *testing.T) {
+	a := testApp(t)
+	reads := &toolRoutingReadSource{}
+	mcpServer := server.NewMCPServer("r5-routing", "test")
+	RegisterWithOptions(mcpServer, a, Options{Reads: reads, V2Primary: true})
+
+	for name, args := range map[string]map[string]any{
+		"get_person_messages":       {"name": "V2 Conversation"},
+		"get_person_messages_range": {"name": "V2 Conversation", "after": "2024-01-01", "before": "2024-03-31"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			registered := mcpServer.GetTool(name)
+			if registered == nil {
+				t.Fatalf("tool %q was not registered", name)
+			}
+			result, err := registered.Handler(context.Background(), toolRequest(args))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.IsError {
+				t.Fatalf("tool %q is gated in v2-primary: %q", name, resultText(t, result))
+			}
+			if !strings.Contains(resultText(t, result), "v2 person") {
+				t.Fatalf("tool %q did not serve the configured v2 source: %q", name, resultText(t, result))
+			}
+		})
+	}
+	if reads.batchCalls != 1 || reads.rangeCalls != 1 {
+		t.Fatalf("configured source calls = batch %d range %d, want 1/1", reads.batchCalls, reads.rangeCalls)
 	}
 }
 

--- a/internal/tools/r5_routing_test.go
+++ b/internal/tools/r5_routing_test.go
@@ -20,8 +20,14 @@ type toolRoutingReadSource struct {
 	searchCalls  int
 	statusCalls  int
 	getConvCalls int
+	batchCalls   int
+	rangeCalls   int
 	lastQuery   string
 	lastFilter  db.SearchFilter
+	lastBatchIDs   []string
+	lastBatchLimit int
+	lastAfterMS    int64
+	lastBeforeMS   int64
 }
 
 func (s *toolRoutingReadSource) ListConversations(limit int) ([]*db.Conversation, error) {
@@ -67,6 +73,36 @@ func (s *toolRoutingReadSource) GetMessagesByConversation(conversationID string,
 
 func (s *toolRoutingReadSource) GetConversation(id string) (*db.Conversation, error) {
 	return &db.Conversation{ConversationID: id, Name: "V2 Thread", SourcePlatform: "sms"}, nil
+}
+
+func (s *toolRoutingReadSource) GetMessagesByConversations(conversationIDs []string, limit int) ([]*db.Message, error) {
+	s.batchCalls++
+	s.lastBatchIDs = conversationIDs
+	s.lastBatchLimit = limit
+	return []*db.Message{{
+		MessageID:      "v2-person-message",
+		ConversationID: "v2-conversation",
+		SenderName:     "V2 Alice",
+		Body:           "v2 person body",
+		TimestampMS:    200,
+		SourcePlatform: "sms",
+	}}, nil
+}
+
+func (s *toolRoutingReadSource) GetMessagesByConversationsRange(conversationIDs []string, afterMS, beforeMS int64, limit int) ([]*db.Message, error) {
+	s.rangeCalls++
+	s.lastBatchIDs = conversationIDs
+	s.lastBatchLimit = limit
+	s.lastAfterMS = afterMS
+	s.lastBeforeMS = beforeMS
+	return []*db.Message{{
+		MessageID:      "v2-person-range-message",
+		ConversationID: "v2-conversation",
+		SenderName:     "V2 Alice",
+		Body:           "v2 person range body",
+		TimestampMS:    200,
+		SourcePlatform: "sms",
+	}}, nil
 }
 
 func TestR5MCPReadHandlersUseConfiguredSource(t *testing.T) {
@@ -196,8 +232,6 @@ func TestR5MCPPersonStoryAndVizToolsUnavailableInV2Primary(t *testing.T) {
 	RegisterWithOptions(mcpServer, a, Options{Reads: a.Store, V2Primary: true})
 
 	for _, name := range []string{
-		"get_person_messages",
-		"get_person_messages_range",
 		"conversation_stats",
 		"generate_story",
 		"person_stats",
@@ -217,10 +251,71 @@ func TestR5MCPPersonStoryAndVizToolsUnavailableInV2Primary(t *testing.T) {
 			if !result.IsError {
 				t.Fatalf("tool %q did not return an MCP error", name)
 			}
-			if got := resultText(t, result); got != "not available while v2 is the serving store" {
+			got := resultText(t, result)
+			if got != unavailableWhileV2Serving {
 				t.Fatalf("tool %q error = %q", name, got)
 			}
+			// The error must point agents at the tools that DO serve v2
+			// reads, not dead-end them.
+			for _, alternative := range []string{"get_person_messages", "search_messages", "get_messages"} {
+				if !strings.Contains(got, alternative) {
+					t.Fatalf("tool %q error does not name alternative %q: %q", name, alternative, got)
+				}
+			}
 		})
+	}
+}
+
+func TestR5MCPGetPersonMessagesRoutesToConfiguredSourceInV2Primary(t *testing.T) {
+	a := testApp(t)
+	reads := &toolRoutingReadSource{}
+	options := Options{Reads: reads, V2Primary: true}
+
+	result, err := getPersonMessagesHandler(a, options)(context.Background(), toolRequest(map[string]any{
+		"name":  "V2 Conversation",
+		"limit": float64(25),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError || !strings.Contains(resultText(t, result), "v2 person body") {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if reads.listCalls != 1 || reads.batchCalls != 1 {
+		t.Fatalf("calls = list %d batch %d, want 1/1", reads.listCalls, reads.batchCalls)
+	}
+	if len(reads.lastBatchIDs) != 1 || reads.lastBatchIDs[0] != "v2-conversation" || reads.lastBatchLimit != 25 {
+		t.Fatalf("batch args = %v limit %d", reads.lastBatchIDs, reads.lastBatchLimit)
+	}
+}
+
+func TestR5MCPGetPersonMessagesRangeRoutesToConfiguredSourceInV2Primary(t *testing.T) {
+	a := testApp(t)
+	reads := &toolRoutingReadSource{}
+	options := Options{Reads: reads, V2Primary: true}
+
+	result, err := getPersonMessagesRangeHandler(a, options)(context.Background(), toolRequest(map[string]any{
+		"name":   "V2 Conversation",
+		"after":  "2024-01-01",
+		"before": "2024-03-31",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError || !strings.Contains(resultText(t, result), "v2 person range body") {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if reads.listCalls != 1 || reads.rangeCalls != 1 {
+		t.Fatalf("calls = list %d range %d, want 1/1", reads.listCalls, reads.rangeCalls)
+	}
+	wantAfter, _ := time.Parse("2006-01-02", "2024-01-01")
+	wantBefore, _ := time.Parse("2006-01-02", "2024-03-31")
+	wantBeforeMS := wantBefore.Add(24*time.Hour - time.Millisecond).UnixMilli()
+	if reads.lastAfterMS != wantAfter.UnixMilli() || reads.lastBeforeMS != wantBeforeMS {
+		t.Fatalf("range = [%d, %d], want [%d, %d]", reads.lastAfterMS, reads.lastBeforeMS, wantAfter.UnixMilli(), wantBeforeMS)
+	}
+	if len(reads.lastBatchIDs) != 1 || reads.lastBatchIDs[0] != "v2-conversation" {
+		t.Fatalf("range conversation ids = %v", reads.lastBatchIDs)
 	}
 }
 

--- a/internal/tools/r5_routing_test.go
+++ b/internal/tools/r5_routing_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,8 @@ type toolRoutingReadSource struct {
 	getConvCalls   int
 	batchCalls     int
 	rangeCalls     int
+	batchFill      int // >0: GetMessagesByConversations returns this many rows
+	rangeFill      int // >0: GetMessagesByConversationsRange returns this many rows
 	lastQuery      string
 	lastFilter     db.SearchFilter
 	lastBatchIDs   []string
@@ -79,14 +82,7 @@ func (s *toolRoutingReadSource) GetMessagesByConversations(conversationIDs []str
 	s.batchCalls++
 	s.lastBatchIDs = conversationIDs
 	s.lastBatchLimit = limit
-	return []*db.Message{{
-		MessageID:      "v2-person-message",
-		ConversationID: "v2-conversation",
-		SenderName:     "V2 Alice",
-		Body:           "v2 person body",
-		TimestampMS:    200,
-		SourcePlatform: "sms",
-	}}, nil
+	return fakePersonMessages("v2-person-message", "v2 person body", s.batchFill), nil
 }
 
 func (s *toolRoutingReadSource) GetMessagesByConversationsRange(conversationIDs []string, afterMS, beforeMS int64, limit int) ([]*db.Message, error) {
@@ -95,14 +91,34 @@ func (s *toolRoutingReadSource) GetMessagesByConversationsRange(conversationIDs 
 	s.lastBatchLimit = limit
 	s.lastAfterMS = afterMS
 	s.lastBeforeMS = beforeMS
-	return []*db.Message{{
-		MessageID:      "v2-person-range-message",
-		ConversationID: "v2-conversation",
-		SenderName:     "V2 Alice",
-		Body:           "v2 person range body",
-		TimestampMS:    200,
-		SourcePlatform: "sms",
-	}}, nil
+	return fakePersonMessages("v2-person-range-message", "v2 person range body", s.rangeFill), nil
+}
+
+// fakePersonMessages returns one message shaped like the routing fakes, or
+// count distinct messages (ids, bodies, and timestamps all differ so the
+// range tool's near-duplicate filter keeps them all).
+func fakePersonMessages(id, body string, count int) []*db.Message {
+	if count < 1 {
+		count = 1
+	}
+	messages := make([]*db.Message, 0, count)
+	for i := 0; i < count; i++ {
+		message := &db.Message{
+			MessageID:      id,
+			ConversationID: "v2-conversation",
+			SenderName:     "V2 Alice",
+			Body:           body,
+			TimestampMS:    200,
+			SourcePlatform: "sms",
+		}
+		if i > 0 {
+			message.MessageID = fmt.Sprintf("%s-%d", id, i)
+			message.Body = fmt.Sprintf("%s %d", body, i)
+			message.TimestampMS = 200 + int64(i)*10_000
+		}
+		messages = append(messages, message)
+	}
+	return messages
 }
 
 func TestR5MCPReadHandlersUseConfiguredSource(t *testing.T) {
@@ -126,7 +142,8 @@ func TestR5MCPReadHandlersUseConfiguredSource(t *testing.T) {
 	t.Run("get messages", func(t *testing.T) {
 		result, err := getMessagesHandler(a, options)(context.Background(), toolRequest(map[string]any{
 			"phone_number": "+15551230000",
-			"after":        "1970-01-01",
+			"after":        "2024-01-01",
+			"before":       "2024-03-31",
 			"limit":        float64(12),
 		}))
 		if err != nil {
@@ -137,6 +154,18 @@ func TestR5MCPReadHandlersUseConfiguredSource(t *testing.T) {
 		}
 		if reads.lastQuery != "" || reads.lastFilter.Phone != "+15551230000" || reads.lastFilter.Limit != 12 {
 			t.Fatalf("get_messages filter = %#v, query=%q", reads.lastFilter, reads.lastQuery)
+		}
+		// Same local-time day bounds as every other surface.
+		wantSince, err := db.ParseDayBound("2024-01-01", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantUntil, err := db.ParseDayBound("2024-03-31", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reads.lastFilter.SinceMS != wantSince || reads.lastFilter.UntilMS != wantUntil {
+			t.Fatalf("get_messages window = [%d, %d], want [%d, %d]", reads.lastFilter.SinceMS, reads.lastFilter.UntilMS, wantSince, wantUntil)
 		}
 	})
 
@@ -335,57 +364,61 @@ func TestR5MCPPersonMessageToolsCapAgentSuppliedLimitsOnV2Only(t *testing.T) {
 	reads := &toolRoutingReadSource{}
 	v2 := Options{Reads: reads, V2Primary: true}
 
-	result, err := getPersonMessagesHandler(a, v2)(context.Background(), toolRequest(map[string]any{
-		"name":  "V2 Conversation",
-		"limit": float64(1_000_000),
-	}))
-	if err != nil {
-		t.Fatal(err)
+	call := func(t *testing.T, handler server.ToolHandlerFunc, args map[string]any) string {
+		t.Helper()
+		result, err := handler(context.Background(), toolRequest(args))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected tool error: %q", resultText(t, result))
+		}
+		return resultText(t, result)
 	}
+	personArgs := map[string]any{"name": "V2 Conversation", "limit": float64(1_000_000)}
+	rangeArgs := map[string]any{"name": "V2 Conversation", "after": "2024-01-01", "before": "2024-03-31", "limit": float64(1_000_000)}
+
+	// v2, read fills the cap: limit is capped and the output says so.
+	reads.batchFill = maxPersonMessagesLimit
+	text := call(t, getPersonMessagesHandler(a, v2), personArgs)
 	if reads.lastBatchLimit != maxPersonMessagesLimit {
 		t.Fatalf("v2 get_person_messages limit = %d, want capped to %d", reads.lastBatchLimit, maxPersonMessagesLimit)
 	}
-	if !strings.Contains(resultText(t, result), "limit capped at 500") {
-		t.Fatalf("capped get_person_messages did not say so: %q", resultText(t, result))
+	if !strings.Contains(text, "limit capped at 500") || !strings.Contains(text, "only the newest 500 messages") {
+		t.Fatalf("truncated get_person_messages did not say so: %q", text)
 	}
-
-	result, err = getPersonMessagesRangeHandler(a, v2)(context.Background(), toolRequest(map[string]any{
-		"name":   "V2 Conversation",
-		"after":  "2024-01-01",
-		"before": "2024-03-31",
-		"limit":  float64(1_000_000),
-	}))
-	if err != nil {
-		t.Fatal(err)
-	}
+	reads.rangeFill = maxPersonMessagesRangeLimit
+	text = call(t, getPersonMessagesRangeHandler(a, v2), rangeArgs)
 	if reads.lastBatchLimit != maxPersonMessagesRangeLimit {
 		t.Fatalf("v2 get_person_messages_range limit = %d, want capped to %d", reads.lastBatchLimit, maxPersonMessagesRangeLimit)
 	}
-	if !strings.Contains(resultText(t, result), "limit capped at 2000") {
-		t.Fatalf("capped get_person_messages_range did not say so: %q", resultText(t, result))
+	if !strings.Contains(text, "limit capped at 2000") {
+		t.Fatalf("truncated get_person_messages_range did not say so: %q", text)
+	}
+
+	// v2, result smaller than the cap: complete, so no notice that would
+	// send the agent back for slices it already has.
+	reads.batchFill, reads.rangeFill = 1, 1
+	for name, text := range map[string]string{
+		"get_person_messages":       call(t, getPersonMessagesHandler(a, v2), personArgs),
+		"get_person_messages_range": call(t, getPersonMessagesRangeHandler(a, v2), rangeArgs),
+	} {
+		if strings.Contains(text, "capped") {
+			t.Fatalf("%s warned about a cap on a complete result: %q", name, text)
+		}
 	}
 
 	// Legacy-primary keeps the caller's value: the single-query store bounds
 	// its own work and never truncated before.
-	legacy := Options{Reads: reads}
-	result, err = getPersonMessagesHandler(a, legacy)(context.Background(), toolRequest(map[string]any{
-		"name":  "V2 Conversation",
-		"limit": float64(1_000_000),
-	}))
-	if err != nil {
-		t.Fatal(err)
-	}
+	text = call(t, getPersonMessagesHandler(a, Options{Reads: reads}), personArgs)
 	if reads.lastBatchLimit != 1_000_000 {
 		t.Fatalf("legacy get_person_messages limit = %d, want the caller's 1000000", reads.lastBatchLimit)
 	}
-	if strings.Contains(resultText(t, result), "capped") {
-		t.Fatalf("legacy get_person_messages claimed a cap: %q", resultText(t, result))
+	if strings.Contains(text, "capped") {
+		t.Fatalf("legacy get_person_messages claimed a cap: %q", text)
 	}
 }
 
-// The un-gating itself, asserted at registration level: re-wrapping either
-// tool in unavailableInV2Primary would fail here, not just in the direct
-// handler tests above.
 func TestR5MCPPersonMessageToolsRegisteredUngatedInV2Primary(t *testing.T) {
 	a := testApp(t)
 	reads := &toolRoutingReadSource{}

--- a/internal/tools/r5_routing_test.go
+++ b/internal/tools/r5_routing_test.go
@@ -323,33 +323,63 @@ func TestR5MCPGetPersonMessagesRangeRoutesToConfiguredSourceInV2Primary(t *testi
 	if len(reads.lastBatchIDs) != 1 || reads.lastBatchIDs[0] != "v2-conversation" {
 		t.Fatalf("range conversation ids = %v", reads.lastBatchIDs)
 	}
+	// Rows are labelled in the same local time the window was parsed in.
+	wantStamp := "[" + time.UnixMilli(200).Format("2006-01-02 15:04") + "]"
+	if !strings.Contains(resultText(t, result), wantStamp) {
+		t.Fatalf("range output lacks local-time stamp %q: %q", wantStamp, resultText(t, result))
+	}
 }
 
-func TestR5MCPPersonMessageToolsClampAgentSuppliedLimits(t *testing.T) {
+func TestR5MCPPersonMessageToolsCapAgentSuppliedLimitsOnV2Only(t *testing.T) {
 	a := testApp(t)
 	reads := &toolRoutingReadSource{}
-	options := Options{Reads: reads, V2Primary: true}
+	v2 := Options{Reads: reads, V2Primary: true}
 
-	if _, err := getPersonMessagesHandler(a, options)(context.Background(), toolRequest(map[string]any{
+	result, err := getPersonMessagesHandler(a, v2)(context.Background(), toolRequest(map[string]any{
 		"name":  "V2 Conversation",
 		"limit": float64(1_000_000),
-	})); err != nil {
+	}))
+	if err != nil {
 		t.Fatal(err)
 	}
 	if reads.lastBatchLimit != maxPersonMessagesLimit {
-		t.Fatalf("get_person_messages limit = %d, want clamped to %d", reads.lastBatchLimit, maxPersonMessagesLimit)
+		t.Fatalf("v2 get_person_messages limit = %d, want capped to %d", reads.lastBatchLimit, maxPersonMessagesLimit)
+	}
+	if !strings.Contains(resultText(t, result), "limit capped at 500") {
+		t.Fatalf("capped get_person_messages did not say so: %q", resultText(t, result))
 	}
 
-	if _, err := getPersonMessagesRangeHandler(a, options)(context.Background(), toolRequest(map[string]any{
+	result, err = getPersonMessagesRangeHandler(a, v2)(context.Background(), toolRequest(map[string]any{
 		"name":   "V2 Conversation",
 		"after":  "2024-01-01",
 		"before": "2024-03-31",
-		"limit":  float64(-5),
-	})); err != nil {
+		"limit":  float64(1_000_000),
+	}))
+	if err != nil {
 		t.Fatal(err)
 	}
-	if reads.lastBatchLimit != 1 {
-		t.Fatalf("get_person_messages_range limit = %d, want clamped to 1", reads.lastBatchLimit)
+	if reads.lastBatchLimit != maxPersonMessagesRangeLimit {
+		t.Fatalf("v2 get_person_messages_range limit = %d, want capped to %d", reads.lastBatchLimit, maxPersonMessagesRangeLimit)
+	}
+	if !strings.Contains(resultText(t, result), "limit capped at 2000") {
+		t.Fatalf("capped get_person_messages_range did not say so: %q", resultText(t, result))
+	}
+
+	// Legacy-primary keeps the caller's value: the single-query store bounds
+	// its own work and never truncated before.
+	legacy := Options{Reads: reads}
+	result, err = getPersonMessagesHandler(a, legacy)(context.Background(), toolRequest(map[string]any{
+		"name":  "V2 Conversation",
+		"limit": float64(1_000_000),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reads.lastBatchLimit != 1_000_000 {
+		t.Fatalf("legacy get_person_messages limit = %d, want the caller's 1000000", reads.lastBatchLimit)
+	}
+	if strings.Contains(resultText(t, result), "capped") {
+		t.Fatalf("legacy get_person_messages claimed a cap: %q", resultText(t, result))
 	}
 }
 

--- a/internal/tools/r5_routing_test.go
+++ b/internal/tools/r5_routing_test.go
@@ -40,6 +40,14 @@ func (s *toolRoutingReadSource) ListConversations(limit int) ([]*db.Conversation
 		Name:           "V2 Conversation",
 		SourcePlatform: "sms",
 		LastMessageTS:  200,
+	}, {
+		// A titleless direct thread exactly as v2 maps them: Name "" and the
+		// peer present only in the Participants JSON.
+		ConversationID: "v2-direct",
+		Name:           "",
+		Participants:   `[{"name":"V2 Alice","number":"+15551230000"},{"name":"Me","number":"+15550009999","is_me":true}]`,
+		SourcePlatform: "whatsapp",
+		LastMessageTS:  100,
 	}}, nil
 }
 
@@ -82,7 +90,7 @@ func (s *toolRoutingReadSource) GetMessagesByConversations(conversationIDs []str
 	s.batchCalls++
 	s.lastBatchIDs = conversationIDs
 	s.lastBatchLimit = limit
-	return fakePersonMessages("v2-person-message", "v2 person body", s.batchFill), nil
+	return fakePersonMessages(conversationIDs[0], "v2-person-message", "v2 person body", s.batchFill), nil
 }
 
 func (s *toolRoutingReadSource) GetMessagesByConversationsRange(conversationIDs []string, afterMS, beforeMS int64, limit int) ([]*db.Message, error) {
@@ -91,13 +99,13 @@ func (s *toolRoutingReadSource) GetMessagesByConversationsRange(conversationIDs 
 	s.lastBatchLimit = limit
 	s.lastAfterMS = afterMS
 	s.lastBeforeMS = beforeMS
-	return fakePersonMessages("v2-person-range-message", "v2 person range body", s.rangeFill), nil
+	return fakePersonMessages(conversationIDs[0], "v2-person-range-message", "v2 person range body", s.rangeFill), nil
 }
 
 // fakePersonMessages returns one message shaped like the routing fakes, or
 // count distinct messages (ids, bodies, and timestamps all differ so the
 // range tool's near-duplicate filter keeps them all).
-func fakePersonMessages(id, body string, count int) []*db.Message {
+func fakePersonMessages(conversationID, id, body string, count int) []*db.Message {
 	if count < 1 {
 		count = 1
 	}
@@ -105,7 +113,7 @@ func fakePersonMessages(id, body string, count int) []*db.Message {
 	for i := 0; i < count; i++ {
 		message := &db.Message{
 			MessageID:      id,
-			ConversationID: "v2-conversation",
+			ConversationID: conversationID,
 			SenderName:     "V2 Alice",
 			Body:           body,
 			TimestampMS:    200,
@@ -416,6 +424,55 @@ func TestR5MCPPersonMessageToolsCapAgentSuppliedLimitsOnV2Only(t *testing.T) {
 	}
 	if strings.Contains(text, "capped") {
 		t.Fatalf("legacy get_person_messages claimed a cap: %q", text)
+	}
+	// ...but never a negative one: SQLite reads a negative LIMIT as no limit.
+	for name, handler := range map[string]server.ToolHandlerFunc{
+		"get_person_messages":       getPersonMessagesHandler(a, Options{Reads: reads}),
+		"get_person_messages_range": getPersonMessagesRangeHandler(a, Options{Reads: reads}),
+	} {
+		args := map[string]any{"name": "V2 Conversation", "after": "2024-01-01", "before": "2024-03-31", "limit": float64(-1)}
+		call(t, handler, args)
+		if reads.lastBatchLimit != 1 {
+			t.Fatalf("legacy %s passed limit %d through; want floor 1", name, reads.lastBatchLimit)
+		}
+	}
+}
+
+// Real v2 direct threads have no title — the peer lives only in Participants.
+// The person tools must match on that and label the thread by the peer.
+func TestR5MCPPersonToolsMatchTitlelessDirectThreadsByParticipant(t *testing.T) {
+	a := testApp(t)
+	reads := &toolRoutingReadSource{}
+	options := Options{Reads: reads, V2Primary: true}
+
+	result, err := getPersonMessagesHandler(a, options)(context.Background(), toolRequest(map[string]any{"name": "v2 alice"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %q", resultText(t, result))
+	}
+	if len(reads.lastBatchIDs) != 1 || reads.lastBatchIDs[0] != "v2-direct" {
+		t.Fatalf("participant match selected %v, want [v2-direct]", reads.lastBatchIDs)
+	}
+	if text := resultText(t, result); !strings.Contains(text, "--- V2 Alice [whatsapp] (ID: v2-direct) ---") {
+		t.Fatalf("titleless thread not labelled by its peer: %q", text)
+	}
+
+	result, err = getPersonMessagesRangeHandler(a, options)(context.Background(), toolRequest(map[string]any{
+		"name": "v2 alice", "after": "2024-01-01", "before": "2024-03-31",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %q", resultText(t, result))
+	}
+	if len(reads.lastBatchIDs) != 1 || reads.lastBatchIDs[0] != "v2-direct" {
+		t.Fatalf("range participant match selected %v, want [v2-direct]", reads.lastBatchIDs)
+	}
+	if text := resultText(t, result); !strings.Contains(text, "V2 Alice [whatsapp]") {
+		t.Fatalf("range header does not label the titleless thread by its peer: %q", text)
 	}
 }
 

--- a/internal/tools/story.go
+++ b/internal/tools/story.go
@@ -326,7 +326,7 @@ func getPersonMessagesRangeTool() mcp.Tool {
 		mcp.WithString("name", mcp.Required(), mcp.Description("Person's name to search for (case-insensitive partial match)")),
 		mcp.WithString("after", mcp.Required(), mcp.Description("Start date (YYYY-MM-DD, local time, e.g. '2024-01-01')")),
 		mcp.WithString("before", mcp.Required(), mcp.Description("End date (YYYY-MM-DD, local time, inclusive to end of day, e.g. '2024-03-31')")),
-		mcp.WithNumber("limit", mcp.Description("Max messages to return (default 500, max 2000)")),
+		mcp.WithNumber("limit", mcp.Description("Max messages to return (default 500; capped at 2000 on the v2 store)")),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 	)
@@ -430,7 +430,7 @@ func findPersonConversations(reads readsource.ReadSource, name string) ([]string
 			if platform == "" {
 				platform = "sms"
 			}
-			convNames = append(convNames, fmt.Sprintf("%s [%s]", c.Name, platform))
+			convNames = append(convNames, fmt.Sprintf("%s [%s]", personConversationLabel(c), platform))
 		}
 	}
 	return matchingConvIDs, convNames, nil

--- a/internal/tools/story.go
+++ b/internal/tools/story.go
@@ -348,7 +348,7 @@ func getPersonMessagesRangeHandler(a *app.App, configured ...Options) server.Too
 		if beforeStr == "" {
 			return errorResult("before is required"), nil
 		}
-		limit := clampLimit(intArg(args, "limit", 500), maxPersonMessagesRangeLimit)
+		limit, capped := personReadLimit(intArg(args, "limit", 500), maxPersonMessagesRangeLimit, options.V2Primary)
 
 		// Same parser as the CLI and /api/search/messages, so one date string
 		// selects the same local-time window on every surface.
@@ -384,10 +384,14 @@ func getPersonMessagesRangeHandler(a *app.App, configured ...Options) server.Too
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "Messages with '%s' from %s to %s (%d messages from %d conversation(s): %s)\n\n",
 			name, afterStr, beforeStr, len(deduped), len(convNames), strings.Join(convNames, ", "))
+		if capped {
+			fmt.Fprintf(&sb, "Note: limit capped at %d on the v2 store; these are the newest messages in the window — narrow the range for complete coverage.\n\n", maxPersonMessagesRangeLimit)
+		}
 		sb.WriteString(messagePreamble)
 
 		for _, m := range deduped {
-			ts := time.UnixMilli(m.TimestampMS).UTC().Format("2006-01-02 15:04")
+			// Local time, matching the local-time window bounds above.
+			ts := time.UnixMilli(m.TimestampMS).Format("2006-01-02 15:04")
 			sender := m.SenderName
 			if m.IsFromMe {
 				sender = "me"

--- a/internal/tools/story.go
+++ b/internal/tools/story.go
@@ -384,8 +384,10 @@ func getPersonMessagesRangeHandler(a *app.App, configured ...Options) server.Too
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "Messages with '%s' from %s to %s (%d messages from %d conversation(s): %s)\n\n",
 			name, afterStr, beforeStr, len(deduped), len(convNames), strings.Join(convNames, ", "))
-		if capped {
-			fmt.Fprintf(&sb, "Note: limit capped at %d on the v2 store; these are the newest messages in the window — narrow the range for complete coverage.\n\n", maxPersonMessagesRangeLimit)
+		// Only when the read actually hit the cap (pre-dedup count): a window
+		// that was fully covered must not tell the agent to narrow it.
+		if capped && len(msgs) >= limit {
+			fmt.Fprintf(&sb, "Note: limit capped at %d on the v2 store and the window holds more; only the newest messages are shown — narrow the range for complete coverage.\n\n", maxPersonMessagesRangeLimit)
 		}
 		sb.WriteString(messagePreamble)
 

--- a/internal/tools/story.go
+++ b/internal/tools/story.go
@@ -324,9 +324,9 @@ func getPersonMessagesRangeTool() mcp.Tool {
 	return mcp.NewTool("get_person_messages_range",
 		mcp.WithDescription("Get messages with a person within a date range across all platforms. Returns chronological messages formatted as '[YYYY-MM-DD HH:MM] sender: body'. Useful for deep-diving into specific periods of a relationship."),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Person's name to search for (case-insensitive partial match)")),
-		mcp.WithString("after", mcp.Required(), mcp.Description("Start date (ISO-8601, e.g. '2024-01-01')")),
-		mcp.WithString("before", mcp.Required(), mcp.Description("End date (ISO-8601, e.g. '2024-03-31')")),
-		mcp.WithNumber("limit", mcp.Description("Max messages to return (default 500)")),
+		mcp.WithString("after", mcp.Required(), mcp.Description("Start date (YYYY-MM-DD, local time, e.g. '2024-01-01')")),
+		mcp.WithString("before", mcp.Required(), mcp.Description("End date (YYYY-MM-DD, local time, inclusive to end of day, e.g. '2024-03-31')")),
+		mcp.WithNumber("limit", mcp.Description("Max messages to return (default 500, max 2000)")),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 	)
@@ -348,21 +348,18 @@ func getPersonMessagesRangeHandler(a *app.App, configured ...Options) server.Too
 		if beforeStr == "" {
 			return errorResult("before is required"), nil
 		}
-		limit := intArg(args, "limit", 500)
+		limit := clampLimit(intArg(args, "limit", 500), maxPersonMessagesRangeLimit)
 
-		afterTime, err := time.Parse("2006-01-02", afterStr)
+		// Same parser as the CLI and /api/search/messages, so one date string
+		// selects the same local-time window on every surface.
+		afterMS, err := db.ParseDayBound(afterStr, false)
 		if err != nil {
 			return errorResult(fmt.Sprintf("invalid 'after' date %q: %v", afterStr, err)), nil
 		}
-		beforeTime, err := time.Parse("2006-01-02", beforeStr)
+		beforeMS, err := db.ParseDayBound(beforeStr, true)
 		if err != nil {
 			return errorResult(fmt.Sprintf("invalid 'before' date %q: %v", beforeStr, err)), nil
 		}
-		// Include the full end date
-		beforeTime = beforeTime.Add(24*time.Hour - time.Millisecond)
-
-		afterMS := afterTime.UnixMilli()
-		beforeMS := beforeTime.UnixMilli()
 
 		// Find matching conversation IDs (reuse collectPersonMessages logic)
 		convIDs, convNames, err := findPersonConversations(options.Reads, name)

--- a/internal/tools/story.go
+++ b/internal/tools/story.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/maxghenis/openmessage/internal/app"
 	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/readsource"
 	"github.com/maxghenis/openmessage/internal/story"
 )
 
@@ -331,7 +332,8 @@ func getPersonMessagesRangeTool() mcp.Tool {
 	)
 }
 
-func getPersonMessagesRangeHandler(a *app.App) server.ToolHandlerFunc {
+func getPersonMessagesRangeHandler(a *app.App, configured ...Options) server.ToolHandlerFunc {
+	options := resolvedOptions(a, configured)
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := req.GetArguments()
 		name := strArg(args, "name")
@@ -363,7 +365,7 @@ func getPersonMessagesRangeHandler(a *app.App) server.ToolHandlerFunc {
 		beforeMS := beforeTime.UnixMilli()
 
 		// Find matching conversation IDs (reuse collectPersonMessages logic)
-		convIDs, convNames, err := findPersonConversations(a, name)
+		convIDs, convNames, err := findPersonConversations(options.Reads, name)
 		if err != nil {
 			return errorResult(err.Error()), nil
 		}
@@ -371,7 +373,7 @@ func getPersonMessagesRangeHandler(a *app.App) server.ToolHandlerFunc {
 			return textResult(fmt.Sprintf("No conversations found with '%s'.", name)), nil
 		}
 
-		msgs, err := a.Store.GetMessagesByConversationsRange(convIDs, afterMS, beforeMS, limit)
+		msgs, err := options.Reads.GetMessagesByConversationsRange(convIDs, afterMS, beforeMS, limit)
 		if err != nil {
 			return errorResult(fmt.Sprintf("get messages: %v", err)), nil
 		}
@@ -405,8 +407,8 @@ func getPersonMessagesRangeHandler(a *app.App) server.ToolHandlerFunc {
 
 // findPersonConversations returns matching conversation IDs and display names
 // for a person. Extracted from collectPersonMessages for reuse.
-func findPersonConversations(a *app.App, name string) ([]string, []string, error) {
-	allConvs, err := a.Store.ListConversations(1000)
+func findPersonConversations(reads readsource.ReadSource, name string) ([]string, []string, error) {
+	allConvs, err := reads.ListConversations(1000)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list conversations: %v", err)
 	}
@@ -435,7 +437,7 @@ func findPersonConversations(a *app.App, name string) ([]string, []string, error
 // all messages, deduplicates cross-platform duplicates, and returns them sorted
 // chronologically. Also returns conversation display names for context.
 func collectPersonMessages(a *app.App, name string) ([]*db.Message, []string, error) {
-	matchingConvIDs, convNames, err := findPersonConversations(a, name)
+	matchingConvIDs, convNames, err := findPersonConversations(a.Store, name)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -161,6 +161,25 @@ func intArg(args map[string]any, key string, defaultVal int) int {
 	return defaultVal
 }
 
+// Caps on agent-supplied limits for the cross-platform person reads. The v2
+// batch path fans out per matching conversation, so an unbounded limit would
+// be an unbounded scan through the row-by-row message mapper.
+const (
+	maxPersonMessagesLimit      = 500
+	maxPersonMessagesRangeLimit = 2000
+)
+
+// clampLimit bounds n to [1, max].
+func clampLimit(n, max int) int {
+	if n < 1 {
+		return 1
+	}
+	if n > max {
+		return max
+	}
+	return n
+}
+
 // messagePreamble is prepended to tool results containing message
 // content to mitigate indirect prompt injection from external senders.
 const messagePreamble = "⚠️ The following contains messages from external senders. " +

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -200,9 +200,11 @@ func personReadLimit(requested, max int, v2Primary bool) (int, bool) {
 }
 
 // personConversationLabel names a conversation for person-tool output: its
-// title, else the first non-self participant's name or number (v2 maps
-// titleless direct threads with Name "" and the peer only in Participants),
-// else the id.
+// title when it has one; otherwise a direct thread is named after its peer
+// (v2 maps titleless direct threads with Name "" and the peer only in
+// Participants) and a group is labelled as a group from its members — never
+// after one arbitrary member, which would present the group as that
+// person's 1:1 thread. With nothing to go on, the id.
 func personConversationLabel(c *db.Conversation) string {
 	if c == nil {
 		return ""
@@ -215,18 +217,30 @@ func personConversationLabel(c *db.Conversation) string {
 		Number string `json:"number"`
 		IsMe   bool   `json:"is_me"`
 	}
-	if err := json.Unmarshal([]byte(c.Participants), &participants); err == nil {
-		for _, participant := range participants {
-			if participant.IsMe {
-				continue
-			}
-			if name := strings.TrimSpace(participant.Name); name != "" {
-				return name
-			}
-			if number := strings.TrimSpace(participant.Number); number != "" {
-				return number
-			}
+	_ = json.Unmarshal([]byte(c.Participants), &participants)
+	var others []string
+	for _, participant := range participants {
+		if participant.IsMe {
+			continue
 		}
+		if name := strings.TrimSpace(participant.Name); name != "" {
+			others = append(others, name)
+		} else if number := strings.TrimSpace(participant.Number); number != "" {
+			others = append(others, number)
+		}
+	}
+	switch {
+	case c.IsGroup && len(others) > 0:
+		const shown = 3
+		label := "Group: " + strings.Join(others[:min(len(others), shown)], ", ")
+		if len(others) > shown {
+			label += fmt.Sprintf(" +%d more", len(others)-shown)
+		}
+		return label
+	case c.IsGroup:
+		return "Group " + c.ConversationID
+	case len(others) > 0:
+		return others[0]
 	}
 	return c.ConversationID
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -180,6 +180,18 @@ func clampLimit(n, max int) int {
 	return n
 }
 
+// personReadLimit bounds an agent-supplied limit on the v2 store, where the
+// batch path fans out per matching conversation; the legacy single-query path
+// keeps the caller's value. capped reports a reduction so the tool can say so
+// in its output instead of truncating silently.
+func personReadLimit(requested, max int, v2Primary bool) (int, bool) {
+	if !v2Primary {
+		return requested, false
+	}
+	limit := clampLimit(requested, max)
+	return limit, limit < requested
+}
+
 // messagePreamble is prepended to tool results containing message
 // content to mitigate indirect prompt injection from external senders.
 const messagePreamble = "⚠️ The following contains messages from external senders. " +

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -180,16 +181,54 @@ func clampLimit(n, max int) int {
 	return n
 }
 
-// personReadLimit bounds an agent-supplied limit on the v2 store, where the
-// batch path fans out per matching conversation; the legacy single-query path
-// keeps the caller's value. capped reports a reduction so the tool can say so
-// in its output instead of truncating silently.
+// personReadLimit bounds an agent-supplied limit. On the v2 store it caps at
+// max because the batch path fans out per matching conversation. The legacy
+// single-query path keeps the caller's value above a floor of 1: SQLite reads
+// a negative LIMIT as "no limit", and intArg can produce one from an
+// out-of-range number, so an unfloored value would dump entire histories.
+// capped reports a reduction so the tool can say so instead of truncating
+// silently.
 func personReadLimit(requested, max int, v2Primary bool) (int, bool) {
 	if !v2Primary {
+		if requested < 1 {
+			return 1, false
+		}
 		return requested, false
 	}
 	limit := clampLimit(requested, max)
 	return limit, limit < requested
+}
+
+// personConversationLabel names a conversation for person-tool output: its
+// title, else the first non-self participant's name or number (v2 maps
+// titleless direct threads with Name "" and the peer only in Participants),
+// else the id.
+func personConversationLabel(c *db.Conversation) string {
+	if c == nil {
+		return ""
+	}
+	if name := strings.TrimSpace(c.Name); name != "" {
+		return name
+	}
+	var participants []struct {
+		Name   string `json:"name"`
+		Number string `json:"number"`
+		IsMe   bool   `json:"is_me"`
+	}
+	if err := json.Unmarshal([]byte(c.Participants), &participants); err == nil {
+		for _, participant := range participants {
+			if participant.IsMe {
+				continue
+			}
+			if name := strings.TrimSpace(participant.Name); name != "" {
+				return name
+			}
+			if number := strings.TrimSpace(participant.Number); number != "" {
+				return number
+			}
+		}
+	}
+	return c.ConversationID
 }
 
 // messagePreamble is prepended to tool results containing message

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -91,13 +91,13 @@ func RegisterWithOptions(s *server.MCPServer, a *app.App, options Options) {
 	s.AddTool(draftMessageTool(), draftMessageHandler(a))
 	s.AddTool(downloadMediaTool(), downloadMediaHandler(a))
 	s.AddTool(importMessagesTool(), importMessagesHandler(a))
-	s.AddTool(getPersonMessagesTool(), unavailableInV2Primary(v2Primary, getPersonMessagesHandler(a)))
+	s.AddTool(getPersonMessagesTool(), getPersonMessagesHandler(a, options))
+	s.AddTool(getPersonMessagesRangeTool(), getPersonMessagesRangeHandler(a, options))
 	s.AddTool(conversationStatsTool(), unavailableInV2Primary(v2Primary, conversationStatsHandler(a)))
 	s.AddTool(generateStoryTool(), unavailableInV2Primary(v2Primary, generateStoryHandler(a)))
 	s.AddTool(personStatsTool(), unavailableInV2Primary(v2Primary, personStatsHandler(a)))
 	s.AddTool(generatePersonStoryTool(), unavailableInV2Primary(v2Primary, generatePersonStoryHandler(a)))
 	s.AddTool(generateVizTool(), unavailableInV2Primary(v2Primary, generateVizHandler(a)))
-	s.AddTool(getPersonMessagesRangeTool(), unavailableInV2Primary(v2Primary, getPersonMessagesRangeHandler(a)))
 	s.AddTool(renderStoryTool(), unavailableInV2Primary(v2Primary, renderStoryHandler(a)))
 	switch {
 	case options.Daemon != nil:
@@ -109,7 +109,16 @@ func RegisterWithOptions(s *server.MCPServer, a *app.App, options Options) {
 	}
 }
 
-const unavailableWhileV2Serving = "not available while v2 is the serving store"
+// unavailableWhileV2Serving explains the gate on the stats/story/viz tools:
+// they load complete conversation histories from the legacy store, which froze
+// at the v2 cutover, and the v2 read path maps messages row-by-row (identity,
+// attachment, send-status lookups per message) — pathological at full-history
+// scale. The error names the tools that DO serve v2 reads so agents don't
+// dead-end here.
+const unavailableWhileV2Serving = "not available while v2 is the serving store: " +
+	"this tool still reads the legacy store, which froze at the v2 cutover. " +
+	"To read messages, use get_person_messages, get_person_messages_range, " +
+	"search_messages, or get_messages instead."
 
 func unavailableInV2Primary(primary bool, legacy server.ToolHandlerFunc) server.ToolHandlerFunc {
 	if !primary {

--- a/internal/v2read/batch.go
+++ b/internal/v2read/batch.go
@@ -53,14 +53,23 @@ func (s *Source) batchMessages(
 	}
 
 	// Prune to the newest limit after every conversation so the working set
-	// never exceeds 2×limit however many conversations match.
+	// never exceeds 2×limit, and once it is full use the oldest kept row as
+	// the floor for later conversations: only rows at least that new can
+	// still enter the result, so their walks stop at the first page that
+	// drops below it. Ties at the floor are fetched and settled by keepNewest.
 	var merged []sqlite.Message
+	floorMS := afterMS
 	for _, conversationID := range resolved {
-		rows, err := s.conversationMessagesInRange(conversationID, afterMS, beforeMS, limit)
+		rows, err := s.conversationMessagesInRange(conversationID, floorMS, beforeMS, limit)
 		if err != nil {
 			return nil, err
 		}
 		merged = keepNewest(append(merged, rows...), limit)
+		if len(merged) == limit {
+			if oldest := merged[len(merged)-1].OccurredAtMS; oldest > floorMS {
+				floorMS = oldest
+			}
+		}
 	}
 
 	// Present ascending.
@@ -102,6 +111,7 @@ func (s *Source) conversationMessagesInRange(
 	collected := make([]sqlite.Message, 0, min(limit, sourceMessagePageSize))
 	for len(collected) < limit {
 		pageSize := min(limit-len(collected), sourceMessagePageSize)
+		s.batchPageQueries.Add(1)
 		page, err := s.messages.ListMessagesByConversation(
 			context.Background(), conversationID, cursorMS, cursorID, pageSize,
 		)

--- a/internal/v2read/batch.go
+++ b/internal/v2read/batch.go
@@ -52,29 +52,37 @@ func (s *Source) batchMessages(
 		resolved = append(resolved, id)
 	}
 
+	// Prune to the newest limit after every conversation so the working set
+	// never exceeds 2×limit however many conversations match.
 	var merged []sqlite.Message
 	for _, conversationID := range resolved {
 		rows, err := s.conversationMessagesInRange(conversationID, afterMS, beforeMS, limit)
 		if err != nil {
 			return nil, err
 		}
-		merged = append(merged, rows...)
+		merged = keepNewest(append(merged, rows...), limit)
 	}
 
-	// Keep the newest limit across the set, then present ascending.
-	sort.Slice(merged, func(i, j int) bool {
-		if merged[i].OccurredAtMS != merged[j].OccurredAtMS {
-			return merged[i].OccurredAtMS > merged[j].OccurredAtMS
-		}
-		return merged[i].MessageID > merged[j].MessageID
-	})
-	if len(merged) > limit {
-		merged = merged[:limit]
-	}
+	// Present ascending.
 	for i, j := 0, len(merged)-1; i < j; i, j = i+1, j-1 {
 		merged[i], merged[j] = merged[j], merged[i]
 	}
 	return s.mapMessages(merged)
+}
+
+// keepNewest orders messages newest-first by (occurred_at_ms, message_id) —
+// the legacy store's tiebreak — and truncates to limit.
+func keepNewest(messages []sqlite.Message, limit int) []sqlite.Message {
+	sort.Slice(messages, func(i, j int) bool {
+		if messages[i].OccurredAtMS != messages[j].OccurredAtMS {
+			return messages[i].OccurredAtMS > messages[j].OccurredAtMS
+		}
+		return messages[i].MessageID > messages[j].MessageID
+	})
+	if len(messages) > limit {
+		messages = messages[:limit]
+	}
+	return messages
 }
 
 // conversationMessagesInRange collects up to limit newest-first rows for one

--- a/internal/v2read/batch.go
+++ b/internal/v2read/batch.go
@@ -1,0 +1,120 @@
+package v2read
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/maxghenis/openmessage/internal/db"
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+// GetMessagesByConversations returns the newest limit messages across the
+// given conversations, ordered by timestamp ascending — the same contract as
+// the legacy store's batch query.
+func (s *Source) GetMessagesByConversations(
+	conversationIDs []string,
+	limit int,
+) ([]*db.Message, error) {
+	return s.batchMessages(conversationIDs, 0, 0, limit)
+}
+
+// GetMessagesByConversationsRange returns the newest limit messages across
+// the given conversations with afterMS <= timestamp <= beforeMS (each bound
+// applied only when > 0), ordered by timestamp ascending.
+func (s *Source) GetMessagesByConversationsRange(
+	conversationIDs []string,
+	afterMS, beforeMS int64,
+	limit int,
+) ([]*db.Message, error) {
+	return s.batchMessages(conversationIDs, afterMS, beforeMS, limit)
+}
+
+func (s *Source) batchMessages(
+	conversationIDs []string,
+	afterMS, beforeMS int64,
+	limit int,
+) ([]*db.Message, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	if len(conversationIDs) == 0 || limit <= 0 {
+		return nil, nil
+	}
+
+	resolved := make([]string, 0, len(conversationIDs))
+	seen := make(map[string]struct{}, len(conversationIDs))
+	for _, id := range conversationIDs {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		resolved = append(resolved, id)
+	}
+
+	var merged []sqlite.Message
+	for _, conversationID := range resolved {
+		rows, err := s.conversationMessagesInRange(conversationID, afterMS, beforeMS, limit)
+		if err != nil {
+			return nil, err
+		}
+		merged = append(merged, rows...)
+	}
+
+	// Keep the newest limit across the set, then present ascending.
+	sort.Slice(merged, func(i, j int) bool {
+		if merged[i].OccurredAtMS != merged[j].OccurredAtMS {
+			return merged[i].OccurredAtMS > merged[j].OccurredAtMS
+		}
+		return merged[i].MessageID > merged[j].MessageID
+	})
+	if len(merged) > limit {
+		merged = merged[:limit]
+	}
+	for i, j := 0, len(merged)-1; i < j; i, j = i+1, j-1 {
+		merged[i], merged[j] = merged[j], merged[i]
+	}
+	return s.mapMessages(merged)
+}
+
+// conversationMessagesInRange collects up to limit newest-first rows for one
+// conversation, bounded by the optional afterMS/beforeMS range. The upper
+// bound rides the repository's exclusive before-cursor (beforeMS+1 makes it
+// inclusive); the lower bound is enforced while walking newest-first pages.
+func (s *Source) conversationMessagesInRange(
+	conversationID string,
+	afterMS, beforeMS int64,
+	limit int,
+) ([]sqlite.Message, error) {
+	var cursorMS int64
+	var cursorID string
+	if beforeMS > 0 {
+		cursorMS = beforeMS + 1
+	}
+	collected := make([]sqlite.Message, 0, min(limit, sourceMessagePageSize))
+	for len(collected) < limit {
+		pageSize := min(limit-len(collected), sourceMessagePageSize)
+		page, err := s.messages.ListMessagesByConversation(
+			context.Background(), conversationID, cursorMS, cursorID, pageSize,
+		)
+		if err != nil {
+			return nil, err
+		}
+		for _, message := range page {
+			if afterMS > 0 && message.OccurredAtMS < afterMS {
+				return collected, nil
+			}
+			collected = append(collected, message)
+		}
+		if len(page) < pageSize {
+			return collected, nil
+		}
+		last := page[len(page)-1]
+		if last.OccurredAtMS == cursorMS && last.MessageID == cursorID {
+			return nil, errors.New("v2 read message pagination did not advance")
+		}
+		cursorMS = last.OccurredAtMS
+		cursorID = last.MessageID
+	}
+	return collected, nil
+}

--- a/internal/v2read/batch_test.go
+++ b/internal/v2read/batch_test.go
@@ -124,6 +124,40 @@ func TestBatchGetMessagesByConversationsWalksBeyondPageSize(t *testing.T) {
 	}
 }
 
+// Once the merged set is full, later conversations are walked only down to
+// the oldest kept row, so the read work is bounded by the result, not by
+// (conversations × limit).
+func TestBatchGetMessagesByConversationsUsesMergedFloorToBoundPageWalks(t *testing.T) {
+	store, messages, source := openSourceTestStore(t)
+	seedSourceAccount(t, store, "batch-account", "google_messages")
+	seedBatchConversation(t, store, "conv-new")
+	seedBatchConversation(t, store, "conv-old")
+
+	total := sourceMessagePageSize + 100
+	for i := 0; i < total; i++ {
+		seedBatchMessage(t, messages, "conv-new", fmt.Sprintf("new-%04d", i), int64(10_000+i))
+		seedBatchMessage(t, messages, "conv-old", fmt.Sprintf("old-%04d", i), int64(1+i))
+	}
+
+	limit := sourceMessagePageSize + 50
+	before := source.batchPageQueries.Load()
+	got, err := source.GetMessagesByConversations([]string{"conv-new", "conv-old"}, limit)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got) != limit {
+		t.Fatalf("count: got %d, want %d", len(got), limit)
+	}
+	if got[0].MessageID != fmt.Sprintf("new-%04d", total-limit) || got[len(got)-1].MessageID != fmt.Sprintf("new-%04d", total-1) {
+		t.Fatalf("range = [%s, %s], want the newest %d of conv-new", got[0].MessageID, got[len(got)-1].MessageID, limit)
+	}
+	// conv-new needs two pages (200 + 50) to fill the result; conv-old's first
+	// page is entirely below the floor, so it costs exactly one page.
+	if pages := source.batchPageQueries.Load() - before; pages != 3 {
+		t.Fatalf("page queries = %d, want 3 (2 to fill from conv-new, 1 floor check on conv-old)", pages)
+	}
+}
+
 func TestBatchGetMessagesByConversationsDedupesInputIDsAndHandlesEmpty(t *testing.T) {
 	store, messages, source := openSourceTestStore(t)
 	seedSourceAccount(t, store, "batch-account", "google_messages")

--- a/internal/v2read/batch_test.go
+++ b/internal/v2read/batch_test.go
@@ -1,0 +1,154 @@
+package v2read
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func seedBatchConversation(t *testing.T, store *sqlite.Store, conversationID string) {
+	t.Helper()
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       conversationID,
+		AccountID:            "batch-account",
+		RemoteConversationID: "remote-" + conversationID,
+		Kind:                 sqlite.ConversationKindDirect,
+		NotificationMode:     sqlite.NotificationModeAll,
+	})
+}
+
+func seedBatchMessage(t *testing.T, messages *sqlite.MessageRepository, conversationID, messageID string, occurredAtMS int64) {
+	t.Helper()
+	importSourceMessage(t, messages, sqlite.Message{
+		MessageID:       messageID,
+		ConversationID:  conversationID,
+		AccountID:       "batch-account",
+		RemoteMessageID: "remote-" + messageID,
+		Direction:       sqlite.MessageDirectionIncoming,
+		Body:            "body " + messageID,
+		State:           sqlite.MessageStateActive,
+		OccurredAtMS:    occurredAtMS,
+	})
+}
+
+func TestBatchGetMessagesByConversationsReturnsNewestLimitAscending(t *testing.T) {
+	store, messages, source := openSourceTestStore(t)
+	seedSourceAccount(t, store, "batch-account", "google_messages")
+	seedBatchConversation(t, store, "conv-1")
+	seedBatchConversation(t, store, "conv-2")
+
+	for i := 0; i < 6; i++ {
+		seedBatchMessage(t, messages, "conv-1", fmt.Sprintf("conv-1-%d", i), int64(1000+i*100))
+		seedBatchMessage(t, messages, "conv-2", fmt.Sprintf("conv-2-%d", i), int64(1050+i*100))
+	}
+
+	got, err := source.GetMessagesByConversations([]string{"conv-1", "conv-2"}, 5)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	assertMessageIDs(t, got, "conv-2-3", "conv-1-4", "conv-2-4", "conv-1-5", "conv-2-5")
+}
+
+func TestBatchGetMessagesByConversationsRangeBoundsAreInclusive(t *testing.T) {
+	store, messages, source := openSourceTestStore(t)
+	seedSourceAccount(t, store, "batch-account", "google_messages")
+	seedBatchConversation(t, store, "conv-1")
+	seedBatchConversation(t, store, "conv-2")
+
+	for i := 0; i < 6; i++ {
+		seedBatchMessage(t, messages, "conv-1", fmt.Sprintf("range-1-%d", i), int64(1000+i*100))
+		seedBatchMessage(t, messages, "conv-2", fmt.Sprintf("range-2-%d", i), int64(1050+i*100))
+	}
+
+	got, err := source.GetMessagesByConversationsRange([]string{"conv-1", "conv-2"}, 1200, 1600, 4)
+	if err != nil {
+		t.Fatalf("get range: %v", err)
+	}
+	assertMessageIDs(t, got, "range-1-4", "range-2-4", "range-1-5", "range-2-5")
+
+	// Exact-boundary timestamps stay included on both ends.
+	edges, err := source.GetMessagesByConversationsRange([]string{"conv-1"}, 1200, 1400, 10)
+	if err != nil {
+		t.Fatalf("get edge range: %v", err)
+	}
+	assertMessageIDs(t, edges, "range-1-2", "range-1-3", "range-1-4")
+}
+
+func TestBatchGetMessagesByConversationsUsesMessageIDTieBreaker(t *testing.T) {
+	store, messages, source := openSourceTestStore(t)
+	seedSourceAccount(t, store, "batch-account", "google_messages")
+	seedBatchConversation(t, store, "conv-1")
+
+	for _, id := range []string{"a", "b", "c"} {
+		seedBatchMessage(t, messages, "conv-1", id, 1000)
+	}
+
+	got, err := source.GetMessagesByConversations([]string{"conv-1"}, 2)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	assertMessageIDs(t, got, "b", "c")
+
+	ranged, err := source.GetMessagesByConversationsRange([]string{"conv-1"}, 900, 1100, 2)
+	if err != nil {
+		t.Fatalf("get range: %v", err)
+	}
+	assertMessageIDs(t, ranged, "b", "c")
+}
+
+func TestBatchGetMessagesByConversationsWalksBeyondPageSize(t *testing.T) {
+	store, messages, source := openSourceTestStore(t)
+	seedSourceAccount(t, store, "batch-account", "google_messages")
+	seedBatchConversation(t, store, "conv-1")
+
+	total := sourceMessagePageSize + 50
+	for i := 0; i < total; i++ {
+		seedBatchMessage(t, messages, "conv-1", fmt.Sprintf("m-%04d", i), int64(1000+i))
+	}
+
+	limit := sourceMessagePageSize + 10
+	got, err := source.GetMessagesByConversationsRange([]string{"conv-1"}, 1, 0, limit)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got) != limit {
+		t.Fatalf("count: got %d, want %d", len(got), limit)
+	}
+	// Newest `limit` of the seeded set, ascending.
+	if got[0].MessageID != fmt.Sprintf("m-%04d", total-limit) {
+		t.Fatalf("first = %q, want %q", got[0].MessageID, fmt.Sprintf("m-%04d", total-limit))
+	}
+	if got[len(got)-1].MessageID != fmt.Sprintf("m-%04d", total-1) {
+		t.Fatalf("last = %q, want %q", got[len(got)-1].MessageID, fmt.Sprintf("m-%04d", total-1))
+	}
+}
+
+func TestBatchGetMessagesByConversationsDedupesInputIDsAndHandlesEmpty(t *testing.T) {
+	store, messages, source := openSourceTestStore(t)
+	seedSourceAccount(t, store, "batch-account", "google_messages")
+	seedBatchConversation(t, store, "conv-1")
+	seedBatchMessage(t, messages, "conv-1", "only", 1000)
+
+	got, err := source.GetMessagesByConversations([]string{"conv-1", "conv-1"}, 10)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	assertMessageIDs(t, got, "only")
+
+	empty, err := source.GetMessagesByConversations(nil, 10)
+	if err != nil {
+		t.Fatalf("get empty: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("empty ids returned %d messages", len(empty))
+	}
+
+	zero, err := source.GetMessagesByConversations([]string{"conv-1"}, 0)
+	if err != nil {
+		t.Fatalf("get zero limit: %v", err)
+	}
+	if len(zero) != 0 {
+		t.Fatalf("zero limit returned %d messages", len(zero))
+	}
+}

--- a/internal/v2read/conversations.go
+++ b/internal/v2read/conversations.go
@@ -33,6 +33,35 @@ func (s *Source) ListConversations(limit int) ([]*db.Conversation, error) {
 	return mapped, nil
 }
 
+// SearchConversationsByMetadata is the v2 counterpart of the legacy metadata
+// search: a bounded title/participant substring match in SQL, mapping only the
+// hits (at most limit) rather than the whole conversation list.
+func (s *Source) SearchConversationsByMetadata(query string, limit int) ([]*db.Conversation, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	conversations, err := s.store.SearchConversationsByName(query, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(conversations) == 0 {
+		return []*db.Conversation{}, nil
+	}
+	accounts, err := s.accountIndex()
+	if err != nil {
+		return nil, fmt.Errorf("search conversations: %w", err)
+	}
+	mapped := make([]*db.Conversation, 0, len(conversations))
+	for _, conversation := range conversations {
+		dto, err := s.mapConversation(conversation, accounts)
+		if err != nil {
+			return nil, err
+		}
+		mapped = append(mapped, dto)
+	}
+	return mapped, nil
+}
+
 // GetConversation returns one v2 conversation as the canonical legacy DTO.
 // The id may be a v2 conversation ID or a legacy remote conversation ID; the
 // returned DTO always carries the canonical v2 ID.

--- a/internal/v2read/conversations_search_test.go
+++ b/internal/v2read/conversations_search_test.go
@@ -1,0 +1,142 @@
+package v2read
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maxghenis/openmessage/internal/storage/sqlite"
+)
+
+func seedSearchFixture(t *testing.T, store *sqlite.Store) {
+	t.Helper()
+	seedSourceAccount(t, store, "search-account", "google_messages")
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conversation-group",
+		AccountID:            "search-account",
+		RemoteConversationID: "remote-group",
+		Kind:                 sqlite.ConversationKindGroup,
+		Title:                "Byte-exact group",
+		NotificationMode:     sqlite.NotificationModeAll,
+		LastMessageAtMS:      300,
+	})
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conversation-direct",
+		AccountID:            "search-account",
+		RemoteConversationID: "remote-direct",
+		Kind:                 sqlite.ConversationKindDirect,
+		NotificationMode:     sqlite.NotificationModeAll,
+		LastMessageAtMS:      200,
+	})
+	if err := store.UpsertIdentity(sqlite.Identity{
+		IdentityID:     "identity-alice",
+		AccountID:      "search-account",
+		Kind:           sqlite.IdentityKind("e164"),
+		CanonicalValue: "+15550000001",
+		RawValue:       "+1 (555) 000-0001",
+		DisplayName:    "Alice Example",
+		MetadataJSON:   `{}`,
+		CreatedAtMS:    sourceTestTimeMS,
+		UpdatedAtMS:    sourceTestTimeMS,
+	}); err != nil {
+		t.Fatalf("UpsertIdentity(): %v", err)
+	}
+	if err := store.ReplaceConversationParticipants("conversation-direct", []sqlite.ConversationParticipant{{
+		AccountID:      "search-account",
+		ConversationID: "conversation-direct",
+		IdentityID:     "identity-alice",
+		Role:           sqlite.ParticipantRoleMember,
+		DisplayName:    "Ali (nickname)",
+		IsActive:       true,
+	}}); err != nil {
+		t.Fatalf("ReplaceConversationParticipants(): %v", err)
+	}
+}
+
+func TestSearchConversationsByMetadataMatchesTitleParticipantsAndAddresses(t *testing.T) {
+	store, _, source := openSourceTestStore(t)
+	seedSearchFixture(t, store)
+
+	for name, query := range map[string]string{
+		"identity display name, case-insensitive": "alice",
+		"participant display name":                "nickname",
+		"canonical address":                       "5550000001",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := source.SearchConversationsByMetadata(query, 10)
+			if err != nil {
+				t.Fatalf("search %q: %v", query, err)
+			}
+			assertConversationIDs(t, got, "conversation-direct")
+			if !strings.Contains(got[0].Participants, "Ali (nickname)") {
+				t.Fatalf("direct conversation participants = %q, want the matched peer", got[0].Participants)
+			}
+		})
+	}
+
+	group, err := source.SearchConversationsByMetadata("BYTE-EXACT", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertConversationIDs(t, group, "conversation-group")
+}
+
+func TestSearchConversationsByMetadataOrdersNewestFirstAndBoundsResults(t *testing.T) {
+	store, _, source := openSourceTestStore(t)
+	seedSearchFixture(t, store)
+	// "e" appears in both the group title and Alice's name.
+	all, err := source.SearchConversationsByMetadata("e", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertConversationIDs(t, all, "conversation-group", "conversation-direct")
+
+	one, err := source.SearchConversationsByMetadata("e", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertConversationIDs(t, one, "conversation-group")
+
+	none, err := source.SearchConversationsByMetadata("zzz-no-such-thread", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("no-match search returned %d rows", len(none))
+	}
+	empty, err := source.SearchConversationsByMetadata("   ", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("blank query returned %d rows", len(empty))
+	}
+}
+
+func TestSearchConversationsByMetadataTreatsLikeMetacharactersLiterally(t *testing.T) {
+	store, _, source := openSourceTestStore(t)
+	seedSearchFixture(t, store)
+
+	for _, query := range []string{"%", "_", `\`} {
+		got, err := source.SearchConversationsByMetadata(query, 10)
+		if err != nil {
+			t.Fatalf("search %q: %v", query, err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("metacharacter query %q matched %d rows; it must match literally", query, len(got))
+		}
+	}
+	seedSourceConversation(t, store, sqlite.Conversation{
+		ConversationID:       "conversation-percent",
+		AccountID:            "search-account",
+		RemoteConversationID: "remote-percent",
+		Kind:                 sqlite.ConversationKindGroup,
+		Title:                "100% done",
+		NotificationMode:     sqlite.NotificationModeAll,
+		LastMessageAtMS:      100,
+	})
+	got, err := source.SearchConversationsByMetadata("%", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertConversationIDs(t, got, "conversation-percent")
+}

--- a/internal/v2read/conversations_search_test.go
+++ b/internal/v2read/conversations_search_test.go
@@ -40,12 +40,32 @@ func seedSearchFixture(t *testing.T, store *sqlite.Store) {
 	}); err != nil {
 		t.Fatalf("UpsertIdentity(): %v", err)
 	}
+	if err := store.UpsertIdentity(sqlite.Identity{
+		IdentityID:     "identity-self",
+		AccountID:      "search-account",
+		Kind:           sqlite.IdentityKind("e164"),
+		CanonicalValue: "+15550009999",
+		RawValue:       "+15550009999",
+		DisplayName:    "Me",
+		IsSelf:         true,
+		MetadataJSON:   `{}`,
+		CreatedAtMS:    sourceTestTimeMS,
+		UpdatedAtMS:    sourceTestTimeMS,
+	}); err != nil {
+		t.Fatalf("UpsertIdentity(self): %v", err)
+	}
 	if err := store.ReplaceConversationParticipants("conversation-direct", []sqlite.ConversationParticipant{{
 		AccountID:      "search-account",
 		ConversationID: "conversation-direct",
 		IdentityID:     "identity-alice",
 		Role:           sqlite.ParticipantRoleMember,
 		DisplayName:    "Ali (nickname)",
+		IsActive:       true,
+	}, {
+		AccountID:      "search-account",
+		ConversationID: "conversation-direct",
+		IdentityID:     "identity-self",
+		Role:           sqlite.ParticipantRoleMember,
 		IsActive:       true,
 	}}); err != nil {
 		t.Fatalf("ReplaceConversationParticipants(): %v", err)
@@ -69,6 +89,13 @@ func TestSearchConversationsByMetadataMatchesTitleParticipantsAndAddresses(t *te
 			assertConversationIDs(t, got, "conversation-direct")
 			if !strings.Contains(got[0].Participants, "Ali (nickname)") {
 				t.Fatalf("direct conversation participants = %q, want the matched peer", got[0].Participants)
+			}
+			// The account owner is flagged so readers can tell it from the peer.
+			if !strings.Contains(got[0].Participants, `"name":"Me","number":"+15550009999","is_me":true`) {
+				t.Fatalf("self participant not flagged is_me: %q", got[0].Participants)
+			}
+			if strings.Contains(got[0].Participants, `"Ali (nickname)","number":"+15550000001","is_me"`) {
+				t.Fatalf("peer participant wrongly flagged is_me: %q", got[0].Participants)
 			}
 		})
 	}

--- a/internal/v2read/map.go
+++ b/internal/v2read/map.go
@@ -13,9 +13,12 @@ import (
 	"github.com/maxghenis/openmessage/internal/storage/sqlite"
 )
 
+// participantDTO mirrors the legacy participants JSON, including the
+// is_me flag readers use to tell the account owner from the peer.
 type participantDTO struct {
 	Name   string `json:"name"`
 	Number string `json:"number"`
+	IsMe   bool   `json:"is_me,omitempty"`
 }
 
 type reactionDTO struct {
@@ -121,6 +124,7 @@ func (s *Source) participantInfos(conversationID string) ([]participantInfo, err
 			dto: participantDTO{
 				Name:   name,
 				Number: identity.CanonicalValue,
+				IsMe:   identity.IsSelf,
 			},
 			isSelf: identity.IsSelf,
 		})

--- a/internal/v2read/source.go
+++ b/internal/v2read/source.go
@@ -4,6 +4,7 @@ package v2read
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/maxghenis/openmessage/internal/readsource"
@@ -19,6 +20,10 @@ type Source struct {
 	attachments *sqlite.MessageAttachmentRepository
 	outbox      *sqlite.OutboxRepository
 	reactions   *sqlite.ReactionRepository
+
+	// batchPageQueries counts the page reads issued by the batch walks so
+	// tests can bound the read work, not just the result.
+	batchPageQueries atomic.Int64
 }
 
 // New constructs a v2 canonical read source. A nil store is retained as an

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1524,6 +1524,12 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "until: "+err.Error(), 400)
 			return
 		}
+		// The legacy store swaps a reversed window and v2 passes it through;
+		// reject it so both stores answer identically.
+		if sinceMS > 0 && untilMS > 0 && sinceMS > untilMS {
+			httpError(w, "since must not be after until", 400)
+			return
+		}
 		filter := db.SearchFilter{
 			Phone:          strings.TrimSpace(r.URL.Query().Get("phone")),
 			ConversationID: strings.TrimSpace(r.URL.Query().Get("conversation_id")),

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1483,23 +1483,18 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			httpError(w, "search: "+err.Error(), 500)
 			return
 		}
-		var (
-			convos        []*db.Conversation
-			identityStore *db.Store
-		)
-		if opts.V2Primary {
-			// The metadata query below is legacy-schema SQL; on v2 match
-			// conversation names/participants from the canonical read source
-			// so searching a person's name still finds their threads even
-			// when the name never appears in message text.
-			convos, err = searchConversationsByName(reads, q, limit)
-		} else {
-			convos, err = store.SearchConversationsByMetadata(q, limit)
+		var identityStore *db.Store
+		if !opts.V2Primary {
 			identityStore = store
 		}
+		// Name/participant matches so searching a person finds their threads
+		// even when the name never appears in message text. Message hits
+		// still render if this fails — one unmappable conversation must not
+		// blank the search box.
+		convos, err := reads.SearchConversationsByMetadata(q, limit)
 		if err != nil {
-			httpError(w, "search: "+err.Error(), 500)
-			return
+			logger.Warn().Err(err).Msg("conversation metadata search failed; serving message hits only")
+			convos = nil
 		}
 		results := mergeSearchResults(reads, identityStore, msgs, convos, limit)
 		writeJSON(w, results)
@@ -1510,7 +1505,11 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	// than the conversation summaries /api/search produces. This is the HTTP
 	// twin of the search_messages MCP tool, for agents and scripts.
 	mux.HandleFunc("/api/search/messages", func(w http.ResponseWriter, r *http.Request) {
-		q := r.URL.Query().Get("q")
+		if r.Method != http.MethodGet {
+			httpError(w, "method not allowed", 405)
+			return
+		}
+		q := strings.TrimSpace(r.URL.Query().Get("q"))
 		if q == "" {
 			httpError(w, "query parameter 'q' is required", 400)
 			return
@@ -3129,36 +3128,6 @@ func splitHostPortDefault(hostport, defaultPort string) (string, string, bool) {
 		port = defaultPort
 	}
 	return u.Hostname(), port, true
-}
-
-// searchConversationsByName is the v2 counterpart of the legacy
-// SearchConversationsByMetadata: a case-insensitive substring match over
-// conversation names and participants from the canonical read source. The
-// legacy query's sender/contact joins have no v2 seam, so this covers the
-// name/participants clauses only — enough to find a thread by person name.
-func searchConversationsByName(reads readsource.ReadSource, query string, limit int) ([]*db.Conversation, error) {
-	if limit <= 0 {
-		return nil, nil
-	}
-	all, err := reads.ListConversations(1000)
-	if err != nil {
-		return nil, err
-	}
-	needle := strings.ToLower(query)
-	matches := make([]*db.Conversation, 0, limit)
-	for _, conv := range all {
-		if conv == nil {
-			continue
-		}
-		if strings.Contains(strings.ToLower(conv.Name), needle) ||
-			strings.Contains(strings.ToLower(conv.Participants), needle) {
-			matches = append(matches, conv)
-			if len(matches) == limit {
-				break
-			}
-		}
-	}
-	return matches, nil
 }
 
 func mergeSearchResults(reads readsource.ReadSource, identityStore *db.Store, msgs []*db.Message, convos []*db.Conversation, limit int) []SearchResult {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1472,7 +1472,7 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 	})
 
 	mux.HandleFunc("/api/search", func(w http.ResponseWriter, r *http.Request) {
-		q := r.URL.Query().Get("q")
+		q := strings.TrimSpace(r.URL.Query().Get("q"))
 		if q == "" {
 			httpError(w, "query parameter 'q' is required", 400)
 			return

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1487,16 +1487,60 @@ func APIHandlerWithOptions(store *db.Store, cli *client.Client, logger zerolog.L
 			convos        []*db.Conversation
 			identityStore *db.Store
 		)
-		if !opts.V2Primary {
+		if opts.V2Primary {
+			// The metadata query below is legacy-schema SQL; on v2 match
+			// conversation names/participants from the canonical read source
+			// so searching a person's name still finds their threads even
+			// when the name never appears in message text.
+			convos, err = searchConversationsByName(reads, q, limit)
+		} else {
 			convos, err = store.SearchConversationsByMetadata(q, limit)
-			if err != nil {
-				httpError(w, "search: "+err.Error(), 500)
-				return
-			}
 			identityStore = store
+		}
+		if err != nil {
+			httpError(w, "search: "+err.Error(), 500)
+			return
 		}
 		results := mergeSearchResults(reads, identityStore, msgs, convos, limit)
 		writeJSON(w, results)
+	})
+
+	// Message-level search: returns raw message rows (MessageID / Body /
+	// TimestampMS…, the same DTO as /api/conversations/<id>/messages) rather
+	// than the conversation summaries /api/search produces. This is the HTTP
+	// twin of the search_messages MCP tool, for agents and scripts.
+	mux.HandleFunc("/api/search/messages", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if q == "" {
+			httpError(w, "query parameter 'q' is required", 400)
+			return
+		}
+		sinceMS, err := db.ParseDayBound(r.URL.Query().Get("since"), false)
+		if err != nil {
+			httpError(w, "since: "+err.Error(), 400)
+			return
+		}
+		untilMS, err := db.ParseDayBound(r.URL.Query().Get("until"), true)
+		if err != nil {
+			httpError(w, "until: "+err.Error(), 400)
+			return
+		}
+		filter := db.SearchFilter{
+			Phone:          strings.TrimSpace(r.URL.Query().Get("phone")),
+			ConversationID: strings.TrimSpace(r.URL.Query().Get("conversation_id")),
+			SinceMS:        sinceMS,
+			UntilMS:        untilMS,
+			Limit:          queryIntClamped(r, "limit", 50, 500),
+		}
+		msgs, err := reads.SearchMessagesFiltered(q, filter)
+		if err != nil {
+			httpError(w, "search: "+err.Error(), 500)
+			return
+		}
+		if msgs == nil {
+			msgs = []*db.Message{}
+		}
+		writeJSON(w, msgs)
 	})
 
 	mux.HandleFunc("/api/avatar", func(w http.ResponseWriter, r *http.Request) {
@@ -3085,6 +3129,36 @@ func splitHostPortDefault(hostport, defaultPort string) (string, string, bool) {
 		port = defaultPort
 	}
 	return u.Hostname(), port, true
+}
+
+// searchConversationsByName is the v2 counterpart of the legacy
+// SearchConversationsByMetadata: a case-insensitive substring match over
+// conversation names and participants from the canonical read source. The
+// legacy query's sender/contact joins have no v2 seam, so this covers the
+// name/participants clauses only — enough to find a thread by person name.
+func searchConversationsByName(reads readsource.ReadSource, query string, limit int) ([]*db.Conversation, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	all, err := reads.ListConversations(1000)
+	if err != nil {
+		return nil, err
+	}
+	needle := strings.ToLower(query)
+	matches := make([]*db.Conversation, 0, limit)
+	for _, conv := range all {
+		if conv == nil {
+			continue
+		}
+		if strings.Contains(strings.ToLower(conv.Name), needle) ||
+			strings.Contains(strings.ToLower(conv.Participants), needle) {
+			matches = append(matches, conv)
+			if len(matches) == limit {
+				break
+			}
+		}
+	}
+	return matches, nil
 }
 
 func mergeSearchResults(reads readsource.ReadSource, identityStore *db.Store, msgs []*db.Message, convos []*db.Conversation, limit int) []SearchResult {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -959,6 +959,7 @@ func TestSearchMessagesEndpointValidation(t *testing.T) {
 
 	for _, path := range []string{
 		"/api/search/messages",
+		"/api/search/messages?q=%20%20",
 		"/api/search/messages?q=x&since=not-a-date",
 		"/api/search/messages?q=x&until=not-a-date",
 	} {
@@ -970,6 +971,15 @@ func TestSearchMessagesEndpointValidation(t *testing.T) {
 		if resp.StatusCode != 400 {
 			t.Fatalf("%s: got status %d, want 400", path, resp.StatusCode)
 		}
+	}
+
+	resp, err := http.Post(ts.server.URL+"/api/search/messages?q=x", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 405 {
+		t.Fatalf("POST: got status %d, want 405", resp.StatusCode)
 	}
 }
 

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -963,6 +963,7 @@ func TestSearchMessagesEndpointValidation(t *testing.T) {
 		"/api/search/messages?q=%20%20",
 		"/api/search/messages?q=x&since=not-a-date",
 		"/api/search/messages?q=x&until=not-a-date",
+		"/api/search/messages?q=x&since=2024-03-31&until=2024-01-01",
 	} {
 		resp, err := http.Get(ts.server.URL + path)
 		if err != nil {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -906,6 +906,90 @@ func TestSearchRequiresQuery(t *testing.T) {
 	}
 }
 
+func TestSearchMessagesEndpointReturnsRawMessageRows(t *testing.T) {
+	ts := newTestServer(t)
+
+	ts.store.UpsertConversation(&db.Conversation{
+		ConversationID: "c1",
+		Name:           "Nathan",
+		LastMessageTS:  200,
+		SourcePlatform: "sms",
+	})
+	ts.store.UpsertMessage(&db.Message{
+		MessageID: "m1", ConversationID: "c1", Body: "lunch tomorrow?",
+		SenderName: "Nathan", TimestampMS: 100,
+	})
+	ts.store.UpsertMessage(&db.Message{
+		MessageID: "m2", ConversationID: "c1", Body: "sure!",
+		TimestampMS: 200,
+	})
+
+	resp, err := http.Get(ts.server.URL + "/api/search/messages?q=lunch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("got status %d, want 200", resp.StatusCode)
+	}
+
+	// The contract is raw message DTOs — the same field names as
+	// /api/conversations/<id>/messages (MessageID, Body, TimestampMS…), not
+	// the conversation summaries /api/search returns.
+	var rows []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0]["MessageID"] != "m1" || rows[0]["Body"] != "lunch tomorrow?" {
+		t.Fatalf("row = %#v", rows[0])
+	}
+	if ts, ok := rows[0]["TimestampMS"].(float64); !ok || int64(ts) != 100 {
+		t.Fatalf("TimestampMS = %#v, want 100", rows[0]["TimestampMS"])
+	}
+	if _, ok := rows[0]["ConversationID"]; !ok {
+		t.Fatalf("row lacks ConversationID: %#v", rows[0])
+	}
+}
+
+func TestSearchMessagesEndpointValidation(t *testing.T) {
+	ts := newTestServer(t)
+
+	for _, path := range []string{
+		"/api/search/messages",
+		"/api/search/messages?q=x&since=not-a-date",
+		"/api/search/messages?q=x&until=not-a-date",
+	} {
+		resp, err := http.Get(ts.server.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 400 {
+			t.Fatalf("%s: got status %d, want 400", path, resp.StatusCode)
+		}
+	}
+}
+
+func TestSearchMessagesEndpointReturnsEmptyArrayNotNull(t *testing.T) {
+	ts := newTestServer(t)
+
+	resp, err := http.Get(ts.server.URL + "/api/search/messages?q=nothing-matches-this")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(raw)) != "[]" {
+		t.Fatalf("empty result body = %q, want []", raw)
+	}
+}
+
 func TestConversationThreadSearchRoute(t *testing.T) {
 	ts := newTestServer(t)
 

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -895,14 +895,15 @@ func TestSearchIncludesConversationMetadataMatches(t *testing.T) {
 func TestSearchRequiresQuery(t *testing.T) {
 	ts := newTestServer(t)
 
-	resp, err := http.Get(ts.server.URL + "/api/search")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 400 {
-		t.Fatalf("got status %d, want 400", resp.StatusCode)
+	for _, path := range []string{"/api/search", "/api/search?q=%20%20"} {
+		resp, err := http.Get(ts.server.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 400 {
+			t.Fatalf("%s: got status %d, want 400", path, resp.StatusCode)
+		}
 	}
 }
 

--- a/internal/web/r5_routing_test.go
+++ b/internal/web/r5_routing_test.go
@@ -164,6 +164,7 @@ func TestR5CanonicalReadRoutesUseConfiguredSource(t *testing.T) {
 		{name: "around", path: "/api/conversations/v2-conversation/messages-around?message_id=v2-message", wantBody: "around from v2", wantCall: "around"},
 		{name: "thread search", path: "/api/conversations/v2-conversation/search?q=search", wantBody: "search from v2", wantCall: "search"},
 		{name: "global search", path: "/api/search?q=search", wantBody: "search from v2", wantCall: "search"},
+		{name: "message search", path: "/api/search/messages?q=search", wantBody: "search from v2", wantCall: "search"},
 	}
 
 	for _, test := range tests {
@@ -188,6 +189,105 @@ func TestR5CanonicalReadRoutesUseConfiguredSource(t *testing.T) {
 
 	if reads.calls["previews"] == 0 {
 		t.Fatal("conversation previews did not use configured read source")
+	}
+}
+
+// searchFilterCapturingSource records the filter /api/search/messages builds
+// from its query parameters.
+type searchFilterCapturingSource struct {
+	readsource.ReadSource
+	lastQuery  string
+	lastFilter db.SearchFilter
+}
+
+func (s *searchFilterCapturingSource) SearchMessagesFiltered(query string, filter db.SearchFilter) ([]*db.Message, error) {
+	s.lastQuery = query
+	s.lastFilter = filter
+	return nil, nil
+}
+
+func TestR5MessageSearchPlumbsFilterParameters(t *testing.T) {
+	legacy, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+
+	reads := &searchFilterCapturingSource{}
+	handler := APIHandlerWithOptions(legacy, nil, zerolog.Nop(), nil, APIOptions{
+		Reads:     reads,
+		V2Primary: true,
+	})
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(
+		http.MethodGet,
+		"http://127.0.0.1/api/search/messages?q=hello&phone=%2B15551230000&conversation_id=c9&limit=7&since=2024-01-01&until=2024-03-31",
+		nil,
+	))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", recorder.Code, recorder.Body.String())
+	}
+	if reads.lastQuery != "hello" {
+		t.Fatalf("query = %q", reads.lastQuery)
+	}
+	wantSince, err := db.ParseDayBound("2024-01-01", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantUntil, err := db.ParseDayBound("2024-03-31", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := db.SearchFilter{
+		Phone:          "+15551230000",
+		ConversationID: "c9",
+		SinceMS:        wantSince,
+		UntilMS:        wantUntil,
+		Limit:          7,
+	}
+	if reads.lastFilter != want {
+		t.Fatalf("filter = %#v, want %#v", reads.lastFilter, want)
+	}
+	if wantUntil <= wantSince {
+		t.Fatalf("until %d not after since %d", wantUntil, wantSince)
+	}
+}
+
+// noMessageHitsSource returns no message hits so /api/search results can only
+// come from conversation-metadata matching.
+type noMessageHitsSource struct {
+	*routingReadSource
+}
+
+func (s *noMessageHitsSource) SearchMessagesFiltered(query string, filter db.SearchFilter) ([]*db.Message, error) {
+	return nil, nil
+}
+
+func TestR5SearchMatchesConversationNamesInV2Primary(t *testing.T) {
+	legacy, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+
+	reads := &noMessageHitsSource{routingReadSource: newRoutingReadSource()}
+	handler := APIHandlerWithOptions(legacy, nil, zerolog.Nop(), nil, APIOptions{
+		Reads:     reads,
+		V2Primary: true,
+	})
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/search?q=alice", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", recorder.Code, recorder.Body.String())
+	}
+	var results []SearchResult
+	if err := json.NewDecoder(recorder.Body).Decode(&results); err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].ConversationID != "v2-conversation" || results[0].Name != "V2 Alice" {
+		t.Fatalf("results = %#v, want the V2 Alice conversation via name matching", results)
 	}
 }
 

--- a/internal/web/r5_routing_test.go
+++ b/internal/web/r5_routing_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -74,6 +75,19 @@ func (s *routingReadSource) GetMessagesAroundMessage(conversationID, messageID s
 func (s *routingReadSource) SearchMessagesFiltered(query string, filter db.SearchFilter) ([]*db.Message, error) {
 	s.calls["search"]++
 	return []*db.Message{routingMessage("search from v2")}, nil
+}
+
+func (s *routingReadSource) SearchConversationsByMetadata(query string, limit int) ([]*db.Conversation, error) {
+	s.calls["conversation_search"]++
+	if !strings.Contains(strings.ToLower(query), "alice") {
+		return nil, nil
+	}
+	return []*db.Conversation{{
+		ConversationID: "v2-conversation",
+		Name:           "V2 Alice",
+		LastMessageTS:  200,
+		SourcePlatform: "sms",
+	}}, nil
 }
 
 func (s *routingReadSource) PlatformStats() ([]db.PlatformStat, error) {
@@ -288,6 +302,45 @@ func TestR5SearchMatchesConversationNamesInV2Primary(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].ConversationID != "v2-conversation" || results[0].Name != "V2 Alice" {
 		t.Fatalf("results = %#v, want the V2 Alice conversation via name matching", results)
+	}
+	if reads.calls["conversation_search"] != 1 {
+		t.Fatalf("SearchConversationsByMetadata calls = %d, want 1 (bounded seam, not a ListConversations scan)", reads.calls["conversation_search"])
+	}
+	if reads.calls["list"] != 0 {
+		t.Fatalf("/api/search listed %d conversation pages; name matching must not scan the list", reads.calls["list"])
+	}
+}
+
+// failingConversationSearchSource makes the metadata match fail so the test
+// can prove message hits still render instead of a 500.
+type failingConversationSearchSource struct {
+	*routingReadSource
+}
+
+func (s *failingConversationSearchSource) SearchConversationsByMetadata(query string, limit int) ([]*db.Conversation, error) {
+	return nil, errors.New("map conversation: account is missing")
+}
+
+func TestR5SearchDegradesToMessageHitsWhenMetadataMatchFails(t *testing.T) {
+	legacy, err := db.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = legacy.Close() })
+
+	reads := &failingConversationSearchSource{routingReadSource: newRoutingReadSource()}
+	handler := APIHandlerWithOptions(legacy, nil, zerolog.Nop(), nil, APIOptions{
+		Reads:     reads,
+		V2Primary: true,
+	})
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/search?q=alice", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with message hits; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "search from v2") {
+		t.Fatalf("message hits missing from degraded search: %s", recorder.Body.String())
 	}
 }
 


### PR DESCRIPTION
Refs #173 (ports the two person-message tools; the stats/story/viz tools remain gated — see the issue comment for the remaining scope).

## The regressions (all verified on the live v2-primary install, 2026-09-03)

1. **`get_person_messages` — the primary "show me texts with \<person\>" tool — errored with `not available while v2 is the serving store`.** Same for `get_person_messages_range`.
2. **`GET /api/search?q=…` returns conversation summaries** (`ConversationID`/`Name`/`Participants`), but the agent skill documented it as message rows (`MessageID`/`Body`/`TimestampMS`), so agents parsed it that way and silently got zero results.
3. Bonus found while in there: **on v2, `/api/search` skipped conversation-metadata matching entirely** (that branch was legacy-only SQL), so searching a person's name found nothing unless the name appeared in message text.

## The fixes

- **`get_person_messages` / `get_person_messages_range` now serve v2** through the canonical read seam. `readsource.ReadSource` grows the two batch queries the legacy handlers used (`GetMessagesByConversations`, `GetMessagesByConversationsRange`) — `*db.Store` already satisfies them, and `v2read` implements them with bounded newest-first page walks preserving the legacy contract (newest `limit` across the set, ascending, message-id tiebreak; range bounds inclusive).
- **New `GET /api/search/messages`** — raw message DTOs, the same shape as `/api/conversations/<id>/messages` and the HTTP twin of the `search_messages` MCP tool. Filters: `phone`, `conversation_id`, `since`/`until` (YYYY-MM-DD, local, `until` inclusive to end of day — `db.ParseDayBound`, moved from the CLI so both accept identical forms), `limit` (default 50, max 500). `/api/search` keeps its conversation-summary contract for the web UI.
- **`/api/search` on v2 now matches conversation names/participants** from the read source (the v2 counterpart of `SearchConversationsByMetadata`'s name/participants clauses).
- **The still-gated stats/story/viz tools** (`conversation_stats`, `generate_story`, `person_stats`, `generate_person_story`, `generate_viz`, `render_story`) stay gated deliberately — they load complete histories, and the v2 mapper does per-row identity/attachment/send-status lookups, pathological at that scale — but the error now says so and names the tools that do work.
- Docs: CLAUDE.md + `docs/agent-runbook.md` document both search contracts.

## Verification (against a `cp -c` clone of the live stores — the running app was not touched)

- MCP stdio (`serve --mcp-stdio`, the exact shape hosts spawn): `get_person_messages {"name":"Jenn Umanzor"}` → messages across 4 conversations (whatsapp + sms), real timestamps; `get_person_messages_range` June 2026 → 5 messages from 2 conversations; `person_stats` → the new actionable error.
- HTTP: `/api/search/messages?q=Jenn` → raw message rows; `/api/search?q=Jenn+Umanzor` → the person's threads found by name; missing `q` and bad dates → 400.
- `GOWORK=off go test ./...` fully green; `go vet` clean.

The live daemon picks up the HTTP routes at the next app deploy (`macos/build.sh` + reinstall per the runbook); MCP hosts pick up the tool fixes when `/usr/local/bin/openmessage` is updated in lockstep, per the runbook's version-skew warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)