### PR TITLE
Prepare v0.3.0 release from upstream main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,84 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g. v0.2.0)'
+        description: 'Existing tag merged into main (e.g. v0.3.0)'
         required: true
 
 permissions:
-  contents: write
+  contents: read
+
+# Release builds must resolve the checked-in public module graph, even if a
+# runner has a Go workspace or private-module configuration left over.
+env:
+  GOENV: 'off'
+  GOWORK: 'off'
+  GOFLAGS: '-mod=readonly'
+  GOPROXY: https://proxy.golang.org
+  GOSUMDB: sum.golang.org
+  GOPRIVATE: ''
+  GONOPROXY: none
+  GONOSUMDB: none
+  GOVCS: '*:off'
+
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
+  prepare:
+    name: Resolve release tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.metadata.outputs.tag }}
+      commit: ${{ steps.metadata.outputs.commit }}
+      version: ${{ steps.metadata.outputs.version }}
+      build: ${{ steps.metadata.outputs.build }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate tag, mainline ancestry, and bundle version
+        id: metadata
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: python3 scripts/release_metadata.py --tag "$RELEASE_TAG" --github-output "$GITHUB_OUTPUT"
+
+  verify:
+    name: Verify release source
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
+          persist-credentials: false
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Verify dependencies with an empty public module cache
+        env:
+          GOMODCACHE: ${{ runner.temp }}/release-modules
+        run: |
+          go mod download
+          go mod verify
+          go list -m -json all > public-modules.json
+          go test ./...
+          go test -race ./...
+      - name: Verify release metadata regression tests
+        run: python3 -m unittest discover -s scripts -p 'test_release_*.py'
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-public-modules
+          path: public-modules.json
+          retention-days: 7
+
   build-cross-platform:
     name: Build CLI binaries
+    needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -31,21 +100,24 @@ jobs:
             goarch: amd64
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
 
       - name: Build binary
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
         run: |
-          version="${GITHUB_REF_NAME:-${{ inputs.tag }}}"
           mkdir -p dist
-          go build -trimpath -ldflags "-s -w -X main.version=${version}" -o dist/openmessage .
+          go build -trimpath -ldflags "-s -w -X main.version=${RELEASE_TAG}" -o dist/openmessage .
           tar -C dist -czf "openmessage-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz" openmessage
 
       - name: Upload artifact
@@ -57,15 +129,19 @@ jobs:
 
   build-macos-app:
     name: Build macOS .app + .dmg
+    needs: prepare
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit }}
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
 
       # Import the Developer ID Application certificate into a temporary
       # keychain so codesign can find it. Skipped when secrets are unset
@@ -89,7 +165,11 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           # Make the new keychain the default search target so codesign sees it
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          existing_keychains=()
+          while IFS= read -r keychain; do
+            existing_keychains+=("$keychain")
+          done < <(security list-keychains -d user | sed 's/^[[:space:]]*"//;s/"[[:space:]]*$//')
+          security list-keychains -d user -s "$KEYCHAIN_PATH" "${existing_keychains[@]}"
 
           # Import the cert and authorize codesign to use it without prompting
           security import "$RUNNER_TEMP/cert.p12" \
@@ -114,13 +194,17 @@ jobs:
           # so a stale dev build can never shadow the installed app in
           # LaunchServices. Shipping artifacts must carry the real id.
           RELEASE: "1"
+          VERSION: ${{ needs.prepare.outputs.tag }}
           DEVELOPER_ID: ${{ secrets.DEVELOPER_ID }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_TEAM_ID: ${{ secrets.AC_TEAM_ID }}
         run: bash macos/build.sh
 
-      - name: Verify release bundle identity
+      - name: Verify release bundle identity and version
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          RELEASE_BUILD: ${{ needs.prepare.outputs.build }}
         run: |
           plist=macos/build/OpenMessage.app/Contents/Info.plist
           id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")
@@ -129,6 +213,12 @@ jobs:
           if [ "$id" != "com.openmessage.app" ] || [ "$name" != "OpenMessage" ]; then
             echo "::error::Release build has id '$id' / name '$name', expected com.openmessage.app / OpenMessage."
             echo "::error::RELEASE=1 was not honored — refusing to ship a dev-identity build."
+            exit 1
+          fi
+          version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$plist")
+          build=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$plist")
+          if [ "$version" != "$RELEASE_VERSION" ] || [ "$build" != "$RELEASE_BUILD" ]; then
+            echo "::error::Packaged bundle version does not match the validated release tag."
             exit 1
           fi
           test -f macos/build/OpenMessage.dmg || {
@@ -162,19 +252,24 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    needs: [build-cross-platform, build-macos-app]
+    needs: [prepare, verify, build-cross-platform, build-macos-app]
+    if: github.repository == 'MaxGhenis/openmessage'
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+      RELEASE_COMMIT: ${{ needs.prepare.outputs.commit }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ needs.prepare.outputs.commit }}
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Determine tag
-        id: tag
-        run: |
-          tag="${GITHUB_REF_NAME:-${{ inputs.tag }}}"
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+      - name: Confirm the tag still identifies the built commit
+        run: test "$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")" = "$RELEASE_COMMIT"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -191,31 +286,33 @@ jobs:
           cp artifacts/OpenMessage-dmg/OpenMessage.dmg release/
 
           # Generate SHA256 checksums for verification + Homebrew updates
