### PR TITLE
Lock the RunServe test logger so leaked daemon goroutines can't race

### DIFF
--- a/cmd/serve_client_test.go
+++ b/cmd/serve_client_test.go
@@ -21,30 +21,32 @@ import (
 	"github.com/maxghenis/openmessage/internal/web"
 )
 
-// TestServeOptionsTransportMatrix pins which serve shapes may own live
-// platform connections. The MCP-stdio-only shape is the per-Claude-session
-// spawn and must default to transportless client mode.
-
-// lockedBuffer is a bytes.Buffer that is safe to share with the goroutines
+// syncBuffer is a bytes.Buffer that is safe to share with the goroutines
 // RunServe's daemon shape leaves running after it returns (legacy sync loops,
 // the scheduler): they keep logging while the test reads the output, which
 // the race detector otherwise reports against whatever test runs next.
-type lockedBuffer struct {
+// zerolog.SyncWriter only serializes writers, so it would not protect the
+// test's String read (same helper as internal/signallive's gate_test.go).
+type syncBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
 }
 
-func (b *lockedBuffer) Write(p []byte) (int, error) {
+func (b *syncBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.Write(p)
 }
 
-func (b *lockedBuffer) String() string {
+func (b *syncBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
 }
+
+// TestServeOptionsTransportMatrix pins which serve shapes may own live
+// platform connections. The MCP-stdio-only shape is the per-Claude-session
+// spawn and must default to transportless client mode.
 
 func TestServeOptionsTransportMatrix(t *testing.T) {
 	tests := []struct {
@@ -103,7 +105,7 @@ func TestRunServeMCPStdioStartsZeroTransportSupervisors(t *testing.T) {
 	dataDir := t.TempDir()
 	setClientModeTestEnv(t, dataDir)
 
-	var logs lockedBuffer
+	var logs syncBuffer
 	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
 		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
 	}
@@ -134,7 +136,7 @@ func TestRunServeMCPStdioStartsZeroTransportSupervisors(t *testing.T) {
 	// above against silently passing because the fixtures changed.
 	daemonDataDir := t.TempDir()
 	setClientModeTestEnv(t, daemonDataDir)
-	var daemonLogs lockedBuffer
+	var daemonLogs syncBuffer
 	if err := RunServe(zerolog.New(&daemonLogs), "--mcp-stdio", "--transports"); err != nil {
 		t.Fatalf("RunServe(--mcp-stdio --transports): %v\n%s", err, daemonLogs.String())
 	}
@@ -185,7 +187,7 @@ func TestRunServeMCPClientAdoptsDaemonTruth(t *testing.T) {
 	setClientModeTestEnv(t, dataDir)
 	t.Setenv("OPENMESSAGES_PORT", daemonURL.Port())
 
-	var logs lockedBuffer
+	var logs syncBuffer
 	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
 		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
 	}
@@ -232,7 +234,7 @@ func TestRunServeMCPClientAdoptsDaemonDataDir(t *testing.T) {
 		t.Fatalf("unset data dir: %v", err)
 	}
 
-	var logs lockedBuffer
+	var logs syncBuffer
 	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
 		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
 	}
@@ -307,7 +309,7 @@ func TestRunServeMCPClientDoesNotRepairStore(t *testing.T) {
 	setClientModeTestEnv(t, dataDir)
 	seedLegacyReactionPlaceholder(t, dataDir)
 
-	var logs lockedBuffer
+	var logs syncBuffer
 	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
 		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
 	}

--- a/cmd/serve_client_test.go
+++ b/cmd/serve_client_test.go
@@ -47,7 +47,6 @@ func (b *syncBuffer) String() string {
 // TestServeOptionsTransportMatrix pins which serve shapes may own live
 // platform connections. The MCP-stdio-only shape is the per-Claude-session
 // spawn and must default to transportless client mode.
-
 func TestServeOptionsTransportMatrix(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/cmd/serve_client_test.go
+++ b/cmd/serve_client_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -23,6 +24,28 @@ import (
 // TestServeOptionsTransportMatrix pins which serve shapes may own live
 // platform connections. The MCP-stdio-only shape is the per-Claude-session
 // spawn and must default to transportless client mode.
+
+// lockedBuffer is a bytes.Buffer that is safe to share with the goroutines
+// RunServe's daemon shape leaves running after it returns (legacy sync loops,
+// the scheduler): they keep logging while the test reads the output, which
+// the race detector otherwise reports against whatever test runs next.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 func TestServeOptionsTransportMatrix(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -80,7 +103,7 @@ func TestRunServeMCPStdioStartsZeroTransportSupervisors(t *testing.T) {
 	dataDir := t.TempDir()
 	setClientModeTestEnv(t, dataDir)
 
-	var logs bytes.Buffer
+	var logs lockedBuffer
 	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
 		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
 	}
@@ -111,7 +134,7 @@ func TestRunServeMCPStdioStartsZeroTransportSupervisors(t *testing.T) {
 	// above against silently passing because the fixtures changed.
 	daemonDataDir := t.TempDir()
 	setClientModeTestEnv(t, daemonDataDir)
-	var daemonLogs bytes.Buffer
+	var daemonLogs lockedBuffer
 	if err := RunServe(zerolog.New(&daemonLogs), "--mcp-stdio", "--transports"); err != nil {
 		t.Fatalf("RunServe(--mcp-stdio --transports): %v\n%s", err, daemonLogs.String())
 	}
@@ -162,7 +185,7 @@ func TestRunServeMCPClientAdoptsDaemonTruth(t *testing.T) {
 	setClientModeTestEnv(t, dataDir)
 	t.Setenv("OPENMESSAGES_PORT", daemonURL.Port())
 
-	var logs bytes.Buffer
+	var logs lockedBuffer
 	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
 		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
 	}
@@ -209,7 +232,7 @@ func TestRunServeMCPClientAdoptsDaemonDataDir(t *testing.T) {
 		t.Fatalf("unset data dir: %v", err)
 	}
 
-	var logs bytes.Buffer
+	var logs lockedBuffer
 	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
 		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
 	}
@@ -284,7 +307,7 @@ func TestRunServeMCPClientDoesNotRepairStore(t *testing.T) {
 	setClientModeTestEnv(t, dataDir)
 	seedLegacyReactionPlaceholder(t, dataDir)
 
-	var logs bytes.Buffer
+	var logs lockedBuffer
 	if err := RunServe(zerolog.New(&logs), "--mcp-stdio"); err != nil {
 		t.Fatalf("RunServe(--mcp-stdio): %v\n%s", err, logs.String())
 	}


### PR DESCRIPTION
`TestRunServeMCPStdioStartsZeroTransportSupervisors` includes a `--transports` contrast case (`cmd/serve_client_test.go:138`). That daemon shape's legacy sync loops (`serve.go:471`) and the scheduler (`internal/app/scheduler.go:37`) outlive `RunServe` and keep logging into a plain `bytes.Buffer`, so the race detector reports the concurrent writes against whatever test runs next — on #174 it surfaced as `TestBuiltBinaryAcceptsPairCommand: race detected during execution of test` ([job log](https://github.com/MaxGhenis/openmessage/actions/runs/33803758976/job/100809176806)), a test the PR never touched. Go Race had passed on the previous 11 `test.yml` runs; it's timing-dependent.

Fix: the `RunServe` test loggers use a mutex-guarded `lockedBuffer` (writes and the test's `String()` reads serialized). Test-only change; no production code.

Verified: `GOWORK=off go test -race -count=1 -run 'TestRunServeMCP|TestBuiltBinary' ./cmd/` passes; full `go test -race ./cmd/` run below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)