-          (cd release && shasum -a 256 * > SHA256SUMS)
+          (cd release && shasum -a 256 ./* > SHA256SUMS)
 
-      - name: Generate release notes
-        id: notes
+      - name: Prepare release notes
         run: |
-          tag="${{ steps.tag.outputs.tag }}"
-          previous=$(git tag --sort=-v:refname | grep -v "^${tag}$" | head -n1)
-          if [ -z "$previous" ]; then
-            git log --pretty=format:"- %s (%h)" > NOTES.md
+          if [ -f "docs/releases/${RELEASE_TAG}.md" ]; then
+            cp "docs/releases/${RELEASE_TAG}.md" NOTES.md
           else
-            git log "${previous}..${tag}" --pretty=format:"- %s (%h)" > NOTES.md
+            previous=$(git describe --tags --abbrev=0 --match 'v[0-9]*' "${RELEASE_COMMIT}^" 2>/dev/null || true)
+            if [ -n "$previous" ]; then
+              git log "${previous}..${RELEASE_COMMIT}" --pretty=format:"- %s (%h)" > NOTES.md
+            else
+              git log "$RELEASE_COMMIT" --pretty=format:"- %s (%h)" > NOTES.md
+            fi
           fi
-          echo "Generated notes from ${previous:-beginning} to ${tag}"
+          printf '\n\nSource commit: %s\n' "$RELEASE_COMMIT" >> NOTES.md
 
       - name: Create or update release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tag="${{ steps.tag.outputs.tag }}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            gh release upload "$tag" release/* --clobber
-            gh release edit "$tag" --notes-file NOTES.md
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" release/* --clobber
+            gh release edit "$RELEASE_TAG" --notes-file NOTES.md
           else
-            gh release create "$tag" \
-              --title "OpenMessage ${tag}" \
+            gh release create "$RELEASE_TAG" \
+              --verify-tag \
+              --title "OpenMessage ${RELEASE_TAG}" \
               --notes-file NOTES.md \
               release/*
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,15 @@ env:
   GO_COVERAGE_MIN: "40.0"
 
 jobs:
+  release-metadata:
+    name: Release Metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test release tag provenance and version validation
+        run: python3 -m unittest discover -s scripts -p 'test_release_*.py'
+
   go-test:
     name: Go Test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Built on [mautrix/gmessages](https://github.com/mautrix/gmessages) (libgm) for t
 
 ### Prerequisites
 
-- **Go 1.22+** ([install](https://go.dev/dl/))
+- **Go 1.25+** ([install](https://go.dev/dl/); see `go.mod` for the build requirement)
 - **Google Messages** on your Android phone
 
 ### 1. Clone and build

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -2,6 +2,47 @@
 
 Use this before shipping a TestFlight/App Store build, public website update, or signed macOS release.
 
+## Preparing the v0.3.0 GitHub release
+
+The release-preparation PR proposes version 0.3.0 / macOS build 19. Review
+[the release notes](releases/v0.3.0.md) with the code and keep the PR in draft
+until the remaining platform checks below are complete. Opening or merging the
+PR does not publish a release.
+
+- Base the release on `MaxGhenis/openmessage` main. Do not merge a local
+  integration branch or rely on an unmerged contributor branch to build it.
+- Keep the checked-in dependency graph. The existing Google Messages replacement
+  is the public `MaxGhenis/gmessages` fork at
+  `0e43542dfa0e0b97e410f185a5842e8740106099`; this proposal does not require
+  PR #179 or a contributor's replacement fork.
+- The release workflow disables Go workspaces and private-module overrides,
+  resolves dependencies through the public Go proxy and checksum database, and
+  verifies/tests them using an empty module cache. Review the uploaded
+  `release-public-modules` artifact for the exact dependency versions.
+- Check the proposed `CFBundleShortVersionString` and `CFBundleVersion` in the
+  macOS source plist. All release artifacts use the same resolved tag/commit;
+  the workflow rejects a missing tag, an unmerged commit, or a tag that disagrees
+  with the app version.
+- After the PR is merged and all release gates pass, a maintainer can push the
+  `v0.3.0` tag at the approved commit. **Pushing the tag triggers publication.**
+  Manual runs also require an existing tag merged into main and build that tag,
+  regardless of the branch chosen in the workflow UI. Neither path creates a
+  tag automatically.
+- Keep the release tag immutable. The workflow checks it again before uploading
+  artifacts. Release notes include the resolved source commit.
+
+For an isolated container check, use a clean Git archive, a unique image name,
+and a disposable container with no host data or credential mounts. Use
+`serve --no-transports` for an unpaired startup check; browser tests use the
+synthetic e2e server. Avoid the default Compose project and port when another
+OpenMessage instance is installed. Do not connect test containers to a real
+message store or reuse a live pairing session.
+
+Release preparation still needs macOS packaging/signing/notarization checks and
+authorized live messaging checks before publication. Linux container results
+do not satisfy those gates. In particular, verify Google account pairing and
+dual-SIM behavior separately; issue #158 is not fully resolved by this release.
+
 ## 1. Worktree And Privacy Preflight
 
 - Run `git status --short` and confirm every changed file is intentional.

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,62 @@
+# OpenMessage v0.3.0
+
+This release brings the packaged app up to date with the changes merged since
+v0.2.9. It includes inbox and composer improvements, more resilient connections,
+and the optional v2 storage and delivery system.
+
+## Inbox and messaging
+
+- Favorite conversations, inbox tabs, contact groups, and a searchable group
+  member panel make conversations easier to find.
+- The composer supports forwarding, scheduled messages, a GIF picker, and
+  drag-and-drop attachments. Duplicate-send prevention and stable message
+  rendering improve reconnects and long threads.
+- Start WhatsApp and Signal conversations directly from the new-message dialog.
+  WhatsApp can also link by phone number.
+- Improved media placeholders, reaction display, notifications, and the
+  installable web UI.
+
+## Reliability and history
+
+- History sync no longer creates empty SMS threads for every contact by default.
+  Contact-based orphan discovery is explicitly opt-in (PR #21; addresses the
+  thread-creation behavior reported in issue #158).
+- Google authentication expiry and stuck connections have clearer repair paths,
+  with more durable session saves and paced recovery.
+- Signal startup tolerates transient probe failures, and Signal subprocess
+  handling reduces temporary-file leaks.
+- The optional v2 system adds a durable inbox/outbox, delivery reconciliation,
+  migration integrity reports, and better conversation identity handling.
+- The `backup` command produces a verified manifest. Person-level MCP reads and
+  message search work with the v2 store.
+
+## Upgrade notes
+
+- Back up the existing OpenMessage data directory before upgrading. A separate
+  copy is needed to roll back; do not overwrite it with the upgraded store.
+- The v2 storage and send paths remain opt-in. This release does not automatically
+  migrate an existing installation or enable v2.
+- A bare `serve` now starts only the web UI. For HTTP MCP alongside the web UI,
+  use `serve --web --mcp-sse`. The stdio MCP client uses the running daemon for
+  live sends, avoiding competing connections to the same messaging account.
+- Live Signal requires signal-cli 0.14.5 or newer; it is not bundled with the
+  CLI archives or container image. Existing Signal users should verify their
+  signal-cli installation before upgrading.
+- Source builds require Go 1.25 or newer. The native app requires macOS 14 or
+  newer. CLI downloads cover Linux and macOS on x86-64 and ARM64.
+- Development macOS builds use a separate app name and bundle identifier.
+  Distributed macOS builds retain the normal OpenMessage identity.
+
+## Known limitations
+
+- The dual-SIM selection and missing-message symptoms in issue #158 are not
+  confirmed fixed. The empty-thread fix does not establish that sending uses
+  the phone's preferred SIM.
+- Google Messages uses an unofficial protocol integration. This release retains
+  the maintainer's existing public dependency pin; it does not include the
+  pending transport update in PR #179.
+- Unpaired container and fixture tests cannot validate live Google, WhatsApp, or
+  Signal delivery. Complete the release checklist with test accounts before
+  publishing.
+
+Full comparison: https://github.com/MaxGhenis/openmessage/compare/v0.2.9...v0.3.0

--- a/macos/OpenMessage/Sources/Info.plist
+++ b/macos/OpenMessage/Sources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.openmessage.app</string>
     <key>CFBundleVersion</key>
-    <string>18</string>
+    <string>19</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.9</string>
+    <string>0.3.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/scripts/release_metadata.py
+++ b/scripts/release_metadata.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Resolve a release tag to an immutable, mainline commit before building."""
+
+import argparse
+from pathlib import Path
+import plistlib
+import re
+import subprocess
+
+
+def git(repo, *args):
+    return subprocess.check_output(["git", "-C", str(repo), *args], stderr=subprocess.PIPE)
+
+
+def resolve_release(repo, tag, main_ref="refs/remotes/origin/main"):
+    if not re.fullmatch(r"v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)", tag):
+        raise ValueError("release tag must be a stable version such as v0.3.0")
+    try:
+        commit = git(repo, "rev-parse", "--verify", f"refs/tags/{tag}^{{commit}}").decode().strip()
+        git(repo, "merge-base", "--is-ancestor", commit, main_ref)
+        plist = plistlib.loads(git(repo, "show", f"{commit}:macos/OpenMessage/Sources/Info.plist"))
+    except subprocess.CalledProcessError as exc:
+        raise ValueError("release tag must exist and point to a commit merged into main") from exc
+    if plist.get("CFBundleShortVersionString") != tag[1:]:
+        raise ValueError("release tag does not match CFBundleShortVersionString at the tagged commit")
+    build = str(plist.get("CFBundleVersion", ""))
+    if not re.fullmatch(r"[1-9][0-9]*", build):
+        raise ValueError("CFBundleVersion must be a positive integer")
+    return {"tag": tag, "commit": commit, "version": tag[1:], "build": build}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+    try:
+        metadata = resolve_release(args.repo, args.tag)
+    except (ValueError, plistlib.InvalidFileException) as exc:
+        parser.exit(1, f"Release validation failed: {exc}\n")
+    output = "".join(f"{key}={value}\n" for key, value in metadata.items())
+    print(output, end="")
+    if args.github_output:
+        with args.github_output.open("a") as target:
+            target.write(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_release_metadata.py
+++ b/scripts/test_release_metadata.py
@@ -1,0 +1,101 @@
+"""Exercise release provenance with disposable repositories and real git tags."""
+
+from pathlib import Path
+import plistlib
+import subprocess
+import tempfile
+import unittest
+
+from release_metadata import resolve_release
+
+
+class ReleaseMetadataTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.repo = Path(self.temp.name)
+        self.git("init", "--quiet", "--initial-branch=main")
+        self.git("config", "user.name", "Release Test")
+        self.git("config", "user.email", "release-test@example.invalid")
+        self.plist = self.repo / "macos/OpenMessage/Sources/Info.plist"
+        self.plist.parent.mkdir(parents=True)
+        self.write_version("0.3.0")
+        self.commit()
+        self.git("update-ref", "refs/remotes/origin/main", "HEAD")
+
+    def git(self, *args):
+        return subprocess.check_output(["git", "-C", str(self.repo), *args], stderr=subprocess.PIPE).decode().strip()
+
+    def write_version(self, version, build="19"):
+        self.plist.write_bytes(plistlib.dumps({"CFBundleShortVersionString": version, "CFBundleVersion": build}))
+
+    def commit(self):
+        self.git("add", ".")
+        self.git("commit", "--quiet", "-m", "Test release")
+
+    def test_lightweight_and_annotated_tags_resolve_to_commit(self):
+        for annotated in (False, True):
+            with self.subTest(annotated=annotated):
+                flags = ["-a", "-m", "Release"] if annotated else []
+                self.git("tag", *flags, "v0.3.0")
+                self.assertEqual(resolve_release(self.repo, "v0.3.0"), {
+                    "tag": "v0.3.0", "commit": self.git("rev-parse", "HEAD"),
+                    "version": "0.3.0", "build": "19",
+                })
+                self.git("tag", "-d", "v0.3.0")
+
+    def test_requested_tag_wins_over_checked_out_branch_and_working_tree(self):
+        self.git("tag", "v0.3.0")
+        tagged = self.git("rev-parse", "HEAD")
+        self.write_version("0.4.0")
+        self.commit()
+        self.git("update-ref", "refs/remotes/origin/main", "HEAD")
+        self.write_version("9.9.9")
+        self.assertEqual(resolve_release(self.repo, "v0.3.0")["commit"], tagged)
+
+    def test_cli_writes_the_validated_commit_to_github_outputs(self):
+        self.git("tag", "v0.3.0")
+        output = self.repo / "github-output"
+        result = subprocess.run([
+            "python3", str(Path(__file__).with_name("release_metadata.py")),
+            "--repo", str(self.repo), "--tag", "v0.3.0", "--github-output", str(output),
+        ], check=True, capture_output=True, text=True)
+        self.assertEqual(output.read_text(), result.stdout)
+        values = dict(line.split("=", 1) for line in output.read_text().splitlines())
+        self.assertEqual(values["commit"], self.git("rev-parse", "HEAD"))
+        self.assertEqual(values["tag"], "v0.3.0")
+
+    def test_unmerged_commit_is_rejected(self):
+        self.git("checkout", "-b", "unmerged")
+        self.write_version("0.3.0", "20")
+        self.commit()
+        self.git("tag", "v0.3.0")
+        with self.assertRaisesRegex(ValueError, "merged into main"):
+            resolve_release(self.repo, "v0.3.0")
+
+    def test_tag_and_bundle_version_must_match(self):
+        self.git("tag", "v0.4.0")
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            resolve_release(self.repo, "v0.4.0")
+
+    def test_missing_tag_or_branch_named_like_tag_is_rejected(self):
+        self.git("branch", "v0.3.0")
+        with self.assertRaisesRegex(ValueError, "must exist"):
+            resolve_release(self.repo, "v0.3.0")
+
+    def test_invalid_tags_are_rejected(self):
+        for tag in ("main", "v0.3.0\ncommit=bad", "v0.3.0;echo bad", "v0.3.0-rc.1", "v00.3.0"):
+            with self.subTest(tag=tag), self.assertRaisesRegex(ValueError, "stable version"):
+                resolve_release(self.repo, tag)
+
+    def test_invalid_build_is_rejected(self):
+        self.write_version("0.3.0", "dev")
+        self.commit()
+        self.git("update-ref", "refs/remotes/origin/main", "HEAD")
+        self.git("tag", "v0.3.0")
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            resolve_release(self.repo, "v0.3.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The latest packaged release, v0.2.9, predates the merged empty-thread fix in #21 and the subsequent inbox, reliability, and optional v2 work. This proposes **v0.3.0 / macOS build 19**, adds upgrade notes, and makes release builds consistently use the requested tag and its resolved commit.

- Fix manual releases selecting the workflow branch name instead of the requested tag. Validate tag existence, mainline ancestry, and macOS version before building; use the same commit and version for every artifact.
- Require dependency verification and Go normal/race tests before publication. Disable workspaces, private-module overrides, and restored Go caches for release builds; resolve modules through the public proxy/checksum database.
- Update release notes/checklist and the documented Go requirement. The dual-SIM symptoms in #158 are **not claimed fixed**.

### Source and dependencies

Based directly on upstream main `c7d7445474ec75662659377da984cb862c62fca0`, with only this release-preparation commit added. Dependency manifests and the Dockerfile are unchanged. The only module replacement remains the maintainer's public `MaxGhenis/gmessages` fork at `0e43542dfa0e0b97e410f185a5842e8740106099`; this PR is independent of #179 and requires no contributor fork, local workspace override, or unmerged integration commit.

### Validation

- [GitHub CI run 34478503088](https://github.com/MaxGhenis/openmessage/actions/runs/34478503088) passed all six checks at head `32716e5b4cde475fef7229bc944ff4b0066c4681`: Release Metadata, Go Test, Go Race, Web E2E, Site Build, and macOS App Build.
- Fresh, credential-free container: all 88 modules resolved/verified publicly; full Go suite passed, 65.0% coverage.
- Full Go race suite and `go vet ./...` passed.
- Playwright: 91 passed, 9 existing skips, synthetic fixtures only.
- Eight release-metadata regression tests and actionlint/ShellCheck passed.
- All four Linux/macOS x86-64/ARM64 CLI targets built; the packaged archive checksums verified.
- Exact PR-head Git archive built with the checked-in Dockerfile. The resulting v0.3.0 image passed UI, empty-inbox, diagnostics, MCP version, and restart checks with networking disabled, no published ports, and a disposable data volume.

### Before publishing

Keep this PR in draft for maintainer release review. Native macOS compilation, tests, and dev/release packaging passed in CI; Apple signing/notarization and authorized live pairing/send/receive, including dual-SIM behavior, remain to be validated. Existing installations were not changed. No release tag or downloads have been published; a maintainer must merge the PR and tag the approved commit to trigger publication.
